### PR TITLE
fix: correct broken path in XFramework.slnx

### DIFF
--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -69,7 +69,7 @@
     <Project Path="src\Tests\Bolt.Tests\Bolt.Tests.csproj" />
   </Folder>
   <Folder Name="/Tests/">
-    <Project Path="srcTestsControlPanel.E2ETestsControlPanel.E2ETests.csproj" />
+    <Project Path="src\Tests\ControlPanel.E2ETests\ControlPanel.E2ETests.csproj" />
     <Project Path="src\Tests\XFramework.Core.Tests\XFramework.Core.Tests.csproj" />
     <Project Path="src\Tests\XFramework.TestInfrastructure\XFramework.TestInfrastructure.csproj" />
     <Project Path="src\Tests\IdentityServer.IntegrationTests\IdentityServer.IntegrationTests.csproj" />


### PR DESCRIPTION
## Summary

- Fixes broken project path for `ControlPanel.E2ETests` in `XFramework.slnx` — missing backslash separators caused `dotnet build XFramework.slnx` to fail with MSB3202

**Before:** `srcTestsControlPanel.E2ETestsControlPanel.E2ETests.csproj`
**After:** `src\Tests\ControlPanel.E2ETests\ControlPanel.E2ETests.csproj`

## Test plan
- [x] `dotnet build XFramework.slnx` — 0 errors (was 1 error before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)