### PR TITLE
Harden Inventario foundation

### DIFF
--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -69,6 +69,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="src\Tests\ControlPanel.E2ETests\ControlPanel.E2ETests.csproj" />
+    <Project Path="src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj" />
     <Project Path="src\Tests\XFramework.Core.Tests\XFramework.Core.Tests.csproj" />
     <Project Path="src\Tests\XFramework.SourceGenerators.Tests\XFramework.SourceGenerators.Tests.csproj" />
     <Project Path="src\Tests\XFramework.TestInfrastructure\XFramework.TestInfrastructure.csproj" />

--- a/src/Kernel/XFramework.Domain/Migrations/20260617222322_InventarioFoundationCore.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260617222322_InventarioFoundationCore.cs
@@ -1,0 +1,435 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class InventarioFoundationCore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(name: "Inventario");
+
+            migrationBuilder.CreateTable(
+                name: "ProductCategory",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_ProductCategory", x => x.ID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Warehouse",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    Code = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    AddressLine = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    City = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Region = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    PostalCode = table.Column<string>(type: "character varying(25)", maxLength: 25, nullable: true),
+                    CountryCode = table.Column<string>(type: "character varying(3)", maxLength: 3, nullable: true),
+                    IsDefault = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_Warehouse", x => x.ID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Product",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    Price = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    StockQuantity = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    CategoryId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Image = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    SKU = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    Brand = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Weight = table.Column<decimal>(type: "numeric(18,3)", precision: 18, scale: 3, nullable: true),
+                    Rating = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: true),
+                    Discount = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: true),
+                    IsAvailable = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_Product", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_Product_Category",
+                        column: x => x.CategoryId,
+                        principalSchema: "Inventario",
+                        principalTable: "ProductCategory",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "InventoryLocation",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    WarehouseId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ParentLocationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Code = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    LocationType = table.Column<int>(type: "integer", nullable: false, defaultValue: 4),
+                    IsPickable = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_InventoryLocation", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryLocation_Parent",
+                        column: x => x.ParentLocationId,
+                        principalSchema: "Inventario",
+                        principalTable: "InventoryLocation",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryLocation_Warehouse",
+                        column: x => x.WarehouseId,
+                        principalSchema: "Inventario",
+                        principalTable: "Warehouse",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProductTransaction",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Quantity = table.Column<int>(type: "integer", nullable: false),
+                    TotalPrice = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    TransactionDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_ProductTransaction", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ProductTransaction_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProductVariation",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    AdditionalPrice = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_ProductVariation", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ProductVariation_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "StockBalance",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    WarehouseId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LocationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OnHandQuantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    ReservedQuantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    AvailableQuantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    LastMovementAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_StockBalance", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_StockBalance_Location",
+                        column: x => x.LocationId,
+                        principalSchema: "Inventario",
+                        principalTable: "InventoryLocation",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_StockBalance_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_StockBalance_Warehouse",
+                        column: x => x.WarehouseId,
+                        principalSchema: "Inventario",
+                        principalTable: "Warehouse",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "InventoryMovement",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    WarehouseId = table.Column<Guid>(type: "uuid", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    StockBalanceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MovementType = table.Column<int>(type: "integer", nullable: false),
+                    QuantityDelta = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    QuantityBefore = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    QuantityAfter = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    MovementDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UnitOfMeasure = table.Column<string>(type: "character varying(25)", maxLength: 25, nullable: true),
+                    ReferenceType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ReferenceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Reason = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_InventoryMovement", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryMovement_Location",
+                        column: x => x.LocationId,
+                        principalSchema: "Inventario",
+                        principalTable: "InventoryLocation",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryMovement_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryMovement_StockBalance",
+                        column: x => x.StockBalanceId,
+                        principalSchema: "Inventario",
+                        principalTable: "StockBalance",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryMovement_Warehouse",
+                        column: x => x.WarehouseId,
+                        principalSchema: "Inventario",
+                        principalTable: "Warehouse",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Reservation",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    WarehouseId = table.Column<Guid>(type: "uuid", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    StockBalanceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Quantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    ReferenceType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ReferenceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ReservedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ReleasedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    FulfilledAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_Reservation", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_Reservation_Location",
+                        column: x => x.LocationId,
+                        principalSchema: "Inventario",
+                        principalTable: "InventoryLocation",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_Reservation_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_Reservation_StockBalance",
+                        column: x => x.StockBalanceId,
+                        principalSchema: "Inventario",
+                        principalTable: "StockBalance",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_Reservation_Warehouse",
+                        column: x => x.WarehouseId,
+                        principalSchema: "Inventario",
+                        principalTable: "Warehouse",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            CreateIndexes(migrationBuilder);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "InventoryMovement", schema: "Inventario");
+            migrationBuilder.DropTable(name: "ProductTransaction", schema: "Inventario");
+            migrationBuilder.DropTable(name: "ProductVariation", schema: "Inventario");
+            migrationBuilder.DropTable(name: "Reservation", schema: "Inventario");
+            migrationBuilder.DropTable(name: "StockBalance", schema: "Inventario");
+            migrationBuilder.DropTable(name: "InventoryLocation", schema: "Inventario");
+            migrationBuilder.DropTable(name: "Product", schema: "Inventario");
+            migrationBuilder.DropTable(name: "Warehouse", schema: "Inventario");
+            migrationBuilder.DropTable(name: "ProductCategory", schema: "Inventario");
+        }
+
+        private static void CreateIndexes(MigrationBuilder migrationBuilder)
+        {
+            CreateTenantIndexes(migrationBuilder, "ProductCategory");
+            CreateTenantIndexes(migrationBuilder, "Warehouse");
+            CreateTenantIndexes(migrationBuilder, "Product");
+            CreateTenantIndexes(migrationBuilder, "InventoryLocation");
+            CreateTenantIndexes(migrationBuilder, "ProductTransaction");
+            CreateTenantIndexes(migrationBuilder, "ProductVariation");
+            CreateTenantIndexes(migrationBuilder, "StockBalance");
+            CreateTenantIndexes(migrationBuilder, "InventoryMovement");
+            CreateTenantIndexes(migrationBuilder, "Reservation");
+
+            migrationBuilder.CreateIndex("IX_ProductCategory_TenantId_Name", "ProductCategory", new[] { "TenantId", "Name" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Warehouse_TenantId_Code", "Warehouse", new[] { "TenantId", "Code" }, schema: "Inventario", unique: true);
+            migrationBuilder.CreateIndex("IX_Product_CategoryId", "Product", "CategoryId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Product_TenantId_CategoryId", "Product", new[] { "TenantId", "CategoryId" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Product_TenantId_SKU", "Product", new[] { "TenantId", "SKU" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_InventoryLocation_ParentLocationId", "InventoryLocation", "ParentLocationId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_InventoryLocation_WarehouseId", "InventoryLocation", "WarehouseId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_InventoryLocation_TenantId_WarehouseId_Code", "InventoryLocation", new[] { "TenantId", "WarehouseId", "Code" }, schema: "Inventario", unique: true);
+            migrationBuilder.CreateIndex("IX_InventoryLocation_TenantId_ParentLocationId", "InventoryLocation", new[] { "TenantId", "ParentLocationId" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_ProductTransaction_ProductId", "ProductTransaction", "ProductId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_ProductTransaction_TenantId_ProductId_TransactionDate", "ProductTransaction", new[] { "TenantId", "ProductId", "TransactionDate" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_ProductVariation_ProductId", "ProductVariation", "ProductId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_ProductVariation_TenantId_ProductId", "ProductVariation", new[] { "TenantId", "ProductId" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_StockBalance_LocationId", "StockBalance", "LocationId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_StockBalance_ProductId", "StockBalance", "ProductId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_StockBalance_WarehouseId", "StockBalance", "WarehouseId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_StockBalance_TenantId_ProductId_WarehouseId_LocationId", "StockBalance", new[] { "TenantId", "ProductId", "WarehouseId", "LocationId" }, schema: "Inventario", unique: true);
+            migrationBuilder.CreateIndex("IX_InventoryMovement_LocationId", "InventoryMovement", "LocationId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_InventoryMovement_ProductId", "InventoryMovement", "ProductId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_InventoryMovement_StockBalanceId", "InventoryMovement", "StockBalanceId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_InventoryMovement_WarehouseId", "InventoryMovement", "WarehouseId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_InventoryMovement_TenantId_ProductId_MovementDate", "InventoryMovement", new[] { "TenantId", "ProductId", "MovementDate" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_InventoryMovement_TenantId_ReferenceType_ReferenceId", "InventoryMovement", new[] { "TenantId", "ReferenceType", "ReferenceId" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Reservation_LocationId", "Reservation", "LocationId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Reservation_ProductId", "Reservation", "ProductId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Reservation_StockBalanceId", "Reservation", "StockBalanceId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Reservation_WarehouseId", "Reservation", "WarehouseId", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Reservation_ExpiresAt", "Reservation", "ExpiresAt", schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Reservation_TenantId_ProductId_Status", "Reservation", new[] { "TenantId", "ProductId", "Status" }, schema: "Inventario");
+            migrationBuilder.CreateIndex("IX_Reservation_TenantId_ReferenceType_ReferenceId", "Reservation", new[] { "TenantId", "ReferenceType", "ReferenceId" }, schema: "Inventario");
+        }
+
+        private static void CreateTenantIndexes(MigrationBuilder migrationBuilder, string table)
+        {
+            migrationBuilder.CreateIndex($"IX_{table}_TenantId", table, "TenantId", schema: "Inventario");
+            migrationBuilder.CreateIndex($"IX_{table}_TenantId_IsDeleted", table, new[] { "TenantId", "IsDeleted" }, schema: "Inventario");
+        }
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductCategoryEntity.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductCategoryEntity.cs
@@ -1,19 +1,9 @@
-using XFramework.Core.Attributes;
-
 namespace XFramework.Inventario.Api.Entities;
 
 /// <summary>
 /// VSA wrapper entity for ProductCategory domain model.
 /// Implements the VSA Wrapper Entity Pattern (ADR-003).
 /// </summary>
-[GenerateEndpoints(
-    Type = EndpointType.Both,
-    Actions = EndpointActions.All,
-    RoutePrefix = "api/productcategories",
-    RequireAuthorization = true,
-    CacheDurationSeconds = 300,
-    CacheKeyPrefix = "productcategories"
-)]
 public partial class ProductCategoryEntity
 {
     public Guid Id { get; set; }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductEntity.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductEntity.cs
@@ -1,19 +1,9 @@
-using XFramework.Core.Attributes;
-
 namespace XFramework.Inventario.Api.Entities;
 
 /// <summary>
 /// VSA wrapper entity for Product domain model.
 /// Implements the VSA Wrapper Entity Pattern (ADR-003).
 /// </summary>
-[GenerateEndpoints(
-    Type = EndpointType.Both,
-    Actions = EndpointActions.All,
-    RoutePrefix = "api/productentities",
-    RequireAuthorization = true,
-    CacheDurationSeconds = 300,
-    CacheKeyPrefix = "productentities"
-)]
 public partial class ProductEntity
 {
     public Guid Id { get; set; }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductTransactionEntity.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductTransactionEntity.cs
@@ -1,19 +1,9 @@
-using XFramework.Core.Attributes;
-
 namespace XFramework.Inventario.Api.Entities;
 
 /// <summary>
 /// VSA wrapper entity for ProductTransaction domain model.
 /// Implements the VSA Wrapper Entity Pattern (ADR-003).
 /// </summary>
-[GenerateEndpoints(
-    Type = EndpointType.Both,
-    Actions = EndpointActions.All,
-    RoutePrefix = "api/producttransactions",
-    RequireAuthorization = true,
-    CacheDurationSeconds = 300,
-    CacheKeyPrefix = "producttransactions"
-)]
 public partial class ProductTransactionEntity
 {
     public Guid Id { get; set; }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductVariationEntity.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductVariationEntity.cs
@@ -1,19 +1,9 @@
-using XFramework.Core.Attributes;
-
 namespace XFramework.Inventario.Api.Entities;
 
 /// <summary>
 /// VSA wrapper entity for ProductVariation domain model.
 /// Implements the VSA Wrapper Entity Pattern (ADR-003).
 /// </summary>
-[GenerateEndpoints(
-    Type = EndpointType.Both,
-    Actions = EndpointActions.All,
-    RoutePrefix = "api/productvariations",
-    RequireAuthorization = true,
-    CacheDurationSeconds = 300,
-    CacheKeyPrefix = "productvariations"
-)]
 public partial class ProductVariationEntity
 {
     public Guid Id { get; set; }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Entities/TestCategory.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Entities/TestCategory.cs
@@ -1,19 +1,9 @@
-using XFramework.Core.Attributes;
-
 namespace XFramework.Inventario.Api.Entities;
 
 /// <summary>
 /// Test category entity to demonstrate the EntityServiceGenerator.
 /// Categories can be used to organize products.
 /// </summary>
-[GenerateEndpoints(
-    Type = EndpointType.Both,
-    Actions = EndpointActions.All,
-    RoutePrefix = "api/testcategories",
-    RequireAuthorization = true,
-    CacheDurationSeconds = 600,
-    CacheKeyPrefix = "testcategories"
-)]
 public partial class TestCategory
 {
     public Guid Id { get; set; }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Entities/TestProduct.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Entities/TestProduct.cs
@@ -1,19 +1,9 @@
-using XFramework.Core.Attributes;
-
 namespace XFramework.Inventario.Api.Entities;
 
 /// <summary>
 /// Test entity to verify the EntityServiceGenerator works correctly.
 /// This entity has all CRUD operations enabled.
 /// </summary>
-[GenerateEndpoints(
-    Type = EndpointType.Both,
-    Actions = EndpointActions.All,
-    RoutePrefix = "api/testproducts",
-    RequireAuthorization = true,
-    CacheDurationSeconds = 600,
-    CacheKeyPrefix = "testproducts"
-)]
 public partial class TestProduct
 {
     public Guid Id { get; set; }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Entities/TestSupplier.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Entities/TestSupplier.cs
@@ -1,19 +1,9 @@
-using XFramework.Core.Attributes;
-
 namespace XFramework.Inventario.Api.Entities;
 
 /// <summary>
 /// Test supplier entity to demonstrate the EntityServiceGenerator with more fields.
 /// Suppliers provide products to the inventory system.
 /// </summary>
-[GenerateEndpoints(
-    Type = EndpointType.Both,
-    Actions = EndpointActions.All,
-    RoutePrefix = "api/testsuppliers",
-    RequireAuthorization = true,
-    CacheDurationSeconds = 600,
-    CacheKeyPrefix = "testsuppliers"
-)]
 public partial class TestSupplier
 {
     public Guid Id { get; set; }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Create/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Create/Endpoint.cs
@@ -8,8 +8,7 @@ public static class CreateProductEndpoint
 {
     [MapPost("/api/products", Tags = ["Products"],
         Summary = "Create a new product",
-        Description = "Creates a new product in the inventory system",
-        ExcludeFromOpenApi = true)]
+        Description = "Creates a new product in the inventory system")]
     public static async Task<Result<ProductResponse>> Handle(
         CreateProductRequest request,
         ProductService productService,

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Delete/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Delete/Endpoint.cs
@@ -8,8 +8,7 @@ public static class DeleteProductEndpoint
 {
     [MapDelete("/api/products/{id:guid}", Tags = ["Products"],
         Summary = "Delete a product",
-        Description = "Soft deletes a product from the inventory",
-        ExcludeFromOpenApi = true)]
+        Description = "Soft deletes a product from the inventory")]
     public static async Task<Result> Handle(
         DeleteProductByIdRequest request,
         ProductService productService,

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Get/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Get/Endpoint.cs
@@ -8,8 +8,7 @@ public static class GetProductEndpoint
 {
     [MapGet("/api/products/{id:guid}", Tags = ["Products"],
         Summary = "Get a product by ID",
-        Description = "Retrieves a single product by its unique identifier",
-        ExcludeFromOpenApi = true)]
+        Description = "Retrieves a single product by its unique identifier")]
     public static async Task<Result<ProductResponse>> Handle(
         GetProductByIdRequest request,
         ProductService productService,

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/GetList/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/GetList/Endpoint.cs
@@ -8,8 +8,7 @@ public static class GetProductsListEndpoint
 {
     [MapGet("/api/products", Tags = ["Products"],
         Summary = "Get a paginated list of products",
-        Description = "Retrieves products with optional filtering by search term, category, and availability",
-        ExcludeFromOpenApi = true)]
+        Description = "Retrieves products with optional filtering by search term, category, and availability")]
     public static async Task<Result<PaginatedProductResponse>> Handle(
         GetProductsRequest request,
         ProductService productService,

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/Endpoint.cs
@@ -1,28 +1,56 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Http.HttpResults;
 using XFramework.Core.Patterns;
-using XFramework.Integration.Attributes;
 using XFramework.Inventario.Api.Services;
 
 namespace Inventario.Api.Features.Products.Update;
 
 public static class UpdateProductEndpoint
 {
-    [MapPut("/api/products/{id:guid}", Tags = ["Products"],
-        Summary = "Update an existing product",
-        Description = "Updates a product and invalidates the cache",
-        ExcludeFromOpenApi = true)]
-    public static async Task<Result<ProductResponse>> Handle(
-        UpdateProductByIdRequest request,
+    public static IEndpointRouteBuilder Map(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/api/products/{id:guid}", Handle)
+            .WithName("UpdateProduct")
+            .WithTags("Products")
+            .WithSummary("Update an existing product")
+            .WithDescription("Updates catalog fields for a product and invalidates the cache")
+            .Produces<ProductResponse>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .Produces(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        return app;
+    }
+
+    private static async Task<Results<Ok<ProductResponse>, ValidationProblem, NotFound, ProblemHttpResult>> Handle(
+        Guid id,
+        UpdateProductRequest request,
+        IValidator<UpdateProductRequest> validator,
         ProductService productService,
         CancellationToken ct)
     {
-        var result = await productService.UpdateAsync(request.Id, request.Body, ct);
+        var validationResult = await validator.ValidateAsync(request, ct);
+        if (!validationResult.IsValid)
+        {
+            var errors = validationResult.Errors
+                .GroupBy(static e => e.PropertyName)
+                .ToDictionary(static g => g.Key, static g => g.Select(static e => e.ErrorMessage).ToArray());
+            return TypedResults.ValidationProblem(errors);
+        }
+
+        var result = await productService.UpdateAsync(id, request, ct);
 
         if (!result.IsSuccess)
-            return Result<ProductResponse>.Failure(result.Message!, result.StatusCode);
+        {
+            return result.StatusCode switch
+            {
+                404 => TypedResults.NotFound(),
+                _ => TypedResults.Problem(detail: result.Message, statusCode: result.StatusCode)
+            };
+        }
 
         var response = ProductResponse.FromProduct(result.Data!);
-        return Result<ProductResponse>.Success(response);
+        return TypedResults.Ok(response);
     }
 }
-
-public record UpdateProductByIdRequest(Guid Id, UpdateProductRequest Body);

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/UpdateProductValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/UpdateProductValidator.cs
@@ -17,9 +17,6 @@ public class UpdateProductValidator : AbstractValidator<UpdateProductRequest>
         RuleFor(x => x.Price)
             .GreaterThan(0).WithMessage("Price must be greater than 0");
 
-        RuleFor(x => x.StockQuantity)
-            .GreaterThanOrEqualTo(0).WithMessage("Stock quantity cannot be negative");
-
         RuleFor(x => x.CategoryId)
             .NotEmpty().WithMessage("Category is required");
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using IdentityServer.Domain.Shared.Contracts;
+using Inventario.Api.Features.Products.Update;
 using Microsoft.Extensions.Caching.Distributed;
 using StackExchange.Redis;
 using XFramework.Core.DataContext;
@@ -32,9 +33,6 @@ builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 // Register DataContext handler for entity query/mutation via Bolt
 builder.Services.AddDataContextHandler(typeof(Program).Assembly);
 
-// Auto-discover and register all generated services
-builder.Services.AddGeneratedServices();
-
 var app = (WebApplication)builder.Build();
 
 // Add correlation ID middleware early in the pipeline for request tracing
@@ -44,13 +42,13 @@ app.UseTenantModuleFeatureGate(options =>
 
 app.EnsureDatabase<DbContext>();
 
-// Auto-discover and map entity-generated endpoints (from [GenerateEndpoints] attribute)
-EndpointDiscoveryExtensions.MapGeneratedEndpoints(app);
-
-// Map feature endpoints (source-generated from [MapPost/Get/...] attributes)
-Inventario.Api.Generated.GeneratedEndpointRoutes.MapGeneratedEndpoints(app);
-
 // Map health check endpoints (liveness, readiness, and detailed health)
 app.MapXFrameworkHealthChecks("Inventario");
+app.MapApiDocumentation();
+
+// Map real product feature endpoints behind authorization.
+var authorizedRoutes = app.MapGroup("").RequireAuthorization();
+Inventario.Api.Generated.GeneratedEndpointRoutes.MapGeneratedEndpoints(authorizedRoutes);
+UpdateProductEndpoint.Map(authorizedRoutes);
 
 app.Run();

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
 using XFramework.Core.Loggers;
 using XFramework.Core.Observability;
 using XFramework.Core.Patterns;
 using XFramework.Core.Services.Caching;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace XFramework.Inventario.Api.Services;
 
@@ -16,15 +18,18 @@ public class ProductService
     private readonly IDataContext _dataContext;
     private readonly ICacheService _cacheService;
     private readonly ILogger<ProductService> _logger;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
     public ProductService(
         IDataContext dataContext,
         ICacheService cacheService,
-        ILogger<ProductService> logger)
+        ILogger<ProductService> logger,
+        IHttpContextAccessor httpContextAccessor)
     {
         _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
         _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
     }
 
     /// <summary>
@@ -32,23 +37,40 @@ public class ProductService
     /// </summary>
     public async Task<Result<Product>> CreateAsync(CreateProductRequest request, CancellationToken ct = default)
     {
+        var tenantResult = GetCurrentTenantId();
+        if (!tenantResult.IsSuccess)
+            return Result<Product>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+
         using var activity = ActivitySources.Product.StartActivity("Product.Create");
         activity?.SetTag("product.name", request.Name);
         activity?.SetTag("product.price", request.Price);
         activity?.SetTag("product.category_id", request.CategoryId);
+        activity?.SetTag("tenant.id", tenantId);
 
         var stopwatch = Stopwatch.StartNew();
 
         try
         {
+            var categoryExists = await _dataContext.Query<ProductCategory>()
+                .AnyAsync(c => c.Id == request.CategoryId && c.TenantId == tenantId, ct);
+            if (!categoryExists)
+            {
+                _logger.EntityNotFound("ProductCategory", request.CategoryId);
+                return Result<Product>.NotFound("Product category not found");
+            }
+
             var productId = Guid.NewGuid();
             activity?.SetTag("product.id", productId);
 
-            _logger.EntityCreating("Product", productId, null);
+            _logger.EntityCreating("Product", productId, tenantId);
 
             var product = new Product
             {
                 Id = productId,
+                TenantId = tenantId,
+                IsEnabled = true,
                 Name = request.Name,
                 Description = request.Description,
                 Price = request.Price,
@@ -62,10 +84,32 @@ public class ProductService
             };
 
             _dataContext.Add(product);
-            await _dataContext.SaveChangesAsync(ct);
+
+            if (request.StockQuantity > 0)
+            {
+                _dataContext.Add(new InventoryMovement
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    IsEnabled = true,
+                    ProductId = productId,
+                    MovementType = InventoryMovementType.OpeningBalance,
+                    QuantityDelta = request.StockQuantity,
+                    QuantityBefore = 0,
+                    QuantityAfter = request.StockQuantity,
+                    MovementDate = DateTime.UtcNow,
+                    ReferenceType = nameof(Product),
+                    ReferenceId = productId,
+                    Reason = "Initial product stock"
+                });
+            }
+
+            var saveResult = await _dataContext.SaveChangesAsync(ct);
+            if (!saveResult.IsSuccess)
+                return Result<Product>.Failure(saveResult.Message ?? "Product save failed", saveResult.StatusCode);
 
             // Cache the newly created product
-            var cacheKey = $"products:{product.Id}";
+            var cacheKey = BuildProductCacheKey(tenantId, product.Id);
             await _cacheService.SetAsync(cacheKey, product,
                 absoluteExpiration: TimeSpan.FromMinutes(10),
                 cancellationToken: ct);
@@ -106,9 +150,15 @@ public class ProductService
     /// </summary>
     public async Task<Result<Product>> GetByIdAsync(Guid id, CancellationToken ct = default)
     {
+        var tenantResult = GetCurrentTenantId();
+        if (!tenantResult.IsSuccess)
+            return Result<Product>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+
         try
         {
-            var cacheKey = $"products:{id}";
+            var cacheKey = BuildProductCacheKey(tenantId, id);
 
             // Try cache first
             var cached = await _cacheService.GetAsync<Product>(cacheKey, ct);
@@ -122,7 +172,7 @@ public class ProductService
 
             var product = await _dataContext.Query<Product>()
                 .Include(p => p.Category)
-                .Where(p => p.Id == id && !p.IsDeleted)
+                .Where(p => p.Id == id && p.TenantId == tenantId && !p.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
             if (product == null)
@@ -154,13 +204,19 @@ public class ProductService
         GetProductsRequest request,
         CancellationToken ct = default)
     {
+        var tenantResult = GetCurrentTenantId();
+        if (!tenantResult.IsSuccess)
+            return Result<PaginatedList<Product>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+
         try
         {
             _logger.EntityListing("Product", request.Page, request.PageSize);
 
             var query = _dataContext.Query<Product>()
                 .Include(p => p.Category)
-                .Where(p => !p.IsDeleted);
+                .Where(p => p.TenantId == tenantId && !p.IsDeleted);
 
             // Apply search filter
             if (!string.IsNullOrWhiteSpace(request.Search))
@@ -219,12 +275,18 @@ public class ProductService
     /// </summary>
     public async Task<Result<Product>> UpdateAsync(Guid id, UpdateProductRequest request, CancellationToken ct = default)
     {
+        var tenantResult = GetCurrentTenantId();
+        if (!tenantResult.IsSuccess)
+            return Result<Product>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+
         try
         {
             _logger.EntityUpdating("Product", id);
 
             var product = await _dataContext.Query<Product>()
-                .Where(p => p.Id == id && !p.IsDeleted)
+                .Where(p => p.Id == id && p.TenantId == tenantId && !p.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
             if (product == null)
@@ -233,11 +295,18 @@ public class ProductService
                 return Result<Product>.NotFound($"Product with ID {id} not found");
             }
 
+            var categoryExists = await _dataContext.Query<ProductCategory>()
+                .AnyAsync(c => c.Id == request.CategoryId && c.TenantId == tenantId, ct);
+            if (!categoryExists)
+            {
+                _logger.EntityNotFound("ProductCategory", request.CategoryId);
+                return Result<Product>.NotFound("Product category not found");
+            }
+
             // Update properties
             product.Name = request.Name;
             product.Description = request.Description;
             product.Price = request.Price;
-            product.StockQuantity = request.StockQuantity;
             product.CategoryId = request.CategoryId;
             product.SKU = request.SKU;
             product.Brand = request.Brand;
@@ -247,14 +316,16 @@ public class ProductService
 
             // Attach as Modified and save
             _dataContext.Update(product);
-            await _dataContext.SaveChangesAsync(ct);
+            var saveResult = await _dataContext.SaveChangesAsync(ct);
+            if (!saveResult.IsSuccess)
+                return Result<Product>.Failure(saveResult.Message ?? "Product update failed", saveResult.StatusCode);
 
             // Invalidate cache
-            var cacheKey = $"products:{id}";
+            var cacheKey = BuildProductCacheKey(tenantId, id);
             await _cacheService.RemoveAsync(cacheKey, ct);
             _logger.CacheInvalidated(cacheKey);
-            await _cacheService.RemoveByPrefixAsync("products:list:", ct);
-            _logger.CacheCleared("products:list:*");
+            await _cacheService.RemoveByPrefixAsync(BuildProductListCachePrefix(tenantId), ct);
+            _logger.CacheCleared($"products:list:{tenantId}:*");
 
             _logger.EntityUpdated("Product", id);
             return Result<Product>.Success(product, "Product updated successfully");
@@ -271,12 +342,18 @@ public class ProductService
     /// </summary>
     public async Task<Result> DeleteAsync(Guid id, CancellationToken ct = default)
     {
+        var tenantResult = GetCurrentTenantId();
+        if (!tenantResult.IsSuccess)
+            return Result.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+
         try
         {
             _logger.EntityDeleting("Product", id);
 
             var product = await _dataContext.Query<Product>()
-                .Where(p => p.Id == id && !p.IsDeleted)
+                .Where(p => p.Id == id && p.TenantId == tenantId && !p.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
             if (product == null)
@@ -287,14 +364,16 @@ public class ProductService
 
             // Soft delete (XDbContext handles IsDeleted flag and DeletedAt timestamp)
             _dataContext.Remove(product);
-            await _dataContext.SaveChangesAsync(ct);
+            var saveResult = await _dataContext.SaveChangesAsync(ct);
+            if (!saveResult.IsSuccess)
+                return Result.Failure(saveResult.Message ?? "Product delete failed", saveResult.StatusCode);
 
             // Invalidate cache
-            var cacheKey = $"products:{id}";
+            var cacheKey = BuildProductCacheKey(tenantId, id);
             await _cacheService.RemoveAsync(cacheKey, ct);
             _logger.CacheInvalidated(cacheKey);
-            await _cacheService.RemoveByPrefixAsync("products:list:", ct);
-            _logger.CacheCleared("products:list:*");
+            await _cacheService.RemoveByPrefixAsync(BuildProductListCachePrefix(tenantId), ct);
+            _logger.CacheCleared($"products:list:{tenantId}:*");
 
             _logger.EntityDeleted("Product", id);
             return Result.Success("Product deleted successfully");
@@ -305,6 +384,28 @@ public class ProductService
             return Result.Failure("An error occurred deleting the product", 500);
         }
     }
+
+    private Result<Guid> GetCurrentTenantId()
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return Result<Guid>.Unauthorized("Authentication is required for product catalog operations");
+
+        var tenantIdClaim = user.FindFirst("tenantId")?.Value
+            ?? user.FindFirst("TenantId")?.Value
+            ?? user.FindFirst("tid")?.Value;
+
+        if (Guid.TryParse(tenantIdClaim, out var tenantId) && tenantId != Guid.Empty)
+            return Result<Guid>.Success(tenantId);
+
+        return Result<Guid>.Forbidden("Authenticated user does not have a valid tenant context");
+    }
+
+    private static string BuildProductCacheKey(Guid tenantId, Guid productId) =>
+        $"products:{tenantId}:{productId}";
+
+    private static string BuildProductListCachePrefix(Guid tenantId) =>
+        $"products:list:{tenantId}:";
 }
 
 /// <summary>
@@ -332,7 +433,6 @@ public record UpdateProductRequest
     public required string Name { get; init; }
     public string? Description { get; init; }
     public decimal Price { get; init; }
-    public int StockQuantity { get; init; }
     public Guid CategoryId { get; init; }
     public string? SKU { get; init; }
     public string? Brand { get; init; }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventarioConfigurationExtensions.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventarioConfigurationExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+internal static class InventarioConfigurationExtensions
+{
+    public static void ConfigureBaseModel<TEntity>(
+        this EntityTypeBuilder<TEntity> entity,
+        string primaryKeyName)
+        where TEntity : BaseModel
+    {
+        entity.HasKey(e => e.Id).HasName(primaryKeyName);
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+
+        entity.Property(e => e.TenantId).IsRequired();
+        entity.Property(e => e.IsEnabled).HasDefaultValue(true);
+        entity.Property(e => e.IsDeleted).HasDefaultValue(false);
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ConcurrencyStamp)
+            .IsConcurrencyToken()
+            .HasDefaultValueSql("(uuid_generate_v4())");
+
+        entity.HasIndex(e => e.TenantId);
+        entity.HasIndex(e => new { e.TenantId, e.IsDeleted });
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryLocationConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryLocationConfiguration.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class InventoryLocationConfiguration : IEntityTypeConfiguration<InventoryLocation>
+{
+    public void Configure(EntityTypeBuilder<InventoryLocation> entity)
+    {
+        entity.ToTable("InventoryLocation", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_InventoryLocation");
+
+        entity.Property(e => e.Code).IsRequired().HasMaxLength(50);
+        entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        entity.Property(e => e.Description).HasMaxLength(1000);
+        entity.Property(e => e.LocationType).HasDefaultValue(InventoryLocationType.Bin);
+        entity.Property(e => e.IsPickable).HasDefaultValue(true);
+
+        entity.HasIndex(e => new { e.TenantId, e.WarehouseId, e.Code }).IsUnique();
+        entity.HasIndex(e => new { e.TenantId, e.ParentLocationId });
+
+        entity.HasOne(e => e.Warehouse)
+            .WithMany(e => e.Locations)
+            .HasForeignKey(e => e.WarehouseId)
+            .OnDelete(DeleteBehavior.Cascade)
+            .HasConstraintName("FK_Inventario_InventoryLocation_Warehouse");
+
+        entity.HasOne(e => e.ParentLocation)
+            .WithMany(e => e.ChildLocations)
+            .HasForeignKey(e => e.ParentLocationId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryLocation_Parent");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryMovementConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryMovementConfiguration.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class InventoryMovementConfiguration : IEntityTypeConfiguration<InventoryMovement>
+{
+    public void Configure(EntityTypeBuilder<InventoryMovement> entity)
+    {
+        entity.ToTable("InventoryMovement", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_InventoryMovement");
+
+        entity.Property(e => e.QuantityDelta).HasPrecision(18, 4);
+        entity.Property(e => e.QuantityBefore).HasPrecision(18, 4);
+        entity.Property(e => e.QuantityAfter).HasPrecision(18, 4);
+        entity.Property(e => e.MovementDate).HasDefaultValueSql("now()");
+        entity.Property(e => e.UnitOfMeasure).HasMaxLength(25);
+        entity.Property(e => e.ReferenceType).HasMaxLength(100);
+        entity.Property(e => e.Reason).HasMaxLength(1000);
+
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.MovementDate });
+        entity.HasIndex(e => new { e.TenantId, e.ReferenceType, e.ReferenceId });
+
+        entity.HasOne(e => e.Product)
+            .WithMany()
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryMovement_Product");
+
+        entity.HasOne(e => e.Warehouse)
+            .WithMany()
+            .HasForeignKey(e => e.WarehouseId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryMovement_Warehouse");
+
+        entity.HasOne(e => e.Location)
+            .WithMany()
+            .HasForeignKey(e => e.LocationId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryMovement_Location");
+
+        entity.HasOne(e => e.StockBalance)
+            .WithMany()
+            .HasForeignKey(e => e.StockBalanceId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryMovement_StockBalance");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductCategoryConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductCategoryConfiguration.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class ProductCategoryConfiguration : IEntityTypeConfiguration<ProductCategory>
+{
+    public void Configure(EntityTypeBuilder<ProductCategory> entity)
+    {
+        entity.ToTable("ProductCategory", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_ProductCategory");
+
+        entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        entity.Property(e => e.Description).HasMaxLength(1000);
+
+        entity.HasIndex(e => new { e.TenantId, e.Name });
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductConfiguration.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class ProductConfiguration : IEntityTypeConfiguration<Product>
+{
+    public void Configure(EntityTypeBuilder<Product> entity)
+    {
+        entity.ToTable("Product", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_Product");
+
+        entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        entity.Property(e => e.Description).HasMaxLength(1000);
+        entity.Property(e => e.Price).HasPrecision(18, 2);
+        entity.Property(e => e.StockQuantity).HasDefaultValue(0);
+        entity.Property(e => e.SKU).HasMaxLength(50);
+        entity.Property(e => e.Brand).HasMaxLength(100);
+        entity.Property(e => e.Weight).HasPrecision(18, 3);
+        entity.Property(e => e.Image).HasMaxLength(2048);
+        entity.Property(e => e.Rating).HasPrecision(5, 2);
+        entity.Property(e => e.Discount).HasPrecision(5, 2);
+        entity.Property(e => e.IsAvailable).HasDefaultValue(true);
+
+        entity.Ignore(e => e.Dimensions);
+        entity.Ignore(e => e.Tags);
+        entity.Ignore(e => e.Reviews);
+
+        entity.HasIndex(e => new { e.TenantId, e.CategoryId });
+        entity.HasIndex(e => new { e.TenantId, e.SKU });
+
+        entity.HasOne(e => e.Category)
+            .WithMany(e => e.Products)
+            .HasForeignKey(e => e.CategoryId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_Product_Category");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductTransactionConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductTransactionConfiguration.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class ProductTransactionConfiguration : IEntityTypeConfiguration<ProductTransaction>
+{
+    public void Configure(EntityTypeBuilder<ProductTransaction> entity)
+    {
+        entity.ToTable("ProductTransaction", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_ProductTransaction");
+
+        entity.Property(e => e.TotalPrice).HasPrecision(18, 2);
+        entity.Property(e => e.TransactionDate).HasDefaultValueSql("now()");
+
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.TransactionDate });
+
+        entity.HasOne(e => e.Product)
+            .WithMany(e => e.Transactions)
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ProductTransaction_Product");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductVariationConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductVariationConfiguration.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class ProductVariationConfiguration : IEntityTypeConfiguration<ProductVariation>
+{
+    public void Configure(EntityTypeBuilder<ProductVariation> entity)
+    {
+        entity.ToTable("ProductVariation", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_ProductVariation");
+
+        entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        entity.Property(e => e.AdditionalPrice).HasPrecision(18, 2);
+
+        entity.HasIndex(e => new { e.TenantId, e.ProductId });
+
+        entity.HasOne(e => e.Product)
+            .WithMany(e => e.Variations)
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Cascade)
+            .HasConstraintName("FK_Inventario_ProductVariation_Product");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ReservationConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ReservationConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class ReservationConfiguration : IEntityTypeConfiguration<Reservation>
+{
+    public void Configure(EntityTypeBuilder<Reservation> entity)
+    {
+        entity.ToTable("Reservation", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_Reservation");
+
+        entity.Property(e => e.Quantity).HasPrecision(18, 4);
+        entity.Property(e => e.Status).HasDefaultValue(ReservationStatus.Active);
+        entity.Property(e => e.ReferenceType).HasMaxLength(100);
+        entity.Property(e => e.ReservedAt).HasDefaultValueSql("now()");
+
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.Status });
+        entity.HasIndex(e => new { e.TenantId, e.ReferenceType, e.ReferenceId });
+        entity.HasIndex(e => e.ExpiresAt);
+
+        entity.HasOne(e => e.Product)
+            .WithMany()
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_Reservation_Product");
+
+        entity.HasOne(e => e.Warehouse)
+            .WithMany()
+            .HasForeignKey(e => e.WarehouseId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_Reservation_Warehouse");
+
+        entity.HasOne(e => e.Location)
+            .WithMany()
+            .HasForeignKey(e => e.LocationId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_Reservation_Location");
+
+        entity.HasOne(e => e.StockBalance)
+            .WithMany()
+            .HasForeignKey(e => e.StockBalanceId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_Reservation_StockBalance");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/StockBalanceConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/StockBalanceConfiguration.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class StockBalanceConfiguration : IEntityTypeConfiguration<StockBalance>
+{
+    public void Configure(EntityTypeBuilder<StockBalance> entity)
+    {
+        entity.ToTable("StockBalance", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_StockBalance");
+
+        entity.Property(e => e.OnHandQuantity).HasPrecision(18, 4);
+        entity.Property(e => e.ReservedQuantity).HasPrecision(18, 4);
+        entity.Property(e => e.AvailableQuantity).HasPrecision(18, 4);
+
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.WarehouseId, e.LocationId }).IsUnique();
+
+        entity.HasOne(e => e.Product)
+            .WithMany()
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_StockBalance_Product");
+
+        entity.HasOne(e => e.Warehouse)
+            .WithMany()
+            .HasForeignKey(e => e.WarehouseId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_StockBalance_Warehouse");
+
+        entity.HasOne(e => e.Location)
+            .WithMany()
+            .HasForeignKey(e => e.LocationId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_StockBalance_Location");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/WarehouseConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/WarehouseConfiguration.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class WarehouseConfiguration : IEntityTypeConfiguration<Warehouse>
+{
+    public void Configure(EntityTypeBuilder<Warehouse> entity)
+    {
+        entity.ToTable("Warehouse", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_Warehouse");
+
+        entity.Property(e => e.Code).IsRequired().HasMaxLength(50);
+        entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        entity.Property(e => e.Description).HasMaxLength(1000);
+        entity.Property(e => e.AddressLine).HasMaxLength(500);
+        entity.Property(e => e.City).HasMaxLength(100);
+        entity.Property(e => e.Region).HasMaxLength(100);
+        entity.Property(e => e.PostalCode).HasMaxLength(25);
+        entity.Property(e => e.CountryCode).HasMaxLength(3);
+        entity.Property(e => e.IsDefault).HasDefaultValue(false);
+
+        entity.HasIndex(e => new { e.TenantId, e.Code }).IsUnique();
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryLocation.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryLocation.cs
@@ -1,0 +1,18 @@
+using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+public class InventoryLocation : BaseModel
+{
+    public Guid WarehouseId { get; set; }
+    public Warehouse? Warehouse { get; set; }
+    public Guid? ParentLocationId { get; set; }
+    public InventoryLocation? ParentLocation { get; set; }
+    public List<InventoryLocation> ChildLocations { get; set; } = new();
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public InventoryLocationType LocationType { get; set; } = InventoryLocationType.Bin;
+    public bool IsPickable { get; set; } = true;
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryMovement.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryMovement.cs
@@ -1,0 +1,25 @@
+using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+public class InventoryMovement : BaseModel
+{
+    public Guid ProductId { get; set; }
+    public Product? Product { get; set; }
+    public Guid? WarehouseId { get; set; }
+    public Warehouse? Warehouse { get; set; }
+    public Guid? LocationId { get; set; }
+    public InventoryLocation? Location { get; set; }
+    public Guid? StockBalanceId { get; set; }
+    public StockBalance? StockBalance { get; set; }
+    public InventoryMovementType MovementType { get; set; }
+    public decimal QuantityDelta { get; set; }
+    public decimal QuantityBefore { get; set; }
+    public decimal QuantityAfter { get; set; }
+    public DateTime MovementDate { get; set; }
+    public string? UnitOfMeasure { get; set; }
+    public string? ReferenceType { get; set; }
+    public Guid? ReferenceId { get; set; }
+    public string? Reason { get; set; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Reservation.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Reservation.cs
@@ -1,0 +1,24 @@
+using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+public class Reservation : BaseModel
+{
+    public Guid ProductId { get; set; }
+    public Product? Product { get; set; }
+    public Guid? WarehouseId { get; set; }
+    public Warehouse? Warehouse { get; set; }
+    public Guid? LocationId { get; set; }
+    public InventoryLocation? Location { get; set; }
+    public Guid? StockBalanceId { get; set; }
+    public StockBalance? StockBalance { get; set; }
+    public decimal Quantity { get; set; }
+    public ReservationStatus Status { get; set; } = ReservationStatus.Active;
+    public string? ReferenceType { get; set; }
+    public Guid? ReferenceId { get; set; }
+    public DateTime ReservedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    public DateTime? ReleasedAt { get; set; }
+    public DateTime? FulfilledAt { get; set; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/StockBalance.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/StockBalance.cs
@@ -1,0 +1,17 @@
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+public class StockBalance : BaseModel
+{
+    public Guid ProductId { get; set; }
+    public Product? Product { get; set; }
+    public Guid WarehouseId { get; set; }
+    public Warehouse? Warehouse { get; set; }
+    public Guid LocationId { get; set; }
+    public InventoryLocation? Location { get; set; }
+    public decimal OnHandQuantity { get; set; }
+    public decimal ReservedQuantity { get; set; }
+    public decimal AvailableQuantity { get; set; }
+    public DateTime? LastMovementAt { get; set; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Warehouse.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Warehouse.cs
@@ -1,0 +1,17 @@
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+public class Warehouse : BaseModel
+{
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? AddressLine { get; set; }
+    public string? City { get; set; }
+    public string? Region { get; set; }
+    public string? PostalCode { get; set; }
+    public string? CountryCode { get; set; }
+    public bool IsDefault { get; set; }
+    public List<InventoryLocation> Locations { get; set; } = new();
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/InventoryLocationType.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/InventoryLocationType.cs
@@ -1,0 +1,13 @@
+namespace XFramework.Inventario.Domain.Shared.Enums;
+
+public enum InventoryLocationType
+{
+    Zone = 0,
+    Aisle = 1,
+    Rack = 2,
+    Shelf = 3,
+    Bin = 4,
+    Receiving = 5,
+    Shipping = 6,
+    Quarantine = 7
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/InventoryMovementType.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/InventoryMovementType.cs
@@ -1,0 +1,13 @@
+namespace XFramework.Inventario.Domain.Shared.Enums;
+
+public enum InventoryMovementType
+{
+    OpeningBalance = 0,
+    Receipt = 1,
+    Adjustment = 2,
+    Transfer = 3,
+    Reservation = 4,
+    Release = 5,
+    Shipment = 6,
+    Return = 7
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/ReservationStatus.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/ReservationStatus.cs
@@ -1,0 +1,10 @@
+namespace XFramework.Inventario.Domain.Shared.Enums;
+
+public enum ReservationStatus
+{
+    Active = 0,
+    Released = 1,
+    Fulfilled = 2,
+    Expired = 3,
+    Cancelled = 4
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Inventario.Domain.Shared.csproj
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Inventario.Domain.Shared.csproj
@@ -12,10 +12,13 @@
 
     <ItemGroup>
         <Folder Include="BusinessObjects\" />
-        <Folder Include="Contracts\" />
-        <Folder Include="Enums\" />
         <Folder Include="Extensions\" />
         <Folder Include="Interfaces\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj
+++ b/src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>Inventario.Api.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
@@ -1,0 +1,413 @@
+using System.Collections;
+using System.Linq.Expressions;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using XFramework.Core.Patterns;
+using XFramework.Core.Services.Caching;
+using XFramework.Domain.Contexts;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace Inventario.Api.Tests;
+
+[TestFixture]
+public sealed class ProductServiceTests
+{
+    [Test]
+    public async Task CreateAsync_AuthenticatedTenant_AssignsTenantAndCreatesOpeningMovement()
+    {
+        var tenantId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var dataContext = new FakeDataContext();
+        dataContext.Set<ProductCategory>().Add(new ProductCategory
+        {
+            Id = categoryId,
+            TenantId = tenantId,
+            Name = "Parts"
+        });
+
+        var cache = new FakeCacheService();
+        var service = CreateService(dataContext, cache, tenantId);
+
+        var result = await service.CreateAsync(new CreateProductRequest
+        {
+            Name = "Widget",
+            Description = "Tenant-owned product",
+            Price = 12.50m,
+            StockQuantity = 7,
+            CategoryId = categoryId,
+            SKU = "W-001"
+        });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.StatusCode.Should().Be(201);
+        result.Data!.TenantId.Should().Be(tenantId);
+        result.Data.StockQuantity.Should().Be(7);
+
+        var movement = dataContext.Added.OfType<InventoryMovement>().Single();
+        movement.TenantId.Should().Be(tenantId);
+        movement.ProductId.Should().Be(result.Data.Id);
+        movement.MovementType.Should().Be(InventoryMovementType.OpeningBalance);
+        movement.QuantityDelta.Should().Be(7);
+        movement.QuantityBefore.Should().Be(0);
+        movement.QuantityAfter.Should().Be(7);
+
+        cache.SetKeys.Should().Contain($"products:{tenantId}:{result.Data.Id}");
+    }
+
+    [Test]
+    public async Task CreateAsync_UnauthenticatedRequest_ReturnsUnauthorizedWithoutSaving()
+    {
+        var dataContext = new FakeDataContext();
+        var service = CreateService(dataContext, new FakeCacheService(), tenantId: null);
+
+        var result = await service.CreateAsync(new CreateProductRequest
+        {
+            Name = "Widget",
+            Price = 12.50m,
+            StockQuantity = 1,
+            CategoryId = Guid.NewGuid()
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(401);
+        dataContext.Added.Should().BeEmpty();
+        dataContext.SaveCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task UpdateAsync_CatalogFieldsChange_DoesNotOverwriteStockQuantity()
+    {
+        var tenantId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var product = new Product
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Name = "Old",
+            Price = 5m,
+            StockQuantity = 12,
+            CategoryId = categoryId,
+            IsAvailable = true
+        };
+
+        var dataContext = new FakeDataContext();
+        dataContext.Set<ProductCategory>().Add(new ProductCategory
+        {
+            Id = categoryId,
+            TenantId = tenantId,
+            Name = "Parts"
+        });
+        dataContext.Set<Product>().Add(product);
+
+        var service = CreateService(dataContext, new FakeCacheService(), tenantId);
+
+        var result = await service.UpdateAsync(product.Id, new UpdateProductRequest
+        {
+            Name = "New",
+            Description = "Catalog edit",
+            Price = 9m,
+            CategoryId = categoryId,
+            SKU = "W-002",
+            Brand = "Acme",
+            Weight = 1.5m,
+            Image = "image.png",
+            IsAvailable = false
+        });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.Data!.StockQuantity.Should().Be(12);
+        product.StockQuantity.Should().Be(12);
+        dataContext.Added.OfType<InventoryMovement>().Should().BeEmpty();
+        dataContext.Updated.Should().ContainSingle(x => ReferenceEquals(x, product));
+    }
+
+    [Test]
+    public void ModelConfiguration_StockBalanceAndReservation_DefinesConcurrencyAndBalanceUniqueness()
+    {
+        using var db = CreateModelOnlyDbContext(Guid.NewGuid());
+
+        var stockBalance = db.Model.FindEntityType(typeof(StockBalance));
+        stockBalance.Should().NotBeNull();
+        stockBalance!.FindProperty(nameof(StockBalance.ConcurrencyStamp))!
+            .IsConcurrencyToken.Should().BeTrue();
+
+        var expectedBalanceIndex = new[]
+        {
+            nameof(StockBalance.TenantId),
+            nameof(StockBalance.ProductId),
+            nameof(StockBalance.WarehouseId),
+            nameof(StockBalance.LocationId)
+        };
+
+        var hasUniqueBalanceIndex = stockBalance.GetIndexes()
+            .Any(index => index.IsUnique
+                && index.Properties.Select(p => p.Name).SequenceEqual(expectedBalanceIndex));
+        hasUniqueBalanceIndex.Should().BeTrue();
+
+        var reservation = db.Model.FindEntityType(typeof(Reservation));
+        reservation.Should().NotBeNull();
+        reservation!.FindProperty(nameof(Reservation.ConcurrencyStamp))!
+            .IsConcurrencyToken.Should().BeTrue();
+    }
+
+    private static ProductService CreateService(
+        FakeDataContext dataContext,
+        FakeCacheService cache,
+        Guid? tenantId)
+    {
+        var httpContextAccessor = new HttpContextAccessor();
+        if (tenantId.HasValue)
+        {
+            httpContextAccessor.HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim("tenantId", tenantId.Value.ToString())],
+                    authenticationType: "Test"))
+            };
+        }
+
+        return new ProductService(
+            dataContext,
+            cache,
+            NullLogger<ProductService>.Instance,
+            httpContextAccessor);
+    }
+
+    private static AppDbContext CreateModelOnlyDbContext(Guid tenantId)
+    {
+        _ = typeof(StockBalance);
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql("Host=localhost;Database=xframework_inventario_model;Username=test;Password=test")
+            .Options;
+
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim("tenantId", tenantId.ToString())],
+                    authenticationType: "Test"))
+            }
+        };
+
+        var configuration = new ConfigurationBuilder().Build();
+        return new AppDbContext(options, httpContextAccessor, configuration);
+    }
+
+    private sealed class FakeDataContext : IDataContext
+    {
+        private readonly Dictionary<Type, IList> sets = [];
+
+        public List<object> Added { get; } = [];
+        public List<object> Updated { get; } = [];
+        public List<object> Removed { get; } = [];
+        public int SaveCount { get; private set; }
+
+        public List<T> Set<T>() where T : class
+        {
+            if (!sets.TryGetValue(typeof(T), out var set))
+            {
+                set = new List<T>();
+                sets[typeof(T)] = set;
+            }
+
+            return (List<T>)set;
+        }
+
+        public IRemoteQuery<T> Query<T>() where T : class =>
+            new InMemoryRemoteQuery<T>(Set<T>().AsQueryable());
+
+        public void Add<T>(T entity) where T : class
+        {
+            Added.Add(entity);
+            Set<T>().Add(entity);
+        }
+
+        public void Update<T>(T entity) where T : class =>
+            Updated.Add(entity);
+
+        public void Remove<T>(T entity) where T : class =>
+            Removed.Add(entity);
+
+        public Task<DataContextResult> SaveChangesAsync(CancellationToken ct = default)
+        {
+            SaveCount++;
+            return Task.FromResult(DataContextResult.Success());
+        }
+    }
+
+    private sealed class InMemoryRemoteQuery<T>(IQueryable<T> queryable) : IRemoteQuery<T>
+        where T : class
+    {
+        private IQueryable<T> query = queryable;
+
+        public IRemoteQuery<T> Where(Expression<Func<T, bool>> predicate)
+        {
+            query = query.Where(predicate);
+            return this;
+        }
+
+        public IRemoteQuery<T> OrderBy<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            query = query.OrderBy(keySelector);
+            return this;
+        }
+
+        public IRemoteQuery<T> OrderByDescending<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            query = query.OrderByDescending(keySelector);
+            return this;
+        }
+
+        public IRemoteQuery<T> ThenBy<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            query = ((IOrderedQueryable<T>)query).ThenBy(keySelector);
+            return this;
+        }
+
+        public IRemoteQuery<T> ThenByDescending<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            query = ((IOrderedQueryable<T>)query).ThenByDescending(keySelector);
+            return this;
+        }
+
+        public IRemoteQuery<T> Skip(int count)
+        {
+            query = query.Skip(count);
+            return this;
+        }
+
+        public IRemoteQuery<T> Take(int count)
+        {
+            query = query.Take(count);
+            return this;
+        }
+
+        public IRemoteQuery<T> Include<TProperty>(Expression<Func<T, TProperty>> navigationSelector) => this;
+
+        public IRemoteQuery<T> Distinct()
+        {
+            query = query.Distinct();
+            return this;
+        }
+
+        public IRemoteQuery<T> DistinctBy<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            query = query.AsEnumerable().DistinctBy(keySelector.Compile()).AsQueryable();
+            return this;
+        }
+
+        public IRemoteQuery<T> NoCache() => this;
+
+        public Task<List<T>> ToListAsync(CancellationToken ct = default) =>
+            Task.FromResult(query.ToList());
+
+        public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) =>
+            Task.FromResult(query.FirstOrDefault());
+
+        public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default) =>
+            Task.FromResult(query.SingleOrDefault());
+
+        public async IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in query)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+
+        public Task<int> CountAsync(CancellationToken ct = default) =>
+            Task.FromResult(query.Count());
+
+        public Task<bool> AnyAsync(CancellationToken ct = default) =>
+            Task.FromResult(query.Any());
+
+        public Task<bool> AnyAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) =>
+            Task.FromResult(query.Any(predicate));
+
+        public Task<bool> AllAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) =>
+            Task.FromResult(query.All(predicate));
+
+        public Task<TResult?> MinAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) =>
+            Task.FromResult(query.Select(selector).Min());
+
+        public Task<TResult?> MaxAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) =>
+            Task.FromResult(query.Select(selector).Max());
+
+        public Task<T?> MinByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) =>
+            Task.FromResult(query.AsEnumerable().MinBy(keySelector.Compile()));
+
+        public Task<T?> MaxByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) =>
+            Task.FromResult(query.AsEnumerable().MaxBy(keySelector.Compile()));
+
+        public Task<decimal> SumAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) =>
+            Task.FromResult(query.Sum(selector));
+
+        public Task<double> AverageAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) =>
+            Task.FromResult((double)query.Average(selector));
+
+        public Task<List<GroupResult<TKey, T>>> GroupByAsync<TKey>(
+            Expression<Func<T, TKey>> keySelector,
+            CancellationToken ct = default)
+        {
+            var compiled = keySelector.Compile();
+            return Task.FromResult(query
+                .AsEnumerable()
+                .GroupBy(compiled)
+                .Select(g => new GroupResult<TKey, T> { Key = g.Key, Items = g.ToList() })
+                .ToList());
+        }
+    }
+
+    private sealed class FakeCacheService : ICacheService
+    {
+        public List<string> SetKeys { get; } = [];
+
+        public Task<Result<T?>> GetAsync<T>(string key, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Result<T?>.Success(default));
+
+        public Task<Result> SetAsync<T>(
+            string key,
+            T value,
+            TimeSpan? absoluteExpiration = null,
+            TimeSpan? slidingExpiration = null,
+            CancellationToken cancellationToken = default)
+        {
+            SetKeys.Add(key);
+            return Task.FromResult(Result.Success());
+        }
+
+        public Task<Result> RemoveAsync(string key, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Result.Success());
+
+        public Task<Result<bool>> ExistsAsync(string key, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Result<bool>.Success(false));
+
+        public Task<Result<T>> GetOrSetAsync<T>(
+            string key,
+            Func<CancellationToken, Task<T>> factory,
+            TimeSpan? absoluteExpiration = null,
+            TimeSpan? slidingExpiration = null,
+            CancellationToken cancellationToken = default) =>
+            factory(cancellationToken).ContinueWith(t => Result<T>.Success(t.Result), cancellationToken);
+
+        public Task<Result<int>> RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Result<int>.Success(0));
+
+        public Result<CacheStatistics> GetStatistics() =>
+            Result<CacheStatistics>.Success(new CacheStatistics());
+
+        public Task<Result> ClearAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Result.Success());
+    }
+}


### PR DESCRIPTION
## Summary
- Secures Inventario product endpoints and removes generated/demo bypass exposure.
- Uses authenticated tenant context for product writes.
- Splits stock mutation foundation from product updates with warehouse/location, balances, movements, and reservations.
- Adds focused Inventario API tests.

## Verification
- dotnet build src\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj
- dotnet test src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj
- git diff --check

## Notes
- Migration is scoped manually to Inventario tables to avoid unrelated cross-module EF snapshot churn.