### PR TITLE
fix: correct Bolt Hub connection configs across services

### DIFF
--- a/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.Staging.json
@@ -14,11 +14,11 @@
     "DefaultUID": "3902761a-822d-4c6b-8e2d-323fd501bcd6"
   },
   "BoltConfiguration": {
-    "ServerUrls": ["https://localhost:6001/hubs/v1/messageQueue/stream"],
+    "ServerUrls": ["http://localhost:7000/stream-flow/queue"],
     "Targets": [],
     "ClientGuid": "c26ce08d-a84b-418d-aad1-9a51320bfb8a",
-    "ClientName": "XFramework",
-    "ClientDescription": "XFramework",
+    "ClientName": "XFramework.Coins",
+    "ClientDescription": "Coins",
     "ReconnectDelay": 1500,
     "MaxRetry": 3,
     "Signature": "kxtEZ])e;#S8bb7R"

--- a/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.json
+++ b/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.json
@@ -52,11 +52,11 @@
     "RefreshTokenLifespan": "00:30:00"    
   },
   "BoltConfiguration": {
-    "ServerUrls": ["https://localhost:6001/hubs/v1/messageQueue/stream"],
+    "ServerUrls": ["http://localhost:7000/stream-flow/queue"],
     "Targets": [],
     "ClientGuid": "c26ce08d-a84b-418d-aad1-9a51320bfb8a",
-    "ClientName": "XFramework",
-    "ClientDescription": "XFramework",
+    "ClientName": "XFramework.Coins",
+    "ClientDescription": "Coins",
     "ReconnectDelay": 1500,
     "MaxRetry": 3,
     "Signature": "kxtEZ])e;#S8bb7R"

--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Development.json
@@ -41,8 +41,8 @@
       "SmsGatewayService": "24ebae0e-9705-4386-a9ba-66c1c710144d"
     },
     "ClientGuid": "3902761a-822d-4c6b-8e2d-323fd501bcd6",
-    "ClientName": "XFramework.IdentityServer",
-    "ClientDescription": "Identity Server",
+    "ClientName": "XFramework.Inventario",
+    "ClientDescription": "Inventario",
     "ReconnectDelay": 1500,
     "MaxRetry": 3,
     "Signature": "kxtEZ])e;#S8bb7R"

--- a/src/Presentation/ControlPanel.Server/appsettings.Development.json
+++ b/src/Presentation/ControlPanel.Server/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "BoltConfiguration": {
+    "ServerUrls": ["http://localhost:7000/stream-flow/queue"]
   }
 }

--- a/src/Presentation/ControlPanel.Server/appsettings.json
+++ b/src/Presentation/ControlPanel.Server/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "BoltConfiguration": {
-    "ServerUrls": ["http://100.75.11.49:7000/stream-flow/queue"],
+    "ServerUrls": ["http://localhost:7000/stream-flow/queue"],
     "ClientGuid": "d4a3f1c2-8b7e-4d5a-9c6f-1e2b3a4d5c6e",
     "ClientName": "ControlPanel",
     "ClientDescription": "XFramework Admin Control Panel",

--- a/src/Presentation/Gateway/appsettings.json
+++ b/src/Presentation/Gateway/appsettings.json
@@ -30,7 +30,7 @@
     "RefreshTokenLifespan": "00:30:00"
   },
   "BoltConfiguration": {
-    "ServerUrls": ["http://10.0.0.4:7200/hubs/v1/messageQueue/stream"],
+    "ServerUrls": ["http://localhost:7000/stream-flow/queue"],
     "Targets": {
       "IdentityServerService": "3902761a-822d-4c6b-8e2d-323fd501bcd6",
       "BillsPaymentService": "fc449d3e-4e78-4c95-8826-970a5dd9d88b",


### PR DESCRIPTION
## Summary

- **Inventario**: Fix `ClientName` from `"XFramework.IdentityServer"` to `"XFramework.Inventario"` (copy-paste error)
- **Coins**: Update `ServerUrls` from old `/hubs/v1/messageQueue/stream` to `/stream-flow/queue`, fix `ClientName` to `"XFramework.Coins"`
- **Coins Staging**: Same endpoint fix
- **Gateway**: Update `ServerUrls` from stale IP `10.0.0.4:7200` + old path to `localhost:7000/stream-flow/queue`
- **ControlPanel.Server**: Update `ServerUrls` from hardcoded remote IP to `localhost:7000/stream-flow/queue`
- **ControlPanel.Server Development**: Add `BoltConfiguration` with localhost URL (was missing entirely)

## Test plan
- [x] Verified all 6 config files have correct `/stream-flow/queue` endpoint
- [x] Verified no service still references `/hubs/v1/messageQueue/stream`
- [ ] Start Bolt Hub + services locally and verify connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)