### PR TITLE
Improve ControlPanel tenant UX

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,8 +85,8 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
 
     <!-- Blazor & UI Components -->
-    <PackageVersion Include="BlazorBlueprint.Components" Version="3.9.2" />
-    <PackageVersion Include="BlazorBlueprint.Primitives" Version="3.9.2" />
+    <PackageVersion Include="BlazorBlueprint.Components" Version="3.12.0" />
+    <PackageVersion Include="BlazorBlueprint.Primitives" Version="3.12.0" />
     <PackageVersion Include="BlazorBlueprint.Icons.Lucide" Version="2.0.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Blazored.SessionStorage" Version="2.4.0" />

--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -1,10 +1,11 @@
 @inherits LayoutComponentBase
+@implements IDisposable
 @using ControlPanel.Server.Services
 @using XFramework.Domain.Shared.DataContext
 
 <div class="flex min-h-screen bg-background text-foreground">
     @* Fixed left sidebar — always visible *@
-    <aside class="w-64 shrink-0 border-r bg-sidebar text-sidebar-foreground">
+    <aside class="app-sidebar w-64 shrink-0 border-r bg-sidebar text-sidebar-foreground">
         <div class="flex flex-col h-full">
             @* Header *@
             <div class="flex items-center gap-2 px-4 h-14 border-b border-sidebar-border">
@@ -20,15 +21,15 @@
             @* Tenant selector *@
             <div class="px-3 py-2 border-b border-sidebar-border">
                 <label class="text-[10px] text-muted-foreground uppercase tracking-wider">Active Tenant</label>
-                <select class="w-full mt-1 text-xs rounded-md border border-sidebar-border bg-sidebar px-2 py-1.5 text-sidebar-foreground"
-                        @bind="_selectedTenantId"
-                        @bind:after="OnTenantChanged">
-                    <option value="">All Tenants</option>
-                    @foreach (var t in _tenants)
-                    {
-                        <option value="@t.Id">@t.Name</option>
-                    }
-                </select>
+                <BbCombobox TValue="string"
+                             Value="@_selectedTenantId"
+                             ValueChanged="@OnTenantSelectionChanged"
+                             Options="@TenantOptions"
+                             Placeholder="All Tenants"
+                             SearchPlaceholder="Search tenants..."
+                             EmptyMessage="No tenants found."
+                             Class="mt-1"
+                             MatchTriggerWidth="true" />
             </div>
 
             @* Scrollable nav *@
@@ -71,8 +72,10 @@
                 <BbThemeSwitcher />
             </div>
         </header>
-        <main class="flex-1 p-6 overflow-y-auto">
-            @Body
+        <main class="app-main flex-1 min-w-0 p-6 overflow-y-auto">
+            <FadeInContent @key="_contentRenderKey">
+                @Body
+            </FadeInContent>
         </main>
     </div>
 </div>
@@ -87,8 +90,16 @@
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<IdentityServer.Domain.Shared.Contracts.Tenant> _tenants = [];
-    private string _selectedTenantId = "";
+    private const string AllTenantsValue = "__all_tenants__";
+    private string _selectedTenantId = AllTenantsValue;
+    private int _contentRenderKey;
     private string _selectedTenantName => TenantFilter.SelectedTenantName ?? "";
