### PR TITLE
• Add App Service deployment stage to various CI/CD pipelines

### DIFF
--- a/.workflows/community.service.yaml
+++ b/.workflows/community.service.yaml
@@ -1,7 +1,20 @@
+# ─────────────────────────────
+# Comminity CI/CD pipeline
+# ─────────────────────────────
+
 trigger:
   - Main
 
 pr: none
+
+# ─── RUN-TIME CHOICES ──────────────────────────────────────────────────
+parameters:
+  # Choose targets when you queue the pipeline.
+  - name: deployToProdOnPrem
+    type: boolean
+    default: false        # keep current behaviour
+
+
 
 variables:
   PublishDirectory: '$(Build.ArtifactStagingDirectory)/community'
@@ -9,10 +22,13 @@ variables:
   ServiceExecutable: 'Community.Api.dll'
   ServiceFilePath: '/etc/systemd/system/xframework-community.service'
   ServiceName: 'xframework-community'
+  AppServiceName: 'XSystem-Community'
   BuildConfiguration: 'Release'
   BuildPlatform: 'any cpu'
   ArtifactName: 'communityArtifact'
   ZipFile: 'community.zip'
+  AzureStagingServiceConnection: 'STAGING_SERVICES_SERVICE_CONNECTION'
+  AzureProductionServiceConnection: 'PRODUCTION_SERVICES_SERVICE_CONNECTION'
 
 stages:
   - stage: BuildAndUpload
@@ -24,7 +40,7 @@ stages:
           name: Default-Linux
         steps:
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -47,7 +63,7 @@ stages:
         steps:
           - checkout: none
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -171,6 +187,7 @@ stages:
                       }
 
   - stage: DeployToProduction
+    condition: and(succeeded(), eq(${{ parameters.deployToProdOnPrem }}, true))
     displayName: 'Deploy to Production'
     dependsOn: DeployToStaging
     jobs:
@@ -264,3 +281,29 @@ stages:
                               exit 1
                           }
                       }
+# ─── DEPLOY TO APP SERVICE (PRODUCTION) ────────────────────────────────
+  - stage: DeployToProductionAppSvc
+    displayName: 'Deploy to Production (App Service)'
+    dependsOn: DeployToStaging
+    condition: succeeded()
+    jobs:
+      - deployment: DeployProdAppSvc
+        environment: 'Production'
+        pool: { name: Default-Linux }
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: $(ArtifactName)
+                
+                - task: AzureWebApp@1
+                  displayName: 'Azure Web App Deploy: XSystem-Community'
+                  inputs:
+                    azureSubscription: $(AzureProductionServiceConnection)
+                    appType:          webAppLinux
+                    appName:          $(AppServiceName)
+                    package:          '$(Pipeline.Workspace)/$(ArtifactName)/$(ZipFile)'
+                    runtimeStack:     'DOTNETCORE|9.0'
+                    startUpCommand:   'dotnet $(ServiceExecutable)'
+

--- a/.workflows/gateway.service.yaml
+++ b/.workflows/gateway.service.yaml
@@ -1,7 +1,20 @@
+# ─────────────────────────────
+# Gateway CI/CD pipeline
+# ─────────────────────────────
+
 trigger:
   - Main
 
 pr: none
+
+# ─── RUN-TIME CHOICES ──────────────────────────────────────────────────
+parameters:
+  # Choose targets when you queue the pipeline.
+  - name: deployToProdOnPrem
+    type: boolean
+    default: false        # keep current behaviour
+
+
 
 variables:
   PublishDirectory: '$(Build.ArtifactStagingDirectory)/gateway'
@@ -9,10 +22,13 @@ variables:
   ServiceExecutable: 'Gateway.dll'
   ServiceFilePath: '/etc/systemd/system/xframework-gateway.service'
   ServiceName: 'xframework-gateway'
+  AppServiceName: 'XSystem-Gateway'
   BuildConfiguration: 'Release'
   BuildPlatform: 'any cpu'
   ArtifactName: 'gatewayArtifact'
   ZipFile: 'gateway.zip'
+  AzureStagingServiceConnection: 'STAGING_SERVICES_SERVICE_CONNECTION'
+  AzureProductionServiceConnection: 'PRODUCTION_SERVICES_SERVICE_CONNECTION'
 
 stages:
   - stage: BuildAndUpload
@@ -24,7 +40,7 @@ stages:
           name: Default-Linux
         steps:
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -47,7 +63,7 @@ stages:
         steps:
           - checkout: none
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -171,6 +187,7 @@ stages:
                       }
 
   - stage: DeployToProduction
