### PR TITLE
Fix bodyless Bolt REST request generation

### DIFF
--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -70,6 +70,7 @@
   <Folder Name="/Tests/">
     <Project Path="src\Tests\ControlPanel.E2ETests\ControlPanel.E2ETests.csproj" />
     <Project Path="src\Tests\XFramework.Core.Tests\XFramework.Core.Tests.csproj" />
+    <Project Path="src\Tests\XFramework.SourceGenerators.Tests\XFramework.SourceGenerators.Tests.csproj" />
     <Project Path="src\Tests\XFramework.TestInfrastructure\XFramework.TestInfrastructure.csproj" />
     <Project Path="src\Tests\IdentityServer.IntegrationTests\IdentityServer.IntegrationTests.csproj" />
     <Project Path="src\Tests\IdentityServer.Benchmarks\IdentityServer.Benchmarks.csproj" />

--- a/src/SourceGenerators/XFramework.SourceGenerators/BoltHandlerGenerator.cs
+++ b/src/SourceGenerators/XFramework.SourceGenerators/BoltHandlerGenerator.cs
@@ -176,6 +176,7 @@ public class BoltHandlerGenerator : ISourceGenerator
         var hasCancellationToken = false;
         var requestTypeFullName = ToGlobalQualified(requestType.ToDisplayString());
         var queryParameters = CollectQueryParameters(requestType);
+        var constructorBoundProperties = CollectConstructorBoundProperties(requestType, queryParameters);
 
         for (int i = 1; i < methodSymbol.Parameters.Length; i++)
         {
@@ -226,6 +227,7 @@ public class BoltHandlerGenerator : ISourceGenerator
             IsGenericResult = isGenericResult,
             DiParameters = diParams,
             QueryParameters = queryParameters,
+            ConstructorBoundProperties = constructorBoundProperties,
             HasCancellationToken = hasCancellationToken,
             Namespace = containingClass.ContainingNamespace.ToDisplayString(),
             HasBoltHandler = hasBolt,
@@ -269,11 +271,73 @@ public class BoltHandlerGenerator : ISourceGenerator
                 PropertyName = property.Name,
                 ParameterName = ToParameterName(property.Name),
                 ParameterTypeFullName = parameterType,
-                AssignWhenHasValue = assignWhenHasValue
+                AssignWhenHasValue = assignWhenHasValue,
+                IsInitOnly = property.SetMethod?.IsInitOnly == true,
+                DefaultValueExpression = GetDefaultValueExpression(property)
             });
         }
 
         return parameters;
+    }
+
+    private static List<string> CollectConstructorBoundProperties(
+        ITypeSymbol requestType,
+        IReadOnlyCollection<QueryParameterInfo> queryParameters)
+    {
+        if (requestType is not INamedTypeSymbol namedType || queryParameters.Count == 0)
+            return new List<string>();
+
+        var queryParametersByName = queryParameters.ToDictionary(
+            static p => p.PropertyName,
+            static p => p.PropertyName,
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var constructor in namedType.InstanceConstructors
+                     .Where(static c => c.DeclaredAccessibility == Accessibility.Public && c.Parameters.Length > 0)
+                     .OrderByDescending(static c => c.Parameters.Length))
+        {
+            var boundProperties = new List<string>();
+            var canBindConstructor = true;
+
+            foreach (var parameter in constructor.Parameters)
+            {
+                if (!queryParametersByName.TryGetValue(parameter.Name, out var propertyName))
+                {
+                    canBindConstructor = false;
+                    break;
+                }
+
+                var queryParameter = queryParameters.First(p =>
+                    string.Equals(p.PropertyName, propertyName, StringComparison.OrdinalIgnoreCase));
+                var parameterType = ToGlobalQualified(parameter.Type.ToDisplayString());
+                if (queryParameter.AssignWhenHasValue)
+                    parameterType += "?";
+
+                if (!string.Equals(parameterType, queryParameter.ParameterTypeFullName, StringComparison.Ordinal))
+                {
+                    canBindConstructor = false;
+                    break;
+                }
+
+                boundProperties.Add(queryParameter.PropertyName);
+            }
+
+            if (canBindConstructor)
+                return boundProperties;
+        }
+
+        return new List<string>();
+    }
+
+    private static string? GetDefaultValueExpression(IPropertySymbol property)
+    {
+        foreach (var syntaxReference in property.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax() is PropertyDeclarationSyntax { Initializer: { } initializer })
+                return initializer.Value.NormalizeWhitespace().ToFullString();
+        }
+
+        return null;
     }
 
     private static bool IsNullableValueType(ITypeSymbol type)