+
+    private List<SelectOption<string>> TenantOptions =>
+    [
+        new(AllTenantsValue, "All Tenants"),
+        .. _tenants.Select(t => new SelectOption<string>(t.Id.ToString(), t.Name ?? t.Id.ToString()[..8]))
+    ];
 
     private List<string> GetBreadcrumbs()
     {
@@ -102,12 +113,19 @@
 
     protected override void OnInitialized()
     {
-        Nav.LocationChanged += (_, _) => InvokeAsync(StateHasChanged);
+        Nav.LocationChanged += OnLocationChanged;
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        TenantFilter.OnTenantsChanged += OnTenantsChanged;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
+        await LoadTenants();
+    }
+
+    private async Task LoadTenants()
+    {
         try
         {
             _tenants = await DataContext.Query<IdentityServer.Domain.Shared.Contracts.Tenant>()
@@ -116,13 +134,25 @@
                 .OrderBy(t => t.Name)
                 .Take(100)
                 .ToListAsync();
+
+            if (TenantFilter.SelectedTenantId is Guid selectedTenantId)
+            {
+                _selectedTenantId = selectedTenantId.ToString();
+            }
+            else
+            {
+                _selectedTenantId = AllTenantsValue;
+            }
+
             StateHasChanged();
         }
         catch { /* Tenant loading is non-critical */ }
     }
 
-    private void OnTenantChanged()
+    private void OnTenantSelectionChanged(string? value)
     {
+        _selectedTenantId = string.IsNullOrWhiteSpace(value) ? AllTenantsValue : value;
+
         if (Guid.TryParse(_selectedTenantId, out var tenantId))
         {
             var name = _tenants.FirstOrDefault(t => t.Id == tenantId)?.Name ?? "";
@@ -132,5 +162,29 @@
         {
             TenantFilter.Clear();
         }
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        _contentRenderKey++;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _contentRenderKey++;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void OnTenantsChanged()
+    {
+        _ = InvokeAsync(LoadTenants);
+    }
+
+    public void Dispose()
+    {
+        Nav.LocationChanged -= OnLocationChanged;
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+        TenantFilter.OnTenantsChanged -= OnTenantsChanged;
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Admin/ReferenceData.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Admin/ReferenceData.razor
@@ -15,22 +15,42 @@
     }
     else
     {
-    <BbTabs DefaultValue="role-types" OnValueChange="@(v => _activeTab = v ?? "role-types")">
-        <BbTabsList>
-            <BbTabsTrigger Value="role-types">Role Types</BbTabsTrigger>
-            <BbTabsTrigger Value="role-type-groups">Role Groups</BbTabsTrigger>
-            <BbTabsTrigger Value="contact-types">Contact Types</BbTabsTrigger>
-            <BbTabsTrigger Value="contact-groups">Contact Groups</BbTabsTrigger>
-            <BbTabsTrigger Value="address-types">Address Types</BbTabsTrigger>
-            <BbTabsTrigger Value="verification-types">Verification Types</BbTabsTrigger>
-            <BbTabsTrigger Value="session-types">Session Types</BbTabsTrigger>
-            <BbTabsTrigger Value="wallet-types">Wallet Types</BbTabsTrigger>
-            <BbTabsTrigger Value="currency-types">Currency Types</BbTabsTrigger>
-            <BbTabsTrigger Value="exchange-rates">Exchange Rates</BbTabsTrigger>
-        </BbTabsList>
+    <FadeInContent>
+    <BbTabs DefaultValue="role-types"
+            Orientation="BlazorBlueprint.Primitives.Tabs.TabsOrientation.Vertical"
+            OnValueChange="@OnReferenceCategoryChanged"
+            Class="reference-data-layout">
+        <div class="reference-data-sidebar">
+            <BbFormFieldInput TValue="string"
+                              @bind-Value="_categorySearch"
+                              Label="Categories"
+                              Placeholder="Search reference data" />
+            <BbTabsList Class="reference-data-nav" Responsive="false">
+                @foreach (var group in VisibleCategoryGroups)
+                {
+                    <div class="reference-data-group">@group.Key</div>
+                    @foreach (var category in group)
+                    {
+                        <BbTabsTrigger Value="@category.Value"
+                                       Label="@category.Label"
+                                       Class="reference-data-trigger">
+                            @category.Label
+                        </BbTabsTrigger>
+                    }
+                }
+            </BbTabsList>
+        </div>
+
+        <div class="reference-data-content">
+        @if (_activeTabLoading)
+        {
+            <CenteredSpinner />
+        }
+        else
+        {
 
         @* ── Role Types ── *@
-        <BbTabsContent Value="role-types">
+        <BbTabsContent Value="role-types" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Role Types</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -62,7 +82,7 @@
         </BbTabsContent>
 
         @* ── Role Type Groups ── *@
-        <BbTabsContent Value="role-type-groups">
+        <BbTabsContent Value="role-type-groups" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Role Groups</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -94,7 +114,7 @@
         </BbTabsContent>
 
         @* ── Contact Types ── *@
-        <BbTabsContent Value="contact-types">
+        <BbTabsContent Value="contact-types" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Contact Types</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -125,7 +145,7 @@
         </BbTabsContent>
 
         @* ── Contact Groups ── *@
-        <BbTabsContent Value="contact-groups">
+        <BbTabsContent Value="contact-groups" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Contact Groups</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -156,7 +176,7 @@
         </BbTabsContent>
 
         @* ── Address Types ── *@
-        <BbTabsContent Value="address-types">
+        <BbTabsContent Value="address-types" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Address Types</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -187,7 +207,7 @@
         </BbTabsContent>
 
         @* ── Verification Types ── *@
-        <BbTabsContent Value="verification-types">
+        <BbTabsContent Value="verification-types" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Verification Types</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -220,7 +240,7 @@
         </BbTabsContent>
 
         @* ── Session Types ── *@
-        <BbTabsContent Value="session-types">
+        <BbTabsContent Value="session-types" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Session Types</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -251,7 +271,7 @@
         </BbTabsContent>
 
         @* ── Wallet Types ── *@
-        <BbTabsContent Value="wallet-types">
+        <BbTabsContent Value="wallet-types" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Wallet Types</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -285,7 +305,7 @@
         </BbTabsContent>
 
         @* ── Currency Types ── *@
-        <BbTabsContent Value="currency-types">
+        <BbTabsContent Value="currency-types" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Currency Types</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -317,7 +337,7 @@
         </BbTabsContent>
 
         @* ── Exchange Rates ── *@
-        <BbTabsContent Value="exchange-rates">
+        <BbTabsContent Value="exchange-rates" Class="xf-fade-in">
             <div class="flex items-center justify-between mb-4">
                 <BbTypographyH3>Exchange Rates</BbTypographyH3>
                 <BbButton OnClick="@(() => OpenAddDialog())">
@@ -350,7 +370,10 @@
                 </Columns>
             </BbDataGrid>
         </BbTabsContent>
+        }
+        </div>
     </BbTabs>
+    </FadeInContent>
     }
 </div>
 
@@ -525,6 +548,30 @@
     private bool _deleteDialogOpen;
     private bool _isEditing;
     private string _activeTab = "role-types";
+    private bool _activeTabLoading;
+    private string _categorySearch = "";
+    private readonly HashSet<string> _loadedTabs = [];
+
+    private static readonly List<ReferenceCategory> _referenceCategories =
+    [
+        new("role-types", "Role Types", "Identity"),
+        new("role-type-groups", "Role Groups", "Identity"),
+        new("contact-types", "Contact Types", "Profile Data"),
+        new("contact-groups", "Contact Groups", "Profile Data"),
+        new("address-types", "Address Types", "Profile Data"),
+        new("verification-types", "Verification Types", "Security"),
+        new("session-types", "Session Types", "Security"),
+        new("wallet-types", "Wallet Types", "Finance"),
+        new("currency-types", "Currency Types", "Finance"),
+        new("exchange-rates", "Exchange Rates", "Finance")
+    ];
+
+    private IEnumerable<IGrouping<string, ReferenceCategory>> VisibleCategoryGroups =>
+        _referenceCategories
+            .Where(x => string.IsNullOrWhiteSpace(_categorySearch)
+                        || x.Label.Contains(_categorySearch, StringComparison.OrdinalIgnoreCase)
+                        || x.Group.Contains(_categorySearch, StringComparison.OrdinalIgnoreCase))
+            .GroupBy(x => x.Group);
 
     // Generic form fields
     private Guid _editingId;
@@ -576,17 +623,45 @@
         _ => "Record"
     };
 
+    private sealed record ReferenceCategory(string Value, string Label, string Group);
+
     protected override async Task OnInitializedAsync()
     {
         _loading = true;
         try
         {
-            await LoadAllData();
+            await ReloadActiveTab();
         }
         catch { /* Non-critical - empty tabs are fine */ }
         finally
         {
             _loading = false;
+        }
+    }
+
+    private async Task OnReferenceCategoryChanged(string? value)
+    {
+        var nextTab = string.IsNullOrWhiteSpace(value) ? "role-types" : value;
+        if (_activeTab == nextTab)
+        {
+            return;
+        }
+
+        _activeTab = nextTab;
+        if (_loadedTabs.Contains(_activeTab))
+        {
+            return;
+        }
+
+        _activeTabLoading = true;
+        await InvokeAsync(StateHasChanged);
+        try
+        {
+            await ReloadActiveTab();
+        }
+        finally
+        {
+            _activeTabLoading = false;
         }
     }
 
@@ -641,6 +716,8 @@
                     _exchangeRates = await LoadList<ExchangeRate>();
                     break;
             }
+
+            _loadedTabs.Add(_activeTab);
         }
         catch { /* reload failure is non-critical */ }
     }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
