### PR TITLE
Migrate ControlPanel CRUD pages to IDataContext

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @using ControlPanel.Server.Services
+@using XFramework.Domain.Shared.DataContext
 
 <div class="flex min-h-screen bg-background text-foreground">
     @* Fixed left sidebar — always visible *@
@@ -81,7 +82,7 @@
 <BbPortalHost />
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Nav { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
@@ -109,8 +110,12 @@
         if (!firstRender) return;
         try
         {
-            var response = await IdentityWrapper.Tenant.GetList(100, 1);
-            _tenants = response?.Response?.Items?.Where(t => !t.IsDeleted).OrderBy(t => t.Name).ToList() ?? [];
+            _tenants = await DataContext.Query<IdentityServer.Domain.Shared.Contracts.Tenant>()
+                .NoCache()
+                .Where(t => !t.IsDeleted)
+                .OrderBy(t => t.Name)
+                .Take(100)
+                .ToListAsync();
             StateHasChanged();
         }
         catch { /* Tenant loading is non-critical */ }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Admin/ReferenceData.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Admin/ReferenceData.razor
@@ -1,4 +1,5 @@
 @page "/admin/reference-data"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Reference Data - Control Panel</PageTitle>
 
@@ -516,8 +517,7 @@
                      OnConfirm="@ConfirmDelete" />
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
 
     private bool _loading = true;
@@ -548,7 +548,6 @@
     // Delete state
     private string _deleteName = "";
     private object? _deleteTarget;
-    private string _deleteEntityType = "";
 
     // Data lists
     private List<IdentityRoleType> _roleTypes = [];
@@ -593,31 +592,16 @@
 
     private async Task LoadAllData()
     {
-        var roleTypesTask = IdentityWrapper.IdentityRoleType.GetList(100, 1);
-        var roleTypeGroupsTask = IdentityWrapper.IdentityRoleTypeGroup.GetList(100, 1);
-        var contactTypesTask = IdentityWrapper.IdentityContactType.GetList(100, 1);
-        var contactGroupsTask = IdentityWrapper.IdentityContactGroup.GetList(100, 1);
-        var addressTypesTask = IdentityWrapper.IdentityAddressType.GetList(100, 1);
-        var verificationTypesTask = IdentityWrapper.IdentityVerificationType.GetList(100, 1);
-        var sessionTypesTask = IdentityWrapper.SessionType.GetList(100, 1);
-        var walletTypesTask = WalletsWrapper.WalletType.GetList(100, 1);
-        var currencyTypesTask = WalletsWrapper.CurrencyType.GetList(100, 1);
-        var exchangeRatesTask = WalletsWrapper.ExchangeRate.GetList(100, 1);
-
-        await Task.WhenAll(roleTypesTask, roleTypeGroupsTask, contactTypesTask, contactGroupsTask,
-            addressTypesTask, verificationTypesTask, sessionTypesTask, walletTypesTask,
-            currencyTypesTask, exchangeRatesTask);
-
-        _roleTypes = roleTypesTask.Result?.Response?.Items?.ToList() ?? [];
-        _roleTypeGroups = roleTypeGroupsTask.Result?.Response?.Items?.ToList() ?? [];
-        _contactTypes = contactTypesTask.Result?.Response?.Items?.ToList() ?? [];
-        _contactGroups = contactGroupsTask.Result?.Response?.Items?.ToList() ?? [];
-        _addressTypes = addressTypesTask.Result?.Response?.Items?.ToList() ?? [];
-        _verificationTypes = verificationTypesTask.Result?.Response?.Items?.ToList() ?? [];
-        _sessionTypes = sessionTypesTask.Result?.Response?.Items?.ToList() ?? [];
-        _walletTypes = walletTypesTask.Result?.Response?.Items?.ToList() ?? [];
-        _currencyTypes = currencyTypesTask.Result?.Response?.Items?.ToList() ?? [];
-        _exchangeRates = exchangeRatesTask.Result?.Response?.Items?.ToList() ?? [];
+        _roleTypes = await LoadList<IdentityRoleType>();
+        _roleTypeGroups = await LoadList<IdentityRoleTypeGroup>();
+        _contactTypes = await LoadList<IdentityContactType>();
+        _contactGroups = await LoadList<IdentityContactGroup>();
+        _addressTypes = await LoadList<IdentityAddressType>();
+        _verificationTypes = await LoadList<IdentityVerificationType>();
+        _sessionTypes = await LoadList<SessionType>();
+        _walletTypes = await LoadList<global::Wallets.Domain.Shared.Contracts.WalletType>();
+        _currencyTypes = await LoadList<global::Wallets.Domain.Shared.Contracts.CurrencyType>();
+        _exchangeRates = await LoadList<ExchangeRate>();
     }
 
     private async Task ReloadActiveTab()
@@ -627,49 +611,45 @@
             switch (_activeTab)
             {
                 case "role-types":
-                    var rt = await IdentityWrapper.IdentityRoleType.GetList(100, 1);
-                    _roleTypes = rt?.Response?.Items?.ToList() ?? [];
+                    _roleTypes = await LoadList<IdentityRoleType>();
                     break;
                 case "role-type-groups":
-                    var rtg = await IdentityWrapper.IdentityRoleTypeGroup.GetList(100, 1);
-                    _roleTypeGroups = rtg?.Response?.Items?.ToList() ?? [];
+                    _roleTypeGroups = await LoadList<IdentityRoleTypeGroup>();
                     break;
                 case "contact-types":
-                    var ct = await IdentityWrapper.IdentityContactType.GetList(100, 1);
-                    _contactTypes = ct?.Response?.Items?.ToList() ?? [];
+                    _contactTypes = await LoadList<IdentityContactType>();
                     break;
                 case "contact-groups":
-                    var cg = await IdentityWrapper.IdentityContactGroup.GetList(100, 1);
-                    _contactGroups = cg?.Response?.Items?.ToList() ?? [];
+                    _contactGroups = await LoadList<IdentityContactGroup>();
                     break;
                 case "address-types":
-                    var at = await IdentityWrapper.IdentityAddressType.GetList(100, 1);
-                    _addressTypes = at?.Response?.Items?.ToList() ?? [];
+                    _addressTypes = await LoadList<IdentityAddressType>();
                     break;
                 case "verification-types":
-                    var vt = await IdentityWrapper.IdentityVerificationType.GetList(100, 1);
-                    _verificationTypes = vt?.Response?.Items?.ToList() ?? [];
+                    _verificationTypes = await LoadList<IdentityVerificationType>();
                     break;
                 case "session-types":
-                    var st = await IdentityWrapper.SessionType.GetList(100, 1);
-                    _sessionTypes = st?.Response?.Items?.ToList() ?? [];
+                    _sessionTypes = await LoadList<SessionType>();
                     break;
                 case "wallet-types":
-                    var wt = await WalletsWrapper.WalletType.GetList(100, 1);
-                    _walletTypes = wt?.Response?.Items?.ToList() ?? [];
+                    _walletTypes = await LoadList<global::Wallets.Domain.Shared.Contracts.WalletType>();
                     break;
                 case "currency-types":
-                    var crt = await WalletsWrapper.CurrencyType.GetList(100, 1);
-                    _currencyTypes = crt?.Response?.Items?.ToList() ?? [];
+                    _currencyTypes = await LoadList<global::Wallets.Domain.Shared.Contracts.CurrencyType>();
                     break;
                 case "exchange-rates":
-                    var er = await WalletsWrapper.ExchangeRate.GetList(100, 1);
-                    _exchangeRates = er?.Response?.Items?.ToList() ?? [];
+                    _exchangeRates = await LoadList<ExchangeRate>();
                     break;
             }
         }
         catch { /* reload failure is non-critical */ }
     }
+
+    private async Task<List<T>> LoadList<T>(int take = 100) where T : class =>
+        await DataContext.Query<T>()
+            .NoCache()
+            .Take(take)
+            .ToListAsync();
 
     // ── Add / Edit Helpers ──
 
@@ -760,7 +740,6 @@
     {
         _deleteTarget = target;
         _deleteName = displayName;
-        _deleteEntityType = target.GetType().Name;
         _deleteDialogOpen = true;
     }
 