@@ -441,6 +505,45 @@ public sealed class {h.ClassName}_{h.MethodName}_BoltHandler : IBoltHandler
     private static string GenerateQueryRequestInitialization(HandlerInfo h)
     {
         var builder = new StringBuilder();
+        var constructorBoundProperties = new HashSet<string>(
+            h.ConstructorBoundProperties,
+            StringComparer.OrdinalIgnoreCase);
+        var requiresInitializer = h.QueryParameters.Any(static p => p.IsInitOnly) ||
+                                  constructorBoundProperties.Count > 0;
+
+        if (requiresInitializer)
+        {
+            var constructorArguments = h.ConstructorBoundProperties
+                .Select(propertyName => h.QueryParameters.First(p =>
+                    string.Equals(p.PropertyName, propertyName, StringComparison.OrdinalIgnoreCase)))
+                .Select(ToQueryValueExpression)
+                .ToList();
+            var initializerParameters = h.QueryParameters
+                .Where(p => !constructorBoundProperties.Contains(p.PropertyName))
+                .ToList();
+            var constructorCall = constructorArguments.Count == 0
+                ? "()"
+                : $"({string.Join(", ", constructorArguments)})";
+
+            if (initializerParameters.Count == 0)
+            {
+                builder.AppendLine($"        var request = new {h.RequestTypeFullName}{constructorCall};");
+            }
+            else
+            {
+                builder.AppendLine($"        var request = new {h.RequestTypeFullName}{constructorCall}");
+                builder.AppendLine("        {");
+                foreach (var queryParameter in initializerParameters)
+                {
+                    builder.AppendLine(
+                        $"            {queryParameter.PropertyName} = {ToQueryValueExpression(queryParameter)},");
+                }
+                builder.AppendLine("        };");
+            }
+
+            return builder.ToString();
+        }
+
         builder.AppendLine($"        var request = new {h.RequestTypeFullName}();");
 
         foreach (var queryParameter in h.QueryParameters)
@@ -458,6 +561,16 @@ public sealed class {h.ClassName}_{h.MethodName}_BoltHandler : IBoltHandler
         }
 
         return builder.ToString();
+    }
+
+    private static string ToQueryValueExpression(QueryParameterInfo queryParameter)
+    {
+        if (!queryParameter.AssignWhenHasValue)
+            return queryParameter.ParameterName;
+
+        return queryParameter.DefaultValueExpression != null
+            ? $"{queryParameter.ParameterName}.GetValueOrDefault({queryParameter.DefaultValueExpression})"
+            : $"{queryParameter.ParameterName}.GetValueOrDefault()";
     }
 
     #endregion
@@ -740,6 +853,7 @@ public static class GeneratedEndpointRoutes
         public bool IsGenericResult { get; set; }
         public List<(string TypeFullName, string Name, bool IsValidator)> DiParameters { get; set; } = new();
         public List<QueryParameterInfo> QueryParameters { get; set; } = new();
+        public List<string> ConstructorBoundProperties { get; set; } = new();
         public bool HasCancellationToken { get; set; }
         public string Namespace { get; set; } = "";
 
@@ -764,6 +878,8 @@ public static class GeneratedEndpointRoutes
         public string ParameterName { get; set; } = "";
         public string ParameterTypeFullName { get; set; } = "";
         public bool AssignWhenHasValue { get; set; }
+        public bool IsInitOnly { get; set; }
+        public string? DefaultValueExpression { get; set; }
     }
 
     #endregion

