### PR TITLE
Update MediatR service registration in dependencies installer

### DIFF
--- a/XFramework/XFramework/Server/XFramework.Api/Installers/ExternalDependencyInstaller.cs
+++ b/XFramework/XFramework/Server/XFramework.Api/Installers/ExternalDependencyInstaller.cs
@@ -11,7 +11,7 @@ namespace XFramework.Api.Installers
         public virtual void InstallServices(IServiceCollection services, IConfiguration configuration)
         {
             // MediatR
-            services.AddMediatR(typeof(CommandBaseHandler).GetTypeInfo().Assembly);
+            services.AddMediatR(o => o.RegisterServicesFromAssemblyContaining<CommandBaseHandler>());
             
             // FluentValidation
             services.AddValidatorsFromAssembly(typeof(CommandBaseHandler).GetTypeInfo().Assembly);


### PR DESCRIPTION
This change updates the way MediatR services are registered in the ExternalDependencyInstaller.cs file. Instead of registering the assembly of the CommandBaseHandler class, we now use the RegisterServicesFromAssemblyContaining method for clearer intent and consistency.