@@ -768,26 +747,31 @@
     {
         if (_deleteTarget is null) return;
 
-        CmdResponse? result = _deleteEntityType switch
+        DataContextResult? result = _deleteTarget switch
         {
-            "IdentityRoleType" => await IdentityWrapper.IdentityRoleType.Delete((IdentityRoleType)_deleteTarget),
-            "IdentityRoleTypeGroup" => await IdentityWrapper.IdentityRoleTypeGroup.Delete((IdentityRoleTypeGroup)_deleteTarget),
-            "IdentityContactType" => await IdentityWrapper.IdentityContactType.Delete((IdentityContactType)_deleteTarget),
-            "IdentityContactGroup" => await IdentityWrapper.IdentityContactGroup.Delete((IdentityContactGroup)_deleteTarget),
-            "IdentityAddressType" => await IdentityWrapper.IdentityAddressType.Delete((IdentityAddressType)_deleteTarget),
-            "IdentityVerificationType" => await IdentityWrapper.IdentityVerificationType.Delete((IdentityVerificationType)_deleteTarget),
-            "SessionType" => await IdentityWrapper.SessionType.Delete((SessionType)_deleteTarget),
-            "WalletType" => await WalletsWrapper.WalletType.Delete((global::Wallets.Domain.Shared.Contracts.WalletType)_deleteTarget),
-            "CurrencyType" => await WalletsWrapper.CurrencyType.Delete((global::Wallets.Domain.Shared.Contracts.CurrencyType)_deleteTarget),
-            "ExchangeRate" => await WalletsWrapper.ExchangeRate.Delete((ExchangeRate)_deleteTarget),
+            IdentityRoleType entity => await RemoveEntity(entity),
+            IdentityRoleTypeGroup entity => await RemoveEntity(entity),
+            IdentityContactType entity => await RemoveEntity(entity),
+            IdentityContactGroup entity => await RemoveEntity(entity),
+            IdentityAddressType entity => await RemoveEntity(entity),
+            IdentityVerificationType entity => await RemoveEntity(entity),
+            SessionType entity => await RemoveEntity(entity),
+            global::Wallets.Domain.Shared.Contracts.WalletType entity => await RemoveEntity(entity),
+            global::Wallets.Domain.Shared.Contracts.CurrencyType entity => await RemoveEntity(entity),
+            ExchangeRate entity => await RemoveEntity(entity),
             _ => null
         };
         ToastService.Show(result?.IsSuccess == true ? $"{TabDisplayName} deleted." : $"Error: {result?.Message}");
         _deleteDialogOpen = false;
         _deleteTarget = null;
         _deleteName = "";
-        _deleteEntityType = "";
         await ReloadActiveTab();
+    }
+
+    private async Task<DataContextResult> RemoveEntity<T>(T entity) where T : class
+    {
+        DataContext.Remove(entity);
+        return await DataContext.SaveChangesAsync();
     }
 
     // ── Save (Create / Update) ──
@@ -846,7 +830,7 @@
                 SystemReferenceId = ParseSystemRef(),
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityRoleType.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -859,7 +843,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityRoleType.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -877,7 +861,7 @@
                 SystemReferenceId = ParseSystemRef(),
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityRoleTypeGroup.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -890,7 +874,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityRoleTypeGroup.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -907,7 +891,7 @@
                 SystemReferenceId = ParseSystemRef(),
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityContactType.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -919,7 +903,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityContactType.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -936,7 +920,7 @@
                 SystemReferenceId = ParseSystemRef(),
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityContactGroup.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -948,7 +932,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityContactGroup.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -965,7 +949,7 @@
                 SystemReferenceId = ParseSystemRef(),
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityAddressType.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -977,7 +961,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityAddressType.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -996,7 +980,7 @@
                 SystemReferenceId = ParseSystemRef(),
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityVerificationType.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -1010,7 +994,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => IdentityWrapper.IdentityVerificationType.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -1027,7 +1011,7 @@
                 SystemReferenceId = ParseSystemRef(),
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => IdentityWrapper.SessionType.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -1039,7 +1023,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => IdentityWrapper.SessionType.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -1063,7 +1047,7 @@
                 MaxTransferRule = decimal.TryParse(_formMaxTransfer, out var maxT) ? maxT : null,
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => WalletsWrapper.WalletType.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -1078,7 +1062,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => WalletsWrapper.WalletType.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -1096,7 +1080,7 @@
                 Description = string.IsNullOrWhiteSpace(_formDescription) ? null : _formDescription,
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => WalletsWrapper.CurrencyType.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -1109,7 +1093,7 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => WalletsWrapper.CurrencyType.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
@@ -1140,7 +1124,7 @@
                 ExpiryDate = DateTime.TryParse(_formExpiry, out var exp) ? exp : null,
                 ModifiedAt = DateTime.UtcNow
             };
-            await PersistAndClose(() => WalletsWrapper.ExchangeRate.Patch(entity));
+            await PersistAndClose(entity);
         }
         else
         {
@@ -1156,13 +1140,22 @@
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            await PersistAndClose(() => WalletsWrapper.ExchangeRate.Create(entity));
+            await PersistAndClose(entity);
         }
     }
 
