### PR TITLE
feat: decentralize DB proxy — per-service query execution

### DIFF
--- a/src/Infrastructure/XFramework.Integration/DataContext/CachingQuery.cs
+++ b/src/Infrastructure/XFramework.Integration/DataContext/CachingQuery.cs
@@ -82,8 +82,8 @@ public class CachingQuery<T> : IRemoteQuery<T> where T : class
     }
 
     // Streaming bypasses cache — results are yielded one by one
-    public IAsyncEnumerable<T> ToAsyncEnumerable(CancellationToken ct = default)
-        => _inner.ToAsyncEnumerable(ct);
+    public IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, CancellationToken ct = default)
+        => _inner.ToAsyncEnumerable(chunkSize, ct);
 
     public async Task<int> CountAsync(CancellationToken ct = default)
     {

--- a/src/Infrastructure/XFramework.Integration/DataContext/RemoteDataContext.cs
+++ b/src/Infrastructure/XFramework.Integration/DataContext/RemoteDataContext.cs
@@ -1,42 +1,196 @@
+using System.Reflection;
+using MemoryPack;
+using Microsoft.Extensions.DependencyInjection;
+using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
 
 namespace XFramework.Integration.DataContext;
 
-/// <summary>
-/// Remote data context that proxies EF Core queries and changes through the Bolt hub.
-/// DB proxy migration to the Bolt thin protocol is parked work (see Task 14).
-/// </summary>
-public class RemoteDataContext : IDataContext
+public class RemoteDataContext(
+    IServiceProvider serviceProvider,
+    RequestMetadata? metadata = null) : IDataContext
 {
-    private const string PendingMigrationMessage =
-        "DB proxy migration to Bolt thin protocol is pending — see DB proxy decentralization parked work (Task 14).";
+    private static readonly Dictionary<string, Type> ResolvedWrapperTypes = new();
+    private static Dictionary<string, string>? _wrapperMap;
+    private static Type? _changeTrackerRegistryType;
+    private static MethodInfo? _hasTrackerMethod;
+    private static MethodInfo? _getTrackerMethod;
 
-    public RemoteDataContext()
-    {
-    }
+    internal readonly List<TrackedEntity> TrackedEntities = [];
+    private readonly List<PendingChange> _pendingChanges = [];
 
     public IRemoteQuery<T> Query<T>() where T : class
     {
-        throw new NotImplementedException(PendingMigrationMessage);
+        return new RemoteQuery<T>(serviceProvider, TrackedEntities, metadata);
     }
 
     public void Add<T>(T entity) where T : class
     {
-        throw new NotImplementedException(PendingMigrationMessage);
+        _pendingChanges.Add(new PendingChange
+        {
+            EntityTypeName = typeof(T).Name,
+            Operation = ChangeOperation.Add,
+            SerializedEntity = MemoryPackSerializer.Serialize(entity)
+        });
     }
 
     public void Update<T>(T entity) where T : class
     {
-        throw new NotImplementedException(PendingMigrationMessage);
+        if (HasTracker<T>())
+        {
+            var tracker = GetTracker<T>();
+            var pk = tracker.GetPrimaryKey(entity);
+            var tracked = TrackedEntities.FirstOrDefault(t =>
+                t.EntityTypeName == typeof(T).Name && t.PrimaryKey == pk);
+
+            if (tracked?.Snapshot is not null)
+            {
+                var patch = tracker.Diff(entity, tracked.Snapshot);
+                if (patch is null) return;
+
+                _pendingChanges.Add(new PendingChange
+                {
+                    EntityTypeName = typeof(T).Name,
+                    Operation = ChangeOperation.Update,
+                    SerializedEntity = MemoryPackSerializer.Serialize(patch)
+                });
+                return;
+            }
+        }
+
+        _pendingChanges.Add(new PendingChange
+        {
+            EntityTypeName = typeof(T).Name,
+            Operation = ChangeOperation.Update,
+            SerializedEntity = MemoryPackSerializer.Serialize(entity)
+        });
     }
 
     public void Remove<T>(T entity) where T : class
     {
-        throw new NotImplementedException(PendingMigrationMessage);
+        _pendingChanges.Add(new PendingChange
+        {
+            EntityTypeName = typeof(T).Name,
+            Operation = ChangeOperation.Remove,
+            SerializedEntity = MemoryPackSerializer.Serialize(entity)
+        });
     }
 
-    public Task<DataContextResult> SaveChangesAsync(CancellationToken ct = default)
+    public async Task<DataContextResult> SaveChangesAsync(CancellationToken ct = default)
     {
-        throw new NotImplementedException(PendingMigrationMessage);
+        if (_pendingChanges.Count == 0) return DataContextResult.Success();
+
+        var wrapperMap = GetServiceWrapperMap();
+
+        var wrapperTypeNames = _pendingChanges
+            .Select(c =>
+            {
+                if (!wrapperMap.TryGetValue(c.EntityTypeName, out var wrapperTypeName))
+                    throw new InvalidOperationException(
+                        $"Entity '{c.EntityTypeName}' is not mapped to any service.");
+                return wrapperTypeName;
+            })
+            .Distinct()
+            .ToList();
+
+        if (wrapperTypeNames.Count > 1)
+            throw new InvalidOperationException(
+                "SaveChangesAsync spans multiple services. Split changes into separate IDataContext scopes per service.");
+
+        var wrapperType = ResolveWrapperType(wrapperTypeNames[0]);
+        var wrapper = (IDataContextServiceWrapper)serviceProvider.GetRequiredService(wrapperType);
+
+        var request = new SaveChangesRequest
+        {
+            Changes = _pendingChanges.Select(c => new ChangeEntry
+            {
+                EntityTypeName = c.EntityTypeName,
+                Operation = c.Operation,
+                SerializedEntity = c.SerializedEntity
+            }).ToList(),
+            Metadata = metadata
+        };
+
+        var resultBytes = await wrapper.ExecuteChangesAsync(
+            MemoryPackSerializer.Serialize(request), ct);
+        var result = MemoryPackSerializer.Deserialize<DataContextResult>(resultBytes);
+
+        if (result is { IsSuccess: true })
+            _pendingChanges.Clear();
+
+        return result ?? DataContextResult.Failure("Failed to deserialize response.");
+    }
+
+    internal static Type ResolveWrapperType(string metadataName)
+    {
+        if (ResolvedWrapperTypes.TryGetValue(metadataName, out var cached))
+            return cached;
+
+        var type = AppDomain.CurrentDomain.GetAssemblies()
+            .Select(a => a.GetType(metadataName))
+            .FirstOrDefault(t => t is not null)
+            ?? throw new InvalidOperationException($"Could not resolve wrapper type '{metadataName}'");
+
+        ResolvedWrapperTypes[metadataName] = type;
+        return type;
+    }
+
+    internal static Dictionary<string, string> GetServiceWrapperMap()
+    {
+        if (_wrapperMap is not null) return _wrapperMap;
+
+        var registrationType = AppDomain.CurrentDomain.GetAssemblies()
+            .Select(a => a.GetType("XFramework.Core.DataContext.DataContextEntityRegistrations"))
+            .FirstOrDefault(t => t is not null);
+
+        if (registrationType is null)
+            throw new InvalidOperationException(
+                "DataContextEntityRegistrations not found. Ensure the source generator has run and the assembly is loaded.");
+
+        var method = registrationType.GetMethod("GetDataContextServiceWrapperMap",
+            BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("GetDataContextServiceWrapperMap method not found.");
+
+        _wrapperMap = (Dictionary<string, string>)method.Invoke(null, null)!;
+        return _wrapperMap;
+    }
+
+    internal static bool HasTracker<T>() where T : class
+    {
+        EnsureChangeTrackerRegistry();
+        if (_changeTrackerRegistryType is null) return false;
+
+        var method = _hasTrackerMethod!.MakeGenericMethod(typeof(T));
+        return (bool)method.Invoke(null, null)!;
+    }
+
+    internal static IEntityChangeTracker<T> GetTracker<T>() where T : class
+    {
+        EnsureChangeTrackerRegistry();
+        var method = _getTrackerMethod!.MakeGenericMethod(typeof(T));
+        return (IEntityChangeTracker<T>)method.Invoke(null, null)!;
+    }
+
+    private static void EnsureChangeTrackerRegistry()
+    {
+        if (_changeTrackerRegistryType is not null || _hasTrackerMethod is not null) return;
+
+        _changeTrackerRegistryType = AppDomain.CurrentDomain.GetAssemblies()
+            .Select(a => a.GetType("XFramework.Integration.DataContext.ChangeTrackerRegistry"))
+            .FirstOrDefault(t => t is not null);
+
+        if (_changeTrackerRegistryType is null) return;
+
+        _hasTrackerMethod = _changeTrackerRegistryType.GetMethod("HasTracker",
+            BindingFlags.Public | BindingFlags.Static);
+        _getTrackerMethod = _changeTrackerRegistryType.GetMethod("GetTracker",
+            BindingFlags.Public | BindingFlags.Static);
+    }
+
+    private record PendingChange
+    {
+        public required string EntityTypeName { get; init; }
+        public required ChangeOperation Operation { get; init; }
+        public required byte[] SerializedEntity { get; init; }
     }
 }

--- a/src/Infrastructure/XFramework.Integration/DataContext/RemoteQuery.cs
+++ b/src/Infrastructure/XFramework.Integration/DataContext/RemoteQuery.cs
@@ -1,29 +1,29 @@
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
-using XFramework.Integration.DataContext.ExpressionVisitor;
+using MemoryPack;
+using Microsoft.Extensions.DependencyInjection;
+using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
+using XFramework.Integration.DataContext.ExpressionVisitor;
 
 namespace XFramework.Integration.DataContext;
 
-/// <summary>
-/// Remote query implementation that proxies EF Core queries through the Bolt hub.
-/// DB proxy migration to the Bolt thin protocol is parked work (see Task 14).
-/// This class retains the QueryDescriptor building logic so CachingQuery can still
-/// inspect it for cache-key construction; execution methods throw NotImplementedException.
-/// </summary>
 public class RemoteQuery<T> : IRemoteQuery<T> where T : class
 {
     private readonly QueryDescriptor _descriptor;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly List<TrackedEntity> _trackedEntities;
+    private readonly RequestMetadata? _metadata;
 
-    private const string PendingMigrationMessage =
-        "DB proxy migration to Bolt thin protocol is pending — see DB proxy decentralization parked work (Task 14).";
-
-    public RemoteQuery()
+    public RemoteQuery(
+        IServiceProvider serviceProvider,
+        List<TrackedEntity> trackedEntities,
+        RequestMetadata? metadata)
     {
-        _descriptor = new QueryDescriptor
-        {
-            EntityTypeName = typeof(T).Name
-        };
+        _serviceProvider = serviceProvider;
+        _trackedEntities = trackedEntities;
+        _metadata = metadata;
+        _descriptor = new QueryDescriptor { EntityTypeName = typeof(T).Name };
     }
 
     internal QueryDescriptor Descriptor => _descriptor;
@@ -115,53 +115,192 @@ public class RemoteQuery<T> : IRemoteQuery<T> where T : class
         return this;
     }
 
-    public Task<List<T>> ToListAsync(CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    // Terminal: materialization
 
-    public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
-
-    public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
-
-    public async IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, [EnumeratorCancellation] CancellationToken ct = default)
+    public async Task<List<T>> ToListAsync(CancellationToken ct = default)
     {
-        throw new NotImplementedException(PendingMigrationMessage);
-        yield break; // Unreachable — satisfies compiler for IAsyncEnumerable
+        _descriptor.Mode = QueryExecutionMode.ToList;
+        var resultBytes = await ExecuteQueryAsync(ct);
+        var result = MemoryPackSerializer.Deserialize<List<T>>(resultBytes);
+        if (result is not null)
+            foreach (var entity in result) TrackEntity(entity);
+        return result ?? [];
     }
 
-    public Task<int> CountAsync(CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    public async Task<T?> FirstOrDefaultAsync(CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.FirstOrDefault;
+        var resultBytes = await ExecuteQueryAsync(ct);
+        var result = MemoryPackSerializer.Deserialize<T?>(resultBytes);
+        if (result is not null) TrackEntity(result);
+        return result;
+    }
 
-    public Task<bool> AnyAsync(CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    public async Task<T?> SingleOrDefaultAsync(CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.SingleOrDefault;
+        var resultBytes = await ExecuteQueryAsync(ct);
+        var result = MemoryPackSerializer.Deserialize<T?>(resultBytes);
+        if (result is not null) TrackEntity(result);
+        return result;
+    }
 
-    public Task<bool> AnyAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    // Terminal: streaming
 
-    public Task<bool> AllAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    public async IAsyncEnumerable<T> ToAsyncEnumerable(
+        int chunkSize = 100,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.Stream;
+        _descriptor.ChunkSize = chunkSize;
+        _descriptor.Metadata = _metadata;
 
-    public Task<TResult?> MinAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+        var wrapper = ResolveWrapper();
+        var descriptorBytes = MemoryPackSerializer.Serialize(_descriptor);
 
-    public Task<TResult?> MaxAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+        await foreach (var chunkBytes in wrapper.ExecuteQueryStreamAsync(descriptorBytes, ct))
+        {
+            var entityBytesList = MemoryPackSerializer.Deserialize<List<byte[]>>(chunkBytes);
+            if (entityBytesList is null) continue;
+            foreach (var entityBytes in entityBytesList)
+            {
+                var entity = MemoryPackSerializer.Deserialize<T>(entityBytes);
+                if (entity is not null)
+                {
+                    TrackEntity(entity);
+                    yield return entity;
+                }
+            }
+        }
+    }
 
-    public Task<T?> MinByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    // Terminal: scalar
 
-    public Task<T?> MaxByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    public async Task<int> CountAsync(CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.Count;
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<int>(resultBytes);
+    }
 
-    public Task<decimal> SumAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    public async Task<bool> AnyAsync(CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.Any;
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<bool>(resultBytes);
+    }
 
-    public Task<double> AverageAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    public async Task<bool> AnyAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.AnyWithPredicate;
+        _descriptor.PredicateFilters = QueryExpressionVisitor.Parse(predicate);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<bool>(resultBytes);
+    }
 
-    public Task<List<GroupResult<TKey, T>>> GroupByAsync<TKey>(
+    public async Task<bool> AllAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.All;
+        _descriptor.PredicateFilters = QueryExpressionVisitor.Parse(predicate);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<bool>(resultBytes);
+    }
+
+    // Terminal: aggregation
+
+    public async Task<TResult?> MinAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.Min;
+        _descriptor.AggregateProperty = SortExpressionParser.GetPropertyName(selector);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<TResult?>(resultBytes);
+    }
+
+    public async Task<TResult?> MaxAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.Max;
+        _descriptor.AggregateProperty = SortExpressionParser.GetPropertyName(selector);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<TResult?>(resultBytes);
+    }
+
+    public async Task<T?> MinByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.MinBy;
+        _descriptor.AggregateProperty = SortExpressionParser.GetPropertyName(keySelector);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        var result = MemoryPackSerializer.Deserialize<T?>(resultBytes);
+        if (result is not null) TrackEntity(result);
+        return result;
+    }
+
+    public async Task<T?> MaxByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.MaxBy;
+        _descriptor.AggregateProperty = SortExpressionParser.GetPropertyName(keySelector);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        var result = MemoryPackSerializer.Deserialize<T?>(resultBytes);
+        if (result is not null) TrackEntity(result);
+        return result;
+    }
+
+    public async Task<decimal> SumAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.Sum;
+        _descriptor.AggregateProperty = SortExpressionParser.GetPropertyName(selector);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<decimal>(resultBytes);
+    }
+
+    public async Task<double> AverageAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default)
+    {
+        _descriptor.Mode = QueryExecutionMode.Average;
+        _descriptor.AggregateProperty = SortExpressionParser.GetPropertyName(selector);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<double>(resultBytes);
+    }
+
+    public async Task<List<GroupResult<TKey, T>>> GroupByAsync<TKey>(
         Expression<Func<T, TKey>> keySelector,
         CancellationToken ct = default)