@@ -12,8 +12,22 @@ else if (_wallet is null)
 {
     <BbTypographyMuted>Wallet not found.</BbTypographyMuted>
 }
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => NavigationManager.NavigateTo("/finance/wallets"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Wallets
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Wallet Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to All Tenants or the wallet's tenant to view this record.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
 else
 {
+    <FadeInContent>
     <div class="space-y-6">
         @* Header *@
         <div class="flex items-center gap-4">
@@ -144,7 +158,7 @@ else
                         <BbTabsTrigger Value="adjust-balance">Adjust Balance</BbTabsTrigger>
                     </BbTabsList>
 
-                    <BbTabsContent Value="add-funds">
+                    <BbTabsContent Value="add-funds" Class="xf-fade-in">
                         <div class="grid gap-4 py-4 md:grid-cols-3">
                             <BbFormFieldInput TValue="string"
                                               @bind-Value="_addFundsAmount"
@@ -170,7 +184,7 @@ else
                         </BbButton>
                     </BbTabsContent>
 
-                    <BbTabsContent Value="withdraw-funds">
+                    <BbTabsContent Value="withdraw-funds" Class="xf-fade-in">
                         <div class="grid gap-4 py-4 md:grid-cols-3">
                             <BbFormFieldInput TValue="string"
                                               @bind-Value="_withdrawAmount"
@@ -196,7 +210,7 @@ else
                         </BbButton>
                     </BbTabsContent>
 
-                    <BbTabsContent Value="adjust-balance">
+                    <BbTabsContent Value="adjust-balance" Class="xf-fade-in">
                         <BbAlert Variant="AlertVariant.Warning" class="mb-4">
                             <BbAlertTitle>Warning</BbAlertTitle>
                             <BbAlertDescription>
@@ -351,6 +365,7 @@ else
             </BbCardContent>
         </BbCard>
     </div>
+    </FadeInContent>
 }
 
 @* Close Wallet Confirmation Dialog *@
@@ -382,12 +397,14 @@ else
     [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     private Wallet? _wallet;
     private List<WalletTransaction> _transactions = [];
     private bool _loading = true;
     private bool _isProcessing;
     private bool _showCloseDialog;
+    private bool _outsideTenantContext;
 
     // Add Funds form
     private string _addFundsAmount = "";
@@ -409,7 +426,10 @@ else
         try
         {
             await LoadWallet();
-            await LoadTransactions();
+            if (_wallet is not null && !_outsideTenantContext)
+            {
+                await LoadTransactions();
+            }
         }
         catch (Exception ex)
         {
@@ -423,10 +443,14 @@ else
 
     private async Task LoadWallet()
     {
+        _outsideTenantContext = false;
         _wallet = await DataContext.Query<Wallet>()
             .Include(x => x.WalletType)
             .Where(x => x.Id == Id)
             .FirstOrDefaultAsync();
+        _outsideTenantContext = _wallet is not null
+            && TenantFilter.SelectedTenantId is Guid tenantId
+            && tenantId != _wallet.TenantId;
     }
 
     private async Task LoadTransactions()

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Wallets.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Wallets.razor
@@ -10,6 +10,7 @@
 }
 else
 {
+<FadeInContent>
 <div class="space-y-6">
     <div class="flex items-center justify-between">
         <div>
@@ -80,9 +81,9 @@ else
                             @(item.AccountNumber ?? "N/A")
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridTemplateColumn Title="Credential ID" Sortable="true">
+                    <BbDataGridTemplateColumn Title="User / Credential" Sortable="true">
                         <ChildContent Context="item">
-                            <span class="font-mono text-xs">@item.CredentialId.ToString()[..8]...</span>
+                            <span class="text-sm">@GetCredentialDisplay(item.CredentialId)</span>
                         </ChildContent>
                     </BbDataGridTemplateColumn>
                     <BbDataGridTemplateColumn Title="Wallet Type">
@@ -149,6 +150,7 @@ else
         </BbCardContent>
     </BbCard>
 </div>
+</FadeInContent>
 }
 
 @* Create Wallet Dialog *@
@@ -159,11 +161,15 @@ else
             <BbDialogDescription>Create a new wallet account for a user credential.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_newCredentialId"
-                              Label="Credential ID"
-                              Placeholder="Enter credential GUID"
-                              Required="true" />
+            <BbFormFieldCombobox TValue="string"
+                                  @bind-Value="_newCredentialId"
+                                  Options="@_credentialOptions"
+                                  Label="User / Credential"
+                                  Placeholder="Select a user"
+                                  SearchPlaceholder="Search users or credentials..."
+                                  EmptyMessage="No users found."
+                                  MatchTriggerWidth="true"
+                                  Required="true" />
             <BbFormFieldSelect TValue="string"
                                @bind-Value="_newWalletTypeId"
                                Label="Wallet Type"
@@ -205,6 +211,9 @@ else
 
     private List<Wallet> _items = [];
     private List<global::Wallets.Domain.Shared.Contracts.WalletType> _walletTypes = [];
+    private List<SelectOption<string>> _credentialOptions = [];
+    private Dictionary<Guid, string> _credentialLabels = [];
+    private Dictionary<Guid, Guid> _credentialTenantIds = [];
     private bool _loading = true;
     private bool _showCreateDialog;
     private bool _isSaving;
@@ -227,7 +236,9 @@ else
         try
         {
             await LoadData();
+            await LoadCredentialOptions();
             _walletTypes = (await DataContext.Query<global::Wallets.Domain.Shared.Contracts.WalletType>()
+                    .NoCache()
                     .Take(100)
                     .ToListAsync())
                 .OrderBy(x => x.Name)
@@ -246,6 +257,7 @@ else
     private async Task LoadData()
     {
         var query = DataContext.Query<Wallet>()
+            .NoCache()
             .Include(x => x.WalletType);
 
         if (TenantFilter.SelectedTenantId is Guid tenantId)
@@ -259,6 +271,29 @@ else
         _totalBalance = _items.Sum(x => x.Balance);
         _activeWallets = _items.Count(x => x.Status == WalletStatus.Active);
         _frozenWallets = _items.Count(x => x.Status == WalletStatus.Frozen);
+    }
+
+    private async Task LoadCredentialOptions()
+    {
+        var query = DataContext.Query<IdentityCredential>()
+            .NoCache()
+            .Include(x => x.IdentityInfo)
+            .Where(x => !x.IsDeleted);
+
+        if (TenantFilter.SelectedTenantId is Guid tenantId)
+        {
+            query = query.Where(x => x.TenantId == tenantId);
+        }
+
+        var credentials = (await query.Take(250).ToListAsync())
+            .OrderBy(GetCredentialSortText)
+            .ToList();
+
+        _credentialOptions = credentials
+            .Select(x => new SelectOption<string>(x.Id.ToString(), BuildCredentialLabel(x)))
+            .ToList();
+        _credentialLabels = credentials.ToDictionary(x => x.Id, BuildCredentialLabel);
+        _credentialTenantIds = credentials.ToDictionary(x => x.Id, x => x.TenantId);
     }
 
     private string GetStatusKey(WalletStatus status) => status switch
@@ -283,7 +318,13 @@ else
     {
         if (!Guid.TryParse(_newCredentialId, out var credentialId))
         {
-            ToastService.Show("Invalid Credential ID. Please enter a valid GUID.");
+            ToastService.Show("Select a user or credential.");
+            return;
+        }
+
+        if (!_credentialTenantIds.TryGetValue(credentialId, out var walletTenantId))
+        {
+            ToastService.Show("Selected credential was not found. Refresh and try again.");
             return;
         }
 
@@ -295,12 +336,6 @@ else
         _isSaving = true;
         try
         {
-            // Get credential's TenantId
-            var credential = await DataContext.Query<IdentityCredential>()
-                .Where(x => x.Id == credentialId)
-                .FirstOrDefaultAsync();
-            var walletTenantId = credential?.TenantId ?? Guid.Empty;
-
             var wallet = new Wallet
             {
                 Id = Guid.NewGuid(),
@@ -322,6 +357,7 @@ else
                 ToastService.Show("Wallet created successfully.");
                 _showCreateDialog = false;
                 await LoadData();
+                await LoadCredentialOptions();
             }
             else
             {
@@ -381,5 +417,38 @@ else
         {
             ToastService.Show($"Error updating wallet: {ex.Message}");
         }
+    }
+
+    private string GetCredentialDisplay(Guid credentialId) =>
+        _credentialLabels.TryGetValue(credentialId, out var label)
+            ? label
+            : $"{credentialId.ToString()[..8]}...";
+
+    private static string GetCredentialSortText(IdentityCredential credential) =>
+        credential.IdentityInfo?.FullName
+        ?? credential.IdentityInfo?.IdentityName
+        ?? credential.UserName
+        ?? credential.UserAlias
+        ?? credential.Id.ToString();
+
+    private static string BuildCredentialLabel(IdentityCredential credential)
+    {
+        var displayName = credential.IdentityInfo?.FullName;
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = credential.IdentityInfo?.IdentityName;
+        }
+
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = credential.UserName ?? credential.UserAlias ?? "Unnamed user";
+        }
+
+        var credentialName = credential.UserName ?? credential.UserAlias;
+        var suffix = string.IsNullOrWhiteSpace(credentialName)
+            ? credential.Id.ToString()[..8]
+            : $"{credentialName} - {credential.Id.ToString()[..8]}";
+
+        return $"{displayName} ({suffix})";
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Roles.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Roles.razor
@@ -20,9 +20,14 @@
     }
     else
     {
+    <FadeInContent>
     <BbDataGrid Items="@_roles">
         <Columns>
-            <BbDataGridPropertyColumn Property="@(x => x.CredentialId)" Title="Credential ID" Sortable="true" />
+            <BbDataGridTemplateColumn Title="User / Credential" Sortable="true">
+                <ChildContent Context="item">
+                    <span class="text-sm">@GetCredentialDisplay(item.CredentialId)</span>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
             <BbDataGridTemplateColumn Title="Role Type">
                 <ChildContent Context="item">
                     @(item.Type?.Name ?? item.TypeId?.ToString() ?? "N/A")
@@ -40,6 +45,7 @@
             </BbDataGridTemplateColumn>
         </Columns>
     </BbDataGrid>
+    </FadeInContent>
     }
 </div>
 
@@ -50,11 +56,15 @@
             <BbDialogDescription>Assign a role to a credential.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_formCredentialId"
-                              Label="Credential ID"
-                              Placeholder="Enter credential GUID"
-                              Required="true" />
+            <BbFormFieldCombobox TValue="string"
+                                  @bind-Value="_formCredentialId"
+                                  Options="@_credentialOptions"
+                                  Label="User / Credential"
+                                  Placeholder="Select a user"
+                                  SearchPlaceholder="Search users or credentials..."
+                                  EmptyMessage="No users found."
+                                  MatchTriggerWidth="true"
+                                  Required="true" />
             @if (_roleTypes.Count == 0)
             {
                 <div>
@@ -64,16 +74,15 @@
             }
             else
             {
-                <BbFormFieldNativeSelect TValue="string"
-                                         @bind-Value="_formTypeId"
-                                         Label="Role Type"
-                                         Placeholder="Select role type">
-                    <option value="">Select role type</option>
+                <BbFormFieldSelect TValue="string"
+                                   @bind-Value="_formTypeId"
+                                   Label="Role Type"
+                                   Placeholder="Select role type">
                     @foreach (var rt in _roleTypes)
                     {
-                        <option value="@rt.Id">@rt.Name (Level @rt.RoleLevel)</option>
+                        <BbSelectItem Value="@rt.Id.ToString()">@rt.Name (Level @rt.RoleLevel)</BbSelectItem>
                     }
-                </BbFormFieldNativeSelect>
+                </BbFormFieldSelect>
             }
             <BbFormFieldInput TValue="string"
                               @bind-Value="_formExpiration"
@@ -98,6 +107,9 @@
 
     private List<IdentityRole> _roles = [];
     private List<IdentityRoleType> _roleTypes = [];
+    private List<SelectOption<string>> _credentialOptions = [];
+    private Dictionary<Guid, string> _credentialLabels = [];
+    private Dictionary<Guid, Guid> _credentialTenantIds = [];
     private bool _loading = true;
     private bool _dialogOpen;
     private bool _deleteDialogOpen;
@@ -112,15 +124,8 @@
         try
         {
             await LoadData();
-            var roleTypeQuery = DataContext.Query<IdentityRoleType>();
-            if (TenantFilter.SelectedTenantId is { } tenantId)
-            {
-                roleTypeQuery = roleTypeQuery.Where(x => x.TenantId == tenantId);
-            }
-
-            _roleTypes = (await roleTypeQuery.Take(100).ToListAsync())
-                .OrderBy(x => x.Name)
-                .ToList();
+            await LoadCredentialOptions();
+            await LoadRoleTypes();
         }
         catch { /* query may fail */ }
         finally
@@ -134,6 +139,7 @@
         try
         {
             var query = DataContext.Query<IdentityRole>()
+                .NoCache()
                 .Include(x => x.Type);
             if (TenantFilter.SelectedTenantId is { } tenantId)
             {
@@ -145,6 +151,43 @@
                 .ToList();
         }
         catch { /* query may fail */ }
+    }
+
+    private async Task LoadRoleTypes()
+    {
+        var roleTypeQuery = DataContext.Query<IdentityRoleType>()
+            .NoCache();
+        if (TenantFilter.SelectedTenantId is { } tenantId)
+        {
+            roleTypeQuery = roleTypeQuery.Where(x => x.TenantId == tenantId);
+        }
+
+        _roleTypes = (await roleTypeQuery.Take(100).ToListAsync())
+            .OrderBy(x => x.Name)
+            .ToList();
+    }
+
+    private async Task LoadCredentialOptions()
+    {
+        var query = DataContext.Query<IdentityCredential>()
+            .NoCache()
+            .Include(x => x.IdentityInfo)
+            .Where(x => !x.IsDeleted);
+
+        if (TenantFilter.SelectedTenantId is { } tenantId)
+        {
+            query = query.Where(x => x.TenantId == tenantId);
+        }
+
+        var credentials = (await query.Take(250).ToListAsync())
+            .OrderBy(GetCredentialSortText)
+            .ToList();
+
+        _credentialOptions = credentials
+            .Select(x => new SelectOption<string>(x.Id.ToString(), BuildCredentialLabel(x)))
+            .ToList();
+        _credentialLabels = credentials.ToDictionary(x => x.Id, BuildCredentialLabel);
+        _credentialTenantIds = credentials.ToDictionary(x => x.Id, x => x.TenantId);
     }
 
     private void OpenAddDialog()
@@ -165,7 +208,13 @@
     {
         if (!Guid.TryParse(_formCredentialId, out var credentialId))
         {
-            ToastService.Show("Invalid Credential ID.");
+            ToastService.Show("Select a user or credential.");
+            return;
+        }
+
+        if (!_credentialTenantIds.TryGetValue(credentialId, out var roleTenantId))
+        {
+            ToastService.Show("Selected credential was not found. Refresh and try again.");
             return;
         }
 
@@ -177,7 +226,7 @@
                 CredentialId = credentialId,
                 TypeId = Guid.TryParse(_formTypeId, out var typeId) ? typeId : null,
                 RoleExpiration = DateTime.TryParse(_formExpiration, out var exp) ? exp : DateTime.UtcNow.AddYears(1),
-                TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
+                TenantId = roleTenantId,
                 CreatedAt = DateTime.UtcNow
             };
 
@@ -186,6 +235,7 @@
             ToastService.Show(result.IsSuccess ? "Role created." : $"Error: {result.Message}");
             _dialogOpen = false;
             await LoadData();
+            await LoadCredentialOptions();
         }
         catch (Exception ex)
         {
@@ -216,5 +266,38 @@
                 await LoadData();
             }
         }
+    }
+
+    private string GetCredentialDisplay(Guid credentialId) =>
+        _credentialLabels.TryGetValue(credentialId, out var label)
+            ? label
+            : $"{credentialId.ToString()[..8]}...";
+
+    private static string GetCredentialSortText(IdentityCredential credential) =>
+        credential.IdentityInfo?.FullName
+        ?? credential.IdentityInfo?.IdentityName
+        ?? credential.UserName
+        ?? credential.UserAlias
+        ?? credential.Id.ToString();
+
+    private static string BuildCredentialLabel(IdentityCredential credential)
+    {
+        var displayName = credential.IdentityInfo?.FullName;
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = credential.IdentityInfo?.IdentityName;
+        }
+
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = credential.UserName ?? credential.UserAlias ?? "Unnamed user";
+        }
+
+        var credentialName = credential.UserName ?? credential.UserAlias;
+        var suffix = string.IsNullOrWhiteSpace(credentialName)
+            ? credential.Id.ToString()[..8]
+            : $"{credentialName} - {credential.Id.ToString()[..8]}";
+
+        return $"{displayName} ({suffix})";
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -6,6 +6,19 @@
 {
     <CenteredSpinner />
 }
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/identity/tenants"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Tenants
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Tenant Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to All Tenants or this tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
 else if (_tenant is null)
 {
     <div class="space-y-4">
@@ -21,6 +34,7 @@ else if (_tenant is null)
 }
 else
 {
+    <FadeInContent>
     <div class="space-y-6">
 
         @* -- Header -- *@
@@ -55,7 +69,7 @@ else
                 <BbTabsTrigger Value="roletypes">Role Types (@_detailRoleTypes.Count)</BbTabsTrigger>
             </BbTabsList>
 
-            <BbTabsContent Value="summary">
+            <BbTabsContent Value="summary" Class="xf-fade-in">
                 <EditableForm @ref="_editableForm" TModel="Tenant" Model="_tenant"
                               OnSave="SaveTenant" OnDiscard="DiscardTenantEdit"
                               Saving="_saving" Title="Tenant Summary">
@@ -90,7 +104,7 @@ else
                 </EditableForm>
             </BbTabsContent>
 
-            <BbTabsContent Value="users">
+            <BbTabsContent Value="users" Class="xf-fade-in">
                 <BbCard>
                     <BbCardContent>
                         @if (_detailUsers.Count == 0)
@@ -119,7 +133,7 @@ else
                 </BbCard>
             </BbTabsContent>
 
-            <BbTabsContent Value="configurations">
+            <BbTabsContent Value="configurations" Class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -175,7 +189,7 @@ else
                 </BbCard>
             </BbTabsContent>
 
-            <BbTabsContent Value="roletypes">
+            <BbTabsContent Value="roletypes" Class="xf-fade-in">
                 <BbCard>
                     <BbCardContent>
                         @if (_detailRoleTypes.Count == 0)
@@ -212,6 +226,7 @@ else
             </BbTabsContent>
         </BbTabs>
     </div>
+    </FadeInContent>
 }
 
 @* -- Add / Edit Configuration Dialog -- *@