--- a/src/Tests/XFramework.SourceGenerators.Tests/BoltHandlerGeneratorTests.cs
+++ b/src/Tests/XFramework.SourceGenerators.Tests/BoltHandlerGeneratorTests.cs
@@ -1,0 +1,286 @@
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+using XFramework.SourceGenerators;
+
+namespace XFramework.SourceGenerators.Tests;
+
+[TestFixture]
+public sealed class BoltHandlerGeneratorTests
+{
+    [Test]
+    public void GenerateRestEndpoint_BodylessEndpointWithPositionalRecordRequest_UsesConstructor()
+    {
+        const string source = """
+
+namespace Sample.Features.Products.Get;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+public static class GetProductEndpoint
+{
+    [MapGet("/api/products/{id:guid}")]
+    public static Task<Result<ProductResponse>> Handle(
+        GetProductByIdRequest request,
+        ProductService productService,
+        CancellationToken ct)
+    {
+        return Task.FromResult(Result<ProductResponse>.Success(new ProductResponse()));
+    }
+}
+
+public record GetProductByIdRequest(Guid Id);
+
+public sealed class ProductResponse;
+
+public sealed class ProductService;
+""";
+
+        var generatedSource = RunGenerator(source, "GetProductEndpoint_Handle_RestEndpoint.g.cs");
+
+        generatedSource.Should().Contain(
+            "var request = new global::Sample.Features.Products.Get.GetProductByIdRequest(id.GetValueOrDefault());");
+        generatedSource.Should().NotContain("request.Id =");
+    }
+
+    [Test]
+    public void GenerateRestEndpoint_BodylessEndpointWithInitOnlyQueryRequest_UsesObjectInitializer()
+    {
+        const string source = """
+
+namespace Sample.Features.Products.GetList;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+public static class GetProductsListEndpoint
+{
+    [MapGet("/api/products")]
+    public static Task<Result<PaginatedProductResponse>> Handle(
+        GetProductsRequest request,
+        ProductService productService,
+        CancellationToken ct)
+    {
+        return Task.FromResult(Result<PaginatedProductResponse>.Success(new PaginatedProductResponse()));
+    }
+}
+
+public record GetProductsRequest
+{
+    public int Page { get; init; } = 1;
+    public int PageSize { get; init; } = 10;
+    public string? Search { get; init; }
+    public Guid? CategoryId { get; init; }
+    public bool? IsAvailable { get; init; }
+}
+
+public sealed class PaginatedProductResponse;
+
+public sealed class ProductService;
+""";
+
+        var generatedSource = RunGenerator(source, "GetProductsListEndpoint_Handle_RestEndpoint.g.cs");
+
+        generatedSource.Should().Contain("var request = new global::Sample.Features.Products.GetList.GetProductsRequest()");
+        generatedSource.Should().Contain("Page = page.GetValueOrDefault(1),");
+        generatedSource.Should().Contain("PageSize = pageSize.GetValueOrDefault(10),");
+        generatedSource.Should().Contain("Search = search,");
+        generatedSource.Should().NotContain("request.Page =");
+        generatedSource.Should().NotContain("request.Search =");
+    }
+
+    private static string RunGenerator(string source, string generatedHintName)
+    {
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        var compilation = CSharpCompilation.Create(
+            "BoltHandlerGeneratorTests",
+            [
+                CSharpSyntaxTree.ParseText(CommonStubs, parseOptions),
+                CSharpSyntaxTree.ParseText(source, parseOptions)
+            ],
+            GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var inputDiagnostics = compilation.GetDiagnostics()
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        inputDiagnostics.Should().BeEmpty();
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [new BoltHandlerGenerator()],
+            parseOptions: parseOptions);
+        driver = driver.RunGeneratorsAndUpdateCompilation(
+            compilation,
+            out var outputCompilation,
+            out var generatorDiagnostics);
+
+        generatorDiagnostics
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .Should()
+            .BeEmpty();
+
+        outputCompilation.GetDiagnostics()
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .Should()
+            .BeEmpty();
+
+        var generatedSource = driver.GetRunResult()
+            .GeneratedTrees
+            .Single(tree => tree.FilePath.EndsWith(generatedHintName, StringComparison.Ordinal))
+            .GetText()
+            .ToString();
+
+        generatedSource.Should().NotBeNullOrWhiteSpace();
+        return generatedSource;
+    }
+
+    private static IEnumerable<MetadataReference> GetMetadataReferences()
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(static assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
+            .Select(static assembly => MetadataReference.CreateFromFile(assembly.Location))
+            .DistinctBy(static reference => reference.Display);
+    }
+
+    private const string CommonStubs = """
+global using System.Threading.Tasks;
+
+using System;
+using System.Collections.Generic;
+
+namespace XFramework.Integration.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class MapGetAttribute(string route) : Attribute
+    {
+        public string Route { get; } = route;
+        public string[]? Tags { get; set; }
+        public string? Summary { get; set; }
+        public string? Description { get; set; }
+        public bool ExcludeFromOpenApi { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class MapDeleteAttribute(string route) : Attribute
+    {
+        public string Route { get; } = route;
+        public string[]? Tags { get; set; }
+        public string? Summary { get; set; }
+        public string? Description { get; set; }
+        public bool ExcludeFromOpenApi { get; set; }
+    }
+}
+
+namespace XFramework.Core.Patterns
+{
+    public class Result
+    {
+        public bool IsSuccess { get; init; } = true;
+        public int StatusCode { get; init; } = 200;
+        public string? Message { get; init; }
+    }
+
+    public sealed class Result<T> : Result
+    {
+        public T? Data { get; init; }
+
+        public static Result<T> Success(T data)
+        {
+            return new Result<T> { Data = data };
+        }
+    }
+}
+
+namespace Microsoft.AspNetCore.Routing
+{
+    public interface IEndpointRouteBuilder;
+}
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public static class EndpointRouteBuilderExtensions
+    {
+        public static RouteHandlerBuilder MapGet(
+            this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder app,
+            string pattern,
+            Delegate handler)
+        {
+            return new RouteHandlerBuilder();
+        }
+
+        public static RouteHandlerBuilder MapDelete(
+            this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder app,
+            string pattern,
+            Delegate handler)
+        {
+            return new RouteHandlerBuilder();
+        }
+    }
+
+    public sealed class RouteHandlerBuilder
+    {
+        public RouteHandlerBuilder WithName(string name) => this;
+        public RouteHandlerBuilder WithTags(params string[] tags) => this;
+        public RouteHandlerBuilder WithSummary(string summary) => this;
+        public RouteHandlerBuilder WithDescription(string description) => this;
+        public RouteHandlerBuilder ExcludeFromDescription() => this;
+    }
+}
+
+namespace Microsoft.AspNetCore.Http
+{
+    public static class TypedResults
+    {
+        public static Microsoft.AspNetCore.Http.HttpResults.Ok<T> Ok<T>(T value) => new();
+        public static Microsoft.AspNetCore.Http.HttpResults.NotFound NotFound() => new();
+
+        public static Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult Problem(
+            string? detail = null,
+            int? statusCode = null)
+        {
+            return new Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult();
+        }
+
+        public static Microsoft.AspNetCore.Http.HttpResults.ValidationProblem ValidationProblem(
+            Dictionary<string, string[]> errors)
+        {
+            return new Microsoft.AspNetCore.Http.HttpResults.ValidationProblem();
+        }
+    }
+}
+
+namespace Microsoft.AspNetCore.Http.HttpResults
+{
+    public sealed class Ok<T>;
+
+    public sealed class NotFound;
+
+    public sealed class ProblemHttpResult;
+
+    public sealed class ValidationProblem;
+
+    public sealed class Results<T1, T2, T3>
+    {
+        public static implicit operator Results<T1, T2, T3>(T1 result) => new();
+        public static implicit operator Results<T1, T2, T3>(T2 result) => new();
+        public static implicit operator Results<T1, T2, T3>(T3 result) => new();
+    }
+
+    public sealed class Results<T1, T2, T3, T4>
+    {
+        public static implicit operator Results<T1, T2, T3, T4>(T1 result) => new();
+        public static implicit operator Results<T1, T2, T3, T4>(T2 result) => new();
+        public static implicit operator Results<T1, T2, T3, T4>(T3 result) => new();
+        public static implicit operator Results<T1, T2, T3, T4>(T4 result) => new();
+    }
+}
+""";
+}