+    condition: and(succeeded(), eq(${{ parameters.deployToProdOnPrem }}, true))
     displayName: 'Deploy to Production'
     dependsOn: DeployToStaging
     jobs:
@@ -264,3 +281,29 @@ stages:
                               exit 1
                           }
                       }
+# ─── DEPLOY TO APP SERVICE (PRODUCTION) ────────────────────────────────
+  - stage: DeployToProductionAppSvc
+    displayName: 'Deploy to Production (App Service)'
+    dependsOn: DeployToStaging
+    condition: succeeded()
+    jobs:
+      - deployment: DeployProdAppSvc
+        environment: 'Production'
+        pool: { name: Default-Linux }
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: $(ArtifactName)
+                
+                - task: AzureWebApp@1
+                  displayName: 'Azure Web App Deploy: XSystem-Gateway'
+                  inputs:
+                    azureSubscription: $(AzureProductionServiceConnection)
+                    appType:          webAppLinux
+                    appName:          $(AppServiceName)
+                    package:          '$(Pipeline.Workspace)/$(ArtifactName)/$(ZipFile)'
+                    runtimeStack:     'DOTNETCORE|9.0'
+                    startUpCommand:   'dotnet $(ServiceExecutable)'
+

--- a/.workflows/identity.service.yaml
+++ b/.workflows/identity.service.yaml
@@ -1,7 +1,20 @@
+# ─────────────────────────────
+# Identity CI/CD pipeline
+# ─────────────────────────────
+
 trigger:
   - Main
 
 pr: none
+
+# ─── RUN-TIME CHOICES ──────────────────────────────────────────────────
+parameters:
+  # Choose targets when you queue the pipeline.
+  - name: deployToProdOnPrem
+    type: boolean
+    default: false        # keep current behaviour
+
+
 
 variables:
   PublishDirectory: '$(Build.ArtifactStagingDirectory)/identity'
@@ -9,10 +22,13 @@ variables:
   ServiceExecutable: 'IdentityServer.Api.dll'
   ServiceFilePath: '/etc/systemd/system/xframework-identity.service'
   ServiceName: 'xframework-identity'
+  AppServiceName: 'XSystems-Identity'
   BuildConfiguration: 'Release'
   BuildPlatform: 'any cpu'
   ArtifactName: 'identityArtifact'
   ZipFile: 'identity.zip'
+  AzureStagingServiceConnection: 'STAGING_SERVICES_SERVICE_CONNECTION'
+  AzureProductionServiceConnection: 'PRODUCTION_SERVICES_SERVICE_CONNECTION'
 
 stages:
   - stage: BuildAndUpload
@@ -24,7 +40,7 @@ stages:
           name: Default-Linux
         steps:
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -47,7 +63,7 @@ stages:
         steps:
           - checkout: none
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -171,6 +187,7 @@ stages:
                       }
 
   - stage: DeployToProduction
+    condition: and(succeeded(), eq(${{ parameters.deployToProdOnPrem }}, true))
     displayName: 'Deploy to Production'
     dependsOn: DeployToStaging
     jobs:
@@ -264,3 +281,29 @@ stages:
                               exit 1
                           }
                       }
+# ─── DEPLOY TO APP SERVICE (PRODUCTION) ────────────────────────────────
+  - stage: DeployToProductionAppSvc
+    displayName: 'Deploy to Production (App Service)'
+    dependsOn: DeployToStaging
+    condition: succeeded()
+    jobs:
+      - deployment: DeployProdAppSvc
+        environment: 'Production'
+        pool: { name: Default-Linux }
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: $(ArtifactName)
+                
+                - task: AzureWebApp@1
+                  displayName: 'Azure Web App Deploy: XSystems-Identity'
+                  inputs:
+                    azureSubscription: $(AzureProductionServiceConnection)
+                    appType:          webAppLinux
+                    appName:          $(AppServiceName)
+                    package:          '$(Pipeline.Workspace)/$(ArtifactName)/$(ZipFile)'
+                    runtimeStack:     'DOTNETCORE|9.0'
+                    startUpCommand:   'dotnet $(ServiceExecutable)'
+

--- a/.workflows/messaging.service.yaml
+++ b/.workflows/messaging.service.yaml
@@ -1,7 +1,20 @@
+# ─────────────────────────────
+# Messaging CI/CD pipeline
+# ─────────────────────────────
+
 trigger:
   - Main
 
 pr: none
+
+# ─── RUN-TIME CHOICES ──────────────────────────────────────────────────
+parameters:
+  # Choose targets when you queue the pipeline.
+  - name: deployToProdOnPrem
+    type: boolean
+    default: false        # keep current behaviour
+
+
 
 variables:
   PublishDirectory: '$(Build.ArtifactStagingDirectory)/messaging'