-        => throw new NotImplementedException(PendingMigrationMessage);
+    {
+        _descriptor.Mode = QueryExecutionMode.GroupBy;
+        _descriptor.GroupByProperty = SortExpressionParser.GetPropertyName(keySelector);
+        var resultBytes = await ExecuteQueryAsync(ct);
+        return MemoryPackSerializer.Deserialize<List<GroupResult<TKey, T>>>(resultBytes) ?? [];
+    }
+
+    // Helpers
+
+    private async Task<byte[]> ExecuteQueryAsync(CancellationToken ct)
+    {
+        _descriptor.Metadata = _metadata;
+        var wrapper = ResolveWrapper();
+        var descriptorBytes = MemoryPackSerializer.Serialize(_descriptor);
+        return await wrapper.ExecuteQueryAsync(descriptorBytes, ct);
+    }
+
+    private IDataContextServiceWrapper ResolveWrapper()
+    {
+        var wrapperMap = RemoteDataContext.GetServiceWrapperMap();
+        if (!wrapperMap.TryGetValue(typeof(T).Name, out var wrapperTypeName))
+            throw new InvalidOperationException(
+                $"Entity '{typeof(T).Name}' is not mapped to any service wrapper.");
+        var wrapperType = RemoteDataContext.ResolveWrapperType(wrapperTypeName);
+        return (IDataContextServiceWrapper)_serviceProvider.GetRequiredService(wrapperType);
+    }
+
+    private void TrackEntity(T entity)
+    {
+        if (!RemoteDataContext.HasTracker<T>()) return;
+        var tracker = RemoteDataContext.GetTracker<T>();
+        var pk = tracker.GetPrimaryKey(entity);
+        var snapshot = tracker.Snapshot(entity);
+        _trackedEntities.Add(new TrackedEntity
+        {
+            EntityTypeName = typeof(T).Name,
+            PrimaryKey = pk,
+            Snapshot = snapshot
+        });
+    }
 }

--- a/src/Infrastructure/XFramework.Integration/DataContext/RemoteQuery.cs
+++ b/src/Infrastructure/XFramework.Integration/DataContext/RemoteQuery.cs
@@ -124,7 +124,7 @@ public class RemoteQuery<T> : IRemoteQuery<T> where T : class
     public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default)
         => throw new NotImplementedException(PendingMigrationMessage);
 
