### PR TITLE
Deploy ControlPanel on xeon-dev

### DIFF
--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -66,6 +66,7 @@ jobs:
             "messaging=http://localhost:5148/health/ready"
             "smsgateway=http://localhost:5274/health/ready"
             "wallets=http://localhost:9696/health/ready"
+            "controlpanel=http://localhost:5000/health/ready"
           )
 
           for check in "${checks[@]}"; do
@@ -98,4 +99,4 @@ jobs:
         shell: bash
         run: |
           docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps || true
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 migrate bolt-hub identityserver messaging smsgateway wallets || true
+          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 migrate bolt-hub identityserver messaging smsgateway wallets controlpanel || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,31 @@ services:
       retries: 15
       start_period: 15s
 
+  # ── Control Panel ───────────────────────────────────────────
+  controlpanel:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT_PATH: src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
+    environment:
+      <<: *common-env
+    ports:
+      - "${CONTROLPANEL_EXPOSE_PORT:-5000}:8080"
+    depends_on:
+      bolt-hub:
+        condition: service_healthy
+      identityserver:
+        condition: service_healthy
+      wallets:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 15s
+
   # ── Seq (structured log aggregator) ──────────────────────────
   seq:
     image: datalust/seq:2025

--- a/src/Presentation/ControlPanel.Server/Health/BoltClientHealthCheck.cs
+++ b/src/Presentation/ControlPanel.Server/Health/BoltClientHealthCheck.cs
@@ -1,0 +1,18 @@
+using Bolt.Client;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ControlPanel.Server.Health;
+
+public sealed class BoltClientHealthCheck(BoltClient client) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var result = client.IsConnected
+            ? HealthCheckResult.Healthy("ControlPanel is connected to Bolt.")
+            : HealthCheckResult.Unhealthy("ControlPanel is not connected to Bolt.");
+
+        return Task.FromResult(result);
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -1,8 +1,12 @@
+using System.Text.Json;
 using BlazorBlueprint.Components;
-using XFramework.Integration.Extensions;
+using ControlPanel.Server.Health;
 using IdentityServer.Integration.Drivers;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Wallets.Integration.Drivers;
 using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Integration.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,6 +31,16 @@ builder.Services.AddBlazorBlueprintComponents(configureTheme: options =>
 // Bolt — thin binary RPC transport to microservices
 builder.Services.AddXFrameworkBoltClient(builder.Configuration);
 
+builder.Services.AddHealthChecks()
+    .AddCheck(
+        "controlpanel-live",
+        () => HealthCheckResult.Healthy("ControlPanel is running."),
+        tags: ["live"])
+    .AddCheck<BoltClientHealthCheck>(
+        "controlpanel-bolt",
+        failureStatus: HealthStatus.Unhealthy,
+        tags: ["ready"]);
+
 // Service wrappers — auto-generated CRUD + custom operations for each microservice
 builder.Services.AddIdentityServerWrapperServices();
 builder.Services.AddWalletsWrapperServices();
@@ -48,8 +62,74 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseAntiforgery();
 
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+    ResponseWriter = WriteHealthResponse,
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status200OK,
+        [HealthStatus.Degraded] = StatusCodes.Status200OK,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    }
+});
+
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("live"),
+    ResponseWriter = WriteHealthResponse,
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status200OK,
+        [HealthStatus.Degraded] = StatusCodes.Status200OK,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    }
+});
+
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready"),
+    ResponseWriter = WriteHealthResponse,
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status200OK,
+        [HealthStatus.Degraded] = StatusCodes.Status503ServiceUnavailable,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    }
+});
+
 app.MapStaticAssets();
 app.MapRazorComponents<ControlPanel.Server.Components.App>()
     .AddInteractiveServerRenderMode();
 
 app.Run();
+
+static async Task WriteHealthResponse(HttpContext context, HealthReport report)
+{
+    context.Response.ContentType = "application/json";
+
+    var response = new
+    {
+        status = report.Status.ToString(),
+        duration = report.TotalDuration.TotalMilliseconds,
+        timestamp = DateTime.UtcNow,
+        checks = report.Entries.Select(entry => new
+        {
+            name = entry.Key,
+            status = entry.Value.Status.ToString(),
+            description = entry.Value.Description,
+            duration = entry.Value.Duration.TotalMilliseconds,
+            tags = entry.Value.Tags,
+            data = entry.Value.Data,
+            exception = entry.Value.Exception?.Message
+        })
+    };
+
+    await context.Response.WriteAsync(
+        JsonSerializer.Serialize(
+            response,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            }));
+}

--- a/src/Presentation/ControlPanel.Server/appsettings.Docker.json
+++ b/src/Presentation/ControlPanel.Server/appsettings.Docker.json
@@ -1,0 +1,8 @@
+{
+  "BoltConfiguration": {
+    "ServerUrls": ["ws://bolt-hub:8080/bolt/ws"]
+  },
+  "Seq": {
+    "Url": "http://seq:80"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds ControlPanel to docker-compose with Docker appsettings and a Bolt client health check.
- Adds ControlPanel readiness checks to the xeon-dev deploy workflow.
- Documents required ControlPanel bootstrap admin env values.

## Verification
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj --configuration Release
- docker-compose -f docker-compose.yml config with dummy env values
- git diff --check