### PR TITLE
Harden Community security and tenant ownership

### DIFF
--- a/src/Modules/XFramework.Community/Community.Api/Features/CommunityIdentities/Create/CreateCommunityIdentityValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/CommunityIdentities/Create/CreateCommunityIdentityValidator.cs
@@ -7,9 +7,6 @@ public sealed class CreateCommunityIdentityValidator : AbstractValidator<CreateC
 {
     public CreateCommunityIdentityValidator()
     {
-        RuleFor(x => x.CredentialId)
-            .NotEmpty().WithMessage("Credential ID is required");
-
         RuleFor(x => x.CommunityIdentityTypeId)
             .NotEmpty().WithMessage("Community Identity Type ID is required");
 

--- a/src/Modules/XFramework.Community/Community.Api/Features/CommunityIdentities/Files/Update/UpdateIdentityFileValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/CommunityIdentities/Files/Update/UpdateIdentityFileValidator.cs
@@ -4,13 +4,9 @@ public sealed class UpdateIdentityFileValidator : AbstractValidator<UpdateIdenti
 {
     public UpdateIdentityFileValidator()
     {
-        RuleFor(x => x.IdentityId)
-            .NotEmpty().WithMessage("Identity ID is required");
         RuleFor(x => x.FileId)
             .NotEmpty().WithMessage("File ID is required");
         RuleFor(x => x.StorageFileId)
             .NotEmpty().WithMessage("Storage File ID is required");
-        RuleFor(x => x.RequestingIdentityId)
-            .NotEmpty().WithMessage("Requesting Identity ID is required");
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Connections/Create/CreateConnectionValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Connections/Create/CreateConnectionValidator.cs
@@ -7,9 +7,6 @@ public sealed class CreateConnectionValidator : AbstractValidator<CreateConnecti
 {
     public CreateConnectionValidator()
     {
-        RuleFor(x => x.SourceIdentityId)
-            .NotEmpty().WithMessage("Source Identity ID is required");
-
         RuleFor(x => x.TargetIdentityId)
             .NotEmpty().WithMessage("Target Identity ID is required");
 
@@ -18,6 +15,7 @@ public sealed class CreateConnectionValidator : AbstractValidator<CreateConnecti
 
         RuleFor(x => x.SourceIdentityId)
             .NotEqual(x => x.TargetIdentityId)
-            .WithMessage("Cannot create a connection to yourself");
+            .WithMessage("Cannot create a connection to yourself")
+            .When(x => x.SourceIdentityId != Guid.Empty);
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Connections/Delete/DeleteConnectionValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Connections/Delete/DeleteConnectionValidator.cs
@@ -9,8 +9,5 @@ public sealed class DeleteConnectionValidator : AbstractValidator<DeleteConnecti
     {
         RuleFor(x => x.Id)
             .NotEmpty().WithMessage("Connection ID is required");
-
-        RuleFor(x => x.RequestingIdentityId)
-            .NotEmpty().WithMessage("Requesting Identity ID is required");
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Connections/GetList/GetConnectionListValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Connections/GetList/GetConnectionListValidator.cs
@@ -7,9 +7,6 @@ public sealed class GetConnectionListValidator : AbstractValidator<GetCommunityC
         RuleFor(x => x.ConnectionTypeId)
             .NotEmpty().WithMessage("Connection Type ID is required");
 
-        RuleFor(x => x.CommunityIdentityId)
-            .NotEmpty().WithMessage("Community Identity ID is required");
-
         RuleFor(x => x.Limit)
             .InclusiveBetween(1, 100).WithMessage("Limit must be between 1 and 100");
     }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Content/Create/CreateContentValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Content/Create/CreateContentValidator.cs
@@ -7,9 +7,6 @@ public sealed class CreateContentValidator : AbstractValidator<CreateContentRequ
 {
     public CreateContentValidator()
     {
-        RuleFor(x => x.IdentityId)
-            .NotEmpty().WithMessage("Identity ID is required");
-
         RuleFor(x => x.Text)
             .NotEmpty().WithMessage("Text is required")
             .MaximumLength(5000).WithMessage("Text cannot exceed 5000 characters");

--- a/src/Modules/XFramework.Community/Community.Api/Features/Content/Delete/DeleteContentValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Content/Delete/DeleteContentValidator.cs
@@ -6,8 +6,5 @@ public sealed class DeleteContentValidator : AbstractValidator<DeleteContentRequ
     {
         RuleFor(x => x.Id)
             .NotEmpty().WithMessage("Content ID is required");
-
-        RuleFor(x => x.RequesterId)
-            .NotEmpty().WithMessage("Requester ID is required");
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Content/Edit/EditContentValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Content/Edit/EditContentValidator.cs
@@ -7,9 +7,6 @@ public sealed class EditContentValidator : AbstractValidator<EditContentRequest>
         RuleFor(x => x.ContentId)
             .NotEmpty().WithMessage("Content ID is required");
 
-        RuleFor(x => x.RequestingIdentityId)
-            .NotEmpty().WithMessage("Requesting Identity ID is required");
-
         RuleFor(x => x.Text)
             .MaximumLength(5000).WithMessage("Text cannot exceed 5000 characters")
             .When(x => x.Text is not null);

--- a/src/Modules/XFramework.Community/Community.Api/Features/Content/Files/Create/CreateContentFileValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Content/Files/Create/CreateContentFileValidator.cs
@@ -8,7 +8,5 @@ public sealed class CreateContentFileValidator : AbstractValidator<CreateContent
             .NotEmpty().WithMessage("Content ID is required");
         RuleFor(x => x.StorageFileId)
             .NotEmpty().WithMessage("Storage File ID is required");
-        RuleFor(x => x.RequestingIdentityId)
-            .NotEmpty().WithMessage("Requesting Identity ID is required");
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Content/Files/Delete/DeleteContentFileValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Content/Files/Delete/DeleteContentFileValidator.cs
@@ -8,7 +8,5 @@ public sealed class DeleteContentFileValidator : AbstractValidator<DeleteContent
             .NotEmpty().WithMessage("Content ID is required");
         RuleFor(x => x.FileId)
             .NotEmpty().WithMessage("File ID is required");
-        RuleFor(x => x.RequestingIdentityId)
-            .NotEmpty().WithMessage("Requesting Identity ID is required");
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Content/Reactions/Create/CreateContentReactionValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Content/Reactions/Create/CreateContentReactionValidator.cs
@@ -13,7 +13,5 @@ public sealed class CreateContentReactionValidator : AbstractValidator<CreateCon
         RuleFor(x => x.TypeId)
             .NotEmpty().WithMessage("Reaction type ID is required");
 
-        RuleFor(x => x.IdentityId)
-            .NotEmpty().WithMessage("Identity ID is required");
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Content/Reactions/Delete/DeleteContentReactionValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Content/Reactions/Delete/DeleteContentReactionValidator.cs
@@ -9,8 +9,5 @@ public sealed class DeleteContentReactionValidator : AbstractValidator<DeleteCon
 
         RuleFor(x => x.ReactionId)
             .NotEmpty().WithMessage("Reaction ID is required");
-
-        RuleFor(x => x.RequesterId)
-            .NotEmpty().WithMessage("Requester ID is required");
     }
 }

--- a/src/Modules/XFramework.Community/Community.Api/Features/Notifications/GetList/GetNotificationsValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Notifications/GetList/GetNotificationsValidator.cs
@@ -7,12 +7,6 @@ public sealed class GetNotificationsValidator : AbstractValidator<GetNotificatio
 {
     public GetNotificationsValidator()
     {
-        RuleFor(x => x.IdentityId)
-            .NotEmpty().WithMessage("Identity ID is required");
-
-        RuleFor(x => x.RequestingIdentityId)
-            .NotEmpty().WithMessage("Requesting Identity ID is required");
-
         RuleFor(x => x.PageSize)
             .InclusiveBetween(1, 100).WithMessage("Page size must be between 1 and 100");
 

--- a/src/Modules/XFramework.Community/Community.Api/Features/Notifications/MarkRead/MarkNotificationsReadValidator.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Features/Notifications/MarkRead/MarkNotificationsReadValidator.cs
@@ -7,9 +7,6 @@ public sealed class MarkNotificationsReadValidator : AbstractValidator<MarkNotif
 {
     public MarkNotificationsReadValidator()
     {
-        RuleFor(x => x.RequestingIdentityId)
-            .NotEmpty().WithMessage("Requesting Identity ID is required");
-
         RuleFor(x => x.NotificationIds)
             .NotEmpty().WithMessage("At least one notification ID is required");
 

--- a/src/Modules/XFramework.Community/Community.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Installers/ServicesInstaller.cs
@@ -11,6 +11,7 @@ public sealed class ServicesInstaller : IInstaller
         services.AddTenantResolver();
         
         // Register Community Services (VSA Architecture)
+        services.AddScoped<ICommunityRequestContext, CommunityRequestContext>();
         services.AddScoped<ICommunityService, CommunityService>();
         services.AddScoped<IContentService, ContentService>();
         services.AddScoped<IConnectionService, ConnectionService>();

--- a/src/Modules/XFramework.Community/Community.Api/Program.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Program.cs
@@ -21,7 +21,7 @@ builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 // Register DataContext handler for entity query/mutation via Bolt
 builder.Services.AddDataContextHandler(typeof(Program).Assembly);
 
-// Rate limiting — global 100/min per IP
+// Rate limiting: global 100/min per IP
 builder.Services.AddXFrameworkRateLimiting();
 
 var app = (WebApplication)builder.Build();
@@ -32,6 +32,8 @@ app.EnsureDatabase<AppDbContext>();
 app.MapXFrameworkHealthChecks("Community");
 
 // Map feature endpoints (source-generated from [MapPost/Get/...] attributes)
-app.MapGeneratedEndpoints();
+// through an authorized route group so manual Community routes are not anonymous.
+var authorizedCommunityRoutes = app.MapGroup("").RequireAuthorization();
+authorizedCommunityRoutes.MapGeneratedEndpoints();
 
 app.Run();

--- a/src/Modules/XFramework.Community/Community.Api/Services/CommunityRequestContext.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Services/CommunityRequestContext.cs
@@ -1,0 +1,141 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using XFramework.Domain.Shared.DataContext;
+
+namespace Community.Api.Services;
+
+public sealed record CommunityRequester(Guid CredentialId, Guid TenantId, CommunityIdentity? Identity)
+{
+    public Guid IdentityId => Identity?.Id ?? Guid.Empty;
+}
+
+public interface ICommunityRequestContext
+{
+    Task<Result<CommunityRequester>> GetRequiredAsync(
+        RequestMetadata? metadata,
+        CancellationToken cancellationToken = default);
+
+    Task<Result<CommunityRequester>> GetRequiredIdentityAsync(
+        RequestMetadata? metadata,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class CommunityRequestContext(
+    IHttpContextAccessor httpContextAccessor,
+    DbContext dbContext,
+    IDataContext dataContext) : ICommunityRequestContext
+{
+    private static readonly string[] CredentialClaimTypes =
+    [
+        ClaimTypes.Name,
+        ClaimTypes.NameIdentifier,
+        "credentialId",
+        "CredentialId",
+        "sub"
+    ];
+
+    private static readonly string[] TenantClaimTypes =
+    [
+        "tenantId",
+        "TenantId",
+        "tid"
+    ];
+
+    public async Task<Result<CommunityRequester>> GetRequiredAsync(
+        RequestMetadata? metadata,
+        CancellationToken cancellationToken = default)
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return Result<CommunityRequester>.Unauthorized("Authenticated user context is required");
+        }
+
+        if (!TryGetClaimGuid(user, CredentialClaimTypes, out var credentialId))
+        {
+            return Result<CommunityRequester>.Unauthorized("Authenticated credential claim is required");
+        }
+
+        var credentialTenantId = await dbContext.Set<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .Where(c => c.Id == credentialId && !c.IsDeleted && c.IsEnabled)
+            .Select(c => c.TenantId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (credentialTenantId == Guid.Empty)
+        {
+            return Result<CommunityRequester>.Unauthorized("Authenticated credential could not be resolved");
+        }
+
+        if (TryGetClaimGuid(user, TenantClaimTypes, out var tenantClaimId)
+            && tenantClaimId != credentialTenantId)
+        {
+            return Result<CommunityRequester>.Forbidden("Authenticated credential does not belong to the requested tenant");
+        }
+
+        if (metadata?.TenantId is { } metadataTenantId
+            && metadataTenantId != Guid.Empty
+            && metadataTenantId != credentialTenantId)
+        {
+            return Result<CommunityRequester>.Forbidden("Request tenant does not match authenticated credential tenant");
+        }
+
+        EnsureTenantClaim(user, credentialTenantId);
+
+        return Result<CommunityRequester>.Success(new(credentialId, credentialTenantId, null));
+    }
+
+    public async Task<Result<CommunityRequester>> GetRequiredIdentityAsync(
+        RequestMetadata? metadata,
+        CancellationToken cancellationToken = default)
+    {
+        var requesterResult = await GetRequiredAsync(metadata, cancellationToken);
+        if (!requesterResult.IsSuccess)
+        {
+            return requesterResult;
+        }
+
+        var requester = requesterResult.Data!;
+        var identity = await dataContext.Query<CommunityIdentity>()
+            .Where(i => i.CredentialId == requester.CredentialId)
+            .Where(i => i.TenantId == requester.TenantId)
+            .Where(i => !i.IsDeleted)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (identity is null)
+        {
+            return Result<CommunityRequester>.NotFound("Community identity for authenticated credential does not exist");
+        }
+
+        return Result<CommunityRequester>.Success(requester with { Identity = identity });
+    }
+
+    private static bool TryGetClaimGuid(
+        ClaimsPrincipal user,
+        IEnumerable<string> claimTypes,
+        out Guid value)
+    {
+        foreach (var claimType in claimTypes)
+        {
+            var rawValue = user.FindFirst(claimType)?.Value;
+            if (Guid.TryParse(rawValue, out value))
+            {
+                return true;
+            }
+        }
+
+        value = Guid.Empty;
+        return false;
+    }
+
+    private static void EnsureTenantClaim(ClaimsPrincipal user, Guid tenantId)
+    {
+        if (TryGetClaimGuid(user, TenantClaimTypes, out _))
+        {
+            return;
+        }
+
+        var identity = user.Identities.FirstOrDefault(i => i.IsAuthenticated);
+        identity?.AddClaim(new("tenantId", tenantId.ToString()));
+    }
+}

--- a/src/Modules/XFramework.Community/Community.Api/Services/CommunitySecurity.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Services/CommunitySecurity.cs
@@ -1,0 +1,25 @@
+using XFramework.Domain.Shared.DataContext;
+
+namespace Community.Api.Services;
+
+internal static class CommunitySecurity
+{
+    public static bool IsSpoofed(Guid suppliedId, Guid actualId) =>
+        suppliedId != Guid.Empty && suppliedId != actualId;
+
+    public static Result<TOut> ToFailure<TIn, TOut>(Result<TIn> result) =>
+        Result<TOut>.Failure(result.Message ?? "Operation failed", result.StatusCode);
+
+    public static Result<CmdResponse>? SaveFailure(DataContextResult result, string operation)
+    {
+        if (result.IsSuccess)
+        {
+            return null;
+        }
+
+        var statusCode = result.StatusCode >= 400 ? result.StatusCode : 500;
+        return Result<CmdResponse>.Failure(
+            result.Message ?? $"{operation} failed to save changes",
+            statusCode);
+    }
+}

--- a/src/Modules/XFramework.Community/Community.Api/Services/CommunityService.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Services/CommunityService.cs
@@ -11,16 +11,16 @@ namespace Community.Api.Services;
 public sealed class CommunityService : ICommunityService
 {
     private readonly IDataContext _dataContext;
-    private readonly ITenantResolver _tenantService;
+    private readonly ICommunityRequestContext _requestContext;
     private readonly ILogger<CommunityService> _logger;
 
     public CommunityService(
         IDataContext dataContext,
-        ITenantResolver tenantService,
+        ICommunityRequestContext requestContext,
         ILogger<CommunityService> logger)
     {
         _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
-        _tenantService = tenantService ?? throw new ArgumentNullException(nameof(tenantService));
+        _requestContext = requestContext ?? throw new ArgumentNullException(nameof(requestContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -31,23 +31,39 @@ public sealed class CommunityService : ICommunityService
     {
         try
         {
-            var tenant = await _tenantService.GetTenant(request.Metadata.TenantId);
+            var requesterResult = await _requestContext.GetRequiredAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.CredentialId, requester.CredentialId))
+                return Result<CmdResponse>.Forbidden("Credential ID does not match authenticated user");
+
+            var existingIdentity = await _dataContext.Query<CommunityIdentity>()
+                .Where(i => i.CredentialId == requester.CredentialId)
+                .Where(i => i.TenantId == requester.TenantId)
+                .Where(i => !i.IsDeleted)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (existingIdentity is not null)
+                return Result<CmdResponse>.Conflict("Authenticated credential already has a community identity");
 
             // Fetch credential with identity info
             var credential = await _dataContext.Query<IdentityCredential>()
-                .Where(i => i.TenantId == tenant.Id)
+                .Where(i => i.TenantId == requester.TenantId)
                 .Include(i => i.IdentityInfo)
-                .Where(i => i.Id == request.CredentialId)
+                .Where(i => i.Id == requester.CredentialId)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (credential == null)
             {
-                _logger.CommunityCredentialNotFound(request.CredentialId);
-                return Result<CmdResponse>.NotFound($"Credential with Id {request.CredentialId} does not exist");
+                _logger.CommunityCredentialNotFound(requester.CredentialId);
+                return Result<CmdResponse>.NotFound($"Credential with Id {requester.CredentialId} does not exist");
             }
 
             // Fetch community identity type
             var communityIdentityType = await _dataContext.Query<CommunityIdentityType>()
+                .Where(i => i.TenantId == requester.TenantId)
                 .Where(i => i.Id == request.CommunityIdentityTypeId)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -83,6 +99,8 @@ public sealed class CommunityService : ICommunityService
             // Create community identity entity
             var entity = new CommunityIdentity
             {
+                TenantId = requester.TenantId,
+                CredentialId = requester.CredentialId,
                 Credential = credential,
                 HandleName = string.IsNullOrWhiteSpace(request.HandleName)
                     ? fallbackHandleName
@@ -97,9 +115,11 @@ public sealed class CommunityService : ICommunityService
                     // Profile Photo
                     new()
                     {
+                        TenantId = requester.TenantId,
                         Type = profilePhotoType,
                         Storage = new()
                         {
+                            TenantId = requester.TenantId,
                             ContentPath = "",
                             Type = pngType
                         }
@@ -107,9 +127,11 @@ public sealed class CommunityService : ICommunityService
                     // Cover Photo
                     new()
                     {
+                        TenantId = requester.TenantId,
                         Type = coverPhotoType,
                         Storage = new()
                         {
+                            TenantId = requester.TenantId,
                             ContentPath = "",
                             Type = pngType
                         }
@@ -118,9 +140,11 @@ public sealed class CommunityService : ICommunityService
             };
 
             _dataContext.Add(entity);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "CreateCommunityIdentity") is { } saveFailure)
+                return saveFailure;
 
-            _logger.CommunityIdentityCreated(request.CredentialId);
+            _logger.CommunityIdentityCreated(requester.CredentialId);
 
             return Result<CmdResponse>.Success(new CmdResponse
             {
@@ -130,7 +154,7 @@ public sealed class CommunityService : ICommunityService
         }
         catch (Exception ex)
         {
-            _logger.CommunityIdentityCreationError(request.CredentialId, ex);
+            _logger.CommunityIdentityCreationError(request.CredentialId == Guid.Empty ? Guid.Empty : request.CredentialId, ex);
             return Result<CmdResponse>.Failure("An error occurred while creating community identity", 500);
         }
     }
@@ -142,8 +166,20 @@ public sealed class CommunityService : ICommunityService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (requester.IdentityId != request.Id)
+                return Result<CmdResponse>.Forbidden("You can only update your own community identity");
+
+            if (CommunitySecurity.IsSpoofed(request.CredentialId, requester.CredentialId))
+                return Result<CmdResponse>.Forbidden("Credential ID does not match authenticated user");
+
             // Fetch existing community identity
             var communityIdentity = await _dataContext.Query<CommunityIdentity>()
+                .Where(i => i.TenantId == requester.TenantId)
                 .Where(i => i.Id == request.Id)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -153,29 +189,11 @@ public sealed class CommunityService : ICommunityService
                 return Result<CmdResponse>.NotFound($"Community identity with id {request.Id} does not exist");
             }
 
-            // Map request to entity using Mapster
-            communityIdentity = request.Adapt(communityIdentity);
-
-            // Update credential if provided
-            if (request.CredentialId != Guid.Empty)
-            {
-                var credential = await _dataContext.Query<IdentityCredential>()
-                    .Where(i => i.Id == request.CredentialId)
-                    .FirstOrDefaultAsync(cancellationToken);
-
-                if (credential == null)
-                {
-                    _logger.CommunityCredentialNotFound(request.CredentialId);
-                    return Result<CmdResponse>.NotFound($"Credential with id {request.CredentialId} does not exist");
-                }
-
-                communityIdentity.Credential = credential;
-            }
-
             // Update community identity type if provided
             if (request.CommunityIdentityTypeId != Guid.Empty)
             {
                 var communityIdentityType = await _dataContext.Query<CommunityIdentityType>()
+                    .Where(i => i.TenantId == requester.TenantId)
                     .Where(i => i.Id == request.CommunityIdentityTypeId)
                     .FirstOrDefaultAsync(cancellationToken);
 
@@ -189,7 +207,9 @@ public sealed class CommunityService : ICommunityService
             }
 
             _dataContext.Update(communityIdentity);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "UpdateCommunityIdentity") is { } saveFailure)
+                return saveFailure;
 
             _logger.CommunityIdentityUpdated(request.Id);
 
@@ -213,8 +233,21 @@ public sealed class CommunityService : ICommunityService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, List<CommunityConnection>>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            var requestedIdentityId = request.CommunityIdentityId == Guid.Empty
+                ? requester.IdentityId
+                : request.CommunityIdentityId;
+
+            if (requestedIdentityId != requester.IdentityId)
+                return Result<List<CommunityConnection>>.Forbidden("You can only retrieve your own connections");
+
             // Fetch connection type
             var connectionType = await _dataContext.Query<CommunityConnectionType>()
+                .Where(i => i.TenantId == requester.TenantId)
                 .Where(i => i.Id == request.ConnectionTypeId)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -226,19 +259,21 @@ public sealed class CommunityService : ICommunityService
 
             // Fetch community identity
             var communityIdentity = await _dataContext.Query<CommunityIdentity>()
-                .Where(i => i.Id == request.CommunityIdentityId)
+                .Where(i => i.TenantId == requester.TenantId)
+                .Where(i => i.Id == requestedIdentityId)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (communityIdentity == null)
             {
-                _logger.CommunityIdentityNotFound(request.CommunityIdentityId);
-                return Result<List<CommunityConnection>>.NotFound($"Community identity with id {request.CommunityIdentityId} does not exist");
+                _logger.CommunityIdentityNotFound(requestedIdentityId);
+                return Result<List<CommunityConnection>>.NotFound($"Community identity with id {requestedIdentityId} does not exist");
             }
 
             // Fetch connection list
             var connectionList = await _dataContext.Query<CommunityConnection>()
                 .Include(i => i.SourceSocialMediaIdentity)
                 .Include(i => i.TargetSocialMediaIdentity)
+                .Where(i => i.TenantId == requester.TenantId)
                 .Where(i => i.TypeId == connectionType.Id)
                 .Where(i => i.SourceSocialMediaIdentityId == communityIdentity.Id ||
                            i.TargetSocialMediaIdentityId == communityIdentity.Id)
@@ -247,11 +282,11 @@ public sealed class CommunityService : ICommunityService
 
             if (!connectionList.Any())
             {
-                _logger.CommunityNoConnectionsFound(request.CommunityIdentityId);
+                _logger.CommunityNoConnectionsFound(requestedIdentityId);
                 return Result<List<CommunityConnection>>.Success([]);
             }
 
-            _logger.CommunityConnectionsRetrieved(connectionList.Count, request.CommunityIdentityId);
+            _logger.CommunityConnectionsRetrieved(connectionList.Count, requestedIdentityId);
 
             return Result<List<CommunityConnection>>.Success(connectionList);
         }
@@ -269,17 +304,27 @@ public sealed class CommunityService : ICommunityService
     {
         try
         {
-            if (request.RequestingIdentityId != request.IdentityId)
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.IdentityId, requester.IdentityId)
+                || CommunitySecurity.IsSpoofed(request.RequestingIdentityId, requester.IdentityId))
+            {
                 return Result<CmdResponse>.Forbidden("You can only update your own identity files");
+            }
 
             var storageFileExists = await _dataContext.Query<StorageFile>()
+                .Where(f => f.TenantId == requester.TenantId)
                 .AnyAsync(f => f.Id == request.StorageFileId, cancellationToken);
 
             if (!storageFileExists)
                 return Result<CmdResponse>.NotFound($"Storage file with Id {request.StorageFileId} does not exist");
 
             var file = await _dataContext.Query<CommunityIdentityFile>()
-                .Where(f => f.Id == request.FileId && f.IdentityId == request.IdentityId && !f.IsDeleted)
+                .Where(f => f.TenantId == requester.TenantId)
+                .Where(f => f.Id == request.FileId && f.IdentityId == requester.IdentityId && !f.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (file == null)
@@ -289,7 +334,9 @@ public sealed class CommunityService : ICommunityService
             file.ModifiedAt = DateTime.UtcNow;
 
             _dataContext.Update(file);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "UpdateIdentityFile") is { } saveFailure)
+                return saveFailure;
 
             return Result<CmdResponse>.Success(new CmdResponse
             {

--- a/src/Modules/XFramework.Community/Community.Api/Services/ConnectionService.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Services/ConnectionService.cs
@@ -10,15 +10,18 @@ public sealed class ConnectionService : IConnectionService
 {
     private readonly IDataContext _dataContext;
     private readonly INotificationService _notificationService;
+    private readonly ICommunityRequestContext _requestContext;
     private readonly ILogger<ConnectionService> _logger;
 
     public ConnectionService(
         IDataContext dataContext,
         INotificationService notificationService,
+        ICommunityRequestContext requestContext,
         ILogger<ConnectionService> logger)
     {
         _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
         _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
+        _requestContext = requestContext ?? throw new ArgumentNullException(nameof(requestContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -29,29 +32,39 @@ public sealed class ConnectionService : IConnectionService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.SourceIdentityId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Source identity ID does not match authenticated user");
+
             // Prevent self-connections
-            if (request.SourceIdentityId == request.TargetIdentityId)
+            if (requester.IdentityId == request.TargetIdentityId)
             {
                 return Result<CmdResponse>.Failure("Cannot create a connection to yourself", 400);
             }
 
             // Check if either party has blocked the other
-            if (await IsBlockedAsync(request.SourceIdentityId, request.TargetIdentityId, cancellationToken))
-                return Result<CmdResponse>.Forbidden("Cannot create connection — a block exists between these identities");
+            if (await IsBlockedAsync(requester.IdentityId, request.TargetIdentityId, cancellationToken))
+                return Result<CmdResponse>.Forbidden("Cannot create connection because a block exists between these identities");
 
             // Validate source identity exists
             var sourceIdentity = await _dataContext.Query<CommunityIdentity>()
-                .Where(i => i.Id == request.SourceIdentityId)
+                .Where(i => i.TenantId == requester.TenantId)
+                .Where(i => i.Id == requester.IdentityId)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (sourceIdentity == null)
             {
-                _logger.CommunityIdentityNotFound(request.SourceIdentityId);
-                return Result<CmdResponse>.NotFound($"Source identity with Id {request.SourceIdentityId} does not exist");
+                _logger.CommunityIdentityNotFound(requester.IdentityId);
+                return Result<CmdResponse>.NotFound($"Source identity with Id {requester.IdentityId} does not exist");
             }
 
             // Validate target identity exists
             var targetIdentity = await _dataContext.Query<CommunityIdentity>()
+                .Where(i => i.TenantId == requester.TenantId)
                 .Where(i => i.Id == request.TargetIdentityId)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -63,6 +76,7 @@ public sealed class ConnectionService : IConnectionService
 
             // Validate connection type exists
             var connectionType = await _dataContext.Query<CommunityConnectionType>()
+                .Where(i => i.TenantId == requester.TenantId)
                 .Where(i => i.Id == request.TypeId)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -74,7 +88,8 @@ public sealed class ConnectionService : IConnectionService
 
             // Check for duplicate connections (same source + target + type)
             var existingConnection = await _dataContext.Query<CommunityConnection>()
-                .Where(i => i.SourceSocialMediaIdentityId == request.SourceIdentityId)
+                .Where(i => i.TenantId == requester.TenantId)
+                .Where(i => i.SourceSocialMediaIdentityId == requester.IdentityId)
                 .Where(i => i.TargetSocialMediaIdentityId == request.TargetIdentityId)
                 .Where(i => i.TypeId == request.TypeId)
                 .Where(i => !i.IsDeleted)
@@ -88,7 +103,8 @@ public sealed class ConnectionService : IConnectionService
             // Create the connection
             var entity = new CommunityConnection
             {
-                SourceSocialMediaIdentityId = request.SourceIdentityId,
+                TenantId = requester.TenantId,
+                SourceSocialMediaIdentityId = requester.IdentityId,
                 TargetSocialMediaIdentityId = request.TargetIdentityId,
                 TypeId = request.TypeId,
                 IsEnabled = true,
@@ -96,19 +112,25 @@ public sealed class ConnectionService : IConnectionService
             };
 
             _dataContext.Add(entity);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "CreateConnection") is { } saveFailure)
+                return saveFailure;
 
-            _logger.CommunityConnectionCreated(entity.Id, request.SourceIdentityId, request.TargetIdentityId);
+            _logger.CommunityConnectionCreated(entity.Id, requester.IdentityId, request.TargetIdentityId);
 
             if (request.TypeId == Community.Domain.Shared.CommunityConnectionTypes.Follow)
             {
-                await _notificationService.CreateNotificationAsync(
+                var notificationResult = await _notificationService.CreateNotificationAsync(
+                    requester.TenantId,
                     request.TargetIdentityId,
-                    request.SourceIdentityId,
+                    requester.IdentityId,
                     Community.Domain.Shared.Enums.NotificationType.Follow,
                     entity.Id,
                     $"{sourceIdentity.HandleName ?? "Someone"} started following you",
                     cancellationToken);
+
+                if (!notificationResult.IsSuccess)
+                    return notificationResult;
             }
 
             return Result<CmdResponse>.Success(new CmdResponse
@@ -131,8 +153,17 @@ public sealed class ConnectionService : IConnectionService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.RequestingIdentityId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Requesting identity ID does not match authenticated user");
+
             // Find the connection
             var connection = await _dataContext.Query<CommunityConnection>()
+                .Where(i => i.TenantId == requester.TenantId)
                 .Where(i => i.Id == request.Id)
                 .Where(i => !i.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
@@ -143,7 +174,7 @@ public sealed class ConnectionService : IConnectionService
             }
 
             // Validate the requester owns the connection (is the source)
-            if (connection.SourceSocialMediaIdentityId != request.RequestingIdentityId)
+            if (connection.SourceSocialMediaIdentityId != requester.IdentityId)
             {
                 return Result<CmdResponse>.Forbidden("You can only delete your own connections");
             }
@@ -154,7 +185,9 @@ public sealed class ConnectionService : IConnectionService
             connection.IsEnabled = false;
 
             _dataContext.Update(connection);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "DeleteConnection") is { } saveFailure)
+                return saveFailure;
 
             _logger.CommunityConnectionDeleted(request.Id);
 

--- a/src/Modules/XFramework.Community/Community.Api/Services/ContentService.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Services/ContentService.cs
@@ -10,15 +10,18 @@ public sealed class ContentService : IContentService
 {
     private readonly IDataContext _dataContext;
     private readonly IConnectionService _connectionService;
+    private readonly ICommunityRequestContext _requestContext;
     private readonly ILogger<ContentService> _logger;
 
     public ContentService(
         IDataContext dataContext,
         IConnectionService connectionService,
+        ICommunityRequestContext requestContext,
         ILogger<ContentService> logger)
     {
         _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
         _connectionService = connectionService ?? throw new ArgumentNullException(nameof(connectionService));
+        _requestContext = requestContext ?? throw new ArgumentNullException(nameof(requestContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -29,18 +32,28 @@ public sealed class ContentService : IContentService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.IdentityId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Identity ID does not match authenticated user");
+
             // Validate identity exists
             var identity = await _dataContext.Query<CommunityIdentity>()
-                .Where(i => i.Id == request.IdentityId && !i.IsDeleted)
+                .Where(i => i.TenantId == requester.TenantId)
+                .Where(i => i.Id == requester.IdentityId && !i.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (identity == null)
             {
-                _logger.CommunityIdentityNotFound(request.IdentityId);
-                return Result<CmdResponse>.NotFound($"Community identity with Id {request.IdentityId} does not exist");
+                _logger.CommunityIdentityNotFound(requester.IdentityId);
+                return Result<CmdResponse>.NotFound($"Community identity with Id {requester.IdentityId} does not exist");
             }
 
             var contentTypeExists = await _dataContext.Query<CommunityContentType>()
+                .Where(t => t.TenantId == requester.TenantId)
                 .AnyAsync(t => t.Id == request.TypeId, cancellationToken);
 
             if (!contentTypeExists)
@@ -54,6 +67,7 @@ public sealed class ContentService : IContentService
             if (request.ParentContentId.HasValue)
             {
                 parentContent = await _dataContext.Query<CommunityContent>()
+                    .Where(c => c.TenantId == requester.TenantId)
                     .Where(c => c.Id == request.ParentContentId.Value && !c.IsDeleted)
                     .FirstOrDefaultAsync(cancellationToken);
 
@@ -64,7 +78,7 @@ public sealed class ContentService : IContentService
                 }
 
                 if (await _connectionService.IsBlockedAsync(
-                        request.IdentityId,
+                        requester.IdentityId,
                         parentContent.SocialMediaIdentityId,
                         cancellationToken))
                 {
@@ -75,27 +89,31 @@ public sealed class ContentService : IContentService
             // Create content record
             var entity = new CommunityContent
             {
+                TenantId = requester.TenantId,
                 Text = request.Text,
                 TypeId = request.TypeId,
-                SocialMediaIdentityId = request.IdentityId,
-                CommunityGroupId = parentContent?.CommunityGroupId ?? request.IdentityId,
+                SocialMediaIdentityId = requester.IdentityId,
+                CommunityGroupId = parentContent?.CommunityGroupId ?? requester.IdentityId,
                 ParentContentId = request.ParentContentId,
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
 
             _dataContext.Add(entity);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "CreateContent") is { } saveFailure)
+                return saveFailure;
 
             // If it's a comment, create a notification for the content author
             if (parentContent is not null)
             {
-                if (parentContent.SocialMediaIdentityId != request.IdentityId)
+                if (parentContent.SocialMediaIdentityId != requester.IdentityId)
                 {
                     var notification = new CommunityNotification
                     {
+                        TenantId = requester.TenantId,
                         RecipientIdentityId = parentContent.SocialMediaIdentityId,
-                        ActorIdentityId = request.IdentityId,
+                        ActorIdentityId = requester.IdentityId,
                         ContentId = entity.Id,
                         Type = "Comment",
                         Message = "commented on your post",
@@ -105,7 +123,9 @@ public sealed class ContentService : IContentService
                     };
 
                     _dataContext.Add(notification);
-                    await _dataContext.SaveChangesAsync(cancellationToken);
+                    var notificationSaveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+                    if (CommunitySecurity.SaveFailure(notificationSaveResult, "CreateCommentNotification") is { } notificationSaveFailure)
+                        return notificationSaveFailure;
                 }
             }
 
@@ -195,7 +215,16 @@ public sealed class ContentService : IContentService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.RequesterId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Requester ID does not match authenticated user");
+
             var content = await _dataContext.Query<CommunityContent>()
+                .Where(c => c.TenantId == requester.TenantId)
                 .Where(c => c.Id == request.Id && !c.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -206,9 +235,9 @@ public sealed class ContentService : IContentService
             }
 
             // Validate requester owns the content
-            if (content.SocialMediaIdentityId != request.RequesterId)
+            if (content.SocialMediaIdentityId != requester.IdentityId)
             {
-                _logger.BusinessRuleViolation("DeleteContent", $"Identity {request.RequesterId} does not own content {request.Id}");
+                _logger.BusinessRuleViolation("DeleteContent", $"Identity {requester.IdentityId} does not own content {request.Id}");
                 return Result<CmdResponse>.Forbidden("You do not have permission to delete this content");
             }
 
@@ -216,7 +245,9 @@ public sealed class ContentService : IContentService
             content.IsDeleted = true;
             content.DeletedAt = DateTime.UtcNow;
             _dataContext.Update(content);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "DeleteContent") is { } saveFailure)
+                return saveFailure;
 
             _logger.EntityDeleted("CommunityContent", request.Id);
 
@@ -240,7 +271,16 @@ public sealed class ContentService : IContentService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.RequestingIdentityId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Requesting identity ID does not match authenticated user");
+
             var content = await _dataContext.Query<CommunityContent>()
+                .Where(c => c.TenantId == requester.TenantId)
                 .Where(c => c.Id == request.ContentId && !c.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -250,9 +290,9 @@ public sealed class ContentService : IContentService
                 return Result<CmdResponse>.NotFound($"Content with Id {request.ContentId} does not exist");
             }
 
-            if (content.SocialMediaIdentityId != request.RequestingIdentityId)
+            if (content.SocialMediaIdentityId != requester.IdentityId)
             {
-                _logger.BusinessRuleViolation("EditContent", $"Identity {request.RequestingIdentityId} does not own content {request.ContentId}");
+                _logger.BusinessRuleViolation("EditContent", $"Identity {requester.IdentityId} does not own content {request.ContentId}");
                 return Result<CmdResponse>.Forbidden("You do not have permission to edit this content");
             }
 
@@ -265,7 +305,9 @@ public sealed class ContentService : IContentService
             content.ModifiedAt = DateTime.UtcNow;
 
             _dataContext.Update(content);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "EditContent") is { } saveFailure)
+                return saveFailure;
 
             _logger.EntityUpdated("CommunityContent", request.ContentId);
 
@@ -289,8 +331,17 @@ public sealed class ContentService : IContentService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.IdentityId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Identity ID does not match authenticated user");
+
             // Validate content exists
             var content = await _dataContext.Query<CommunityContent>()
+                .Where(c => c.TenantId == requester.TenantId)
                 .Where(c => c.Id == request.ContentId && !c.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -302,16 +353,18 @@ public sealed class ContentService : IContentService
 
             // Validate identity exists
             var identity = await _dataContext.Query<CommunityIdentity>()
-                .Where(i => i.Id == request.IdentityId && !i.IsDeleted)
+                .Where(i => i.TenantId == requester.TenantId)
+                .Where(i => i.Id == requester.IdentityId && !i.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (identity == null)
             {
-                _logger.CommunityIdentityNotFound(request.IdentityId);
-                return Result<CmdResponse>.NotFound($"Community identity with Id {request.IdentityId} does not exist");
+                _logger.CommunityIdentityNotFound(requester.IdentityId);
+                return Result<CmdResponse>.NotFound($"Community identity with Id {requester.IdentityId} does not exist");
             }
 
             var reactionTypeExists = await _dataContext.Query<CommunityContentReactionType>()
+                .Where(t => t.TenantId == requester.TenantId)
                 .AnyAsync(t => t.Id == request.TypeId, cancellationToken);
 
             if (!reactionTypeExists)
@@ -321,43 +374,48 @@ public sealed class ContentService : IContentService
             }
 
             // Block check
-            if (await _connectionService.IsBlockedAsync(request.IdentityId, content.SocialMediaIdentityId, cancellationToken))
-                return Result<CmdResponse>.Forbidden("Cannot react — a block exists between you and the content author");
+            if (await _connectionService.IsBlockedAsync(requester.IdentityId, content.SocialMediaIdentityId, cancellationToken))
+                return Result<CmdResponse>.Forbidden("Cannot react because a block exists between you and the content author");
 
             // Prevent duplicate (same identity + same type on same content)
             var existingReaction = await _dataContext.Query<CommunityContentReaction>()
+                .Where(r => r.TenantId == requester.TenantId)
                 .Where(r => r.ContentId == request.ContentId
-                         && r.SocialMediaIdentityId == request.IdentityId
+                         && r.SocialMediaIdentityId == requester.IdentityId
                          && r.TypeId == request.TypeId
                          && !r.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (existingReaction != null)
             {
-                _logger.BusinessRuleViolation("CreateContentReaction", $"Duplicate reaction: identity {request.IdentityId} already reacted with type {request.TypeId} on content {request.ContentId}");
+                _logger.BusinessRuleViolation("CreateContentReaction", $"Duplicate reaction: identity {requester.IdentityId} already reacted with type {request.TypeId} on content {request.ContentId}");
                 return Result<CmdResponse>.Conflict("You have already reacted with this type on this content");
             }
 
             // Create reaction
             var entity = new CommunityContentReaction
             {
+                TenantId = requester.TenantId,
                 ContentId = request.ContentId,
                 TypeId = request.TypeId,
-                SocialMediaIdentityId = request.IdentityId,
+                SocialMediaIdentityId = requester.IdentityId,
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
             };
 
             _dataContext.Add(entity);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "CreateContentReaction") is { } saveFailure)
+                return saveFailure;
 
             // Create notification for content author (if not reacting to own content)
-            if (content.SocialMediaIdentityId != request.IdentityId)
+            if (content.SocialMediaIdentityId != requester.IdentityId)
             {
                 var notification = new CommunityNotification
                 {
+                    TenantId = requester.TenantId,
                     RecipientIdentityId = content.SocialMediaIdentityId,
-                    ActorIdentityId = request.IdentityId,
+                    ActorIdentityId = requester.IdentityId,
                     ContentId = content.Id,
                     Type = "Reaction",
                     Message = "reacted to your post",
@@ -367,7 +425,9 @@ public sealed class ContentService : IContentService
                 };
 
                 _dataContext.Add(notification);
-                await _dataContext.SaveChangesAsync(cancellationToken);
+                var notificationSaveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+                if (CommunitySecurity.SaveFailure(notificationSaveResult, "CreateReactionNotification") is { } notificationSaveFailure)
+                    return notificationSaveFailure;
             }
 
             _logger.EntityCreated("CommunityContentReaction", entity.Id);
@@ -392,7 +452,16 @@ public sealed class ContentService : IContentService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.RequesterId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Requester ID does not match authenticated user");
+
             var reaction = await _dataContext.Query<CommunityContentReaction>()
+                .Where(r => r.TenantId == requester.TenantId)
                 .Where(r => r.Id == request.ReactionId && r.ContentId == request.ContentId && !r.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -403,9 +472,9 @@ public sealed class ContentService : IContentService
             }
 
             // Validate requester owns the reaction
-            if (reaction.SocialMediaIdentityId != request.RequesterId)
+            if (reaction.SocialMediaIdentityId != requester.IdentityId)
             {
-                _logger.BusinessRuleViolation("DeleteContentReaction", $"Identity {request.RequesterId} does not own reaction {request.ReactionId}");
+                _logger.BusinessRuleViolation("DeleteContentReaction", $"Identity {requester.IdentityId} does not own reaction {request.ReactionId}");
                 return Result<CmdResponse>.Forbidden("You do not have permission to delete this reaction");
             }
 
@@ -413,7 +482,9 @@ public sealed class ContentService : IContentService
             reaction.IsDeleted = true;
             reaction.DeletedAt = DateTime.UtcNow;
             _dataContext.Update(reaction);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "DeleteContentReaction") is { } saveFailure)
+                return saveFailure;
 
             _logger.EntityDeleted("CommunityContentReaction", request.ReactionId);
 
@@ -576,17 +647,27 @@ public sealed class ContentService : IContentService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.RequestingIdentityId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Requesting identity ID does not match authenticated user");
+
             var content = await _dataContext.Query<CommunityContent>()
+                .Where(c => c.TenantId == requester.TenantId)
                 .Where(c => c.Id == request.ContentId && !c.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (content == null)
                 return Result<CmdResponse>.NotFound($"Content with Id {request.ContentId} does not exist");
 
-            if (content.SocialMediaIdentityId != request.RequestingIdentityId)
+            if (content.SocialMediaIdentityId != requester.IdentityId)
                 return Result<CmdResponse>.Forbidden("You do not have permission to attach files to this content");
 
             var storageFileExists = await _dataContext.Query<StorageFile>()
+                .Where(f => f.TenantId == requester.TenantId)
                 .AnyAsync(f => f.Id == request.StorageFileId, cancellationToken);
 
             if (!storageFileExists)
@@ -594,6 +675,7 @@ public sealed class ContentService : IContentService
 
             var entity = new CommunityContentFile
             {
+                TenantId = requester.TenantId,
                 ContentId = request.ContentId,
                 StorageId = request.StorageFileId,
                 CreatedAt = DateTime.UtcNow,
@@ -601,7 +683,9 @@ public sealed class ContentService : IContentService
             };
 
             _dataContext.Add(entity);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "CreateContentFile") is { } saveFailure)
+                return saveFailure;
 
             return Result<CmdResponse>.Success(new CmdResponse
             {
@@ -658,17 +742,27 @@ public sealed class ContentService : IContentService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.RequestingIdentityId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Requesting identity ID does not match authenticated user");
+
             var content = await _dataContext.Query<CommunityContent>()
+                .Where(c => c.TenantId == requester.TenantId)
                 .Where(c => c.Id == request.ContentId && !c.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (content == null)
                 return Result<CmdResponse>.NotFound($"Content with Id {request.ContentId} does not exist");
 
-            if (content.SocialMediaIdentityId != request.RequestingIdentityId)
+            if (content.SocialMediaIdentityId != requester.IdentityId)
                 return Result<CmdResponse>.Forbidden("You do not have permission to remove files from this content");
 
             var file = await _dataContext.Query<CommunityContentFile>()
+                .Where(f => f.TenantId == requester.TenantId)
                 .Where(f => f.Id == request.FileId && f.ContentId == request.ContentId && !f.IsDeleted)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -678,7 +772,9 @@ public sealed class ContentService : IContentService
             file.IsDeleted = true;
             file.DeletedAt = DateTime.UtcNow;
             _dataContext.Update(file);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "DeleteContentFile") is { } saveFailure)
+                return saveFailure;
 
             return Result<CmdResponse>.Success(new CmdResponse
             {

--- a/src/Modules/XFramework.Community/Community.Api/Services/INotificationService.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Services/INotificationService.cs
@@ -22,7 +22,8 @@ public interface INotificationService
     /// <summary>
     /// Creates a notification (internal helper, not exposed as an endpoint).
     /// </summary>
-    Task CreateNotificationAsync(
+    Task<Result<CmdResponse>> CreateNotificationAsync(
+        Guid tenantId,
         Guid recipientIdentityId,
         Guid actorIdentityId,
         Community.Domain.Shared.Enums.NotificationType type,

--- a/src/Modules/XFramework.Community/Community.Api/Services/NotificationService.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Services/NotificationService.cs
@@ -9,13 +9,16 @@ namespace Community.Api.Services;
 public sealed class NotificationService : INotificationService
 {
     private readonly IDataContext _dataContext;
+    private readonly ICommunityRequestContext _requestContext;
     private readonly ILogger<NotificationService> _logger;
 
     public NotificationService(
         IDataContext dataContext,
+        ICommunityRequestContext requestContext,
         ILogger<NotificationService> logger)
     {
         _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
+        _requestContext = requestContext ?? throw new ArgumentNullException(nameof(requestContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -26,6 +29,14 @@ public sealed class NotificationService : INotificationService
     {
         try
         {
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, CmdResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.RequestingIdentityId, requester.IdentityId))
+                return Result<CmdResponse>.Forbidden("Requesting identity ID does not match authenticated user");
+
             if (request.NotificationIds.Count == 0)
             {
                 return Result<CmdResponse>.Failure("At least one notification ID is required", 400);
@@ -34,8 +45,9 @@ public sealed class NotificationService : INotificationService
             var notificationIds = request.NotificationIds.Distinct().ToList();
 
             var notifications = await _dataContext.Query<CommunityNotification>()
+                .Where(n => n.TenantId == requester.TenantId)
                 .Where(n => notificationIds.Contains(n.Id))
-                .Where(n => n.RecipientIdentityId == request.RequestingIdentityId)
+                .Where(n => n.RecipientIdentityId == requester.IdentityId)
                 .Where(n => !n.IsDeleted)
                 .ToListAsync(cancellationToken);
 
@@ -51,7 +63,9 @@ public sealed class NotificationService : INotificationService
                 _dataContext.Update(notification);
             }
 
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "MarkNotificationsRead") is { } saveFailure)
+                return saveFailure;
 
             _logger.CommunityNotificationsMarkedRead(notifications.Count);
 
@@ -75,25 +89,33 @@ public sealed class NotificationService : INotificationService
     {
         try
         {
-            if (request.RequestingIdentityId != request.IdentityId)
+            var requesterResult = await _requestContext.GetRequiredIdentityAsync(request.Metadata, cancellationToken);
+            if (!requesterResult.IsSuccess)
+                return CommunitySecurity.ToFailure<CommunityRequester, GetNotificationsResponse>(requesterResult);
+
+            var requester = requesterResult.Data!;
+            if (CommunitySecurity.IsSpoofed(request.IdentityId, requester.IdentityId)
+                || CommunitySecurity.IsSpoofed(request.RequestingIdentityId, requester.IdentityId))
             {
                 return Result<GetNotificationsResponse>.Forbidden("You can only retrieve your own notifications");
             }
 
             // Validate identity exists
             var identity = await _dataContext.Query<CommunityIdentity>()
-                .Where(i => i.Id == request.IdentityId)
+                .Where(i => i.TenantId == requester.TenantId)
+                .Where(i => i.Id == requester.IdentityId)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (identity == null)
             {
-                _logger.CommunityIdentityNotFound(request.IdentityId);
-                return Result<GetNotificationsResponse>.NotFound($"Identity with Id {request.IdentityId} does not exist");
+                _logger.CommunityIdentityNotFound(requester.IdentityId);
+                return Result<GetNotificationsResponse>.NotFound($"Identity with Id {requester.IdentityId} does not exist");
             }
 
             // Build query
             var query = _dataContext.Query<CommunityNotification>()
-                .Where(n => n.RecipientIdentityId == request.IdentityId)
+                .Where(n => n.TenantId == requester.TenantId)
+                .Where(n => n.RecipientIdentityId == requester.IdentityId)
                 .Where(n => !n.IsDeleted);
 
             // Apply optional IsRead filter
@@ -124,7 +146,7 @@ public sealed class NotificationService : INotificationService
                 CreatedAt = n.CreatedAt
             }).ToList();
 
-            _logger.CommunityNotificationsRetrieved(notifications.Count, request.IdentityId);
+            _logger.CommunityNotificationsRetrieved(notifications.Count, requester.IdentityId);
 
             return Result<GetNotificationsResponse>.Success(new GetNotificationsResponse
             {
@@ -136,13 +158,14 @@ public sealed class NotificationService : INotificationService
         }
         catch (Exception ex)
         {
-            _logger.CommunityNotificationsError(request.IdentityId, ex);
+            _logger.CommunityNotificationsError(request.IdentityId == Guid.Empty ? Guid.Empty : request.IdentityId, ex);
             return Result<GetNotificationsResponse>.Failure("An error occurred while retrieving notifications", 500);
         }
     }
 
     /// <inheritdoc />
-    public async Task CreateNotificationAsync(
+    public async Task<Result<CmdResponse>> CreateNotificationAsync(
+        Guid tenantId,
         Guid recipientIdentityId,
         Guid actorIdentityId,
         NotificationType type,
@@ -154,6 +177,7 @@ public sealed class NotificationService : INotificationService
         {
             var notification = new CommunityNotification
             {
+                TenantId = tenantId,
                 RecipientIdentityId = recipientIdentityId,
                 ActorIdentityId = actorIdentityId,
                 Type = type.ToString(),
@@ -164,14 +188,21 @@ public sealed class NotificationService : INotificationService
             };
 
             _dataContext.Add(notification);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            var saveResult = await _dataContext.SaveChangesAsync(cancellationToken);
+            if (CommunitySecurity.SaveFailure(saveResult, "CreateNotification") is { } saveFailure)
+                return saveFailure;
 
             _logger.CommunityNotificationCreated(notification.Id, recipientIdentityId);
+            return Result<CmdResponse>.Success(new CmdResponse
+            {
+                HttpStatusCode = HttpStatusCode.Created,
+                Message = "Notification created successfully"
+            }, 201);
         }
         catch (Exception ex)
         {
-            // Log but don't fail the parent operation if notification creation fails
             _logger.CommunityNotificationCreateError(recipientIdentityId, ex);
+            return Result<CmdResponse>.Failure("An error occurred while creating notification", 500);
         }
     }
 }

--- a/src/Tests/Community.Tests/Community.Tests.csproj
+++ b/src/Tests/Community.Tests/Community.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>Community.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Modules\XFramework.Community\Community.Api\Community.Api.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/Community.Tests/Services/CommunitySecurityTests.cs
+++ b/src/Tests/Community.Tests/Services/CommunitySecurityTests.cs
@@ -1,0 +1,586 @@
+using System.Collections;
+using System.Linq.Expressions;
+using System.Security.Claims;
+using Community.Api.Services;
+using Community.Domain.Shared.Contracts;
+using Community.Domain.Shared.Contracts.Requests;
+using Community.Domain.Shared.Contracts.Responses;
+using Community.Domain.Shared.Enums;
+using FluentAssertions;
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts;
+using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Domain.Shared.DataContext;
+
+namespace Community.Tests.Services;
+
+[TestFixture]
+public sealed class CommunitySecurityTests
+{
+    private static readonly Guid TenantId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid OtherTenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid CredentialId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid IdentityInfoId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid IdentityId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid OtherIdentityId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+    [Test]
+    public async Task GetRequiredAsync_TokenWithoutTenantClaim_DerivesTenantFromCredential()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<AuthLookupDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var dbContext = new AuthLookupDbContext(options);
+        await dbContext.Database.EnsureCreatedAsync();
+        dbContext.Tenants.Add(new Tenant
+        {
+            Id = TenantId,
+            TenantId = TenantId,
+            Name = "Test Tenant",
+            IsEnabled = true
+        });
+        dbContext.IdentityInformation.Add(new IdentityInformation
+        {
+            Id = IdentityInfoId,
+            TenantId = TenantId,
+            IdentityName = "Requester",
+            IsEnabled = true
+        });
+        dbContext.IdentityCredentials.Add(new IdentityCredential
+        {
+            Id = CredentialId,
+            IdentityInfoId = IdentityInfoId,
+            TenantId = TenantId,
+            UserName = "requester",
+            IsEnabled = true
+        });
+        await dbContext.SaveChangesAsync();
+
+        var identity = new ClaimsIdentity([new Claim(ClaimTypes.Name, CredentialId.ToString())], "TestAuth");
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity)
+            }
+        };
+
+        var requestContext = new CommunityRequestContext(
+            httpContextAccessor,
+            dbContext,
+            new FakeDataContext());
+
+        var result = await requestContext.GetRequiredAsync(new RequestMetadata { TenantId = TenantId });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.CredentialId.Should().Be(CredentialId);
+        result.Data.TenantId.Should().Be(TenantId);
+        httpContextAccessor.HttpContext.User.FindFirst("tenantId")?.Value.Should().Be(TenantId.ToString());
+    }
+
+    [Test]
+    public async Task GetRequiredAsync_MetadataTenantMismatch_ReturnsForbidden()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<AuthLookupDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var dbContext = new AuthLookupDbContext(options);
+        await dbContext.Database.EnsureCreatedAsync();
+        dbContext.Tenants.Add(new Tenant
+        {
+            Id = TenantId,
+            TenantId = TenantId,
+            Name = "Test Tenant",
+            IsEnabled = true
+        });
+        dbContext.IdentityInformation.Add(new IdentityInformation
+        {
+            Id = IdentityInfoId,
+            TenantId = TenantId,
+            IdentityName = "Requester",
+            IsEnabled = true
+        });
+        dbContext.IdentityCredentials.Add(new IdentityCredential
+        {
+            Id = CredentialId,
+            IdentityInfoId = IdentityInfoId,
+            TenantId = TenantId,
+            UserName = "requester",
+            IsEnabled = true
+        });
+        await dbContext.SaveChangesAsync();
+
+        var identity = new ClaimsIdentity([new Claim(ClaimTypes.Name, CredentialId.ToString())], "TestAuth");
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity)
+            }
+        };
+
+        var requestContext = new CommunityRequestContext(
+            httpContextAccessor,
+            dbContext,
+            new FakeDataContext());
+
+        var result = await requestContext.GetRequiredAsync(new RequestMetadata { TenantId = OtherTenantId });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+        httpContextAccessor.HttpContext.User.FindFirst("tenantId").Should().BeNull();
+    }
+
+    [Test]
+    public async Task UpdateCommunityIdentityAsync_SpoofedProfile_ReturnsForbidden()
+    {
+        var dataContext = new FakeDataContext();
+        var requesterContext = RequesterContext();
+        dataContext.Seed(CurrentIdentity());
+
+        var service = new CommunityService(
+            dataContext,
+            requesterContext,
+            NullLogger<CommunityService>.Instance);
+
+        var result = await service.UpdateCommunityIdentityAsync(new UpdateCommunityIdentityRequest
+        {
+            Id = OtherIdentityId,
+            CommunityIdentityTypeId = Guid.NewGuid()
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+        dataContext.Updated.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task CreateContentAsync_SpoofedIdentityId_ReturnsForbidden()
+    {
+        var dataContext = new FakeDataContext();
+        dataContext.Seed(
+            CurrentIdentity(),
+            new CommunityContentType { Id = Guid.NewGuid(), TenantId = TenantId, Name = "Post" });
+
+        var service = CreateContentService(dataContext);
+
+        var result = await service.CreateContentAsync(new CreateContentRequest
+        {
+            IdentityId = OtherIdentityId,
+            TypeId = dataContext.Items<CommunityContentType>().Single().Id,
+            Text = "spoofed"
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+        dataContext.Added.OfType<CommunityContent>().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task CreateContentAsync_CurrentIdentity_SetsTenantFromAuthenticatedContext()
+    {
+        var dataContext = new FakeDataContext();
+        var typeId = Guid.NewGuid();
+        dataContext.Seed(
+            CurrentIdentity(),
+            new CommunityContentType { Id = typeId, TenantId = TenantId, Name = "Post" });
+
+        var service = CreateContentService(dataContext);
+
+        var result = await service.CreateContentAsync(new CreateContentRequest
+        {
+            Metadata = new RequestMetadata { TenantId = TenantId },
+            TypeId = typeId,
+            Text = "owned by current identity"
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        var content = dataContext.Added.OfType<CommunityContent>().Single();
+        content.TenantId.Should().Be(TenantId);
+        content.SocialMediaIdentityId.Should().Be(IdentityId);
+    }
+
+    [Test]
+    public async Task CreateContentReactionAsync_BlockedAuthor_ReturnsForbidden()
+    {
+        var dataContext = new FakeDataContext();
+        var contentId = Guid.NewGuid();
+        var reactionTypeId = Guid.NewGuid();
+        dataContext.Seed(
+            CurrentIdentity(),
+            new CommunityContent
+            {
+                Id = contentId,
+                TenantId = TenantId,
+                SocialMediaIdentityId = OtherIdentityId,
+                TypeId = Guid.NewGuid(),
+                IsEnabled = true
+            },
+            new CommunityContentReactionType { Id = reactionTypeId, TenantId = TenantId, Name = "Like", Emoji = "+" });
+
+        var service = CreateContentService(dataContext, blocked: true);
+
+        var result = await service.CreateContentReactionAsync(new CreateContentReactionRequest
+        {
+            ContentId = contentId,
+            TypeId = reactionTypeId
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+        dataContext.Added.OfType<CommunityContentReaction>().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task CreateConnectionAsync_SaveFailure_ReturnsFailure()
+    {
+        var dataContext = new FakeDataContext();
+        var typeId = Guid.NewGuid();
+        dataContext.Seed(
+            CurrentIdentity(),
+            new CommunityIdentity { Id = OtherIdentityId, TenantId = TenantId, CredentialId = Guid.NewGuid(), IsEnabled = true },
+            new CommunityConnectionType { Id = typeId, TenantId = TenantId, Name = "Follow" });
+        dataContext.QueueSaveResult(DataContextResult.Failure("database unavailable", 500));
+
+        var notificationService = new StubNotificationService();
+        var service = new ConnectionService(
+            dataContext,
+            notificationService,
+            RequesterContext(),
+            NullLogger<ConnectionService>.Instance);
+
+        var result = await service.CreateConnectionAsync(new CreateConnectionRequest
+        {
+            TargetIdentityId = OtherIdentityId,
+            TypeId = typeId
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(500);
+        result.Message.Should().Be("database unavailable");
+        dataContext.Added.OfType<CommunityConnection>().Single().TenantId.Should().Be(TenantId);
+        notificationService.Created.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task MarkNotificationsReadAsync_NotificationOwnedByOtherIdentity_ReturnsNotFound()
+    {
+        var notificationId = Guid.NewGuid();
+        var dataContext = new FakeDataContext();
+        var notification = new CommunityNotification
+        {
+            Id = notificationId,
+            TenantId = TenantId,
+            RecipientIdentityId = OtherIdentityId,
+            ActorIdentityId = IdentityId,
+            Type = "Follow",
+            IsEnabled = true,
+            IsRead = false
+        };
+        dataContext.Seed(CurrentIdentity(), notification);
+
+        var service = new NotificationService(
+            dataContext,
+            RequesterContext(),
+            NullLogger<NotificationService>.Instance);
+
+        var result = await service.MarkNotificationsReadAsync(new MarkNotificationsReadRequest
+        {
+            NotificationIds = [notificationId]
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(404);
+        notification.IsRead.Should().BeFalse();
+    }
+
+    private static ContentService CreateContentService(FakeDataContext dataContext, bool blocked = false) =>
+        new(
+            dataContext,
+            new StubConnectionService(blocked),
+            RequesterContext(),
+            NullLogger<ContentService>.Instance);
+
+    private static StubCommunityRequestContext RequesterContext() =>
+        new(new CommunityRequester(CredentialId, TenantId, CurrentIdentity()));
+
+    private static CommunityIdentity CurrentIdentity() => new()
+    {
+        Id = IdentityId,
+        TenantId = TenantId,
+        CredentialId = CredentialId,
+        IsEnabled = true,
+        HandleName = "Current"
+    };
+
+    private sealed class AuthLookupDbContext(DbContextOptions<AuthLookupDbContext> options) : DbContext(options)
+    {
+        public DbSet<Tenant> Tenants => Set<Tenant>();
+        public DbSet<IdentityInformation> IdentityInformation => Set<IdentityInformation>();
+        public DbSet<IdentityCredential> IdentityCredentials => Set<IdentityCredential>();
+    }
+
+    private sealed class StubCommunityRequestContext(CommunityRequester requester) : ICommunityRequestContext
+    {
+        public Task<Result<CommunityRequester>> GetRequiredAsync(
+            RequestMetadata? metadata,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(Result<CommunityRequester>.Success(requester));
+
+        public Task<Result<CommunityRequester>> GetRequiredIdentityAsync(
+            RequestMetadata? metadata,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(Result<CommunityRequester>.Success(requester));
+    }
+
+    private sealed class StubConnectionService(bool blocked) : IConnectionService
+    {
+        public Task<Result<CmdResponse>> CreateConnectionAsync(
+            CreateConnectionRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<Result<CmdResponse>> DeleteConnectionAsync(
+            DeleteConnectionRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<bool> IsBlockedAsync(Guid identityA, Guid identityB, CancellationToken cancellationToken = default) =>
+            Task.FromResult(blocked);
+
+        public Task<HashSet<Guid>> GetBlockedIdentityIdsAsync(Guid identityId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new HashSet<Guid>());
+    }
+
+    private sealed class StubNotificationService : INotificationService
+    {
+        public bool Created { get; private set; }
+
+        public Task<Result<CmdResponse>> MarkNotificationsReadAsync(
+            MarkNotificationsReadRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<Result<GetNotificationsResponse>> GetNotificationsAsync(
+            GetNotificationsRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<Result<CmdResponse>> CreateNotificationAsync(
+            Guid tenantId,
+            Guid recipientIdentityId,
+            Guid actorIdentityId,
+            NotificationType type,
+            Guid? referenceId,
+            string message,
+            CancellationToken cancellationToken = default)
+        {
+            Created = true;
+            return Task.FromResult(Result<CmdResponse>.Success(new CmdResponse()));
+        }
+    }
+
+    private sealed class FakeDataContext : IDataContext
+    {
+        private readonly Dictionary<Type, IList> _sets = [];
+        private readonly Queue<DataContextResult> _saveResults = [];
+
+        public List<object> Added { get; } = [];
+        public List<object> Updated { get; } = [];
+
+        public void Seed(params object[] entities)
+        {
+            foreach (var entity in entities)
+            {
+                var set = GetOrCreateSet(entity.GetType());
+                set.Add(entity);
+            }
+        }
+
+        public List<T> Items<T>() where T : class
+        {
+            if (!_sets.TryGetValue(typeof(T), out var set))
+            {
+                set = new List<T>();
+                _sets[typeof(T)] = set;
+            }
+
+            return (List<T>)set;
+        }
+
+        private IList GetOrCreateSet(Type type)
+        {
+            if (!_sets.TryGetValue(type, out var set))
+            {
+                var listType = typeof(List<>).MakeGenericType(type);
+                set = (IList)Activator.CreateInstance(listType)!;
+                _sets[type] = set;
+            }
+
+            return set;
+        }
+
+        public void QueueSaveResult(DataContextResult result) => _saveResults.Enqueue(result);
+
+        public IRemoteQuery<T> Query<T>() where T : class =>
+            new FakeRemoteQuery<T>(Items<T>().AsQueryable());
+
+        public void Add<T>(T entity) where T : class
+        {
+            if (entity is BaseModel { Id: var id } model && id == Guid.Empty)
+            {
+                model.Id = Guid.NewGuid();
+            }
+
+            Items<T>().Add(entity);
+            Added.Add(entity);
+        }
+
+        public void Update<T>(T entity) where T : class => Updated.Add(entity);
+
+        public void Remove<T>(T entity) where T : class => Items<T>().Remove(entity);
+
+        public Task<DataContextResult> SaveChangesAsync(CancellationToken ct = default) =>
+            Task.FromResult(_saveResults.Count > 0 ? _saveResults.Dequeue() : DataContextResult.Success());
+    }
+
+    private sealed class FakeRemoteQuery<T>(IQueryable<T> queryable) : IRemoteQuery<T>
+        where T : class
+    {
+        private IQueryable<T> _queryable = queryable;
+
+        public IRemoteQuery<T> Where(Expression<Func<T, bool>> predicate)
+        {
+            _queryable = _queryable.Where(predicate);
+            return this;
+        }
+
+        public IRemoteQuery<T> OrderBy<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            _queryable = _queryable.OrderBy(keySelector);
+            return this;
+        }
+
+        public IRemoteQuery<T> OrderByDescending<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            _queryable = _queryable.OrderByDescending(keySelector);
+            return this;
+        }
+
+        public IRemoteQuery<T> ThenBy<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            _queryable = ((IOrderedQueryable<T>)_queryable).ThenBy(keySelector);
+            return this;
+        }
+
+        public IRemoteQuery<T> ThenByDescending<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            _queryable = ((IOrderedQueryable<T>)_queryable).ThenByDescending(keySelector);
+            return this;
+        }
+
+        public IRemoteQuery<T> Skip(int count)
+        {
+            _queryable = _queryable.Skip(count);
+            return this;
+        }
+
+        public IRemoteQuery<T> Take(int count)
+        {
+            _queryable = _queryable.Take(count);
+            return this;
+        }
+
+        public IRemoteQuery<T> Include<TProperty>(Expression<Func<T, TProperty>> navigationSelector) => this;
+
+        public IRemoteQuery<T> Distinct()
+        {
+            _queryable = _queryable.Distinct();
+            return this;
+        }
+
+        public IRemoteQuery<T> DistinctBy<TKey>(Expression<Func<T, TKey>> keySelector)
+        {
+            _queryable = _queryable.AsEnumerable().DistinctBy(keySelector.Compile()).AsQueryable();
+            return this;
+        }
+
+        public IRemoteQuery<T> NoCache() => this;
+
+        public Task<List<T>> ToListAsync(CancellationToken ct = default) =>
+            Task.FromResult(_queryable.ToList());
+
+        public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) =>
+            Task.FromResult(_queryable.FirstOrDefault());
+
+        public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default) =>
+            Task.FromResult(_queryable.SingleOrDefault());
+
+        public async IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in _queryable)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+
+        public Task<int> CountAsync(CancellationToken ct = default) =>
+            Task.FromResult(_queryable.Count());
+
+        public Task<bool> AnyAsync(CancellationToken ct = default) =>
+            Task.FromResult(_queryable.Any());
+
+        public Task<bool> AnyAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) =>
+            Task.FromResult(_queryable.Any(predicate));
+
+        public Task<bool> AllAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) =>
+            Task.FromResult(_queryable.All(predicate));
+
+        public Task<TResult?> MinAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) =>
+            Task.FromResult(_queryable.Select(selector).Min());
+
+        public Task<TResult?> MaxAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) =>
+            Task.FromResult(_queryable.Select(selector).Max());
+
+        public Task<T?> MinByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) =>
+            Task.FromResult(_queryable.AsEnumerable().MinBy(keySelector.Compile()));
+
+        public Task<T?> MaxByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) =>
+            Task.FromResult(_queryable.AsEnumerable().MaxBy(keySelector.Compile()));
+
+        public Task<decimal> SumAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) =>
+            Task.FromResult(_queryable.Sum(selector));
+
+        public Task<double> AverageAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) =>
+            Task.FromResult((double)_queryable.Average(selector));
+
+        public Task<List<GroupResult<TKey, T>>> GroupByAsync<TKey>(
+            Expression<Func<T, TKey>> keySelector,
+            CancellationToken ct = default)
+        {
+            var compiled = keySelector.Compile();
+            return Task.FromResult(_queryable
+                .AsEnumerable()
+                .GroupBy(compiled)
+                .Select(g => new GroupResult<TKey, T> { Key = g.Key, Items = g.ToList() })
+                .ToList());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Requires authorization on Community generated endpoints.
- Resolves requester credential and tenant from authenticated context instead of trusting client actor IDs.
- Adds tenant assignment, ownership checks, save-result handling, and spoofing/tenant-isolation tests.

## Verification
- dotnet test src\Tests\Community.Tests\Community.Tests.csproj
- dotnet build src\Modules\XFramework.Community\Community.Api\Community.Api.csproj --no-restore
- git diff --cached --check