@@ -261,10 +276,12 @@ else
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     private Tenant? _tenant;
     private bool _loading;
     private bool _saving;
+    private bool _outsideTenantContext;
     private EditableForm<Tenant>? _editableForm;
 
     // -- Editable fields --
@@ -305,6 +322,16 @@ else
         _loading = true;
         try
         {
+            _outsideTenantContext = TenantFilter.SelectedTenantId is Guid tenantId && tenantId != Id;
+            if (_outsideTenantContext)
+            {
+                _tenant = null;
+                _detailUsers = [];
+                _detailConfigs = [];
+                _detailRoleTypes = [];
+                return;
+            }
+
             _tenant = await DataContext.Query<Tenant>()
                 .Where(x => x.Id == Id)
                 .FirstOrDefaultAsync();

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
@@ -23,6 +23,7 @@
     }
     else
     {
+    <FadeInContent>
     <BbCard>
         <BbCardHeader>
             <BbCardTitle>Tenants</BbCardTitle>
@@ -98,6 +99,7 @@
             </BbDataGrid>
         </BbCardContent>
     </BbCard>
+    </FadeInContent>
     }
 </div>
 
@@ -123,14 +125,14 @@
                                   @bind-Value="_tenantForm.VersionString"
                                   Label="Version"
                                   Placeholder="1.0" />