@@ -9,10 +22,13 @@ variables:
   ServiceExecutable: 'Messaging.Api.dll'
   ServiceFilePath: '/etc/systemd/system/xframework-messaging.service'
   ServiceName: 'xframework-messaging'
+  AppServiceName: 'XSystem-Messaging'
   BuildConfiguration: 'Release'
   BuildPlatform: 'any cpu'
   ArtifactName: 'messagingArtifact'
   ZipFile: 'messaging.zip'
+  AzureStagingServiceConnection: 'STAGING_SERVICES_SERVICE_CONNECTION'
+  AzureProductionServiceConnection: 'PRODUCTION_SERVICES_SERVICE_CONNECTION'
 
 stages:
   - stage: BuildAndUpload
@@ -24,7 +40,7 @@ stages:
           name: Default-Linux
         steps:
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -47,7 +63,7 @@ stages:
         steps:
           - checkout: none
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -171,6 +187,7 @@ stages:
                       }
 
   - stage: DeployToProduction
+    condition: and(succeeded(), eq(${{ parameters.deployToProdOnPrem }}, true))
     displayName: 'Deploy to Production'
     dependsOn: DeployToStaging
     jobs:
@@ -264,3 +281,29 @@ stages:
                               exit 1
                           }
                       }
+# ─── DEPLOY TO APP SERVICE (PRODUCTION) ────────────────────────────────
+  - stage: DeployToProductionAppSvc
+    displayName: 'Deploy to Production (App Service)'
+    dependsOn: DeployToStaging
+    condition: succeeded()
+    jobs:
+      - deployment: DeployProdAppSvc
+        environment: 'Production'
+        pool: { name: Default-Linux }
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: $(ArtifactName)
+                
+                - task: AzureWebApp@1
+                  displayName: 'Azure Web App Deploy: XSystem-Messaging'
+                  inputs:
+                    azureSubscription: $(AzureProductionServiceConnection)
+                    appType:          webAppLinux
+                    appName:          $(AppServiceName)
+                    package:          '$(Pipeline.Workspace)/$(ArtifactName)/$(ZipFile)'
+                    runtimeStack:     'DOTNETCORE|9.0'
+                    startUpCommand:   'dotnet $(ServiceExecutable)'
+

--- a/.workflows/smsGateway.service.yaml
+++ b/.workflows/smsGateway.service.yaml
@@ -1,7 +1,20 @@
+# ─────────────────────────────
+# SmsGateway CI/CD pipeline
+# ─────────────────────────────
+
 trigger:
   - Main
 
 pr: none
+
+# ─── RUN-TIME CHOICES ──────────────────────────────────────────────────
+parameters:
+  # Choose targets when you queue the pipeline.
+  - name: deployToProdOnPrem
+    type: boolean
+    default: false        # keep current behaviour
+
+
 
 variables:
   PublishDirectory: '$(Build.ArtifactStagingDirectory)/smsGateway'
@@ -9,10 +22,13 @@ variables:
   ServiceExecutable: 'SmsGateway.Api.dll'
   ServiceFilePath: '/etc/systemd/system/xframework-smsGateway.service'
   ServiceName: 'xframework-smsGateway'
+  AppServiceName: 'XSystem-SmsGateway'
   BuildConfiguration: 'Release'
   BuildPlatform: 'any cpu'
   ArtifactName: 'smsGatewayArtifact'
   ZipFile: 'smsGateway.zip'
+  AzureStagingServiceConnection: 'STAGING_SERVICES_SERVICE_CONNECTION'
+  AzureProductionServiceConnection: 'PRODUCTION_SERVICES_SERVICE_CONNECTION'
 
 stages:
   - stage: BuildAndUpload
@@ -24,7 +40,7 @@ stages:
           name: Default-Linux
         steps:
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -47,7 +63,7 @@ stages:
         steps:
           - checkout: none
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -171,6 +187,7 @@ stages:
                       }
 
   - stage: DeployToProduction
+    condition: and(succeeded(), eq(${{ parameters.deployToProdOnPrem }}, true))
     displayName: 'Deploy to Production'
     dependsOn: DeployToStaging
     jobs:
@@ -264,3 +281,29 @@ stages:
                               exit 1
                           }
                       }