-    public async IAsyncEnumerable<T> ToAsyncEnumerable([EnumeratorCancellation] CancellationToken ct = default)
+    public async IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, [EnumeratorCancellation] CancellationToken ct = default)
     {
         throw new NotImplementedException(PendingMigrationMessage);
         yield break; // Unreachable — satisfies compiler for IAsyncEnumerable

--- a/src/Infrastructure/XFramework.Integration/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/XFramework.Integration/Extensions/ServiceCollectionExtensions.cs
@@ -4,9 +4,12 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.Configurations;
+using XFramework.Domain.Shared.DataContext;
 using XFramework.Integration.Abstractions;
 using XFramework.Integration.Abstractions.Wrappers;
+using XFramework.Integration.DataContext;
 using XFramework.Integration.Drivers;
 
 namespace XFramework.Integration.Extensions;
@@ -47,6 +50,19 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IMessageBusWrapper, BoltDriver>();
 
+        return services;
+    }
+
+    /// <summary>
+    /// Registers RemoteDataContext as the IDataContext implementation for remote/WASM clients.
+    /// </summary>
+    public static IServiceCollection AddRemoteDataContext(this IServiceCollection services)
+    {
+        services.AddScoped<IDataContext>(sp =>
+        {
+            var metadata = sp.GetService<RequestMetadata>() ?? new RequestMetadata();
+            return new RemoteDataContext(sp, metadata);
+        });
         return services;
     }
 }

--- a/src/Kernel/XFramework.Core/DataContext/DataContextBoltHandler.cs
+++ b/src/Kernel/XFramework.Core/DataContext/DataContextBoltHandler.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using Bolt.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Integration.Abstractions;
+
+namespace XFramework.Core.DataContext;
+
+public class DataContextBoltHandler : IBoltHandler
+{
+    public void Register(BoltClient client, ILogger logger, IServiceScopeFactory scopeFactory)
+    {
+        client.RegisterHandler("__db_query__", async (payload, requestId) =>
+        {
+            using var scope = scopeFactory.CreateScope();
+            var queryService = scope.ServiceProvider.GetRequiredService<IQueryExecutionService>();
+            try
+            {
+                var result = await queryService.ExecuteAsync(payload.ToArray());
+                return (HttpStatusCode.OK, (ReadOnlyMemory<byte>)result);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "__db_query__ failed (requestId={RequestId})", requestId);
+                var error = MemoryPack.MemoryPackSerializer.Serialize(DataContextResult.Failure(ex.Message));
+                return (HttpStatusCode.InternalServerError, (ReadOnlyMemory<byte>)error);
+            }
+        });
+
+        client.RegisterHandler("__db_changes__", async (payload, requestId) =>
+        {
+            using var scope = scopeFactory.CreateScope();
+            var queryService = scope.ServiceProvider.GetRequiredService<IQueryExecutionService>();
+            try
+            {
+                var result = await queryService.ExecuteChangesAsync(payload.ToArray());
+                return (HttpStatusCode.OK, (ReadOnlyMemory<byte>)result);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "__db_changes__ failed (requestId={RequestId})", requestId);
+                var error = MemoryPack.MemoryPackSerializer.Serialize(DataContextResult.Failure(ex.Message));
+                return (HttpStatusCode.InternalServerError, (ReadOnlyMemory<byte>)error);
+            }
+        });
+
+        client.RegisterStreamHandler("__db_query_stream__", async stream =>
+        {
+            using var scope = scopeFactory.CreateScope();
+            var queryService = scope.ServiceProvider.GetRequiredService<IQueryExecutionService>();
+
+            var (hasData, payload) = await stream.ReadAsync();
+            if (!hasData)
+            {
+                await stream.CloseAsync(HttpStatusCode.BadRequest);
+                return;
+            }
+
+            try
+            {
+                var descriptorBytes = payload.ToArray();
+                var descriptor = MemoryPack.MemoryPackSerializer.Deserialize<QueryDescriptor>(
+                    (ReadOnlySpan<byte>)descriptorBytes);
+                var chunkSize = descriptor?.ChunkSize ?? 100;
+
+                var chunk = new List<byte[]>(chunkSize);
+                await foreach (var entityBytes in queryService.ExecuteStreamAsync(descriptorBytes))
+                {
+                    chunk.Add(entityBytes);
+                    if (chunk.Count >= chunkSize)
+                    {
+                        await stream.SendAsync((ReadOnlyMemory<byte>)MemoryPack.MemoryPackSerializer.Serialize(chunk));
+                        chunk = new List<byte[]>(chunkSize);
+                    }
+                }
+
+                if (chunk.Count > 0)
+                    await stream.SendAsync((ReadOnlyMemory<byte>)MemoryPack.MemoryPackSerializer.Serialize(chunk));
+
+                await stream.CloseAsync(HttpStatusCode.OK);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "__db_query_stream__ failed");
+                await stream.CloseAsync(HttpStatusCode.InternalServerError);
+            }
+        });
+
+        logger.LogInformation("Registered DataContext Bolt handlers (__db_query__, __db_changes__, __db_query_stream__)");
+    }
+}

