### PR TITLE
Fix PlatformAbstractions package source mapping

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,6 +6,7 @@
     </packageSources>
     <packageSourceMapping>
         <packageSource key="nuget.org">
+            <package pattern="Microsoft.DotNet.PlatformAbstractions" />
             <package pattern="*" />
         </packageSource>
         <packageSource key="dotnet-tools">


### PR DESCRIPTION
## Summary

- Map Microsoft.DotNet.PlatformAbstractions explicitly to nuget.org so package source mapping does not route it only to dotnet-tools.
- Keeps the existing package source mapping intact and narrow.

## Validation

- dotnet restore src/Tests/Bolt.Tests/Bolt.Tests.csproj --no-cache --force-evaluate with isolated packages cache
- dotnet restore src/Tests/IdentityServer.Benchmarks/IdentityServer.Benchmarks.csproj --no-cache --force-evaluate with isolated packages cache
- git diff --check

## Notes

This addresses the current develop Publish NuGet Packages restore failure for Microsoft.DotNet.PlatformAbstractions.