--- a/src/Tests/XFramework.SourceGenerators.Tests/XFramework.SourceGenerators.Tests.csproj
+++ b/src/Tests/XFramework.SourceGenerators.Tests/XFramework.SourceGenerators.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>14</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>XFramework.SourceGenerators.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SourceGenerators\XFramework.SourceGenerators\XFramework.SourceGenerators.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Generate bodyless Bolt REST requests with positional constructor arguments when the request record requires them.
- Generate object initializers for init-only query/route request properties while preserving default property initializers.
- Add focused Roslyn regression coverage for positional records and init-only query request records.

## Verification
- dotnet test src\\Tests\\XFramework.SourceGenerators.Tests\\XFramework.SourceGenerators.Tests.csproj -c Release -p:XFrameworkVersion=1.0.1-dev.local -p:BoltVersion=1.0.0-dev.local -m:1 /nr:false
- dotnet build src\\Modules\\XFramework.Inventario\\Inventario.Api\\Inventario.Api.csproj -c Release -p:XFrameworkVersion=1.0.1-dev.local -p:BoltVersion=1.0.0-dev.local -m:1 /nr:false
- dotnet build XFramework.slnx -c Release -p:XFrameworkVersion=1.0.1-dev.local -p:BoltVersion=1.0.0-dev.local -m:1 /nr:false