--- a/src/Kernel/XFramework.Core/DataContext/DataContextHandlerExtensions.cs
+++ b/src/Kernel/XFramework.Core/DataContext/DataContextHandlerExtensions.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using Bolt.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace XFramework.Core.DataContext;
+
+public static class DataContextHandlerExtensions
+{
+    public static IServiceCollection AddDataContextHandler(this IServiceCollection services, Assembly entityAssembly)
+    {
+        services.AddSingleton<IQueryExecutionService>(sp =>
+        {
+            var queryService = ActivatorUtilities.CreateInstance<QueryExecutionService>(sp);
+
+            var registrationType = entityAssembly.GetTypes()
+                .FirstOrDefault(t => t.Name == "DataContextEntityRegistrations");
+
+            if (registrationType is not null)
+            {
+                var method = registrationType.GetMethod("GetDataContextEntityTypes",
+                    BindingFlags.Public | BindingFlags.Static);
+                if (method?.Invoke(null, null) is Dictionary<string, Type> entityTypes)
+                {
+                    foreach (var (name, type) in entityTypes)
+                        queryService.RegisterEntity(type, name);
+                }
+            }
+
+            return queryService;
+        });
+
+        services.AddHostedService<DataContextBoltHandlerRegistration>();
+
+        return services;
+    }
+
+    private sealed class DataContextBoltHandlerRegistration(
+        BoltClient client,
+        IServiceScopeFactory scopeFactory,
+        ILogger<DataContextBoltHandler> logger) : IHostedService
+    {
+        public Task StartAsync(CancellationToken ct)
+        {
+            new DataContextBoltHandler().Register(client, logger, scopeFactory);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+}

--- a/src/Kernel/XFramework.Core/DataContext/IQueryExecutionService.cs
+++ b/src/Kernel/XFramework.Core/DataContext/IQueryExecutionService.cs
@@ -1,4 +1,4 @@
-namespace Bolt.Hub.Services;
+namespace XFramework.Core.DataContext;
 
 public interface IQueryExecutionService
 {

--- a/src/Kernel/XFramework.Core/DataContext/QueryExecutionService.cs
+++ b/src/Kernel/XFramework.Core/DataContext/QueryExecutionService.cs
@@ -37,7 +37,14 @@ public sealed class QueryExecutionService(
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
 
             var result = await QueryDescriptorExecutor.ExecuteAsync(dbContext, entityType, descriptor, ct);
-            return MemoryPack.MemoryPackSerializer.Serialize(result);
+
+            // MemoryPackSerializer.Serialize(object?) uses the object formatter which fails
+            // for runtime-typed results. Use the actual result type for correct serialization.
+            if (result is null)
+                return [];
+
+            var resultType = GetResultType(descriptor.Mode, entityType);
+            return MemoryPack.MemoryPackSerializer.Serialize(resultType, result);
         }
         catch (Exception ex)
         {
@@ -45,6 +52,18 @@ public sealed class QueryExecutionService(
             return SerializeError(ex.Message);
         }
     }
+
+    private static Type GetResultType(QueryExecutionMode mode, Type entityType) => mode switch
+    {
+        QueryExecutionMode.ToList => typeof(List<>).MakeGenericType(entityType),
+        QueryExecutionMode.FirstOrDefault or QueryExecutionMode.SingleOrDefault
+            or QueryExecutionMode.MinBy or QueryExecutionMode.MaxBy => entityType,
+        QueryExecutionMode.Count => typeof(int),
+        QueryExecutionMode.Any or QueryExecutionMode.AnyWithPredicate or QueryExecutionMode.All => typeof(bool),
+        QueryExecutionMode.Sum => typeof(decimal),
+        QueryExecutionMode.Average => typeof(double),
+        _ => typeof(object)
+    };
 
     public async IAsyncEnumerable<byte[]> ExecuteStreamAsync(
         byte[] queryDescriptorBytes,

--- a/src/Kernel/XFramework.Core/DataContext/QueryExecutionService.cs
+++ b/src/Kernel/XFramework.Core/DataContext/QueryExecutionService.cs
@@ -1,9 +1,10 @@
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using XFramework.Core.DataContext;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using XFramework.Domain.Shared.DataContext;
 
-namespace Bolt.Hub.Services;
+namespace XFramework.Core.DataContext;
 
 public sealed class QueryExecutionService(
     IServiceProvider serviceProvider,

--- a/src/Kernel/XFramework.Core/DataContext/QueryExecutionService.cs
+++ b/src/Kernel/XFramework.Core/DataContext/QueryExecutionService.cs
@@ -82,6 +82,40 @@ public sealed class QueryExecutionService(
                 if (!_entityTypes.TryGetValue(change.EntityTypeName, out var entityType))
                     return SerializeError($"Entity type '{change.EntityTypeName}' is not registered.");
 
+                // For Update operations, try FieldPatch first before deserializing as entity
+                if (change.Operation == ChangeOperation.Update)
+                {
+                    FieldPatch? patch = null;
+                    try
+                    {
+                        patch = MemoryPack.MemoryPackSerializer.Deserialize<FieldPatch>(
+                            (ReadOnlySpan<byte>)change.SerializedEntity);
+                    }
+                    catch { }
+
+                    if (patch is { EntityId.Length: > 0, Changes.Count: > 0 })
+                    {
+                        var pkValue = MemoryPack.MemoryPackSerializer.Deserialize<Guid>(
+                            (ReadOnlySpan<byte>)patch.EntityId);
+                        var existing = await dbContext.FindAsync(entityType, pkValue);
+                        if (existing is null)
+                            return SerializeError($"Entity '{change.EntityTypeName}' with PK '{pkValue}' not found.");
+
+                        foreach (var (propertyName, valueBytes) in patch.Changes)
+                        {
+                            var prop = entityType.GetProperty(propertyName);
+                            if (prop is null) continue;
+
+                            var value = MemoryPack.MemoryPackSerializer.Deserialize(
+                                prop.PropertyType, (ReadOnlySpan<byte>)valueBytes);
+                            prop.SetValue(existing, value);
+                        }
+
+                        continue;
+                    }
+                }
+
+                // Deserialize as full entity for Add, Remove, or Update fallback
                 var entity = MemoryPack.MemoryPackSerializer.Deserialize(entityType, (ReadOnlySpan<byte>)change.SerializedEntity);
                 if (entity is null)
                     return SerializeError($"Failed to deserialize entity of type '{change.EntityTypeName}'.");

--- a/src/Kernel/XFramework.Core/DataContext/ServerQuery.cs
+++ b/src/Kernel/XFramework.Core/DataContext/ServerQuery.cs
@@ -96,7 +96,7 @@ public class ServerQuery<T> : IRemoteQuery<T> where T : class
     public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default)
         => _queryable.SingleOrDefaultAsync(ct);
 
-    public async IAsyncEnumerable<T> ToAsyncEnumerable([EnumeratorCancellation] CancellationToken ct = default)
+    public async IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, [EnumeratorCancellation] CancellationToken ct = default)
     {
         await foreach (var item in _queryable.AsAsyncEnumerable().WithCancellation(ct))
         {

--- a/src/Libraries/Bolt/Bolt.Protocol/Protocol/BoltCodec.cs
+++ b/src/Libraries/Bolt/Bolt.Protocol/Protocol/BoltCodec.cs
@@ -40,10 +40,6 @@ public static class BoltCodec
     // Unsubscribe header is variable: 1 + 4 + 4 + N (9 + subscriberId)
     // Ack header is variable: 1 + 4 + 4 + N + 8 (17 + subscriberId)
 
-    // ExecuteQuery/ExecuteChanges shim (DB proxy transitional)
-    public const int ExecuteQueryHeaderSize = 1 + 16 + 4;          // 21 bytes + payload
-    public const int ExecuteChangesHeaderSize = 1 + 16 + 4;        // 21 bytes + payload
-
     #region Encoding
 
     /// <summary>

--- a/src/Libraries/Bolt/Bolt.Protocol/Protocol/FrameType.cs
+++ b/src/Libraries/Bolt/Bolt.Protocol/Protocol/FrameType.cs
@@ -25,10 +25,6 @@ public enum FrameType : byte
     Event = 0x09,
     /// <summary>Acknowledge durable messages: [1:type] [4:topicHash] [4:subscriberIdLen] [subscriberId] [8:upToSequenceNumber]</summary>
     Ack = 0x0A,
-    /// <summary>Hub-side query execution (transitional shim): [1:type] [16:requestId] [4:payloadLen] [payload]</summary>
-    ExecuteQuery = 0x0B,
-    /// <summary>Hub-side change execution (transitional shim): [1:type] [16:requestId] [4:payloadLen] [payload]</summary>
-    ExecuteChanges = 0x0C,
     /// <summary>Open bidirectional stream: [1:type] [16:streamId] [4:recipientHash] [4:commandHash]</summary>
     StreamOpen = 0x10,
     /// <summary>Stream data chunk: [1:type] [16:streamId] [4:payloadLen] [payload]</summary>

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/DependencyInstaller.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/DependencyInstaller.cs
@@ -1,4 +1,4 @@
-﻿using Bolt.Hub.Services;
+﻿using XFramework.Core.DataContext;
 using XFramework.Domain.Shared.Interfaces;
 
 namespace Bolt.Hub.Installers;

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/DependencyInstaller.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/DependencyInstaller.cs
@@ -1,5 +1,4 @@
-﻿using XFramework.Core.DataContext;
-using XFramework.Domain.Shared.Interfaces;
+﻿using XFramework.Domain.Shared.Interfaces;
 
 namespace Bolt.Hub.Installers;
 
@@ -7,6 +6,5 @@ public sealed class DependencyInstaller : IInstaller
 {
     public void InstallServices<TApp>(IServiceCollection services, IConfiguration configuration, IHostEnvironment hostEnvironment)
     {
-        services.AddScoped<IQueryExecutionService, QueryExecutionService>();
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Program.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Program.cs
@@ -1,9 +1,10 @@
 using Community.Api.Generated;
-using XFramework.Extensions;
+using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
 using XFramework.Core.Health;
 using XFramework.Core.Middlewares;
 using XFramework.Core.RateLimiting;
+using XFramework.Extensions;
 
 var builder = XApplication.Configure<Program>();
 
@@ -14,6 +15,9 @@ builder.Services.AddXFrameworkHealthChecks<AppDbContext>(
 
 // Register FluentValidation validators from this assembly
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
+
+// Register DataContext handler for entity query/mutation via Bolt
+builder.Services.AddDataContextHandler(typeof(Program).Assembly);
 
 // Rate limiting — global 100/min per IP
 builder.Services.AddXFrameworkRateLimiting();

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Program.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Program.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using IdentityServer.Api.Generated;
+using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
 using XFramework.Core.Health;
 using XFramework.Core.Middlewares;
@@ -12,6 +13,9 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 
 // Register FluentValidation validators from this assembly
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
+
+// Register DataContext handler for entity query/mutation via Bolt
+builder.Services.AddDataContextHandler(typeof(Program).Assembly);
 
 // Rate limiting — global 100/min per IP + stricter "auth" and "password-reset" policies
 builder.Services.AddXFrameworkRateLimiting();

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using Microsoft.Extensions.Caching.Distributed;
 using StackExchange.Redis;
+using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
 using XFramework.Core.Health;
 using XFramework.Core.Middlewares;
@@ -24,6 +25,9 @@ builder.Services.AddSingleton<IConnectionMultiplexer>(sp => null!);
 
 // Register FluentValidation validators from this assembly
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
+
+// Register DataContext handler for entity query/mutation via Bolt
+builder.Services.AddDataContextHandler(typeof(Program).Assembly);
 
 // Auto-discover and register all generated services
 builder.Services.AddGeneratedServices();

--- a/src/Modules/XFramework.Wallets/Wallets.Api/Program.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/Program.cs
@@ -5,6 +5,7 @@ using Wallets.Api.Features.Batch.TransferBatch;
 using Wallets.Api.Features.Wallets.Get;
 using Wallets.Api.Features.Wallets.GetByCredential;
 using Wallets.Api.Generated;
+using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
 using XFramework.Core.Health;
 using XFramework.Core.Middlewares;
@@ -27,6 +28,9 @@ builder.Services.AddOpenApi("v1", options =>
 
 // Register FluentValidation validators from this assembly
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
+
+// Register DataContext handler for entity query/mutation via Bolt
+builder.Services.AddDataContextHandler(typeof(Program).Assembly);
 
 // Rate limiting — global 100/min per IP
 builder.Services.AddXFrameworkRateLimiting();

--- a/src/Shared/XFramework.Domain.Shared/DataContext/DataContextConcurrencyException.cs
+++ b/src/Shared/XFramework.Domain.Shared/DataContext/DataContextConcurrencyException.cs
@@ -1,0 +1,12 @@
+namespace XFramework.Domain.Shared.DataContext;
+
+public class DataContextConcurrencyException : Exception
+{
+    public string EntityTypeName { get; init; } = string.Empty;
+    public byte[] EntityId { get; init; } = [];
+    public Dictionary<string, byte[]> CurrentDbValues { get; init; } = new();
+    public Dictionary<string, byte[]> ClientValues { get; init; } = new();
+
+    public DataContextConcurrencyException(string message) : base(message) { }
+    public DataContextConcurrencyException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Shared/XFramework.Domain.Shared/DataContext/FieldPatch.cs
+++ b/src/Shared/XFramework.Domain.Shared/DataContext/FieldPatch.cs
@@ -1,0 +1,8 @@
+namespace XFramework.Domain.Shared.DataContext;
+
+[MemoryPackable]
+public partial class FieldPatch
+{
+    [MemoryPackOrder(0)] public byte[] EntityId { get; set; } = [];
+    [MemoryPackOrder(1)] public Dictionary<string, byte[]> Changes { get; set; } = new();
+}

--- a/src/Shared/XFramework.Domain.Shared/DataContext/IDataContextServiceWrapper.cs
+++ b/src/Shared/XFramework.Domain.Shared/DataContext/IDataContextServiceWrapper.cs
@@ -1,0 +1,8 @@
+namespace XFramework.Domain.Shared.DataContext;
+
+public interface IDataContextServiceWrapper
+{
+    Task<byte[]> ExecuteQueryAsync(byte[] queryDescriptorBytes, CancellationToken ct = default);
+    Task<byte[]> ExecuteChangesAsync(byte[] saveChangesRequestBytes, CancellationToken ct = default);
+    IAsyncEnumerable<byte[]> ExecuteQueryStreamAsync(byte[] queryDescriptorBytes, CancellationToken ct = default);
+}

--- a/src/Shared/XFramework.Domain.Shared/DataContext/IEntityChangeTracker.cs
+++ b/src/Shared/XFramework.Domain.Shared/DataContext/IEntityChangeTracker.cs
@@ -1,0 +1,8 @@
+namespace XFramework.Domain.Shared.DataContext;
+
+public interface IEntityChangeTracker<T> where T : class
+{
+    object Snapshot(T entity);
+    FieldPatch? Diff(T current, object snapshot);
+    Guid GetPrimaryKey(T entity);
+}

--- a/src/Shared/XFramework.Domain.Shared/DataContext/IRemoteQuery.cs
+++ b/src/Shared/XFramework.Domain.Shared/DataContext/IRemoteQuery.cs
@@ -31,7 +31,7 @@ public interface IRemoteQuery<T> where T : class
     Task<List<T>> ToListAsync(CancellationToken ct = default);
     Task<T?> FirstOrDefaultAsync(CancellationToken ct = default);
     Task<T?> SingleOrDefaultAsync(CancellationToken ct = default);
-    IAsyncEnumerable<T> ToAsyncEnumerable(CancellationToken ct = default);
+    IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, CancellationToken ct = default);
 
     // Terminal: scalar
     Task<int> CountAsync(CancellationToken ct = default);

--- a/src/Shared/XFramework.Domain.Shared/DataContext/QueryDescriptor.cs
+++ b/src/Shared/XFramework.Domain.Shared/DataContext/QueryDescriptor.cs
@@ -18,4 +18,6 @@ public partial class QueryDescriptor
     [MemoryPackOrder(10)] public string? AggregateProperty { get; set; }
     [MemoryPackOrder(11)] public string? GroupByProperty { get; set; }
     [MemoryPackOrder(12)] public List<QueryFilter>? PredicateFilters { get; set; }
+    [MemoryPackOrder(13)] public int? ChunkSize { get; set; }
+    [MemoryPackOrder(14)] public RequestMetadata? Metadata { get; set; }
 }

--- a/src/Shared/XFramework.Domain.Shared/DataContext/SaveChangesRequest.cs
+++ b/src/Shared/XFramework.Domain.Shared/DataContext/SaveChangesRequest.cs
@@ -1,7 +1,10 @@
+using XFramework.Domain.Shared.BusinessObjects;
+
 namespace XFramework.Domain.Shared.DataContext;
 
 [MemoryPackable]
 public partial class SaveChangesRequest
 {
     [MemoryPackOrder(0)] public List<ChangeEntry> Changes { get; set; } = [];
+    [MemoryPackOrder(1)] public RequestMetadata? Metadata { get; set; }
 }

--- a/src/Shared/XFramework.Domain.Shared/DataContext/TrackedEntity.cs
+++ b/src/Shared/XFramework.Domain.Shared/DataContext/TrackedEntity.cs
@@ -1,0 +1,11 @@
+namespace XFramework.Domain.Shared.DataContext;
+
+[MemoryPackable]
+public partial class TrackedEntity
+{
+    [MemoryPackOrder(0)] public string EntityTypeName { get; set; } = string.Empty;
+    [MemoryPackOrder(1)] public Guid PrimaryKey { get; set; }
+    [MemoryPackOrder(2)] public byte[] SnapshotBytes { get; set; } = [];
+
+    [MemoryPackIgnore] public object? Snapshot { get; set; }
+}

--- a/src/SourceGenerators/XFramework.SourceGenerators/ChangeTrackerGenerator.cs
+++ b/src/SourceGenerators/XFramework.SourceGenerators/ChangeTrackerGenerator.cs
@@ -1,0 +1,372 @@
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace XFramework.SourceGenerators;
+
+/// <summary>
+/// Source generator that creates per-entity snapshot records, change trackers, and a registry
+/// for entities marked with [GenerateEndpoints]. Used by RemoteDataContext to produce FieldPatch
+/// diffs for efficient wire-format updates.
+///
+/// For each entity, generates:
+/// 1. {Entity}Snapshot — MemoryPackable record holding copies of all scalar properties
+/// 2. {Entity}ChangeTracker : IEntityChangeTracker&lt;{Entity}&gt; — Snapshot(), Diff(), GetPrimaryKey()
+/// 3. ChangeTrackerRegistry — static Type → tracker instance lookup
+///
+/// Runs only in *.Integration projects (by assembly name convention).
+/// Discovers entities from referenced assemblies via cross-assembly scanning.
+/// </summary>
+[Generator]
+public class ChangeTrackerGenerator : IIncrementalGenerator
+{
+    // SpecialType values that are known scalar types (covers keyword aliases like string, bool, int, etc.)
+    private static readonly HashSet<SpecialType> ScalarSpecialTypes = new()
+    {
+        SpecialType.System_Boolean,
+        SpecialType.System_Byte,
+        SpecialType.System_SByte,
+        SpecialType.System_Int16,
+        SpecialType.System_UInt16,
+        SpecialType.System_Int32,
+        SpecialType.System_UInt32,
+        SpecialType.System_Int64,
+        SpecialType.System_UInt64,
+        SpecialType.System_Single,
+        SpecialType.System_Double,
+        SpecialType.System_Decimal,
+        SpecialType.System_String,
+        SpecialType.System_DateTime
+    };
+
+    // Non-special scalar types that need FQN matching (no SpecialType enum value in Roslyn).
+    private static readonly HashSet<string> ScalarMetadataNames = new()
+    {
+        "System.Guid",
+        "System.DateTimeOffset",
+        "System.DateOnly",
+        "System.TimeOnly",
+        "System.TimeSpan"
+    };
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Pure auto-discovery: use CompilationProvider to scan referenced assemblies
+        // for [GenerateEndpoints] entities. Triggers only in *.Integration projects.
+        context.RegisterSourceOutput(context.CompilationProvider,
+            static (spc, compilation) => Execute(compilation, spc));
+    }
+
+    private static void Execute(Compilation compilation, SourceProductionContext context)
+    {
+        var assemblyName = compilation.AssemblyName ?? "";
+
+        // Only run in Integration projects
+        if (!assemblyName.EndsWith(".Integration"))
+            return;
+
+        var moduleName = assemblyName.Split('.').First();
+
+        // Discover entities with [GenerateEndpoints] from referenced assemblies
+        var entities = DiscoverEntities(compilation, moduleName);
+
+        if (entities.Count == 0)
+            return;
+
+        // Generate per-entity snapshot + change tracker files
+        foreach (var entity in entities)
+        {
+            var source = GenerateEntityChangeTracker(entity);
+            context.AddSource(
+                $"{entity.ClassName}ChangeTracker.g.cs",
+                SourceText.From(source, Encoding.UTF8));
+        }
+
+        // Generate the registry
+        var registrySource = GenerateRegistry(entities);
+        context.AddSource(
+            "ChangeTrackerRegistry.g.cs",
+            SourceText.From(registrySource, Encoding.UTF8));
+    }
+
+    private static List<EntityInfo> DiscoverEntities(Compilation compilation, string moduleName)
+    {
+        var entities = new List<EntityInfo>();
+        var seen = new HashSet<string>();
+        var coreAttr = "XFramework.Core.Attributes.GenerateEndpointsAttribute";
+        var sharedAttr = "XFramework.Domain.Shared.Attributes.GenerateEndpointsAttribute";
+
+        foreach (var reference in compilation.References)
+        {
+            var symbol = compilation.GetAssemblyOrModuleSymbol(reference);
+            if (symbol is not IAssemblySymbol assembly)
+                continue;
+
+            // Scan module's own assemblies
+            // Also scan XFramework.Domain.Shared for IdentityServer (manages StorageFile etc.)
+            var isModuleAssembly = assembly.Name.StartsWith(moduleName, StringComparison.OrdinalIgnoreCase);
+            var isSharedForIdentity = moduleName == "IdentityServer" &&
+                assembly.Name.StartsWith("XFramework.Domain.Shared", StringComparison.OrdinalIgnoreCase);
+            if (!isModuleAssembly && !isSharedForIdentity)
+                continue;
+
+            foreach (var type in GetTypesFromNamespace(assembly.GlobalNamespace))
+            {
+                if (type.IsAbstract || type.TypeKind != TypeKind.Class)
+                    continue;
+
+                var hasAttribute = false;
+                foreach (var attr in type.GetAttributes())
+                {
+                    var attrName = attr.AttributeClass?.ToDisplayString();
+                    if (attrName == coreAttr || attrName == sharedAttr)
+                    {
+                        hasAttribute = true;
+                        break;
+                    }
+                }
+
+                if (!hasAttribute)
+                    continue;
+
+                var fqn = type.ToDisplayString();
+                if (!seen.Add(fqn))
+                    continue;
+
+                var scalarProps = GetScalarProperties(type);
+                if (scalarProps.Count == 0)
+                    continue;
+
+                entities.Add(new EntityInfo
+                {
+                    ClassName = type.Name,
+                    Namespace = type.ContainingNamespace.ToDisplayString(),
+                    FullyQualifiedName = fqn,
+                    ScalarProperties = scalarProps
+                });
+            }
+        }
+
+        entities.Sort((a, b) => string.Compare(a.ClassName, b.ClassName, StringComparison.Ordinal));
+        return entities;
+    }
+
+    /// <summary>
+    /// Collects all public instance properties with setters that are scalar types,
+    /// excluding the "Id" property (PK). Walks the full inheritance hierarchy.
+    /// </summary>
+    private static List<PropertyInfo> GetScalarProperties(INamedTypeSymbol type)
+    {
+        var props = new List<PropertyInfo>();
+        var seen = new HashSet<string>();
+        var order = 0;
+
+        // Walk the type hierarchy (most-derived first)
+        var current = type;
+        while (current != null)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member is not IPropertySymbol prop)
+                    continue;
+
+                // Public instance properties with setters only
+                if (prop.DeclaredAccessibility != Accessibility.Public)
+                    continue;
+                if (prop.IsStatic || prop.IsIndexer || prop.IsReadOnly)
+                    continue;
+                if (prop.SetMethod == null)
+                    continue;
+
+                // Skip Id (PK)
+                if (prop.Name == "Id")
+                    continue;
+
+                // Deduplicate (overrides in derived types)
+                if (!seen.Add(prop.Name))
+                    continue;
+
+                // Check if the property type is scalar
+                if (!IsScalarType(prop.Type))
+                    continue;
+
+                var fullyQualifiedType = prop.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+                props.Add(new PropertyInfo
+                {
+                    Name = prop.Name,
+                    FullyQualifiedTypeName = fullyQualifiedType,
+                    Order = order++
+                });
+            }
+
+            current = current.BaseType;
+        }
+
+        return props;
+    }
+
+    /// <summary>
+    /// Determines whether a type symbol represents a scalar type suitable for change tracking.
+    /// </summary>
+    private static bool IsScalarType(ITypeSymbol typeSymbol)
+    {
+        // Handle nullable value types: Nullable<T>
+        if (typeSymbol is INamedTypeSymbol namedType &&
+            namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            return IsScalarType(namedType.TypeArguments[0]);
+        }
+
+        // Enums are scalar
+        if (typeSymbol.TypeKind == TypeKind.Enum)
+            return true;
+
+        // byte[] (array of System.Byte) is scalar
+        if (typeSymbol is IArrayTypeSymbol arrayType)
+        {
+            return arrayType.ElementType.SpecialType == SpecialType.System_Byte;
+        }
+
+        // Check SpecialType first (covers string, bool, int, decimal, DateTime, etc.)
+        if (ScalarSpecialTypes.Contains(typeSymbol.SpecialType))
+            return true;
+
+        // Check non-special scalar types by metadata name (Guid, DateTimeOffset, DateOnly, TimeOnly, TimeSpan)
+        var metadataName = GetFullMetadataName(typeSymbol);
+        return ScalarMetadataNames.Contains(metadataName);
+    }
+
+    /// <summary>
+    /// Gets the full metadata name (e.g. "System.Guid") for a type symbol, which is stable
+    /// regardless of C# keyword aliases or display format settings.
+    /// </summary>
+    private static string GetFullMetadataName(ITypeSymbol symbol)
+    {
+        if (symbol.ContainingNamespace == null || symbol.ContainingNamespace.IsGlobalNamespace)
+            return symbol.MetadataName;
+        return $"{symbol.ContainingNamespace.ToDisplayString()}.{symbol.MetadataName}";
+    }
+
+    private static string GenerateEntityChangeTracker(EntityInfo entity)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine("using MemoryPack;");
+        sb.AppendLine("using XFramework.Domain.Shared.DataContext;");
+        sb.AppendLine();
+        sb.AppendLine($"namespace {entity.Namespace};");
+        sb.AppendLine();
+
+        // Snapshot record
+        sb.AppendLine("[MemoryPackable]");
+        sb.AppendLine($"public partial record {entity.ClassName}Snapshot");
+        sb.AppendLine("{");
+        foreach (var prop in entity.ScalarProperties)
+        {
+            sb.AppendLine($"    [MemoryPackOrder({prop.Order})] public {prop.FullyQualifiedTypeName} {prop.Name} {{ get; init; }}");
+        }
+        sb.AppendLine("}");
+        sb.AppendLine();
+
+        // ChangeTracker class
+        var globalEntity = $"global::{entity.FullyQualifiedName}";
+        sb.AppendLine($"public sealed class {entity.ClassName}ChangeTracker : IEntityChangeTracker<{globalEntity}>");
+        sb.AppendLine("{");
+
+        // GetPrimaryKey
+        sb.AppendLine($"    public System.Guid GetPrimaryKey({globalEntity} entity) => entity.Id;");
+        sb.AppendLine();
+
+        // Snapshot
+        sb.AppendLine($"    public object Snapshot({globalEntity} entity) => new {entity.ClassName}Snapshot");
+        sb.AppendLine("    {");
+        foreach (var prop in entity.ScalarProperties)
+        {
+            sb.AppendLine($"        {prop.Name} = entity.{prop.Name},");
+        }
+        sb.AppendLine("    };");
+        sb.AppendLine();
+
+        // Diff
+        sb.AppendLine($"    public FieldPatch? Diff({globalEntity} current, object snapshotObj)");
+        sb.AppendLine("    {");
+        sb.AppendLine($"        var original = ({entity.ClassName}Snapshot)snapshotObj;");
+        sb.AppendLine("        var changes = new System.Collections.Generic.Dictionary<string, byte[]>();");
+        sb.AppendLine();
+        foreach (var prop in entity.ScalarProperties)
+        {
+            sb.AppendLine($"        if (!System.Collections.Generic.EqualityComparer<{prop.FullyQualifiedTypeName}>.Default.Equals(current.{prop.Name}, original.{prop.Name}))");
+            sb.AppendLine($"            changes[\"{prop.Name}\"] = MemoryPack.MemoryPackSerializer.Serialize(current.{prop.Name});");
+        }
+        sb.AppendLine();
+        sb.AppendLine("        if (changes.Count == 0) return null;");
+        sb.AppendLine();
+        sb.AppendLine("        return new FieldPatch");
+        sb.AppendLine("        {");
+        sb.AppendLine("            EntityId = MemoryPack.MemoryPackSerializer.Serialize(current.Id),");
+        sb.AppendLine("            Changes = changes");
+        sb.AppendLine("        };");
+        sb.AppendLine("    }");
+
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private static string GenerateRegistry(List<EntityInfo> entities)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine("using XFramework.Domain.Shared.DataContext;");
+        sb.AppendLine();
+        sb.AppendLine("namespace XFramework.Integration.DataContext;");
+        sb.AppendLine();
+        sb.AppendLine("public static class ChangeTrackerRegistry");
+        sb.AppendLine("{");
+        sb.AppendLine("    private static readonly System.Collections.Generic.Dictionary<System.Type, object> Trackers = new()");
+        sb.AppendLine("    {");
+        foreach (var entity in entities)
+        {
+            sb.AppendLine($"        [typeof(global::{entity.FullyQualifiedName})] = new global::{entity.Namespace}.{entity.ClassName}ChangeTracker(),");
+        }
+        sb.AppendLine("    };");
+        sb.AppendLine();
+        sb.AppendLine("    public static IEntityChangeTracker<T> GetTracker<T>() where T : class");
+        sb.AppendLine("        => (IEntityChangeTracker<T>)Trackers[typeof(T)];");
+        sb.AppendLine();
+        sb.AppendLine("    public static bool HasTracker<T>() where T : class");
+        sb.AppendLine("        => Trackers.ContainsKey(typeof(T));");
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private static IEnumerable<INamedTypeSymbol> GetTypesFromNamespace(INamespaceSymbol ns)
+    {
+        foreach (var type in ns.GetTypeMembers())
+            yield return type;
+        foreach (var childNs in ns.GetNamespaceMembers())
+            foreach (var type in GetTypesFromNamespace(childNs))
+                yield return type;
+    }
+
+    private class EntityInfo
+    {
+        public string ClassName { get; set; } = "";
+        public string Namespace { get; set; } = "";
+        public string FullyQualifiedName { get; set; } = "";
+        public List<PropertyInfo> ScalarProperties { get; set; } = new();
+    }
+
+    private class PropertyInfo
+    {
+        public string Name { get; set; } = "";
+        public string FullyQualifiedTypeName { get; set; } = "";
+        public int Order { get; set; }
+    }
+}

--- a/src/SourceGenerators/XFramework.SourceGenerators/DataContextRegistrationGenerator.cs
+++ b/src/SourceGenerators/XFramework.SourceGenerators/DataContextRegistrationGenerator.cs
@@ -50,7 +50,8 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
             return new EntityRegistrationInfo
             {
                 ClassName = classSymbol.Name,
-                FullyQualifiedName = classSymbol.ToDisplayString()
+                FullyQualifiedName = classSymbol.ToDisplayString(),
+                AssemblyName = classSymbol.ContainingAssembly?.Name ?? ""
             };
         }
 
@@ -85,7 +86,8 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
                     allEntities.Add(new EntityRegistrationInfo
                     {
                         ClassName = type.Name,
-                        FullyQualifiedName = type.ToDisplayString()
+                        FullyQualifiedName = type.ToDisplayString(),
+                        AssemblyName = assembly.Name
                     });
                 }
             }
@@ -112,6 +114,7 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
         sb.AppendLine("/// <summary>");
         sb.AppendLine("/// Auto-generated entity type registry for DataContext.");
         sb.AppendLine("/// Call GetDataContextEntityTypes() to get the allowlist for QueryExecutionService.");
+        sb.AppendLine("/// Call GetDataContextServiceWrapperMap() to get entity-to-service-wrapper routing.");
         sb.AppendLine("/// </summary>");
         sb.AppendLine("public static class DataContextEntityRegistrations");
         sb.AppendLine("{");
@@ -123,6 +126,42 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
             sb.AppendLine($"        [\"{entity.ClassName}\"] = typeof(global::{entity.FullyQualifiedName}),");
         }
 
+        sb.AppendLine("    };");
+        sb.AppendLine();
+
+        // Generate GetDataContextServiceWrapperMap() — maps entity names to their module's wrapper type name.
+        // The wrapper types are source-generated in Integration projects, so they may not be resolvable
+        // via typeof() at compile time. We emit string-based metadata names that the consumer resolves
+        // at runtime from loaded assemblies (e.g., via Type.GetType() or assembly scanning).
+        var wrapperMappings = new List<(string EntityName, string WrapperMetadataName)>();
+        foreach (var entity in validEntities)
+        {
+            if (string.IsNullOrEmpty(entity.AssemblyName))
+                continue;
+
+            var moduleName = entity.AssemblyName.Split('.')[0];
+            var wrapperMetadataName = $"{moduleName}.Integration.Drivers.I{moduleName}ServiceWrapper";
+
+            // Try to resolve from compilation first (covers pre-compiled referenced assemblies)
+            var wrapperSymbol = compilation.GetTypeByMetadataName(wrapperMetadataName);
+            if (wrapperSymbol != null)
+            {
+                wrapperMappings.Add((entity.ClassName, wrapperSymbol.ToDisplayString()));
+            }
+            else
+            {
+                // Wrapper is likely source-generated in the same or a peer compilation —
+                // emit the conventional name so the consumer can resolve at runtime
+                wrapperMappings.Add((entity.ClassName, wrapperMetadataName));
+            }
+        }
+
+        sb.AppendLine("    public static Dictionary<string, string> GetDataContextServiceWrapperMap() => new()");
+        sb.AppendLine("    {");
+        foreach (var (entityName, wrapperName) in wrapperMappings)
+        {
+            sb.AppendLine($"        [\"{entityName}\"] = \"{wrapperName}\",");
+        }
         sb.AppendLine("    };");
         sb.AppendLine("}");
 
@@ -145,5 +184,6 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
     {
         public string ClassName { get; set; } = "";
         public string FullyQualifiedName { get; set; } = "";
+        public string AssemblyName { get; set; } = "";
     }
 }

