### PR TITLE
Restore active plans index

### DIFF
--- a/docs/plans/ACTIVE.md
+++ b/docs/plans/ACTIVE.md
@@ -1,0 +1,52 @@
+---
+status: active-index
+last_updated: 2026-06-13
+owner: ai-agents
+---
+
+# Active Plans
+
+Agents: read this file before starting or resuming non-trivial work. If the user says "continue", "pick this back up", or references unfinished work, choose the matching entry by title, status, branch, relevant files, or resume prompt, then read the linked plan before editing.
+
+## Active
+
+No active plans currently registered on develop.
+
+| Plan | Status | Branch | Last Updated | Resume Prompt |
+|---|---|---|---|---|
+
+## Blocked
+
+No blocked plans currently registered on develop.
+
+| Plan | Blocker | Branch | Last Updated | Resume Prompt |
+|---|---|---|---|---|
+
+## Draft / Pending
+
+No draft or pending plans currently registered on develop.
+
+| Plan | Status | Branch | Last Updated | Resume Prompt |
+|---|---|---|---|---|
+
+## Recently Completed
+
+| Plan | Completed | Outcome |
+|---|---|---|
+| [AI Agent Knowledgebase Refresh](2026-05-21-001-refactor-ai-agent-knowledgebase-plan.md) | 2026-05-21 | Refreshed canonical agent guidance, docs navigation, and historical guidance labeling. |
+
+## Archived / Superseded
+
+No archived or superseded active plans currently registered on develop.
+
+| Plan | Archived | Reason |
+|---|---|---|
+
+## Maintenance Rules
+
+- Add active work to Active when the plan is created or activated.
+- Move blocked work to Blocked or set its Active status to `blocked` with a blocker note.
+- Remove completed work from Active and add it to Recently Completed in the same change.
+- Remove abandoned or superseded work from Active and add it to Archived / Superseded.
+- Keep resume prompts imperative and specific enough for a fresh agent session.
+- Keep this file concise; put detailed task checklists in the linked plan file.


### PR DESCRIPTION
## Summary

- Restore docs/plans/ACTIVE.md so AGENTS.md and CLAUDE.md point at an existing resumable-work index.
- Keep the index accurate for current develop: no active, blocked, or draft plans registered; recently completed history only links to an existing plan file.

## Validation

- Listed docs/plans files including ACTIVE.md.
- Checked all local markdown links in ACTIVE.md resolve.