-                <BbFormFieldNativeSelect TValue="string"
-                                         @bind-Value="_tenantForm.StatusString"
-                                         Label="Status">
-                    <option value="0">Pending</option>
-                    <option value="1">Active</option>
-                    <option value="2">Suspended</option>
-                    <option value="3">Inactive</option>
-                </BbFormFieldNativeSelect>
+                <BbFormFieldSelect TValue="string"
+                                   @bind-Value="_tenantForm.StatusString"
+                                   Label="Status">
+                    <BbSelectItem Value="0">Pending</BbSelectItem>
+                    <BbSelectItem Value="1">Active</BbSelectItem>
+                    <BbSelectItem Value="2">Suspended</BbSelectItem>
+                    <BbSelectItem Value="3">Inactive</BbSelectItem>
+                </BbFormFieldSelect>
             </div>
             <div class="grid grid-cols-2 gap-4">
                 <BbFormFieldInput TValue="string"
@@ -170,6 +172,7 @@
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     // -- Tenant list state --
     private List<Tenant> _tenants = [];
@@ -196,12 +199,12 @@
         _loading = true;
         try
         {
-            _tenants = (await DataContext.Query<Tenant>()
-                    .Take(100)
-                    .ToListAsync())
+            _tenants = await DataContext.Query<Tenant>()
+                .NoCache()
                 .Where(x => !x.IsDeleted)
                 .OrderByDescending(x => x.CreatedAt)
-                .ToList();
+                .Take(100)
+                .ToListAsync();
         }
         catch (Exception ex)
         {
@@ -258,15 +261,26 @@
 
             if (result.IsSuccess)
             {
+                var createdTenant = await DataContext.Query<Tenant>()
+                    .NoCache()
+                    .Where(x => x.Id == tenantId)
+                    .FirstOrDefaultAsync();
+
+                if (createdTenant is null || createdTenant.IsDeleted)
+                {
+                    ToastService.Show("Tenant save completed, but the tenant could not be reloaded.");
+                    return;
+                }
+
                 ToastService.Show("Tenant created successfully.");
+                _tenantDialogOpen = false;
+                await LoadTenants();
+                TenantFilter.NotifyTenantsChanged();
             }
             else
             {
                 ToastService.Show($"Failed to create tenant: {result.Message}");
             }
-
-            _tenantDialogOpen = false;
-            await LoadTenants();
         }
         catch (Exception ex)
         {
@@ -314,6 +328,7 @@
             if (result.IsSuccess)
             {
                 ToastService.Show("Tenant deleted.");
+                TenantFilter.NotifyTenantsChanged();
             }
             else
             {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/UserDetail.razor
@@ -20,8 +20,22 @@ else if (_user is null)
         </BbAlert>
     </div>
 }
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/identity/users"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Users
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>User Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to All Tenants or the user's tenant to view this record.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
 else
 {
+    <FadeInContent>
     <div class="space-y-6">
         <!-- Header -->
         <div class="flex items-center justify-between">
@@ -61,7 +75,7 @@ else
             </BbTabsList>
 
             <!-- User Info Tab -->
-            <BbTabsContent Value="info">
+            <BbTabsContent Value="info" Class="xf-fade-in">
                 <EditableForm @ref="_editableForm" TModel="IdentityInformation" Model="_user"
                               OnSave="SaveUserEdit" OnDiscard="DiscardUserEdit"
                               Saving="_saving" Title="User Information">
@@ -92,7 +106,7 @@ else
             </BbTabsContent>
 
             <!-- Credentials Tab -->
-            <BbTabsContent Value="credentials">
+            <BbTabsContent Value="credentials" Class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -135,7 +149,7 @@ else
             </BbTabsContent>
 
             <!-- Roles Tab -->
-            <BbTabsContent Value="roles">
+            <BbTabsContent Value="roles" Class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -197,7 +211,7 @@ else
             </BbTabsContent>
 
             <!-- Contacts Tab -->
-            <BbTabsContent Value="contacts">
+            <BbTabsContent Value="contacts" Class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -247,7 +261,7 @@ else
             </BbTabsContent>
 
             <!-- Addresses Tab -->
-            <BbTabsContent Value="addresses">
+            <BbTabsContent Value="addresses" Class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -294,7 +308,7 @@ else
             </BbTabsContent>
 
             <!-- Sessions Tab -->
-            <BbTabsContent Value="sessions">
+            <BbTabsContent Value="sessions" Class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <BbCardTitle>Sessions</BbCardTitle>
@@ -359,7 +373,7 @@ else
             </BbTabsContent>
 
             <!-- Auth Logs Tab -->
-            <BbTabsContent Value="auth-logs">
+            <BbTabsContent Value="auth-logs" Class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <BbCardTitle>Authorization Logs</BbCardTitle>
@@ -393,7 +407,7 @@ else
             </BbTabsContent>
 
             <!-- Wallets Tab -->
-            <BbTabsContent Value="wallets">
+            <BbTabsContent Value="wallets" Class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <BbCardTitle>Wallets</BbCardTitle>
@@ -457,6 +471,7 @@ else
             </BbTabsContent>
         </BbTabs>
     </div>
+    </FadeInContent>
 }
 
 <!-- Create Credential Dialog -->
@@ -638,6 +653,7 @@ else
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     // Main data
     private IdentityInformation? _user;
@@ -656,6 +672,7 @@ else
     // State
     private bool _loading = true;
     private bool _saving;
+    private bool _outsideTenantContext;
 
     // Editable form
     private EditableForm<IdentityInformation>? _editableForm;
@@ -706,11 +723,18 @@ else
         _loading = true;
         try
         {
+            _outsideTenantContext = false;
             _user = await DataContext.Query<IdentityInformation>()
                 .Where(x => x.Id == Id)
                 .FirstOrDefaultAsync();
 
             if (_user is null) return;
+            _outsideTenantContext = TenantFilter.SelectedTenantId is Guid tenantId && tenantId != _user.TenantId;
+            if (_outsideTenantContext)
+            {
+                ClearChildData();
+                return;
+            }
 
             SyncEditFields();
             await LoadCredentials();
@@ -730,6 +754,17 @@ else
         {
             _loading = false;
         }
+    }
+
+    private void ClearChildData()
+    {
+        _credentials = [];
+        _roles = [];
+        _contacts = [];
+        _addresses = [];
+        _sessions = [];
+        _authLogs = [];
+        _wallets = [];
     }
 
     private async Task LoadCredentials()

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Users.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Users.razor
@@ -26,6 +26,7 @@
     }
     else
     {
+        <FadeInContent>
         <BbCard>
             <BbCardHeader>
                 <BbCardTitle>All Users (@_users.Count)</BbCardTitle>
@@ -99,6 +100,7 @@
                 </BbDataGrid>
             </BbCardContent>
         </BbCard>
+        </FadeInContent>
     }
 </div>
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/Configurations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Lookups/Configurations.razor
@@ -18,6 +18,7 @@
     }
     else
     {
+    <FadeInContent>
     <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
         <Columns>
             <BbDataGridPropertyColumn Property="@(x => x.Key)" Title="Key" Sortable="true" />
@@ -41,6 +42,7 @@
             </BbDataGridTemplateColumn>
         </Columns>
     </BbDataGrid>
+    </FadeInContent>
     }
 </div>
 