-    private async Task PersistAndClose<T>(Func<Task<CmdResponse<T>>> action)
+    private async Task PersistAndClose<T>(T entity) where T : class
     {
-        var result = await action();
+        if (_isEditing)
+        {
+            DataContext.Update(entity);
+        }
+        else
+        {
+            DataContext.Add(entity);
+        }
+
+        var result = await DataContext.SaveChangesAsync();
         if (!result.IsSuccess)
         {
             ToastService.Show($"Error: {result.Message}");

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Dashboard.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Dashboard.razor
@@ -1,4 +1,5 @@
 @page "/"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Dashboard - Control Panel</PageTitle>
 
@@ -67,8 +68,7 @@ else
 }
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private ILogger<Dashboard> Logger { get; set; } = default!;
 
     private bool _loading = true;
@@ -83,17 +83,17 @@ else
         _loading = true;
         try
         {
-            var usersTask = IdentityWrapper.IdentityInformation.GetList(1, 1);
-            var sessionsTask = IdentityWrapper.Session.GetList(1, 1);
-            var walletsTask = WalletsWrapper.Wallet.GetList(1, 1);
-            var tenantsTask = IdentityWrapper.Tenant.GetList(1, 1);
+            var usersTask = DataContext.Query<IdentityInformation>().NoCache().CountAsync();
+            var sessionsTask = DataContext.Query<Session>().NoCache().CountAsync();
+            var walletsTask = DataContext.Query<Wallet>().NoCache().CountAsync();
+            var tenantsTask = DataContext.Query<Tenant>().NoCache().CountAsync();
 
             await Task.WhenAll(usersTask, sessionsTask, walletsTask, tenantsTask);
 
-            _userCount = usersTask.Result?.Response?.TotalItems ?? 0;
-            _sessionCount = sessionsTask.Result?.Response?.TotalItems ?? 0;
-            _walletCount = walletsTask.Result?.Response?.TotalItems ?? 0;
-            _tenantCount = tenantsTask.Result?.Response?.TotalItems ?? 0;
+            _userCount = usersTask.Result;
+            _sessionCount = sessionsTask.Result;
+            _walletCount = walletsTask.Result;
+            _tenantCount = tenantsTask.Result;
         }
         catch (Exception ex)
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/DepositRequests.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/DepositRequests.razor
@@ -1,4 +1,5 @@
 @page "/finance/deposit-requests"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Deposit Requests - Control Panel</PageTitle>
 
@@ -33,7 +34,7 @@
 </div>
 
 @code {
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private ControlPanel.Server.Services.TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<DepositRequest> _items = [];
@@ -49,15 +50,13 @@
         _loading = true;
         try
         {
-            var result = await WalletsWrapper.DepositRequest.GetList(
-                pageSize: 100,
-                pageNumber: 1,
-                tenantId: TenantFilter.SelectedTenantId,
-                includeNavigations: true);
-            if (result?.IsSuccess == true)
+            var query = DataContext.Query<DepositRequest>();
+            if (TenantFilter.SelectedTenantId is Guid tenantId)
             {
-                _items = result.Response?.Items.ToList() ?? [];
+                query = query.Where(x => x.TenantId == tenantId);
             }
+
+            _items = await query.Take(100).ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Transactions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Transactions.razor
@@ -1,4 +1,5 @@
 @page "/finance/transactions"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Transactions - Control Panel</PageTitle>
 
@@ -51,7 +52,7 @@
 </div>
 
 @code {
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private ControlPanel.Server.Services.TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<WalletTransaction> _items = [];
@@ -67,15 +68,13 @@
         _loading = true;
         try
         {
-            var result = await WalletsWrapper.WalletTransaction.GetList(
-                pageSize: 100,
-                pageNumber: 1,
-                tenantId: TenantFilter.SelectedTenantId,
-                includeNavigations: true);
-            if (result?.IsSuccess == true)
+            var query = DataContext.Query<WalletTransaction>();
+            if (TenantFilter.SelectedTenantId is Guid tenantId)
             {
-                _items = result.Response?.Items.ToList() ?? [];
+                query = query.Where(x => x.TenantId == tenantId);
             }
+
+            _items = await query.Take(100).ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Transfers.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Transfers.razor
@@ -1,4 +1,5 @@
 @page "/finance/transfers"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Transfers - Control Panel</PageTitle>
 
@@ -30,7 +31,7 @@
 </div>
 
 @code {
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private ControlPanel.Server.Services.TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<WalletTransfer> _items = [];
@@ -46,15 +47,13 @@
         _loading = true;
         try
         {
-            var result = await WalletsWrapper.WalletTransfer.GetList(
-                pageSize: 100,
-                pageNumber: 1,
-                tenantId: TenantFilter.SelectedTenantId,
-                includeNavigations: true);
-            if (result?.IsSuccess == true)
+            var query = DataContext.Query<WalletTransfer>();
+            if (TenantFilter.SelectedTenantId is Guid tenantId)
             {
-                _items = result.Response?.Items.ToList() ?? [];
+                query = query.Where(x => x.TenantId == tenantId);
             }
+
+            _items = await query.Take(100).ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
@@ -1,5 +1,6 @@
 @page "/finance/wallets/{Id:guid}"
 @using global::Wallets.Domain.Shared.Enums
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Wallet Detail - Control Panel</PageTitle>
 
@@ -378,7 +379,7 @@ else
 
 @code {
     [Parameter] public Guid Id { get; set; }
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
 
@@ -422,31 +423,18 @@ else
 
     private async Task LoadWallet()
     {
-        var result = await WalletsWrapper.Wallet.Get(
-            Id,
-            includeNavigations: true,
-            includes: [nameof(Wallet.WalletType)]);
-        _wallet = result?.Response;
+        _wallet = await DataContext.Query<Wallet>()
+            .Include(x => x.WalletType)
+            .Where(x => x.Id == Id)
+            .FirstOrDefaultAsync();
     }
 
     private async Task LoadTransactions()
     {
-        var result = await WalletsWrapper.WalletTransaction.GetList(
-            pageSize: 100,
-            pageNumber: 1,
-            filter:
-            [
-                new()
-                {
-                    PropertyName = nameof(WalletTransaction.WalletId),
-                    Operation = QueryFilterOperation.Equal,
-                    Value = Id
-                }
-            ]);
-        if (result?.IsSuccess == true)
-        {
-            _transactions = result.Response?.Items.ToList() ?? [];
-        }
+        _transactions = await DataContext.Query<WalletTransaction>()
+            .Where(x => x.WalletId == Id)
+            .Take(100)
+            .ToListAsync();
     }
 
     private string GetStatusKey(WalletStatus status) => status switch
@@ -470,8 +458,9 @@ else
         try
         {
             // Fetch fresh wallet state
-            var freshResult = await WalletsWrapper.Wallet.Get(Id);
-            var fresh = freshResult?.Response;
+            var fresh = await DataContext.Query<Wallet>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -501,20 +490,15 @@ else
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            var txResult = await WalletsWrapper.WalletTransaction.Create(transaction);
-
-            if (txResult?.IsSuccess != true)
-            {
-                ToastService.Show($"Failed to create transaction: {txResult?.Message}");
-                return;
-            }
 
             // Update wallet balance
+            DataContext.Add(transaction);
             fresh.Balance = newBalance;
             fresh.ModifiedAt = DateTime.UtcNow;
-            var walletResult = await WalletsWrapper.Wallet.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (walletResult?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show($"Added {amount:N2} to wallet. New balance: {newBalance:N2}");
                 _addFundsAmount = "";
@@ -525,7 +509,7 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to update wallet balance: {walletResult?.Message}");
+                ToastService.Show($"Failed to update wallet balance: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -550,8 +534,9 @@ else
         try
         {
             // Fetch fresh wallet state
-            var freshResult = await WalletsWrapper.Wallet.Get(Id);
-            var fresh = freshResult?.Response;
+            var fresh = await DataContext.Query<Wallet>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -587,20 +572,15 @@ else
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            var txResult = await WalletsWrapper.WalletTransaction.Create(transaction);
-
-            if (txResult?.IsSuccess != true)
-            {
-                ToastService.Show($"Failed to create transaction: {txResult?.Message}");
-                return;
-            }
 
             // Update wallet balance
+            DataContext.Add(transaction);
             fresh.Balance = newBalance;
             fresh.ModifiedAt = DateTime.UtcNow;
-            var walletResult = await WalletsWrapper.Wallet.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (walletResult?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show($"Withdrew {amount:N2} from wallet. New balance: {newBalance:N2}");
                 _withdrawAmount = "";
@@ -611,7 +591,7 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to update wallet balance: {walletResult?.Message}");
+                ToastService.Show($"Failed to update wallet balance: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -636,8 +616,9 @@ else
         try
         {
             // Fetch fresh wallet state
-            var freshResult = await WalletsWrapper.Wallet.Get(Id);
-            var fresh = freshResult?.Response;
+            var fresh = await DataContext.Query<Wallet>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -669,20 +650,15 @@ else
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
-            var txResult = await WalletsWrapper.WalletTransaction.Create(transaction);
-
-            if (txResult?.IsSuccess != true)
-            {
-                ToastService.Show($"Failed to create transaction: {txResult?.Message}");
-                return;
-            }
 
             // Update wallet balance directly
+            DataContext.Add(transaction);
             fresh.Balance = newBalance;
             fresh.ModifiedAt = DateTime.UtcNow;
-            var walletResult = await WalletsWrapper.Wallet.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (walletResult?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show($"Balance adjusted from {oldBalance:N2} to {newBalance:N2}.");
                 _adjustBalance = "";
@@ -692,7 +668,7 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to adjust balance: {walletResult?.Message}");
+                ToastService.Show($"Failed to adjust balance: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -709,8 +685,9 @@ else
     {
         try
         {
-            var freshResult = await WalletsWrapper.Wallet.Get(Id);
-            var fresh = freshResult?.Response;
+            var fresh = await DataContext.Query<Wallet>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -727,15 +704,16 @@ else
             fresh.Status = WalletStatus.Frozen;
             fresh.ModifiedAt = DateTime.UtcNow;
 
-            var result = await WalletsWrapper.Wallet.Patch(fresh);
-            if (result?.IsSuccess == true)
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
             {
                 ToastService.Show("Wallet frozen successfully.");
                 await LoadWallet();
             }
             else
             {
-                ToastService.Show($"Failed to freeze wallet: {result?.Message}");
+                ToastService.Show($"Failed to freeze wallet: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -748,8 +726,9 @@ else
     {
         try
         {
-            var freshResult = await WalletsWrapper.Wallet.Get(Id);
-            var fresh = freshResult?.Response;
+            var fresh = await DataContext.Query<Wallet>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -766,15 +745,16 @@ else
             fresh.Status = WalletStatus.Active;
             fresh.ModifiedAt = DateTime.UtcNow;
 
-            var result = await WalletsWrapper.Wallet.Patch(fresh);
-            if (result?.IsSuccess == true)
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
             {
                 ToastService.Show("Wallet unfrozen successfully.");
                 await LoadWallet();
             }
             else
             {
-                ToastService.Show($"Failed to unfreeze wallet: {result?.Message}");
+                ToastService.Show($"Failed to unfreeze wallet: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -787,8 +767,9 @@ else
     {
         try
         {
-            var freshResult = await WalletsWrapper.Wallet.Get(Id);
-            var fresh = freshResult?.Response;
+            var fresh = await DataContext.Query<Wallet>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -806,8 +787,9 @@ else
             fresh.Status = WalletStatus.Closed;
             fresh.ModifiedAt = DateTime.UtcNow;
 
-            var result = await WalletsWrapper.Wallet.Patch(fresh);
-            if (result?.IsSuccess == true)
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
             {
                 ToastService.Show("Wallet closed successfully.");
                 _showCloseDialog = false;
@@ -815,7 +797,7 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to close wallet: {result?.Message}");
+                ToastService.Show($"Failed to close wallet: {result.Message}");
             }
         }
         catch (Exception ex)

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Wallets.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Wallets.razor
@@ -1,5 +1,6 @@
 @page "/finance/wallets"
 @using global::Wallets.Domain.Shared.Enums
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Wallet Management - Control Panel</PageTitle>
 
@@ -197,8 +198,7 @@ else
 </BbDialog>
 
 @code {
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private ControlPanel.Server.Services.TenantFilterService TenantFilter { get; set; } = default!;
@@ -227,16 +227,11 @@ else
         try
         {
             await LoadData();
-            var wtResult = await WalletsWrapper.WalletType.GetList(
-                pageSize: 100,
-                pageNumber: 1,
-                includeNavigations: false);
-            if (wtResult?.IsSuccess == true)
-            {
-                _walletTypes = wtResult.Response?.Items
-                    .OrderBy(x => x.Name)
-                    .ToList() ?? [];
-            }
+            _walletTypes = (await DataContext.Query<global::Wallets.Domain.Shared.Contracts.WalletType>()
+                    .Take(100)
+                    .ToListAsync())
+                .OrderBy(x => x.Name)
+                .ToList();
         }
         catch (Exception ex)
         {
@@ -250,17 +245,15 @@ else
 
     private async Task LoadData()
     {
-        var result = await WalletsWrapper.Wallet.GetList(
-            pageSize: 100,
-            pageNumber: 1,
-            tenantId: TenantFilter.SelectedTenantId,
-            includeNavigations: true,
-            includes: [nameof(Wallet.WalletType)]);
+        var query = DataContext.Query<Wallet>()
+            .Include(x => x.WalletType);
 
-        if (result?.IsSuccess == true)
+        if (TenantFilter.SelectedTenantId is Guid tenantId)
         {
-            _items = result.Response?.Items.ToList() ?? [];
+            query = query.Where(x => x.TenantId == tenantId);
         }
+
+        _items = await query.Take(100).ToListAsync();
 
         _totalWallets = _items.Count;
         _totalBalance = _items.Sum(x => x.Balance);
@@ -303,8 +296,10 @@ else
         try
         {
             // Get credential's TenantId
-            var credResult = await IdentityWrapper.IdentityCredential.Get(credentialId);
-            var walletTenantId = credResult?.Response?.TenantId ?? Guid.Empty;
+            var credential = await DataContext.Query<IdentityCredential>()
+                .Where(x => x.Id == credentialId)
+                .FirstOrDefaultAsync();
+            var walletTenantId = credential?.TenantId ?? Guid.Empty;
 
             var wallet = new Wallet
             {
@@ -319,9 +314,10 @@ else
                 IsEnabled = true
             };
 
-            var result = await WalletsWrapper.Wallet.Create(wallet);
+            DataContext.Add(wallet);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("Wallet created successfully.");
                 _showCreateDialog = false;
@@ -329,7 +325,7 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to create wallet: {result?.Message}");
+                ToastService.Show($"Failed to create wallet: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -348,8 +344,9 @@ else
 
         try
         {
-            var freshResult = await WalletsWrapper.Wallet.Get(wallet.Id);
-            var fresh = freshResult?.Response;
+            var fresh = await DataContext.Query<Wallet>()
+                .Where(x => x.Id == wallet.Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -367,16 +364,17 @@ else
             fresh.Status = newStatus;
             fresh.ModifiedAt = DateTime.UtcNow;
 
-            var result = await WalletsWrapper.Wallet.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show($"Wallet {(newStatus == WalletStatus.Frozen ? "frozen" : "unfrozen")} successfully.");
                 await LoadData();
             }
             else
             {
-                ToastService.Show($"Failed to update wallet: {result?.Message}");
+                ToastService.Show($"Failed to update wallet: {result.Message}");
             }
         }
         catch (Exception ex)

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WithdrawalRequests.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WithdrawalRequests.razor
@@ -1,4 +1,5 @@
 @page "/finance/withdrawal-requests"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Withdrawal Requests - Control Panel</PageTitle>
 
@@ -33,7 +34,7 @@
 </div>
 
 @code {
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private ControlPanel.Server.Services.TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<WithdrawalRequest> _items = [];
@@ -49,15 +50,13 @@
         _loading = true;
         try
         {
-            var result = await WalletsWrapper.WithdrawalRequest.GetList(
-                pageSize: 100,
-                pageNumber: 1,
-                tenantId: TenantFilter.SelectedTenantId,
-                includeNavigations: true);
-            if (result?.IsSuccess == true)
+            var query = DataContext.Query<WithdrawalRequest>();
+            if (TenantFilter.SelectedTenantId is Guid tenantId)
             {
-                _items = result.Response?.Items.ToList() ?? [];
+                query = query.Where(x => x.TenantId == tenantId);
             }
+
+            _items = await query.Take(100).ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Addresses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Addresses.razor
@@ -101,7 +101,7 @@
                      OnConfirm="@ConfirmDelete" />
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
@@ -137,8 +137,15 @@
     {
         try
         {
-            var response = await IdentityWrapper.IdentityAddress.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId);
-            _addresses = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            var query = DataContext.Query<IdentityAddress>();
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                query = query.Where(x => x.TenantId == tenantId);
+            }
+
+            _addresses = (await query.Take(100).ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch { /* query may fail */ }
     }
@@ -186,8 +193,9 @@
         {
             if (_isEditing)
             {
-                var getResponse = await IdentityWrapper.IdentityAddress.Get(_editingId);
-                var addr = getResponse?.Response;
+                var addr = await DataContext.Query<IdentityAddress>()
+                    .Where(x => x.Id == _editingId)
+                    .FirstOrDefaultAsync();
 
                 if (addr is not null)
                 {
@@ -198,8 +206,9 @@
                     addr.Subdivision = _formSubdivision;
                     addr.ConsolidatedName = _formConsolidatedName;
                     addr.ModifiedAt = DateTime.UtcNow;
-                    var result = await IdentityWrapper.IdentityAddress.Patch(addr);
-                    ToastService.Show(result?.IsSuccess == true ? "Address updated." : $"Error: {result?.Message}");
+                    DataContext.Update(addr);
+                    var result = await DataContext.SaveChangesAsync();
+                    ToastService.Show(result.IsSuccess ? "Address updated." : $"Error: {result.Message}");
                 }
             }
             else
@@ -207,6 +216,7 @@
                 var addr = new IdentityAddress
                 {
                     Id = Guid.NewGuid(),
+                    TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
                     IdentityInfoId = identityInfoId,
                     UnitNumber = _formUnitNumber,
                     Street = _formStreet,
@@ -215,8 +225,9 @@
                     ConsolidatedName = _formConsolidatedName,
                     CreatedAt = DateTime.UtcNow
                 };
-                var result = await IdentityWrapper.IdentityAddress.Create(addr);
-                ToastService.Show(result?.IsSuccess == true ? "Address created." : $"Error: {result?.Message}");
+                DataContext.Add(addr);
+                var result = await DataContext.SaveChangesAsync();
+                ToastService.Show(result.IsSuccess ? "Address created." : $"Error: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -236,8 +247,9 @@
             {
                 _deletingAddress.IsDeleted = true;
                 _deletingAddress.IsEnabled = false;
-                var result = await IdentityWrapper.IdentityAddress.Patch(_deletingAddress);
-                ToastService.Show(result?.IsSuccess == true ? "Address deleted." : $"Error: {result?.Message}");
+                DataContext.Update(_deletingAddress);
+                var result = await DataContext.SaveChangesAsync();
+                ToastService.Show(result.IsSuccess ? "Address deleted." : $"Error: {result.Message}");
             }
             catch (Exception ex)
             {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/AuthLogs.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/AuthLogs.razor
@@ -35,7 +35,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<AuthorizationLog> _logs = [];
@@ -51,8 +51,15 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.AuthorizationLog.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId);
-            _logs = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            var query = DataContext.Query<AuthorizationLog>();
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                query = query.Where(x => x.TenantId == tenantId);
+            }
+
+            _logs = (await query.Take(100).ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch { /* query may fail */ }
         finally

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Contacts.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Contacts.razor
@@ -88,7 +88,7 @@
                      OnConfirm="@ConfirmDelete" />
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
@@ -122,8 +122,16 @@
     {
         try
         {
-            var response = await IdentityWrapper.IdentityContact.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId, includeNavigations: true);
-            _contacts = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            var query = DataContext.Query<IdentityContact>()
+                .Include(x => x.Type);
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                query = query.Where(x => x.TenantId == tenantId);
+            }
+
+            _contacts = (await query.Take(100).ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch { /* query may fail */ }
     }
@@ -179,8 +187,9 @@
         {
             if (_isEditing)
             {
-                var getResponse = await IdentityWrapper.IdentityContact.Get(_editingId);
-                var contact = getResponse?.Response;
+                var contact = await DataContext.Query<IdentityContact>()
+                    .Where(x => x.Id == _editingId)
+                    .FirstOrDefaultAsync();
 
                 if (contact is not null)
                 {
@@ -189,8 +198,9 @@
                     contact.TypeId = Guid.TryParse(_formTypeId, out var typeId) ? typeId : null;
                     contact.GroupId = groupId;
                     contact.ModifiedAt = DateTime.UtcNow;
-                    var result = await IdentityWrapper.IdentityContact.Patch(contact);
-                    ToastService.Show(result?.IsSuccess == true ? "Contact updated." : $"Error: {result?.Message}");
+                    DataContext.Update(contact);
+                    var result = await DataContext.SaveChangesAsync();
+                    ToastService.Show(result.IsSuccess ? "Contact updated." : $"Error: {result.Message}");
                 }
             }
             else
@@ -198,14 +208,16 @@
                 var contact = new IdentityContact
                 {
                     Id = Guid.NewGuid(),
+                    TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
                     Value = _formValue,
                     CredentialId = credentialId,
                     TypeId = Guid.TryParse(_formTypeId, out var typeId) ? typeId : null,
                     GroupId = groupId,
                     CreatedAt = DateTime.UtcNow
                 };
-                var result = await IdentityWrapper.IdentityContact.Create(contact);
-                ToastService.Show(result?.IsSuccess == true ? "Contact created." : $"Error: {result?.Message}");
+                DataContext.Add(contact);
+                var result = await DataContext.SaveChangesAsync();
+                ToastService.Show(result.IsSuccess ? "Contact created." : $"Error: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -225,8 +237,9 @@
             {
                 _deletingContact.IsDeleted = true;
                 _deletingContact.IsEnabled = false;
-                var result = await IdentityWrapper.IdentityContact.Patch(_deletingContact);
-                ToastService.Show(result?.IsSuccess == true ? "Contact deleted." : $"Error: {result?.Message}");
+                DataContext.Update(_deletingContact);
+                var result = await DataContext.SaveChangesAsync();
+                ToastService.Show(result.IsSuccess ? "Contact deleted." : $"Error: {result.Message}");
             }
             catch (Exception ex)
             {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Credentials.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Credentials.razor
@@ -41,7 +41,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
@@ -58,8 +58,15 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityCredential.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId);
-            _credentials = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            var query = DataContext.Query<IdentityCredential>();
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                query = query.Where(x => x.TenantId == tenantId);
+            }
+
+            _credentials = (await query.Take(100).ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch { /* query may fail */ }
         finally

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Roles.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Roles.razor
@@ -92,7 +92,7 @@
                      OnConfirm="@ConfirmDelete" />
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
@@ -112,8 +112,15 @@
         try
         {
             await LoadData();
-            var roleTypeResponse = await IdentityWrapper.IdentityRoleType.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId);
-            _roleTypes = roleTypeResponse?.Response?.Items?.OrderBy(x => x.Name).ToList() ?? [];
+            var roleTypeQuery = DataContext.Query<IdentityRoleType>();
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                roleTypeQuery = roleTypeQuery.Where(x => x.TenantId == tenantId);
+            }
+
+            _roleTypes = (await roleTypeQuery.Take(100).ToListAsync())
+                .OrderBy(x => x.Name)
+                .ToList();
         }
         catch { /* query may fail */ }
         finally
@@ -126,8 +133,16 @@
     {
         try
         {
-            var response = await IdentityWrapper.IdentityRole.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId, includeNavigations: true);
-            _roles = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            var query = DataContext.Query<IdentityRole>()
+                .Include(x => x.Type);
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                query = query.Where(x => x.TenantId == tenantId);
+            }
+
+            _roles = (await query.Take(100).ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch { /* query may fail */ }
     }
@@ -162,11 +177,13 @@
                 CredentialId = credentialId,
                 TypeId = Guid.TryParse(_formTypeId, out var typeId) ? typeId : null,
                 RoleExpiration = DateTime.TryParse(_formExpiration, out var exp) ? exp : DateTime.UtcNow.AddYears(1),
+                TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
                 CreatedAt = DateTime.UtcNow
             };
 
-            var result = await IdentityWrapper.IdentityRole.Create(role);
-            ToastService.Show(result?.IsSuccess == true ? "Role created." : $"Error: {result?.Message}");
+            DataContext.Add(role);
+            var result = await DataContext.SaveChangesAsync();
+            ToastService.Show(result.IsSuccess ? "Role created." : $"Error: {result.Message}");
             _dialogOpen = false;
             await LoadData();
         }
@@ -184,8 +201,9 @@
             {
                 _deletingRole.IsDeleted = true;
                 _deletingRole.IsEnabled = false;
-                var result = await IdentityWrapper.IdentityRole.Patch(_deletingRole);
-                ToastService.Show(result?.IsSuccess == true ? "Role deleted." : $"Error: {result?.Message}");
+                DataContext.Update(_deletingRole);
+                var result = await DataContext.SaveChangesAsync();
+                ToastService.Show(result.IsSuccess ? "Role deleted." : $"Error: {result.Message}");
             }
             catch (Exception ex)
             {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Sessions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Sessions.razor
@@ -38,7 +38,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<Session> _sessions = [];
@@ -54,8 +54,15 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.Session.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId);
-            _sessions = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            var query = DataContext.Query<Session>();
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                query = query.Where(x => x.TenantId == tenantId);
+            }
+
+            _sessions = (await query.Take(100).ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch (Exception ex)
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -258,7 +258,7 @@ else
 @code {
     [Parameter] public Guid Id { get; set; }
 
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
 
@@ -305,8 +305,9 @@ else
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.Tenant.Get(Id);
-            _tenant = response?.Response;
+            _tenant = await DataContext.Query<Tenant>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
             if (_tenant is not null)
             {
                 SyncEditFields();
@@ -333,17 +334,34 @@ else
     {
         try
         {
-            var usersResponse = await IdentityWrapper.IdentityInformation.GetList(100, 1, tenantId: Id);
-            _detailUsers = usersResponse?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            _detailUsers = (await DataContext.Query<IdentityInformation>()
+                    .Where(x => x.TenantId == Id)
+                    .Take(100)
+                    .ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
 
-            var configsResponse = await IdentityWrapper.RegistryConfiguration.GetList(100, 1, tenantId: Id, includeNavigations: true);
-            _detailConfigs = configsResponse?.Response?.Items?.OrderBy(x => x.Key).ToList() ?? [];
+            _detailConfigs = (await DataContext.Query<RegistryConfiguration>()
+                    .Where(x => x.TenantId == Id)
+                    .Include(x => x.Group)
+                    .Take(100)
+                    .ToListAsync())
+                .OrderBy(x => x.Key)
+                .ToList();
 
-            var roleTypesResponse = await IdentityWrapper.IdentityRoleType.GetList(100, 1, tenantId: Id, includeNavigations: true);
-            _detailRoleTypes = roleTypesResponse?.Response?.Items?.OrderBy(x => x.Name).ToList() ?? [];
+            _detailRoleTypes = (await DataContext.Query<IdentityRoleType>()
+                    .Where(x => x.TenantId == Id)
+                    .Include(x => x.Group)
+                    .Take(100)
+                    .ToListAsync())
+                .OrderBy(x => x.Name)
+                .ToList();
 
-            var groupsResponse = await IdentityWrapper.RegistryConfigurationGroup.GetList(100, 1);
-            _configGroups = groupsResponse?.Response?.Items?.OrderBy(x => x.Name).ToList() ?? [];
+            _configGroups = (await DataContext.Query<RegistryConfigurationGroup>()
+                    .Take(100)
+                    .ToListAsync())
+                .OrderBy(x => x.Name)
+                .ToList();
         }
         catch (Exception ex) { ToastService.Show($"Failed to load tenant details: {ex.Message}"); }
     }
@@ -354,8 +372,9 @@ else
         _saving = true;
         try
         {
-            var getResponse = await IdentityWrapper.Tenant.Get(Id);
-            var tenant = getResponse?.Response;
+            var tenant = await DataContext.Query<Tenant>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
             if (tenant is null) { ToastService.Show("Tenant not found."); return; }
 
             tenant.Name = _editName;
@@ -367,9 +386,10 @@ else
             tenant.ParentTenantId = Guid.TryParse(_editParentTenantId, out var pid) ? pid : null;
             tenant.ModifiedAt = DateTime.UtcNow;
 
-            var result = await IdentityWrapper.Tenant.Patch(tenant);
-            if (result?.IsSuccess == true) { ToastService.Show("Tenant updated."); _tenant = tenant; _editableForm?.ExitEditMode(); }
-            else { ToastService.Show($"Failed: {result?.Message}"); }
+            DataContext.Update(tenant);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess) { ToastService.Show("Tenant updated."); _tenant = tenant; _editableForm?.ExitEditMode(); }
+            else { ToastService.Show($"Failed: {result.Message}"); }
         }
         catch (Exception ex) { ToastService.Show($"Error: {ex.Message}"); }
         finally { _saving = false; }
@@ -382,14 +402,16 @@ else
         if (_tenant is null) return;
         try
         {
-            var getResponse = await IdentityWrapper.Tenant.Get(Id);
-            var fresh = getResponse?.Response;
+            var fresh = await DataContext.Query<Tenant>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
             if (fresh is null) { ToastService.Show("Tenant not found."); return; }
             fresh.IsEnabled = !fresh.IsEnabled;
             fresh.ModifiedAt = DateTime.UtcNow;
-            var result = await IdentityWrapper.Tenant.Patch(fresh);
-            if (result?.IsSuccess == true) { ToastService.Show(fresh.IsEnabled ? "Tenant enabled." : "Tenant disabled."); _tenant = fresh; }
-            else { ToastService.Show($"Failed: {result?.Message}"); }
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess) { ToastService.Show(fresh.IsEnabled ? "Tenant enabled." : "Tenant disabled."); _tenant = fresh; }
+            else { ToastService.Show($"Failed: {result.Message}"); }
         }
         catch (Exception ex) { ToastService.Show($"Error: {ex.Message}"); }
     }
@@ -410,20 +432,23 @@ else
         {
             if (_isEditingConfig)
             {
-                var getResponse = await IdentityWrapper.RegistryConfiguration.Get(_editingConfigId);
-                var c = getResponse?.Response;
+                var c = await DataContext.Query<RegistryConfiguration>()
+                    .Where(x => x.Id == _editingConfigId)
+                    .FirstOrDefaultAsync();
                 if (c is null) { ToastService.Show("Not found."); return; }
                 c.Key = _configForm.Key; c.Value = _configForm.Value; c.Unit = _configForm.Unit;
                 c.GroupId = Guid.TryParse(_configForm.GroupIdString, out var gid) ? gid : c.GroupId;
                 c.ModifiedAt = DateTime.UtcNow;
-                var r = await IdentityWrapper.RegistryConfiguration.Patch(c);
-                ToastService.Show(r?.IsSuccess == true ? "Updated." : $"Error: {r?.Message}");
+                DataContext.Update(c);
+                var r = await DataContext.SaveChangesAsync();
+                ToastService.Show(r.IsSuccess ? "Updated." : $"Error: {r.Message}");
             }
             else
             {
                 var config = new RegistryConfiguration { Id = Guid.NewGuid(), Key = _configForm.Key, Value = _configForm.Value, Unit = _configForm.Unit, GroupId = Guid.TryParse(_configForm.GroupIdString, out var gid) ? gid : Guid.Empty, TenantId = Id, CreatedAt = DateTime.UtcNow, IsEnabled = true };
-                var r = await IdentityWrapper.RegistryConfiguration.Create(config);
-                ToastService.Show(r?.IsSuccess == true ? "Created." : $"Error: {r?.Message}");
+                DataContext.Add(config);
+                var r = await DataContext.SaveChangesAsync();
+                ToastService.Show(r.IsSuccess ? "Created." : $"Error: {r.Message}");
             }
             _configDialogOpen = false;
             await LoadDetailData();
@@ -439,8 +464,9 @@ else
         {
             _deletingConfig.IsDeleted = true;
             _deletingConfig.IsEnabled = false;
-            var r = await IdentityWrapper.RegistryConfiguration.Patch(_deletingConfig);
-            ToastService.Show(r?.IsSuccess == true ? "Deleted." : $"Error: {r?.Message}");
+            DataContext.Update(_deletingConfig);
+            var r = await DataContext.SaveChangesAsync();
+            ToastService.Show(r.IsSuccess ? "Deleted." : $"Error: {r.Message}");
             _deleteConfigDialogOpen = false; _deletingConfig = null;
             await LoadDetailData();
         }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
@@ -167,7 +167,7 @@
                      OnConfirm="@ConfirmDeleteTenant" />
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
 
@@ -196,11 +196,12 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.Tenant.GetList(100, 1);
-            _tenants = response?.Response?.Items?
+            _tenants = (await DataContext.Query<Tenant>()
+                    .Take(100)
+                    .ToListAsync())
                 .Where(x => !x.IsDeleted)
                 .OrderByDescending(x => x.CreatedAt)
-                .ToList() ?? [];
+                .ToList();
         }
         catch (Exception ex)
         {
@@ -252,15 +253,16 @@
                 IsEnabled = true
             };
 
-            var result = await IdentityWrapper.Tenant.Create(tenant);
+            DataContext.Add(tenant);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("Tenant created successfully.");
             }
             else
             {
-                ToastService.Show($"Failed to create tenant: {result?.Message}");
+                ToastService.Show($"Failed to create tenant: {result.Message}");
             }
 
             _tenantDialogOpen = false;
@@ -290,8 +292,9 @@
 
         try
         {
-            var getResponse = await IdentityWrapper.Tenant.Get(_deletingTenant.Id);
-            var fresh = getResponse?.Response;
+            var fresh = await DataContext.Query<Tenant>()
+                .Where(x => x.Id == _deletingTenant.Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -305,15 +308,16 @@
             fresh.DeletedAt = DateTime.UtcNow;
             fresh.ModifiedAt = DateTime.UtcNow;
 
-            var result = await IdentityWrapper.Tenant.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("Tenant deleted.");
             }
             else
             {
-                ToastService.Show($"Failed to delete tenant: {result?.Message}");
+                ToastService.Show($"Failed to delete tenant: {result.Message}");
             }
 
             _deleteDialogOpen = false;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/UserDetail.razor
@@ -635,8 +635,7 @@ else
 @code {
     [Parameter] public Guid Id { get; set; }
 
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
 
@@ -707,8 +706,9 @@ else
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityInformation.Get(Id);
-            _user = response?.Response;
+            _user = await DataContext.Query<IdentityInformation>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
 
             if (_user is null) return;
 
@@ -736,11 +736,12 @@ else
     {
         try
         {
-            var response = await IdentityWrapper.IdentityCredential.GetList(100, 1, filter:
-            [
-                new() { PropertyName = nameof(IdentityCredential.IdentityInfoId), Operation = QueryFilterOperation.Equal, Value = Id }
-            ]);
-            _credentials = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            _credentials = (await DataContext.Query<IdentityCredential>()
+                    .Where(x => x.IdentityInfoId == Id)
+                    .Take(100)
+                    .ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch { _credentials = []; }
     }
@@ -753,11 +754,12 @@ else
             _roles = [];
             foreach (var credId in credentialIds)
             {
-                var response = await IdentityWrapper.IdentityRole.GetList(100, 1, includeNavigations: true, filter:
-                [
-                    new() { PropertyName = nameof(IdentityRole.CredentialId), Operation = QueryFilterOperation.Equal, Value = credId }
-                ]);
-                _roles.AddRange(response?.Response?.Items ?? []);
+                var roles = await DataContext.Query<IdentityRole>()
+                    .Where(x => x.CredentialId == credId)
+                    .Include(x => x.Type)
+                    .Take(100)
+                    .ToListAsync();
+                _roles.AddRange(roles);
             }
             _roles = _roles.OrderByDescending(x => x.CreatedAt).ToList();
         }
@@ -772,11 +774,12 @@ else
             _contacts = [];
             foreach (var credId in credentialIds)
             {
-                var response = await IdentityWrapper.IdentityContact.GetList(100, 1, includeNavigations: true, filter:
-                [
-                    new() { PropertyName = nameof(IdentityContact.CredentialId), Operation = QueryFilterOperation.Equal, Value = credId }
-                ]);
-                _contacts.AddRange(response?.Response?.Items ?? []);
+                var contacts = await DataContext.Query<IdentityContact>()
+                    .Where(x => x.CredentialId == credId)
+                    .Include(x => x.Type)
+                    .Take(100)
+                    .ToListAsync();
+                _contacts.AddRange(contacts);
             }
             _contacts = _contacts.OrderByDescending(x => x.CreatedAt).ToList();
         }
@@ -787,11 +790,12 @@ else
     {
         try
         {
-            var response = await IdentityWrapper.IdentityAddress.GetList(100, 1, filter:
-            [
-                new() { PropertyName = nameof(IdentityAddress.IdentityInfoId), Operation = QueryFilterOperation.Equal, Value = Id }
-            ]);
-            _addresses = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            _addresses = (await DataContext.Query<IdentityAddress>()
+                    .Where(x => x.IdentityInfoId == Id)
+                    .Take(100)
+                    .ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch { _addresses = []; }
     }
@@ -804,11 +808,11 @@ else
             _sessions = [];
             foreach (var credId in credentialIds)
             {
-                var response = await IdentityWrapper.Session.GetList(100, 1, filter:
-                [
-                    new() { PropertyName = nameof(Session.CredentialId), Operation = QueryFilterOperation.Equal, Value = credId }
-                ]);
-                _sessions.AddRange(response?.Response?.Items ?? []);
+                var sessions = await DataContext.Query<Session>()
+                    .Where(x => x.CredentialId == credId)
+                    .Take(100)
+                    .ToListAsync();
+                _sessions.AddRange(sessions);
             }
             _sessions = _sessions.OrderByDescending(x => x.CreatedAt).ToList();
         }
@@ -823,11 +827,11 @@ else
             _authLogs = [];
             foreach (var credId in credentialIds)
             {
-                var response = await IdentityWrapper.AuthorizationLog.GetList(100, 1, filter:
-                [
-                    new() { PropertyName = nameof(AuthorizationLog.CredentialId), Operation = QueryFilterOperation.Equal, Value = credId }
-                ]);
-                _authLogs.AddRange(response?.Response?.Items ?? []);
+                var authLogs = await DataContext.Query<AuthorizationLog>()
+                    .Where(x => x.CredentialId == credId)
+                    .Take(100)
+                    .ToListAsync();
+                _authLogs.AddRange(authLogs);
             }
             _authLogs = _authLogs.OrderByDescending(x => x.CreatedAt).ToList();
         }
@@ -842,11 +846,11 @@ else
             _wallets = [];
             foreach (var credId in credentialIds)
             {
-                var response = await WalletsWrapper.Wallet.GetList(100, 1, filter:
-                [
-                    new() { PropertyName = nameof(Wallet.CredentialId), Operation = QueryFilterOperation.Equal, Value = credId }
-                ]);
-                _wallets.AddRange(response?.Response?.Items ?? []);
+                var wallets = await DataContext.Query<Wallet>()
+                    .Where(x => x.CredentialId == credId)
+                    .Take(100)
+                    .ToListAsync();
+                _wallets.AddRange(wallets);
             }
             _wallets = _wallets.OrderByDescending(x => x.CreatedAt).ToList();
         }
@@ -857,11 +861,17 @@ else
     {
         try
         {
-            var roleTypeResponse = await IdentityWrapper.IdentityRoleType.GetList(100, 1);
-            _roleTypes = roleTypeResponse?.Response?.Items?.OrderBy(x => x.Name).ToList() ?? [];
+            _roleTypes = (await DataContext.Query<IdentityRoleType>()
+                    .Take(100)
+                    .ToListAsync())
+                .OrderBy(x => x.Name)
+                .ToList();
 
-            var contactTypeResponse = await IdentityWrapper.IdentityContactType.GetList(100, 1);
-            _contactTypes = contactTypeResponse?.Response?.Items?.OrderBy(x => x.Name).ToList() ?? [];
+            _contactTypes = (await DataContext.Query<IdentityContactType>()
+                    .Take(100)
+                    .ToListAsync())
+                .OrderBy(x => x.Name)
+                .ToList();
         }
         catch { /* lookups may fail */ }
     }
@@ -889,8 +899,9 @@ else
         _saving = true;
         try
         {
-            var getResponse = await IdentityWrapper.IdentityInformation.Get(Id);
-            var fresh = getResponse?.Response;
+            var fresh = await DataContext.Query<IdentityInformation>()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -909,9 +920,10 @@ else
             fresh.IsVerified = _editIsVerified == "true";
             fresh.ModifiedAt = DateTime.UtcNow;
 
-            var result = await IdentityWrapper.IdentityInformation.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("User updated successfully.");
                 _user = fresh;
@@ -920,7 +932,7 @@ else
             }
             else
             {
-                ToastService.Show($"Error: {result?.Message}");
+                ToastService.Show($"Error: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -974,9 +986,10 @@ else
                 CreatedAt = DateTime.UtcNow
             };
 
-            var result = await IdentityWrapper.IdentityCredential.Create(credential);
+            DataContext.Add(credential);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("Credential created.");
                 _createCredDialogOpen = false;
@@ -984,7 +997,7 @@ else
             }
             else
             {
-                ToastService.Show($"Error: {result?.Message}");
+                ToastService.Show($"Error: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -1036,9 +1049,10 @@ else
                 CreatedAt = DateTime.UtcNow
             };
 
-            var result = await IdentityWrapper.IdentityRole.Create(role);
+            DataContext.Add(role);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("Role assigned.");
                 _assignRoleDialogOpen = false;
@@ -1046,7 +1060,7 @@ else
             }
             else
             {
-                ToastService.Show($"Error: {result?.Message}");
+                ToastService.Show($"Error: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -1073,15 +1087,16 @@ else
         {
             _removingRole.IsDeleted = true;
             _removingRole.IsEnabled = false;
-            var result = await IdentityWrapper.IdentityRole.Patch(_removingRole);
+            DataContext.Update(_removingRole);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("Role removed.");
             }
             else
             {
-                ToastService.Show($"Error: {result?.Message}");
+                ToastService.Show($"Error: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -1139,8 +1154,9 @@ else
         {
             if (_editingContact is not null)
             {
-                var getResponse = await IdentityWrapper.IdentityContact.Get(_editingContact.Id);
-                var fresh = getResponse?.Response;
+                var fresh = await DataContext.Query<IdentityContact>()
+                    .Where(x => x.Id == _editingContact.Id)
+                    .FirstOrDefaultAsync();
 
                 if (fresh is not null)
                 {
@@ -1149,8 +1165,9 @@ else
                     fresh.TypeId = Guid.TryParse(_contactForm.TypeId, out var tid) ? tid : null;
                     fresh.ModifiedAt = DateTime.UtcNow;
 
-                    var result = await IdentityWrapper.IdentityContact.Patch(fresh);
-                    ToastService.Show(result?.IsSuccess == true ? "Contact updated." : $"Error: {result?.Message}");
+                    DataContext.Update(fresh);
+                    var result = await DataContext.SaveChangesAsync();
+                    ToastService.Show(result.IsSuccess ? "Contact updated." : $"Error: {result.Message}");
                 }
             }
             else
@@ -1166,8 +1183,9 @@ else
                     CreatedAt = DateTime.UtcNow
                 };
 
-                var result = await IdentityWrapper.IdentityContact.Create(contact);
-                ToastService.Show(result?.IsSuccess == true ? "Contact created." : $"Error: {result?.Message}");
+                DataContext.Add(contact);
+                var result = await DataContext.SaveChangesAsync();
+                ToastService.Show(result.IsSuccess ? "Contact created." : $"Error: {result.Message}");
             }
 
             _contactDialogOpen = false;
@@ -1189,8 +1207,9 @@ else
         {
             contact.IsDeleted = true;
             contact.IsEnabled = false;
-            var result = await IdentityWrapper.IdentityContact.Patch(contact);
-            ToastService.Show(result?.IsSuccess == true ? "Contact deleted." : $"Error: {result?.Message}");
+            DataContext.Update(contact);
+            var result = await DataContext.SaveChangesAsync();
+            ToastService.Show(result.IsSuccess ? "Contact deleted." : $"Error: {result.Message}");
             await LoadContacts();
         }
         catch (Exception ex)
@@ -1230,8 +1249,9 @@ else
         {
             if (_editingAddress is not null)
             {
-                var getResponse = await IdentityWrapper.IdentityAddress.Get(_editingAddress.Id);
-                var fresh = getResponse?.Response;
+                var fresh = await DataContext.Query<IdentityAddress>()
+                    .Where(x => x.Id == _editingAddress.Id)
+                    .FirstOrDefaultAsync();
 
                 if (fresh is not null)
                 {
@@ -1243,8 +1263,9 @@ else
                     fresh.DefaultAddress = _addressForm.IsDefault == "true";
                     fresh.ModifiedAt = DateTime.UtcNow;
 
-                    var result = await IdentityWrapper.IdentityAddress.Patch(fresh);
-                    ToastService.Show(result?.IsSuccess == true ? "Address updated." : $"Error: {result?.Message}");
+                    DataContext.Update(fresh);
+                    var result = await DataContext.SaveChangesAsync();
+                    ToastService.Show(result.IsSuccess ? "Address updated." : $"Error: {result.Message}");
                 }
             }
             else
@@ -1264,8 +1285,9 @@ else
                     CreatedAt = DateTime.UtcNow
                 };
 
-                var result = await IdentityWrapper.IdentityAddress.Create(address);
-                ToastService.Show(result?.IsSuccess == true ? "Address created." : $"Error: {result?.Message}");
+                DataContext.Add(address);
+                var result = await DataContext.SaveChangesAsync();
+                ToastService.Show(result.IsSuccess ? "Address created." : $"Error: {result.Message}");
             }
 
             _addressDialogOpen = false;
@@ -1287,8 +1309,9 @@ else
         {
             address.IsDeleted = true;
             address.IsEnabled = false;
-            var result = await IdentityWrapper.IdentityAddress.Patch(address);
-            ToastService.Show(result?.IsSuccess == true ? "Address deleted." : $"Error: {result?.Message}");
+            DataContext.Update(address);
+            var result = await DataContext.SaveChangesAsync();
+            ToastService.Show(result.IsSuccess ? "Address deleted." : $"Error: {result.Message}");
             await LoadAddresses();
         }
         catch (Exception ex)
@@ -1303,8 +1326,9 @@ else
     {
         try
         {
-            var getResponse = await IdentityWrapper.Session.Get(session.Id);
-            var fresh = getResponse?.Response;
+            var fresh = await DataContext.Query<Session>()
+                .Where(x => x.Id == session.Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -1315,16 +1339,17 @@ else
             fresh.Status = CurrentSessionState.Inactive;
             fresh.ModifiedAt = DateTime.UtcNow;
 
-            var result = await IdentityWrapper.Session.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("Session terminated.");
                 await LoadSessions();
             }
             else
             {
-                ToastService.Show($"Error: {result?.Message}");
+                ToastService.Show($"Error: {result.Message}");
             }
         }
         catch (Exception ex)

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Users.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Users.razor
@@ -175,7 +175,7 @@
                      OnConfirm="@ConfirmDelete" />
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
@@ -203,13 +203,25 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityInformation.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId);
-            _users = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            var userQuery = DataContext.Query<IdentityInformation>();
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                userQuery = userQuery.Where(x => x.TenantId == tenantId);
+            }
+
+            _users = (await userQuery.Take(100).ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
 
             // Load credentials to map usernames
             _credentialUsernames.Clear();
-            var credResponse = await IdentityWrapper.IdentityCredential.GetList(500, 1, tenantId: TenantFilter.SelectedTenantId);
-            var credentials = credResponse?.Response?.Items ?? [];
+            var credentialQuery = DataContext.Query<IdentityCredential>();
+            if (TenantFilter.SelectedTenantId is { } credentialTenantId)
+            {
+                credentialQuery = credentialQuery.Where(x => x.TenantId == credentialTenantId);
+            }
+
+            var credentials = await credentialQuery.Take(500).ToListAsync();
             foreach (var user in _users)
             {
                 var cred = credentials.FirstOrDefault(c => c.IdentityInfoId == user.Id);
@@ -248,8 +260,9 @@
         try
         {
             // Get the first available tenant for the new user
-            var tenantResponse = await IdentityWrapper.Tenant.GetList(1, 1);
-            var tenant = tenantResponse?.Response?.Items?.FirstOrDefault();
+            var tenant = await DataContext.Query<Tenant>()
+                .Take(1)
+                .FirstOrDefaultAsync();
             if (tenant is null)
             {
                 ToastService.Show("No tenants exist. Create a tenant first.");
@@ -273,9 +286,10 @@
                 CreatedAt = DateTime.UtcNow
             };
 
-            var result = await IdentityWrapper.IdentityInformation.Create(user);
+            DataContext.Add(user);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("User created successfully.");
                 _createDialogOpen = false;
@@ -283,7 +297,7 @@
             }
             else
             {
-                ToastService.Show($"Error creating user: {result?.Message}");
+                ToastService.Show($"Error creating user: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -300,8 +314,9 @@
     {
         try
         {
-            var getResponse = await IdentityWrapper.IdentityInformation.Get(user.Id);
-            var fresh = getResponse?.Response;
+            var fresh = await DataContext.Query<IdentityInformation>()
+                .Where(x => x.Id == user.Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -311,16 +326,17 @@
 
             fresh.IsEnabled = !fresh.IsEnabled;
             fresh.ModifiedAt = DateTime.UtcNow;
-            var result = await IdentityWrapper.IdentityInformation.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show(fresh.IsEnabled ? "User enabled." : "User disabled.");
                 await LoadData();
             }
             else
             {
-                ToastService.Show($"Error: {result?.Message}");
+                ToastService.Show($"Error: {result.Message}");
             }
         }
         catch (Exception ex)
@@ -341,8 +357,9 @@
 
         try
         {
-            var getResponse = await IdentityWrapper.IdentityInformation.Get(_deletingUser.Id);
-            var fresh = getResponse?.Response;
+            var fresh = await DataContext.Query<IdentityInformation>()
+                .Where(x => x.Id == _deletingUser.Id)
+                .FirstOrDefaultAsync();
 
             if (fresh is null)
             {
@@ -354,15 +371,16 @@
             fresh.IsEnabled = false;
             fresh.DeletedAt = DateTime.UtcNow;
             fresh.ModifiedAt = DateTime.UtcNow;
-            var result = await IdentityWrapper.IdentityInformation.Patch(fresh);
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
 
-            if (result?.IsSuccess == true)
+            if (result.IsSuccess)
             {
                 ToastService.Show("User deleted.");
             }
             else
             {
-                ToastService.Show($"Error: {result?.Message}");
+                ToastService.Show($"Error: {result.Message}");
             }
         }
         catch (Exception ex)

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Verifications.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Verifications.razor
@@ -55,7 +55,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<IdentityVerification> _verifications = [];
@@ -71,8 +71,16 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityVerification.GetList(100, 1, tenantId: TenantFilter.SelectedTenantId, includeNavigations: true);
-            _verifications = response?.Response?.Items?.OrderByDescending(x => x.CreatedAt).ToList() ?? [];
+            var query = DataContext.Query<IdentityVerification>()
+                .Include(x => x.VerificationType);
+            if (TenantFilter.SelectedTenantId is { } tenantId)
+            {
+                query = query.Where(x => x.TenantId == tenantId);
+            }
+
+            _verifications = (await query.Take(100).ToListAsync())
+                .OrderByDescending(x => x.CreatedAt)
+                .ToList();
         }
         catch { /* query may fail */ }
         finally

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/AddressHierarchy.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/AddressHierarchy.razor
@@ -1,4 +1,5 @@
 @page "/lookups/address-hierarchy"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Address Hierarchy - Control Panel</PageTitle>
 
@@ -97,7 +98,7 @@ else
 }
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<AddressCountry> _countries = [];
     private List<AddressRegion> _regions = [];
@@ -111,20 +112,30 @@ else
         _loading = true;
         try
         {
-            var countriesResponse = await IdentityWrapper.AddressCountry.GetList(500, 1);
-            _countries = countriesResponse?.Response?.Items?.ToList() ?? [];
+            _countries = await DataContext.Query<AddressCountry>()
+                .NoCache()
+                .Take(500)
+                .ToListAsync();
 
-            var regionsResponse = await IdentityWrapper.AddressRegion.GetList(100, 1);
-            _regions = regionsResponse?.Response?.Items?.ToList() ?? [];
+            _regions = await DataContext.Query<AddressRegion>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
 
-            var provincesResponse = await IdentityWrapper.AddressProvince.GetList(200, 1);
-            _provinces = provincesResponse?.Response?.Items?.ToList() ?? [];
+            _provinces = await DataContext.Query<AddressProvince>()
+                .NoCache()
+                .Take(200)
+                .ToListAsync();
 
-            var citiesResponse = await IdentityWrapper.AddressCity.GetList(500, 1);
-            _cities = citiesResponse?.Response?.Items?.ToList() ?? [];
+            _cities = await DataContext.Query<AddressCity>()
+                .NoCache()
+                .Take(500)
+                .ToListAsync();
 
-            var barangaysResponse = await IdentityWrapper.AddressBarangay.GetList(500, 1);
-            _barangays = barangaysResponse?.Response?.Items?.ToList() ?? [];
+            _barangays = await DataContext.Query<AddressBarangay>()
+                .NoCache()
+                .Take(500)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/AddressTypes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/AddressTypes.razor
@@ -1,4 +1,5 @@
 @page "/lookups/address-types"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Address Types - Control Panel</PageTitle>
 
@@ -23,7 +24,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<IdentityAddressType> _items = [];
     private bool _loading = true;
@@ -33,8 +34,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityAddressType.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<IdentityAddressType>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/ConfigurationGroups.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/ConfigurationGroups.razor
@@ -1,4 +1,5 @@
 @page "/lookups/configuration-groups"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Configuration Groups - Control Panel</PageTitle>
 
@@ -24,7 +25,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<RegistryConfigurationGroup> _items = [];
     private bool _loading = true;
@@ -34,8 +35,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.RegistryConfigurationGroup.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<RegistryConfigurationGroup>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/Configurations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/Configurations.razor
@@ -1,4 +1,5 @@
 @page "/lookups/configurations"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Configurations - Control Panel</PageTitle>
 
@@ -80,7 +81,7 @@
                      OnConfirm="@DeleteConfiguration" />
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
 
     private List<RegistryConfiguration> _items = [];
@@ -106,8 +107,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.RegistryConfiguration.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<RegistryConfiguration>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {
@@ -158,12 +161,7 @@
                 GroupId = Guid.TryParse(_formGroupId, out var gid) ? gid : _editTarget.GroupId,
                 ModifiedAt = DateTime.UtcNow
             };
-            var result = await IdentityWrapper.RegistryConfiguration.Patch(entity);
-            if (result?.IsSuccess != true)
-            {
-                ToastService.Show($"Error: {result?.Message}");
-                return;
-            }
+            DataContext.Update(entity);
         }
         else
         {
@@ -176,12 +174,14 @@
                 GroupId = Guid.TryParse(_formGroupId, out var gid) ? gid : Guid.Empty,
                 CreatedAt = DateTime.UtcNow
             };
-            var result = await IdentityWrapper.RegistryConfiguration.Create(config);
-            if (result?.IsSuccess != true)
-            {
-                ToastService.Show($"Error: {result?.Message}");
-                return;
-            }
+            DataContext.Add(config);
+        }
+
+        var result = await DataContext.SaveChangesAsync();
+        if (!result.IsSuccess)
+        {
+            ToastService.Show($"Error: {result.Message}");
+            return;
         }
 
         _showFormDialog = false;
@@ -192,8 +192,9 @@
     {
         if (_deleteTarget is not null)
         {
-            var result = await IdentityWrapper.RegistryConfiguration.Delete(_deleteTarget);
-            ToastService.Show(result?.IsSuccess == true ? "Configuration deleted." : $"Error: {result?.Message}");
+            DataContext.Remove(_deleteTarget);
+            var result = await DataContext.SaveChangesAsync();
+            ToastService.Show(result.IsSuccess ? "Configuration deleted." : $"Error: {result.Message}");
             _showDeleteDialog = false;
             _deleteTarget = null;
             await LoadData();

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/ContactGroups.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/ContactGroups.razor
@@ -1,4 +1,5 @@
 @page "/lookups/contact-groups"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Contact Groups - Control Panel</PageTitle>
 
@@ -23,7 +24,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<IdentityContactGroup> _items = [];
     private bool _loading = true;
@@ -33,8 +34,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityContactGroup.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<IdentityContactGroup>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/ContactTypes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/ContactTypes.razor
@@ -1,4 +1,5 @@
 @page "/lookups/contact-types"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Contact Types - Control Panel</PageTitle>
 
@@ -23,7 +24,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<IdentityContactType> _items = [];
     private bool _loading = true;
@@ -33,8 +34,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityContactType.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<IdentityContactType>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/CurrencyTypes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/CurrencyTypes.razor
@@ -1,4 +1,5 @@
 @page "/lookups/currency-types"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Currency Types - Control Panel</PageTitle>
 
@@ -26,7 +27,7 @@
 </div>
 
 @code {
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<global::Wallets.Domain.Shared.Contracts.CurrencyType> _items = [];
     private bool _loading = true;
@@ -36,8 +37,10 @@
         _loading = true;
         try
         {
-            var response = await WalletsWrapper.CurrencyType.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<global::Wallets.Domain.Shared.Contracts.CurrencyType>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/ExchangeRates.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/ExchangeRates.razor
@@ -1,4 +1,5 @@
 @page "/lookups/exchange-rates"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Exchange Rates - Control Panel</PageTitle>
 
@@ -27,7 +28,7 @@
 </div>
 
 @code {
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<ExchangeRate> _items = [];
     private bool _loading = true;
@@ -37,8 +38,10 @@
         _loading = true;
         try
         {
-            var response = await WalletsWrapper.ExchangeRate.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<ExchangeRate>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/RoleTypeGroups.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/RoleTypeGroups.razor
@@ -1,4 +1,5 @@
 @page "/lookups/role-type-groups"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Role Type Groups - Control Panel</PageTitle>
 
@@ -24,7 +25,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<IdentityRoleTypeGroup> _items = [];
     private bool _loading = true;
@@ -34,8 +35,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityRoleTypeGroup.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<IdentityRoleTypeGroup>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/RoleTypes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/RoleTypes.razor
@@ -1,4 +1,5 @@
 @page "/lookups/role-types"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Role Types - Control Panel</PageTitle>
 
@@ -25,7 +26,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<IdentityRoleType> _items = [];
     private bool _loading = true;
@@ -35,8 +36,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityRoleType.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<IdentityRoleType>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/SessionTypes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/SessionTypes.razor
@@ -1,4 +1,5 @@
 @page "/lookups/session-types"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Session Types - Control Panel</PageTitle>
 
@@ -23,7 +24,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<SessionType> _items = [];
     private bool _loading = true;
@@ -33,8 +34,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.SessionType.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<SessionType>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/VerificationTypes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/VerificationTypes.razor
@@ -1,4 +1,5 @@
 @page "/lookups/verification-types"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Verification Types - Control Panel</PageTitle>
 
@@ -25,7 +26,7 @@
 </div>
 
 @code {
-    [Inject] private IIdentityServerServiceWrapper IdentityWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<IdentityVerificationType> _items = [];
     private bool _loading = true;
@@ -35,8 +36,10 @@
         _loading = true;
         try
         {
-            var response = await IdentityWrapper.IdentityVerificationType.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<IdentityVerificationType>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/WalletTypes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/WalletTypes.razor
@@ -1,4 +1,5 @@
 @page "/lookups/wallet-types"
+@using XFramework.Domain.Shared.DataContext
 
 <PageTitle>Wallet Types - Control Panel</PageTitle>
 
@@ -28,7 +29,7 @@
 </div>
 
 @code {
-    [Inject] private IWalletsServiceWrapper WalletsWrapper { get; set; } = default!;
+    [Inject] private IDataContext DataContext { get; set; } = default!;
 
     private List<global::Wallets.Domain.Shared.Contracts.WalletType> _items = [];
     private bool _loading = true;
@@ -38,8 +39,10 @@
         _loading = true;
         try
         {
-            var response = await WalletsWrapper.WalletType.GetList(100, 1);
-            _items = response?.Response?.Items?.ToList() ?? [];
+            _items = await DataContext.Query<global::Wallets.Domain.Shared.Contracts.WalletType>()
+                .NoCache()
+                .Take(100)
+                .ToListAsync();
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Migrates ControlPanel generic CRUD/query paths from generated wrappers to `IDataContext` across Admin, Lookups, Identity, Finance, Dashboard, and tenant selector layout.
- Keeps wrapper service registration available for business RPC flows, but removes generated CRUD wrapper call sites from `ControlPanel.Server` UI code.
- Uses `DataContext.Query<T>()`, `Add`, `Update`, `Remove`, and `SaveChangesAsync` for page-level entity work.

## Validation
- `rg (IdentityWrapper|WalletsWrapper)\.[A-Z][A-Za-z0-9]+\.(Get|GetList|Create|Update|Delete|List|Add|Remove) src\Presentation\ControlPanel.Server` returned no matches.
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj --no-restore -v:minimal /nr:false`
- `dotnet restore src\Modules\XFramework.Blazor\XFramework.Blazor.csproj`
- `dotnet build src\Modules\XFramework.Blazor\XFramework.Blazor.csproj --no-restore -v:minimal /nr:false`

## Notes
- Build warnings are existing package/source warnings on `develop` (`NU1507`, `NU1903`, `NU1510`) and existing nullable/analyzer warnings in shared Blazor code. PR #199 addresses the package source/audit warnings.