### PR TITLE
Harden CI package restore and environment defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,15 @@ DB_HOST=postgres
 DB_PORT=5432
 DB_NAME=XFramework
 DB_USER=dbAdmin
-DB_PASSWORD=4*5WD-K8%f*NqmPY
+DB_PASSWORD=change-me-local-db-password
+
+# Token signing
+JWT_SECRET=change-me-local-jwt-secret-with-at-least-64-characters
+
+# Optional app-level secrets used by gateway/coins when those services are enabled.
+ENCRYPTION_SECRET=change-me-local-encryption-secret
+PADDED_ENCRYPTION_SECRET=change-me-local-padded-encryption-secret
+COINS_WALLET_PASSWORD=change-me-local-wallet-password
 
 # ── StreamFlow ────────────────────────────────────────────────
 # For local dev, "streamflow" resolves to the compose container.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,6 @@ jobs:
 
       - name: Test (unit tests only)
         run: dotnet test src/Tests/XFramework.Core.Tests/ -c Release --no-build
-        continue-on-error: true
 
       - name: Pack
         run: |
@@ -52,16 +51,20 @@ jobs:
             -p:XFrameworkVersion=${{ steps.version.outputs.xframework_version }} \
             -p:BoltVersion=${{ steps.version.outputs.bolt_version }} \
             -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg \
-            --no-restore || true
-          # Pack individually for projects that fail in solution-wide pack
-          echo "Packages created:"
-          ls -1 nupkgs/*.nupkg 2>/dev/null | wc -l
+            --no-restore
+
+          package_count=$(find nupkgs -maxdepth 1 -name '*.nupkg' | wc -l)
+          echo "Packages created: $package_count"
+          if [ "$package_count" -eq 0 ]; then
+            echo "No NuGet packages were produced."
+            exit 1
+          fi
 
       - name: Publish to NuGet
         run: |
           for pkg in nupkgs/*.nupkg; do
             echo "Publishing $pkg..."
-            dotnet nuget push "$pkg" -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate || true
+            dotnet nuget push "$pkg" -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Upload packages as artifacts

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,8 +62,8 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
 
     <!-- Serialization -->
-    <PackageVersion Include="MessagePack" Version="3.1.0" />
-    <PackageVersion Include="MessagePack.Annotations" Version="3.1.0" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
+    <PackageVersion Include="MessagePack.Annotations" Version="3.1.7" />
     <PackageVersion Include="MemoryPack" Version="1.21.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,4 +4,13 @@
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
         <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     </packageSources>
+    <packageSourceMapping>
+        <packageSource key="nuget.org">
+            <package pattern="*" />
+        </packageSource>
+        <packageSource key="dotnet-tools">
+            <package pattern="Microsoft.DotNet.*" />
+            <package pattern="dotnet-*" />
+        </packageSource>
+    </packageSourceMapping>
 </configuration>

--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -55,7 +55,6 @@
   </Folder>
   <Folder Name="/Presentation/">
     <Project Path="src\Modules\XFramework.Blazor\XFramework.Blazor.csproj" />
-    <Project Path="src\Presentation\ControlPanel\ControlPanel.csproj" />
     <Project Path="src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj" />
     <Project Path="src\Presentation\Fluid\Fluid.csproj" />
     <Project Path="src\Presentation\Gateway\Gateway.csproj" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@
 x-common-env: &common-env
   ASPNETCORE_URLS: http://+:8080
   ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Docker}
+  DefaultDatabaseConnection: Host=${DB_HOST:-postgres};Port=${DB_PORT:-5432};Database=${DB_NAME:-XFramework};Username=${DB_USER:-dbAdmin};Password=${DB_PASSWORD:?Set DB_PASSWORD in .env}
+  JwtOptions__Secret: ${JWT_SECRET:?Set JWT_SECRET in .env}
 
 services:
 
@@ -18,7 +20,7 @@ services:
     environment:
       POSTGRES_DB: ${DB_NAME:-XFramework}
       POSTGRES_USER: ${DB_USER:-dbAdmin}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-4*5WD-K8%f*NqmPY}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?Set DB_PASSWORD in .env}
     ports:
       - "${DB_EXPOSE_PORT:-5432}:5432"
     volumes:
@@ -38,7 +40,7 @@ services:
         PROJECT_PATH: src/Tools/XFramework.MigrationRunner/XFramework.MigrationRunner.csproj
     entrypoint: ["dotnet", "XFramework.MigrationRunner.dll"]
     environment:
-      DefaultDatabaseConnection: Host=${DB_HOST:-postgres};Port=${DB_PORT:-5432};Database=${DB_NAME:-XFramework};Username=${DB_USER:-dbAdmin};Password=${DB_PASSWORD:-4*5WD-K8%f*NqmPY}
+      DefaultDatabaseConnection: Host=${DB_HOST:-postgres};Port=${DB_PORT:-5432};Database=${DB_NAME:-XFramework};Username=${DB_USER:-dbAdmin};Password=${DB_PASSWORD:?Set DB_PASSWORD in .env}
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Development.json
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "Application": {
     "DefaultUID": "3902761a-822d-4c6b-8e2d-323fd501bcd6",
@@ -27,7 +27,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Docker.json
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Docker.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "Seq": {
     "Url": "http://seq:80"

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Staging.json
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Staging.json
@@ -15,7 +15,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "Application": {
     "DefaultUID": "3902761a-822d-4c6b-8e2d-323fd501bcd6",
@@ -24,7 +24,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.json
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.json
@@ -15,7 +15,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "Application": {
     "DefaultUID": "3902761a-822d-4c6b-8e2d-323fd501bcd6",
@@ -24,7 +24,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.Development.json
@@ -11,7 +11,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "Application": {
     "DefaultUID": "3902761a-822d-4c6b-8e2d-323fd501bcd6"
@@ -30,7 +30,7 @@
     "WalletConfiguration": {
       "PublicKey": "",
       "WalletIdentifier": "cda0ac06-2bf7-4df5-a76d-e891c2e225b8",
-      "WalletPassword": "EG7@XaYpGeXq@5SR"
+      "WalletPassword": "CHANGE_ME_WALLET_PASSWORD_USE_ENVIRONMENT"
     },
     "ApiUrl": "https://api.blockchain.info/v2/",
     "ServiceUrl": "http://127.0.0.1:3000/",

--- a/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.Staging.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "Application": {
     "DefaultUID": "3902761a-822d-4c6b-8e2d-323fd501bcd6"
@@ -27,7 +27,7 @@
     "WalletConfiguration": {
       "PublicKey": "",
       "WalletIdentifier": "cda0ac06-2bf7-4df5-a76d-e891c2e225b8",
-      "WalletPassword": "EG7@XaYpGeXq@5SR"
+      "WalletPassword": "CHANGE_ME_WALLET_PASSWORD_USE_ENVIRONMENT"
     },
     "ApiUrl": "https://api.blockchain.info/v2/",
     "ServiceUrl": "http://127.0.0.1:3000/",

--- a/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.json
+++ b/src/Modules/XFramework.Coins/Server/Coins.Api/appsettings.json
@@ -13,7 +13,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DatabaseConnection": "Host=localhost;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "Application": {
     "DefaultUID": "3902761a-822d-4c6b-8e2d-323fd501bcd6"
@@ -21,7 +21,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"    
   },
@@ -39,7 +39,7 @@
     "WalletConfiguration" : {
       "PublicKey": "",
       "WalletIdentifier": "cda0ac06-2bf7-4df5-a76d-e891c2e225b8",
-      "WalletPassword": "EG7@XaYpGeXq@5SR"
+      "WalletPassword": "CHANGE_ME_WALLET_PASSWORD_USE_ENVIRONMENT"
     },
     "ApiUrl": "https://api.blockchain.info/v2/",
     "ServiceUrl": "http://127.0.0.1:3000/",

--- a/src/Modules/XFramework.Community/Community.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.Community/Community.Api/appsettings.Development.json
@@ -24,7 +24,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5000",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Community/Community.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.Community/Community.Api/appsettings.Staging.json
@@ -21,7 +21,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5000",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Community/Community.Api/appsettings.json
+++ b/src/Modules/XFramework.Community/Community.Api/appsettings.json
@@ -21,7 +21,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=BqzX}V~,/p:7]K(FRH-bun!6PG?_g^<#h2EdtAQM[35x8;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
+    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
   },
   "Application": {
     "MemoryLimit": "512MB"
@@ -29,7 +29,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/appsettings.Docker.json
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/appsettings.Docker.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "BoltConfiguration": {
     "ServerUrls": ["ws://bolt-hub:8080/bolt/ws"]

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/appsettings.Staging.json
@@ -24,7 +24,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/appsettings.json
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/appsettings.json
@@ -23,7 +23,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"    
   },

--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=BqzX}V~,/p:7]K(FRH-bun!6PG?_g^<#h2EdtAQM[35x8;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
+    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
   },
   "Application": {
     "MemoryLimit": "512MB"
@@ -29,7 +29,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Staging.json
@@ -24,7 +24,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.json
@@ -38,7 +38,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"    
   },

--- a/src/Modules/XFramework.Messaging/Messaging.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=BqzX}V~,/p:7]K(FRH-bun!6PG?_g^<#h2EdtAQM[35x8;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
+    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
   },
   "Tenant": {
     "DefaultId": "7602c2d3-01df-4bdb-9a67-02c144e4a2ac"
@@ -26,7 +26,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Messaging/Messaging.Api/appsettings.Docker.json
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/appsettings.Docker.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "BoltConfiguration": {
     "ServerUrls": ["ws://bolt-hub:8080/bolt/ws"]

--- a/src/Modules/XFramework.Messaging/Messaging.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/appsettings.Staging.json
@@ -24,7 +24,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Messaging/Messaging.Api/appsettings.json
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/appsettings.json
@@ -20,7 +20,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"    
   },

--- a/src/Modules/XFramework.SmsGateway/SmsGateway.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.SmsGateway/SmsGateway.Api/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=BqzX}V~,/p:7]K(FRH-bun!6PG?_g^<#h2EdtAQM[35x8;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
+    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
   },
   "Tenant": {
     "DefaultId": "7602c2d3-01df-4bdb-9a67-02c144e4a2ac"
@@ -26,7 +26,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.SmsGateway/SmsGateway.Api/appsettings.Docker.json
+++ b/src/Modules/XFramework.SmsGateway/SmsGateway.Api/appsettings.Docker.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "BoltConfiguration": {
     "ServerUrls": ["ws://bolt-hub:8080/bolt/ws"]

--- a/src/Modules/XFramework.SmsGateway/SmsGateway.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.SmsGateway/SmsGateway.Api/appsettings.Staging.json
@@ -24,7 +24,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.SmsGateway/SmsGateway.Api/appsettings.json
+++ b/src/Modules/XFramework.SmsGateway/SmsGateway.Api/appsettings.json
@@ -20,7 +20,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"    
   },

--- a/src/Modules/XFramework.Wallets/Wallets.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=BqzX}V~,/p:7]K(FRH-bun!6PG?_g^<#h2EdtAQM[35x8;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
+    "DefaultDatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
   },
   "Application": {
     "DefaultUID": "ec57bc89-914d-4d92-a36f-12a1ce3b221c",
@@ -30,7 +30,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Wallets/Wallets.Api/appsettings.Docker.json
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/appsettings.Docker.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=4*5WD-K8%f*NqmPY"
+    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
   },
   "BoltConfiguration": {
     "ServerUrls": ["ws://bolt-hub:8080/bolt/ws"]

--- a/src/Modules/XFramework.Wallets/Wallets.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/appsettings.Staging.json
@@ -25,7 +25,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Modules/XFramework.Wallets/Wallets.Api/appsettings.json
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/appsettings.json
@@ -39,7 +39,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Presentation/Gateway/appsettings.Development.json
+++ b/src/Presentation/Gateway/appsettings.Development.json
@@ -15,11 +15,11 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=BqzX}V~,/p:7]K(FRH-bun!6PG?_g^<#h2EdtAQM[35x8;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
+    "DatabaseConnection": "Host=localhost;Database=XnelSystems;Username=xnelsystems-migration;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT;Pooling=true;MinPoolSize=2;MaxPoolSize=900;Timeout=300;CommandTimeout=300;"
   },
   "Application": {
-    "EncryptionSecret" : "R3c7J}sYD6+V#{Shn>@&8Ax.z?Kx=yM{",
-    "PaddedEncryptionSecret" : "-}e4?6J-@_$-_*mM?3'F",
+    "EncryptionSecret" : "CHANGE_ME_ENCRYPTION_SECRET_USE_ENVIRONMENT",
+    "PaddedEncryptionSecret" : "CHANGE_ME_PADDED_ENCRYPTION_SECRET_USE_ENVIRONMENT",
     "MemoryLimit": "512MB"
   },
   "Tenant": {
@@ -28,7 +28,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },

--- a/src/Presentation/Gateway/appsettings.json
+++ b/src/Presentation/Gateway/appsettings.json
@@ -15,8 +15,8 @@
   },
   "AllowedHosts": "*",
   "Application": {
-    "EncryptionSecret" : "R3c7J}sYD6+V#{Shn>@&8Ax.z?Kx=yM{",
-    "PaddedEncryptionSecret" : "-}e4?6J-@_$-_*mM?3'F",
+    "EncryptionSecret" : "CHANGE_ME_ENCRYPTION_SECRET_USE_ENVIRONMENT",
+    "PaddedEncryptionSecret" : "CHANGE_ME_PADDED_ENCRYPTION_SECRET_USE_ENVIRONMENT",
     "MemoryLimit": "512MB"
   },
   "Tenant": {
@@ -25,7 +25,7 @@
   "JwtOptions": {
     "ValidAudience": "http://localhost:5001",
     "ValidIssuer": "http://localhost:5001",
-    "Secret": "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },


### PR DESCRIPTION
## Summary
- Remove committed default secrets from compose and module/gateway appsettings, replacing them with placeholders or required environment values.
- Make Docker compose require `DB_PASSWORD` and `JWT_SECRET`, with safe example values in `.env.example`.
- Stop the publish workflow from swallowing test, pack, and NuGet push failures.
- Add NuGet package source mapping, remove stale missing ControlPanel project entry from `XFramework.slnx`, and update `MessagePack`/`MessagePack.Annotations` to `3.1.7` to clear the high-severity audit gate.

## Validation
- `docker-compose --env-file .env.example config --quiet`
- `dotnet restore XFramework.slnx`
- `dotnet build src\Kernel\XFramework.Core\XFramework.Core.csproj --no-restore -v:minimal /nr:false`
- `dotnet list src\Kernel\XFramework.Core\XFramework.Core.csproj package --vulnerable --include-transitive`
- `dotnet list src\Tests\Bolt.Tests\Bolt.Tests.csproj package --vulnerable --include-transitive`
- xeon-dev Testcontainers via loopback SSH+socat tunnel:
  - `dotnet test src\Tests\IdentityServer.IntegrationTests\IdentityServer.IntegrationTests.csproj --logger console;verbosity=minimal -m:1 /nr:false` passed: 51 passed, 2 skipped.
  - `dotnet test src\Tests\Wallets.IntegrationTests\Wallets.IntegrationTests.csproj --logger console;verbosity=minimal -m:1 /nr:false` passed: 22 passed.
- Secret literal scan for the removed committed secrets returned no matches.
- Tunnel was cleaned up and no `org.testcontainers=true` containers were left running on xeon-dev.

## Notes
- Merge this before cache/runtime readiness PRs if you want their exact no-audit-override test commands to pass on `develop`.