--- a/src/SourceGenerators/XFramework.SourceGenerators/ServiceWrapperGenerator.cs
+++ b/src/SourceGenerators/XFramework.SourceGenerators/ServiceWrapperGenerator.cs
@@ -71,11 +71,13 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
             using XFramework.Domain.Shared.Contracts.Requests;
             using XFramework.Domain.Shared.Contracts.Responses;
             using XFramework.Domain.Shared.Interfaces;
+            using XFramework.Domain.Shared.DataContext;
             using XFramework.Integration.Drivers;
             using XFramework.Integration.Abstractions;
             using XFramework.Integration.Abstractions.Wrappers;
             using Microsoft.Extensions.DependencyInjection;
             using Microsoft.Extensions.Configuration;
+            using Bolt.Client;
             using XFramework;
             using System.Linq.Expressions;
             using Serilog;
@@ -93,7 +95,7 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
         sb.AppendLine("{");
 
         // ── Interface ──
-        sb.AppendLine($"public partial interface I{serviceName}ServiceWrapper : IXFrameworkService, IServiceWrapper");
+        sb.AppendLine($"public partial interface I{serviceName}ServiceWrapper : IXFrameworkService, IServiceWrapper, IDataContextServiceWrapper");
         sb.AppendLine("{");
         foreach (var model in models)
         {
@@ -117,10 +119,46 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
         {
             sb.AppendLine($"I{models[i]}CrudService {models[i]}{(i < models.Count - 1 ? "," : "")}");
         }
-        sb.AppendLine($", IMessageBusWrapper messageBusDriver, IConfiguration configuration");
+        sb.AppendLine($", IMessageBusWrapper messageBusDriver, IConfiguration configuration, BoltClient boltClient");
         sb.AppendLine($") : DriverBase(messageBusDriver, configuration), I{serviceName}ServiceWrapper");
         sb.AppendLine("{");
         sb.AppendLine($"    public override void Initialize() => TargetClient = \"{serviceId}\";");
+        sb.AppendLine();
+        sb.AppendLine($$"""
+                            public async System.Threading.Tasks.Task<byte[]> ExecuteQueryAsync(byte[] queryDescriptorBytes, System.Threading.CancellationToken ct = default)
+                            {
+                                if (string.IsNullOrEmpty(TargetClient)) Initialize();
+                                var (status, data) = await boltClient.InvokeAsync(TargetClient, "__db_query__", queryDescriptorBytes, ct);
+                                return data.ToArray();
+                            }
+
+                            public async System.Threading.Tasks.Task<byte[]> ExecuteChangesAsync(byte[] saveChangesRequestBytes, System.Threading.CancellationToken ct = default)
+                            {
+                                if (string.IsNullOrEmpty(TargetClient)) Initialize();
+                                var (status, data) = await boltClient.InvokeAsync(TargetClient, "__db_changes__", saveChangesRequestBytes, ct);
+                                return data.ToArray();
+                            }
+
+                            public async System.Collections.Generic.IAsyncEnumerable<byte[]> ExecuteQueryStreamAsync(
+                                byte[] queryDescriptorBytes,
+                                [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken ct = default)
+                            {
+                                if (string.IsNullOrEmpty(TargetClient)) Initialize();
+                                var stream = await boltClient.OpenStreamAsync(TargetClient, "__db_query_stream__", ct);
+                                try
+                                {
+                                    await stream.SendAsync((System.ReadOnlyMemory<byte>)queryDescriptorBytes, ct);
+                                    await foreach (var chunk in stream.ReadAllAsync(ct))
+                                    {
+                                        yield return chunk.ToArray();
+                                    }
+                                }
+                                finally
+                                {
+                                    await stream.DisposeAsync();
+                                }
+                            }
+                        """);
 
         foreach (var req in customRequests)
         {

--- a/src/Tests/IdentityServer.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
@@ -7,10 +7,14 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Bolt.Hub.Extensions;
 using Testcontainers.PostgreSql;
+using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
 using XFramework.Core.Middlewares;
 using XFramework.Domain.Contexts;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.DataContext;
 using XFramework.Extensions;
+using XFramework.Integration.Security;
 using XFramework.Integration.Abstractions.Wrappers;
 using XFramework.Integration.Extensions;
 using Contracts = IdentityServer.Domain.Shared.Contracts;
@@ -40,6 +44,13 @@ public class IntegrationTestFixture
     /// </summary>
     public static IIdentityServerServiceWrapper ServiceWrapper =>
         _testClientApp.Services.GetRequiredService<IIdentityServerServiceWrapper>();
+
+    /// <summary>
+    /// RemoteDataContext that queries IdentityServer through the Bolt transport.
+    /// Creates a new scope each call so tests get a fresh context.
+    /// </summary>
+    public static IDataContext DataContext =>
+        _testClientApp.Services.CreateScope().ServiceProvider.GetRequiredService<IDataContext>();
 
     public static readonly Guid TestTenantId = Guid.Parse("7602c2d3-01df-4bdb-9a67-02c144e4a2ac");
 
@@ -109,17 +120,50 @@ public class IntegrationTestFixture
         return app;
     }
 
+    /// <summary>
+    /// The generated wrapper TargetClient = SHA256("IdentityServer").
+    /// The BoltClient must register with this same ID so the hub routes requests correctly.
+    /// </summary>
+    private static readonly string IdentityServerServiceId =
+        XFramework.Integration.Security.Cryptography.ToSha256("IdentityServer");
+
     private static WebApplication StartIdentityServer()
     {
-        var builder = XApplication.Configure<AuthService>();
+        // Build manually (instead of XApplication.Configure<AuthService>()) so that config
+        // overrides are applied BEFORE the installers read BoltConfiguration to create BoltClient.
+        var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseUrls(IdentityServerUrl);
-        // ClientName = "IdentityServer.Test" → SignalRService registers as SHA256("IdentityServer")
-        // This matches the generated wrapper's TargetClient
-        OverrideConfiguration(builder, "IdentityServer.Test", "3902761a-822d-4c6b-8e2d-323fd501bcd6");
-        builder.Configuration["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/stream-flow/queue";
 
+        // Override configuration first — installers read config at registration time
+        OverrideConfiguration(builder, "IdentityServer", Guid.NewGuid().ToString());
+        builder.Configuration["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/bolt/ws";
+
+        // Register services that the installers normally provide, except WrapperInstaller
+        // (WrapperInstaller calls AddXFrameworkBoltClient which reads ClientGuid as Guid?,
+        // but the service ID is a SHA256 hex string — not a valid GUID).
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddDbContext<DbContext, AppDbContext>((sp, options) => options
+            .UseNpgsql(ConnectionString,
+                npgsql => npgsql.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery))
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.BoolWithDefaultWarning,
+                Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning)));
+        builder.Services.AddServerDataContext<AppDbContext>();
+
+        builder.Services.InstallStandardServices<AuthService>(builder.Configuration);
         builder.Services.AddScoped<IAuthService, AuthService>();
         builder.Services.AddValidatorsFromAssemblyContaining<AuthService>();
+
+        // Register BoltClient with the correct service ID (SHA256 of module name)
+        // so the hub can route wrapper requests to this instance.
+        builder.Services.AddBoltClient(bolt => bolt
+            .WithServer($"{BoltUrl}/bolt/ws")
+            .WithClientId(IdentityServerServiceId)
+            .WithClientName("IdentityServer"));
+
+        // Register DataContext handler so IdentityServer can serve __db_query__/__db_changes__ via Bolt
+        builder.Services.AddDataContextHandler(typeof(AuthService).Assembly);
 
         var app = (WebApplication)builder.Build();
         app.UseCorrelationId();
@@ -158,6 +202,16 @@ public class IntegrationTestFixture
 
         // Register the IdentityServer service wrapper (generated — uses Bolt transport)
         builder.Services.AddIdentityServerWrapperServices();
+
+        // Register RemoteDataContext so IDataContext queries go through Bolt to IdentityServer
+        builder.Services.AddRemoteDataContext();
+
+        // RequestMetadata provides tenant context for remote queries
+        builder.Services.AddScoped(_ => new RequestMetadata
+        {
+            TenantId = TestTenantId,
+            RequestId = Guid.NewGuid()
+        });
 
         var app = builder.Build();
         app.MapGet("/health/live", () => Results.Ok("healthy"));
@@ -208,8 +262,16 @@ public class IntegrationTestFixture
 
     private static async Task MigrateAndSeed()
     {
+        // Force-load module Domain.Shared assemblies so AppDbContext.OnModelCreating
+        // discovers their IEntityTypeConfiguration<T> registrations via AppDomain scan.
+        // The CLR lazy-loads assemblies; accessing a type forces immediate load.
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(Wallets.Domain.Shared.Contracts.WalletType).TypeHandle);
+
         var options = new DbContextOptionsBuilder<AppDbContext>()
             .UseNpgsql(ConnectionString)
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning))
             .Options;
 
         await using var db = new AppDbContext(options);

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/DataContextTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/DataContextTests.cs
@@ -1,0 +1,62 @@
+using IdentityServer.Domain.Shared.Contracts;
+using XFramework.Domain.Shared.DataContext;
+
+namespace IdentityServer.IntegrationTests;
+
+/// <summary>
+/// End-to-end tests for RemoteDataContext: test client -> Bolt Hub -> IdentityServer -> DbContext -> PostgreSQL.
+/// Verifies that IDataContext queries sent from the test client are routed through Bolt
+/// to the IdentityServer service, executed against the real database, and returned.
+/// </summary>
+[TestFixture]
+public class DataContextTests
+{
+    [Test]
+    public async Task RemoteQuery_ToListAsync_ReturnsEntitiesFromService()
+    {
+        var ctx = IntegrationTestFixture.DataContext;
+
+        var results = await ctx.Query<Tenant>()
+            .Where(t => t.Id == IntegrationTestFixture.TestTenantId)
+            .ToListAsync();
+
+        results.Should().NotBeEmpty();
+        results[0].Id.Should().Be(IntegrationTestFixture.TestTenantId);
+    }
+
+    [Test]
+    public async Task RemoteQuery_FirstOrDefaultAsync_ReturnsSingleEntity()
+    {
+        var ctx = IntegrationTestFixture.DataContext;
+
+        var result = await ctx.Query<Tenant>()
+            .Where(t => t.Id == IntegrationTestFixture.TestTenantId)
+            .FirstOrDefaultAsync();
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(IntegrationTestFixture.TestTenantId);
+    }
+
+    [Test]
+    public async Task RemoteQuery_CountAsync_ReturnsCount()
+    {
+        var ctx = IntegrationTestFixture.DataContext;
+
+        var count = await ctx.Query<Tenant>()
+            .Where(t => t.Id == IntegrationTestFixture.TestTenantId)
+            .CountAsync();
+
+        count.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task RemoteQuery_AnyAsync_ReturnsTrue()
+    {
+        var ctx = IntegrationTestFixture.DataContext;
+
+        var exists = await ctx.Query<Tenant>()
+            .AnyAsync();
+
+        exists.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- **Decentralize DB proxy**: Each service now handles its own `IDataContext` queries via `__db_query__`/`__db_changes__`/`__db_query_stream__` Bolt handlers. The Hub is no longer a DB proxy — it's a pure message router.
- **Source-generated change tracking**: New `ChangeTrackerGenerator` emits per-entity `{Entity}Snapshot` + `{Entity}ChangeTracker` for field-level diffs (no reflection, no proxies). Generates 26 trackers for IdentityServer, 10 for Wallets.
- **Source-generated routing map**: `DataContextRegistrationGenerator` extended to emit `entityTypeName → serviceWrapper` mapping. `ServiceWrapperGenerator` extended with `IDataContextServiceWrapper` (ExecuteQueryAsync, ExecuteChangesAsync, ExecuteQueryStreamAsync).
- **RemoteDataContext fully implemented**: Routes queries through service wrappers, buffers Add/Update/Remove with EF-style change tracking, validates single-service per SaveChangesAsync.
- **RemoteQuery all 15 terminals implemented**: ToListAsync, FirstOrDefaultAsync, CountAsync, AnyAsync, SumAsync, GroupByAsync, etc. + `ToAsyncEnumerable(chunkSize)` streaming via BoltStream.
- **Hub cleanup**: Removed `ExecuteQuery`/`ExecuteChanges` (0x0B/0x0C) transitional frame types and Hub's QueryExecutionService registration.

## Key design decisions

| Decision | Choice |
|----------|--------|
| Routing | Static compile-time map from `[GenerateEndpoints]` |
| Handler | Single `__db_query__` / `__db_changes__` per service |
| Wire format | Existing `QueryDescriptor` + `SaveChangesRequest` (MemoryPack) |
| Updates | Field-level `FieldPatch` diffs via source-generated trackers |
| Transport | Via service wrappers (no new Bolt frame types) |
| Streaming | `ToAsyncEnumerable(chunkSize)` via BoltStream (reliable TCP) |
| Concurrency | Typed `DataContextConcurrencyException` thrown to caller |

## Files changed (29 files, +1231/-91)

**New types**: FieldPatch, IEntityChangeTracker, TrackedEntity, DataContextConcurrencyException, IDataContextServiceWrapper, DataContextBoltHandler, DataContextHandlerExtensions, ChangeTrackerGenerator

**Rewritten**: RemoteDataContext (186 lines, was 42 stubs), RemoteQuery (231 lines, was 167 stubs)

**Moved**: QueryExecutionService from Bolt.Hub → XFramework.Core

**4 services wired**: IdentityServer, Wallets, Community, Inventario

## Test plan

- [x] Full solution builds with 0 errors
- [x] RemoteQuery_ToListAsync_ReturnsEntitiesFromService — PASSED
- [x] RemoteQuery_FirstOrDefaultAsync_ReturnsSingleEntity — PASSED
- [x] RemoteQuery_CountAsync_ReturnsCount — PASSED
- [x] RemoteQuery_AnyAsync_ReturnsTrue — PASSED
- [ ] Run full existing test suite for regressions
- [ ] Test from Blazor WASM client (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)