+# ─── DEPLOY TO APP SERVICE (PRODUCTION) ────────────────────────────────
+  - stage: DeployToProductionAppSvc
+    displayName: 'Deploy to Production (App Service)'
+    dependsOn: DeployToStaging
+    condition: succeeded()
+    jobs:
+      - deployment: DeployProdAppSvc
+        environment: 'Production'
+        pool: { name: Default-Linux }
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: $(ArtifactName)
+                
+                - task: AzureWebApp@1
+                  displayName: 'Azure Web App Deploy: XSystem-SmsGateway'
+                  inputs:
+                    azureSubscription: $(AzureProductionServiceConnection)
+                    appType:          webAppLinux
+                    appName:          $(AppServiceName)
+                    package:          '$(Pipeline.Workspace)/$(ArtifactName)/$(ZipFile)'
+                    runtimeStack:     'DOTNETCORE|9.0'
+                    startUpCommand:   'dotnet $(ServiceExecutable)'
+

--- a/.workflows/wallets.service.yaml
+++ b/.workflows/wallets.service.yaml
@@ -1,7 +1,20 @@
+# ─────────────────────────────
+# StreamFlow CI/CD pipeline
+# ─────────────────────────────
+
 trigger:
   - Main
 
 pr: none
+
+# ─── RUN-TIME CHOICES ──────────────────────────────────────────────────
+parameters:
+  # Choose targets when you queue the pipeline.
+  - name: deployToProdOnPrem
+    type: boolean
+    default: false        # keep current behaviour
+
+
 
 variables:
   PublishDirectory: '$(Build.ArtifactStagingDirectory)/wallets'
@@ -9,10 +22,13 @@ variables:
   ServiceExecutable: 'Wallets.Api.dll'
   ServiceFilePath: '/etc/systemd/system/xframework-wallets.service'
   ServiceName: 'xframework-wallets'
+  AppServiceName: 'Xsystems-Wallet'
   BuildConfiguration: 'Release'
   BuildPlatform: 'any cpu'
   ArtifactName: 'walletsArtifact'
   ZipFile: 'wallets.zip'
+  AzureStagingServiceConnection: 'STAGING_SERVICES_SERVICE_CONNECTION'
+  AzureProductionServiceConnection: 'PRODUCTION_SERVICES_SERVICE_CONNECTION'
 
 stages:
   - stage: BuildAndUpload
@@ -24,7 +40,7 @@ stages:
           name: Default-Linux
         steps:
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -47,7 +63,7 @@ stages:
         steps:
           - checkout: none
           - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
+            displayName: 'Use .NET SDK 9'
             inputs:
               version: 9.0.x
 
@@ -171,6 +187,7 @@ stages:
                       }
 
   - stage: DeployToProduction
+    condition: and(succeeded(), eq(${{ parameters.deployToProdOnPrem }}, true))
     displayName: 'Deploy to Production'
     dependsOn: DeployToStaging
     jobs:
@@ -264,3 +281,29 @@ stages:
                               exit 1
                           }
                       }
+# ─── DEPLOY TO APP SERVICE (PRODUCTION) ────────────────────────────────
+  - stage: DeployToProductionAppSvc
+    displayName: 'Deploy to Production (App Service)'
+    dependsOn: DeployToStaging
+    condition: succeeded()
+    jobs:
+      - deployment: DeployProdAppSvc
+        environment: 'Production'
+        pool: { name: Default-Linux }
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: $(ArtifactName)
+                
+                - task: AzureWebApp@1
+                  displayName: 'Azure Web App Deploy: Xsystems-Wallet'
+                  inputs:
+                    azureSubscription: $(AzureProductionServiceConnection)
+                    appType:          webAppLinux
+                    appName:          $(AppServiceName)
+                    package:          '$(Pipeline.Workspace)/$(ArtifactName)/$(ZipFile)'
+                    runtimeStack:     'DOTNETCORE|9.0'
+                    startUpCommand:   'dotnet $(ServiceExecutable)'
+

--- a/src/Modules/XFramework.StreamFlow/StreamFlow.Stream/appsettings.json
+++ b/src/Modules/XFramework.StreamFlow/StreamFlow.Stream/appsettings.json
@@ -31,12 +31,5 @@
   "StreamFlowConfiguration": {
     "QueueDepth": 256,
     "QueueMessages": true
-  },
-  "Kestrel": {
-    "Endpoints": {
-      "Http": {
-        "Url": "http://0.0.0.0:7000"
-      }
-    }
   }
 }


### PR DESCRIPTION
  - Included `DeployToProductionAppSvc` in `messaging`, `gateway`, `smsGateway`, `community`, `wallets`, and `identity` workflows.
  - Added parameters for `AzureWebApp@1` task: `runtimeStack`, `appType`, `startUpCommand`.
  - Enabled deployment to Azure App Services for `.NET Core 9.0`. • Use `.NET SDK 9` for all affected workflows.
• Introduced `deployToProdOnPrem` parameter for conditional on-premises production deployment. • Removed redundant Kestrel endpoint configuration in `StreamFlow` appsettings.