--- a/src/Presentation/ControlPanel.Server/Components/Shared/FadeInContent.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/FadeInContent.razor
@@ -1,0 +1,12 @@
+<div class="@CssClass">
+    @ChildContent
+</div>
+
+@code {
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public string? Class { get; set; }
+
+    private string CssClass => string.IsNullOrWhiteSpace(Class)
+        ? "xf-fade-in"
+        : $"xf-fade-in {Class}";
+}

--- a/src/Presentation/ControlPanel.Server/Services/TenantFilterService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/TenantFilterService.cs
@@ -10,6 +10,7 @@ public class TenantFilterService
     public string? SelectedTenantName { get; private set; }
 
     public event Action? OnChanged;
+    public event Action? OnTenantsChanged;
 
     public void SetTenant(Guid? tenantId, string? tenantName)
     {
@@ -24,4 +25,6 @@ public class TenantFilterService
         SelectedTenantName = null;
         OnChanged?.Invoke();
     }
+
+    public void NotifyTenantsChanged() => OnTenantsChanged?.Invoke();
 }

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -8,3 +8,83 @@
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
 }
+
+@keyframes xf-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.xf-fade-in {
+    animation: xf-fade-in 500ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .xf-fade-in {
+        animation: none;
+    }
+}
+
+.reference-data-layout {
+    display: grid;
+    grid-template-columns: minmax(12rem, 14rem) minmax(0, 1fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.reference-data-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-width: 0;
+}
+
+.reference-data-nav {
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: stretch !important;
+    height: auto !important;
+    max-width: 100%;
+    min-width: 0;
+    overflow: visible !important;
+}
+
+.reference-data-group {
+    padding: 0.5rem 0.75rem 0.25rem;
+    color: var(--muted-foreground);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.reference-data-trigger {
+    justify-content: flex-start !important;
+    min-width: 0 !important;
+    white-space: normal !important;
+    width: 100%;
+}
+
+.reference-data-content {
+    min-width: 0;
+}
+
+@media (max-width: 768px) {
+    .app-sidebar {
+        width: 12rem;
+    }
+
+    .app-main {
+        padding: 0.75rem;
+    }
+
+    .reference-data-layout {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/SourceGenerators/XFramework.SourceGenerators/ServiceWrapperGenerator.cs
+++ b/src/SourceGenerators/XFramework.SourceGenerators/ServiceWrapperGenerator.cs
@@ -132,6 +132,9 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
                             {
                                 if (string.IsNullOrEmpty(TargetClient)) Initialize();
                                 var (status, data) = await boltClient.InvokeAsync(TargetClient, "__db_query__", queryDescriptorBytes, ct);
+                                if ((int)status < 200 || (int)status >= 300)
+                                    throw new System.InvalidOperationException($"DataContext query request failed with status {(int)status} ({status}).");
+
                                 return data.ToArray();
                             }
 
@@ -139,6 +142,12 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
                             {
                                 if (string.IsNullOrEmpty(TargetClient)) Initialize();
                                 var (status, data) = await boltClient.InvokeAsync(TargetClient, "__db_changes__", saveChangesRequestBytes, ct);
+                                if ((int)status < 200 || (int)status >= 300)
+                                {
+                                    var failure = DataContextResult.Failure($"DataContext change request failed with status {(int)status} ({status}).", (int)status);
+                                    return MemoryPack.MemoryPackSerializer.Serialize(failure);
+                                }
+
                                 return data.ToArray();
                             }
 


### PR DESCRIPTION
## Summary
- update BlazorBlueprint Components/Primitives to 3.12.0 and keep Lucide icons at 2.0.0
- add shared 500ms fade-in content wrapper with reduced-motion handling
- replace the sidebar tenant selector with a BlazorBlueprint combobox and force page remount/reload on tenant changes
- improve tenant create/list reload behavior and prevent false success when a saved tenant cannot be reloaded
- replace wallet/role credential GUID fields with searchable user/credential comboboxes
- revamp Reference Data from horizontal tabs to compact grouped vertical navigation
- add tenant-context empty states to user, tenant, and wallet detail pages
- make generated DataContext wrapper calls respect non-2xx Bolt statuses

## Verification
- dotnet restore
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false
- dotnet build src/Modules/XFramework.Blazor/XFramework.Blazor.csproj -m:1 /nr:false
- browser smoke on http://localhost:5001 for tenant selector styling, Reference Data desktop/narrow layout, Roles create dialog, Wallet create dialog, and tenant create feedback

## Notes
- Browser smoke against the current xeon-dev backend still could not reload a newly created disposable tenant. The UI now reports that clearly instead of showing success with an empty list. SSH/Docker inspection of xeon-dev timed out from this shell, so I could not confirm whether the row reached Postgres.