### PR TITLE
Harden Messaging security and realtime outbox

### DIFF
--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/Attachments/Create/CreateMessageFileValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/Attachments/Create/CreateMessageFileValidator.cs
@@ -15,8 +15,5 @@ public sealed class CreateMessageFileValidator : AbstractValidator<CreateMessage
 
         RuleFor(x => x.StorageFileId)
             .NotEmpty().WithMessage("Storage File ID is required");
-
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester Credential ID is required");
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/Attachments/GetList/GetMessageFilesValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/Attachments/GetList/GetMessageFilesValidator.cs
@@ -12,8 +12,5 @@ public sealed class GetMessageFilesValidator : AbstractValidator<GetMessageFiles
 
         RuleFor(x => x.MessageId)
             .NotEmpty().WithMessage("Message ID is required");
-
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester Credential ID is required");
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/CreateMessage/CreateThreadMessageValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/CreateMessage/CreateThreadMessageValidator.cs
@@ -10,9 +10,6 @@ public sealed class CreateThreadMessageValidator : AbstractValidator<CreateThrea
         RuleFor(x => x.ThreadId)
             .NotEmpty().WithMessage("Thread ID is required");
 
-        RuleFor(x => x.SenderCredentialId)
-            .NotEmpty().WithMessage("Sender credential ID is required");
-
         RuleFor(x => x.Text)
             .NotEmpty().WithMessage("Message text is required")
             .MaximumLength(5000).WithMessage("Message text cannot exceed 5000 characters");

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/DeleteMessage/DeleteThreadMessageValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/DeleteMessage/DeleteThreadMessageValidator.cs
@@ -12,8 +12,5 @@ public sealed class DeleteThreadMessageValidator : AbstractValidator<DeleteThrea
 
         RuleFor(x => x.MessageId)
             .NotEmpty().WithMessage("Message ID is required");
-
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester Credential ID is required");
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/EditMessage/EditThreadMessageValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/EditMessage/EditThreadMessageValidator.cs
@@ -13,9 +13,6 @@ public sealed class EditThreadMessageValidator : AbstractValidator<EditThreadMes
         RuleFor(x => x.MessageId)
             .NotEmpty().WithMessage("Message ID is required");
 
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester Credential ID is required");
-
         RuleFor(x => x.Text)
             .NotEmpty().WithMessage("Text is required")
             .MaximumLength(5000).WithMessage("Text cannot exceed 5000 characters");

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/GetMessages/GetThreadMessagesValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/GetMessages/GetThreadMessagesValidator.cs
@@ -10,9 +10,6 @@ public sealed class GetThreadMessagesValidator : AbstractValidator<GetThreadMess
         RuleFor(x => x.ThreadId)
             .NotEmpty().WithMessage("Thread ID is required");
 
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester credential ID is required");
-
         RuleFor(x => x.PageSize)
             .InclusiveBetween(1, 100).WithMessage("Page size must be between 1 and 100");
 

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/MarkRead/MarkMessagesReadValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/MarkRead/MarkMessagesReadValidator.cs
@@ -10,9 +10,6 @@ public sealed class MarkMessagesReadValidator : AbstractValidator<MarkMessagesRe
         RuleFor(x => x.ThreadId)
             .NotEmpty().WithMessage("Thread ID is required");
 
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester Credential ID is required");
-
         RuleFor(x => x.MessageIds)
             .NotEmpty().WithMessage("At least one message ID is required")
             .Must(ids => ids.Distinct().Count() == ids.Count)

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/Reactions/Create/CreateMessageReactionValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/Reactions/Create/CreateMessageReactionValidator.cs
@@ -15,8 +15,5 @@ public sealed class CreateMessageReactionValidator : AbstractValidator<CreateMes
 
         RuleFor(x => x.TypeId)
             .NotEmpty().WithMessage("Reaction Type ID is required");
-
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester Credential ID is required");
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/Reactions/Delete/DeleteMessageReactionValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/Reactions/Delete/DeleteMessageReactionValidator.cs
@@ -9,8 +9,5 @@ public sealed class DeleteMessageReactionValidator : AbstractValidator<DeleteMes
     {
         RuleFor(x => x.ReactionId)
             .NotEmpty().WithMessage("Reaction ID is required");
-
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester Credential ID is required");
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Threads/Get/GetThreadValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Threads/Get/GetThreadValidator.cs
@@ -9,8 +9,5 @@ public sealed class GetThreadValidator : AbstractValidator<GetThreadRequest>
     {
         RuleFor(x => x.Id)
             .NotEmpty().WithMessage("Thread ID is required");
-
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester credential ID is required");
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Threads/GetList/GetThreadListValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Threads/GetList/GetThreadListValidator.cs
@@ -7,9 +7,6 @@ public sealed class GetThreadListValidator : AbstractValidator<GetThreadListRequ
 {
     public GetThreadListValidator()
     {
-        RuleFor(x => x.CredentialId)
-            .NotEmpty().WithMessage("Credential ID is required");
-
         RuleFor(x => x.PageSize)
             .InclusiveBetween(1, 100).WithMessage("Page size must be between 1 and 100");
 

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Threads/Update/UpdateThreadValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Threads/Update/UpdateThreadValidator.cs
@@ -10,9 +10,6 @@ public sealed class UpdateThreadValidator : AbstractValidator<UpdateThreadReques
         RuleFor(x => x.ThreadId)
             .NotEmpty().WithMessage("Thread ID is required");
 
-        RuleFor(x => x.RequesterCredentialId)
-            .NotEmpty().WithMessage("Requester Credential ID is required");
-
         RuleFor(x => x.Name)
             .MaximumLength(200).WithMessage("Name cannot exceed 200 characters")
             .When(x => x.Name is not null);

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Installers/ServicesInstaller.cs
@@ -17,5 +17,6 @@ public sealed class ServicesInstaller : IInstaller
 
         // Register ThreadService
         services.AddScoped<IThreadService, ThreadService>();
+        services.AddScoped<IMessagingRequestContextResolver, MessagingRequestContextResolver>();
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Program.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddXFrameworkHealthChecks<AppDbContext>(
 // Register services
 builder.Services.AddScoped<IMessagingService, MessagingService>();
 builder.Services.AddScoped<IThreadService, ThreadService>();
+builder.Services.AddScoped<IMessagingRequestContextResolver, MessagingRequestContextResolver>();
 
 // Register validators from this assembly
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
@@ -39,6 +40,7 @@ app.MapXFrameworkHealthChecks("Messaging");
 app.MapApiDocumentation();
 
 // Map feature endpoints (source-generated from [MapPost/Patch/...] attributes)
-app.MapGeneratedEndpoints();
+var securedMessagingEndpoints = app.MapGroup(string.Empty).RequireAuthorization();
+securedMessagingEndpoints.MapGeneratedEndpoints();
 
 app.Run();

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Services/MessagingRequestContextResolver.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Services/MessagingRequestContextResolver.cs
@@ -1,0 +1,71 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using XFramework.Core.Patterns;
+
+namespace Messaging.Api.Services;
+
+public sealed record MessagingRequestContext(Guid CredentialId, Guid TenantId);
+
+public interface IMessagingRequestContextResolver
+{
+    Result<MessagingRequestContext> Resolve(RequestMetadata? metadata);
+}
+
+public sealed class MessagingRequestContextResolver(IHttpContextAccessor httpContextAccessor)
+    : IMessagingRequestContextResolver
+{
+    public Result<MessagingRequestContext> Resolve(RequestMetadata? metadata)
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        var isAuthenticatedHttpRequest = user?.Identity?.IsAuthenticated == true;
+        var credentialId = isAuthenticatedHttpRequest
+            ? ResolveCredentialId(user)
+            : metadata?.CredentialId;
+        var tenantId = ResolveTenantId(user) ?? metadata?.TenantId;
+
+        if (credentialId is null || credentialId == Guid.Empty)
+            return Result<MessagingRequestContext>.Unauthorized("Authenticated credential could not be resolved");
+
+        if (tenantId is null || tenantId == Guid.Empty)
+            return Result<MessagingRequestContext>.Unauthorized("Authenticated tenant could not be resolved");
+
+        return Result<MessagingRequestContext>.Success(new(credentialId.Value, tenantId.Value));
+    }
+
+    private static Guid? ResolveCredentialId(ClaimsPrincipal? user)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+            return null;
+
+        return ParseClaim(
+            user,
+            ClaimTypes.Name,
+            "credentialId",
+            "CredentialId",
+            "sub");
+    }
+
+    private static Guid? ResolveTenantId(ClaimsPrincipal? user)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+            return null;
+
+        return ParseClaim(
+            user,
+            "tenantId",
+            "TenantId",
+            "tid");
+    }
+
+    private static Guid? ParseClaim(ClaimsPrincipal user, params string[] claimTypes)
+    {
+        foreach (var claimType in claimTypes)
+        {
+            var value = user.FindFirst(claimType)?.Value;
+            if (Guid.TryParse(value, out var id))
+                return id;
+        }
+
+        return null;
+    }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Services/ThreadService.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Services/ThreadService.cs
@@ -44,6 +44,7 @@ public sealed class ThreadService(
 
             var existingMembers = await dataContext.Query<IdentityCredential>()
                 .Where(c => allMemberIds.Contains(c.Id))
+                .Where(c => c.TenantId == caller.TenantId)
                 .Where(c => !c.IsDeleted && c.IsEnabled)
                 .ToListAsync(ct);
 
@@ -134,6 +135,7 @@ public sealed class ThreadService(
             // Get memberships for this credential
             var memberships = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .ToListAsync(ct);
 
@@ -142,6 +144,7 @@ public sealed class ThreadService(
 
             var threads = await dataContext.Query<MessageThread>()
                 .Where(t => memberThreadIds.Contains(t.Id))
+                .Where(t => t.TenantId == caller.TenantId)
                 .Where(t => !t.IsDeleted)
                 .OrderByDescending(t => t.CreatedAt)
                 .Skip(pageIndex * pageSize)
@@ -153,6 +156,7 @@ public sealed class ThreadService(
             // Get member counts per thread using GroupByAsync
             var memberGroups = await dataContext.Query<MessageThreadMember>()
                 .Where(m => threadIds.Contains(m.MessageThreadId))
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .GroupByAsync(m => m.MessageThreadId, ct);
 
@@ -161,6 +165,7 @@ public sealed class ThreadService(
             // Get messages for these threads to find last message per thread
             var threadMessages = await dataContext.Query<Message>()
                 .Where(m => threadIds.Contains(m.MessageThreadId))
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .OrderByDescending(m => m.CreatedAt)
                 .ToListAsync(ct);
@@ -216,6 +221,7 @@ public sealed class ThreadService(
 
             var thread = await dataContext.Query<MessageThread>()
                 .Where(t => t.Id == request.Id)
+                .Where(t => t.TenantId == caller.TenantId)
                 .Where(t => !t.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -227,6 +233,7 @@ public sealed class ThreadService(
             var requesterMember = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == thread.Id)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -235,6 +242,7 @@ public sealed class ThreadService(
 
             var members = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == thread.Id)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .ToListAsync(ct);
 
@@ -273,6 +281,7 @@ public sealed class ThreadService(
             var caller = callerResult.Data!;
             var thread = await dataContext.Query<MessageThread>()
                 .Where(t => t.Id == request.ThreadId)
+                .Where(t => t.TenantId == caller.TenantId)
                 .Where(t => !t.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -282,6 +291,7 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -342,6 +352,7 @@ public sealed class ThreadService(
             // Validate thread exists
             var thread = await dataContext.Query<MessageThread>()
                 .Where(t => t.Id == request.ThreadId)
+                .Where(t => t.TenantId == caller.TenantId)
                 .Where(t => !t.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -350,7 +361,7 @@ public sealed class ThreadService(
                 return Result<CmdResponse>.NotFound("Thread not found");
             }
 
-            var actorMember = await GetActiveMemberAsync(request.ThreadId, caller.CredentialId, ct);
+            var actorMember = await GetActiveMemberAsync(caller.TenantId, request.ThreadId, caller.CredentialId, ct);
             if (actorMember is null)
                 return Result<CmdResponse>.Failure("Requester is not a member of this thread", 403);
 
@@ -360,6 +371,7 @@ public sealed class ThreadService(
             // Validate credential exists
             var credential = await dataContext.Query<IdentityCredential>()
                 .Where(c => c.Id == request.CredentialId)
+                .Where(c => c.TenantId == caller.TenantId)
                 .Where(c => !c.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -372,6 +384,7 @@ public sealed class ThreadService(
             var existingMember = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == request.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -382,6 +395,7 @@ public sealed class ThreadService(
 
             var group = await dataContext.Query<MessageThreadMemberGroup>()
                 .Where(g => g.MessageThreadId == request.ThreadId)
+                .Where(g => g.TenantId == caller.TenantId)
                 .Where(g => !g.IsDeleted && g.IsEnabled)
                 .OrderBy(g => g.CreatedAt)
                 .FirstOrDefaultAsync(ct);
@@ -447,7 +461,7 @@ public sealed class ThreadService(
                 return CallerFailure<CmdResponse>(callerResult);
 
             var caller = callerResult.Data!;
-            var actorMember = await GetActiveMemberAsync(request.ThreadId, caller.CredentialId, ct);
+            var actorMember = await GetActiveMemberAsync(caller.TenantId, request.ThreadId, caller.CredentialId, ct);
             if (actorMember is null)
                 return Result<CmdResponse>.Failure("Requester is not a member of this thread", 403);
 
@@ -455,6 +469,7 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == request.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -469,6 +484,7 @@ public sealed class ThreadService(
             // Validate can't remove if they are the last member
             var memberCount = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .CountAsync(ct);
 
@@ -524,6 +540,7 @@ public sealed class ThreadService(
             // Validate thread exists
             var thread = await dataContext.Query<MessageThread>()
                 .Where(t => t.Id == request.ThreadId)
+                .Where(t => t.TenantId == caller.TenantId)
                 .Where(t => !t.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -536,6 +553,7 @@ public sealed class ThreadService(
             var senderMember = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -601,6 +619,7 @@ public sealed class ThreadService(
             var requesterMember = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -611,11 +630,13 @@ public sealed class ThreadService(
 
             var totalCount = await dataContext.Query<Message>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .CountAsync(ct);
 
             var messages = await dataContext.Query<Message>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .OrderByDescending(m => m.CreatedAt)
                 .Skip(pageIndex * pageSize)
@@ -626,6 +647,7 @@ public sealed class ThreadService(
             var fetchedMessageIds = messages.Select(m => m.Id).ToList();
             var existingDeliveries = await dataContext.Query<MessageDelivery>()
                 .Where(d => d.MessageThreadMemberId == requesterMember.Id)
+                .Where(d => d.TenantId == caller.TenantId)
                 .Where(d => fetchedMessageIds.Contains(d.MessageId))
                 .Where(d => !d.IsDeleted)
                 .ToListAsync(ct);
@@ -655,6 +677,7 @@ public sealed class ThreadService(
             var memberIds = messages.Select(m => m.MessageThreadMemberId).Distinct().ToList();
             var members = await dataContext.Query<MessageThreadMember>()
                 .Where(m => memberIds.Contains(m.Id))
+                .Where(m => m.TenantId == caller.TenantId)
                 .ToListAsync(ct);
 
             var memberMap = members.ToDictionary(m => m.Id);
@@ -699,6 +722,7 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -708,13 +732,14 @@ public sealed class ThreadService(
             var message = await dataContext.Query<Message>()
                 .Where(m => m.Id == request.MessageId)
                 .Where(m => m.MessageThreadId == request.ThreadId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
             if (message is null)
                 return Result<CmdResponse>.NotFound("Message not found");
 
-            if (message.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.Id, ct))
+            if (message.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.TenantId, member.Id, ct))
                 return Result<CmdResponse>.Failure("You can only delete your own messages", 403);
 
             message.IsDeleted = true;
@@ -763,6 +788,7 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -772,13 +798,14 @@ public sealed class ThreadService(
             var message = await dataContext.Query<Message>()
                 .Where(m => m.Id == request.MessageId)
                 .Where(m => m.MessageThreadId == request.ThreadId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
             if (message is null)
                 return Result<CmdResponse>.NotFound("Message not found");
 
-            if (message.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.Id, ct))
+            if (message.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.TenantId, member.Id, ct))
                 return Result<CmdResponse>.Failure("You can only edit your own messages", 403);
 
             message.Text = request.Text;
@@ -825,6 +852,7 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -834,6 +862,7 @@ public sealed class ThreadService(
             var message = await dataContext.Query<Message>()
                 .Where(m => m.Id == request.MessageId)
                 .Where(m => m.MessageThreadId == request.ThreadId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -879,6 +908,7 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -888,6 +918,7 @@ public sealed class ThreadService(
             var messageExists = await dataContext.Query<Message>()
                 .Where(m => m.Id == request.MessageId)
                 .Where(m => m.MessageThreadId == request.ThreadId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .AnyAsync(ct);
 
@@ -896,6 +927,7 @@ public sealed class ThreadService(
 
             var fileEntities = await dataContext.Query<MessageFile>()
                 .Where(f => f.MessageId == request.MessageId)
+                .Where(f => f.TenantId == caller.TenantId)
                 .Where(f => !f.IsDeleted && f.IsEnabled)
                 .ToListAsync(ct);
 
@@ -928,6 +960,7 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -937,6 +970,7 @@ public sealed class ThreadService(
             var message = await dataContext.Query<Message>()
                 .Where(m => m.Id == request.MessageId)
                 .Where(m => m.MessageThreadId == request.ThreadId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -948,6 +982,7 @@ public sealed class ThreadService(
                 .Where(r => r.MessageId == request.MessageId)
                 .Where(r => r.TypeId == request.TypeId)
                 .Where(r => r.MessageThreadMemberId == member.Id)
+                .Where(r => r.TenantId == caller.TenantId)
                 .Where(r => !r.IsDeleted && r.IsEnabled)
                 .AnyAsync(ct);
 
@@ -1008,6 +1043,7 @@ public sealed class ThreadService(
             var caller = callerResult.Data!;
             var reaction = await dataContext.Query<MessageReaction>()
                 .Where(r => r.Id == request.ReactionId)
+                .Where(r => r.TenantId == caller.TenantId)
                 .Where(r => !r.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -1017,6 +1053,7 @@ public sealed class ThreadService(
             // Verify requester is a member of the thread through the reaction's message
             var message = await dataContext.Query<Message>()
                 .Where(m => m.Id == reaction.MessageId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -1026,13 +1063,14 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == message.MessageThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
             if (member is null)
                 return Result<CmdResponse>.Failure("Requester is not a member of this thread", 403);
 
-            if (reaction.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.Id, ct))
+            if (reaction.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.TenantId, member.Id, ct))
                 return Result<CmdResponse>.Forbidden("You can only delete your own reactions");
 
             reaction.IsDeleted = true;
@@ -1082,6 +1120,7 @@ public sealed class ThreadService(
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -1092,6 +1131,7 @@ public sealed class ThreadService(
             var threadMessages = await dataContext.Query<Message>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
                 .Where(m => requestedMessageIds.Contains(m.Id))
+                .Where(m => m.TenantId == caller.TenantId)
                 .Where(m => !m.IsDeleted)
                 .ToListAsync(ct);
 
@@ -1101,6 +1141,7 @@ public sealed class ThreadService(
             var existingDeliveries = await dataContext.Query<MessageDelivery>()
                 .Where(d => d.MessageThreadMemberId == member.Id)
                 .Where(d => requestedMessageIds.Contains(d.MessageId))
+                .Where(d => d.TenantId == caller.TenantId)
                 .Where(d => !d.IsDeleted)
                 .ToListAsync(ct);
 
@@ -1183,19 +1224,22 @@ public sealed class ThreadService(
         };
 
     private async Task<MessageThreadMember?> GetActiveMemberAsync(
+        Guid tenantId,
         Guid threadId,
         Guid credentialId,
         CancellationToken ct) =>
         await dataContext.Query<MessageThreadMember>()
             .Where(m => m.MessageThreadId == threadId)
             .Where(m => m.CredentialId == credentialId)
+            .Where(m => m.TenantId == tenantId)
             .Where(m => !m.IsDeleted && m.IsEnabled)
             .FirstOrDefaultAsync(ct);
 
-    private async Task<bool> ThreadHasExplicitRolesAsync(Guid threadId, CancellationToken ct)
+    private async Task<bool> ThreadHasExplicitRolesAsync(Guid tenantId, Guid threadId, CancellationToken ct)
     {
         var members = await dataContext.Query<MessageThreadMember>()
             .Where(m => m.MessageThreadId == threadId)
+            .Where(m => m.TenantId == tenantId)
             .Where(m => !m.IsDeleted && m.IsEnabled)
             .ToListAsync(ct);
 
@@ -1205,14 +1249,16 @@ public sealed class ThreadService(
 
         return await dataContext.Query<MessageThreadMemberRole>()
             .Where(r => memberIds.Contains(r.MessageThreadMemberId))
+            .Where(r => r.TenantId == tenantId)
             .Where(r => !r.IsDeleted && r.IsEnabled)
             .AnyAsync(ct);
     }
 
-    private async Task<bool> MemberHasAdminRoleAsync(Guid memberId, CancellationToken ct)
+    private async Task<bool> MemberHasAdminRoleAsync(Guid tenantId, Guid memberId, CancellationToken ct)
     {
         var memberRoles = await dataContext.Query<MessageThreadMemberRole>()
             .Where(r => r.MessageThreadMemberId == memberId)
+            .Where(r => r.TenantId == tenantId)
             .Where(r => !r.IsDeleted && r.IsEnabled)
             .ToListAsync(ct);
 
@@ -1223,16 +1269,17 @@ public sealed class ThreadService(
         return await dataContext.Query<IdentityRole>()
             .Where(r => roleIds.Contains(r.Id))
             .Where(r => r.TypeId == IdentityConstants.RoleType.Admin)
+            .Where(r => r.TenantId == tenantId)
             .Where(r => !r.IsDeleted && r.IsEnabled)
             .AnyAsync(ct);
     }
 
     private async Task<bool> CanManageThreadAsync(MessageThreadMember member, CancellationToken ct)
     {
-        if (await MemberHasAdminRoleAsync(member.Id, ct))
+        if (await MemberHasAdminRoleAsync(member.TenantId, member.Id, ct))
             return true;
 
-        return !await ThreadHasExplicitRolesAsync(member.MessageThreadId, ct);
+        return !await ThreadHasExplicitRolesAsync(member.TenantId, member.MessageThreadId, ct);
     }
 
     private async Task AddAdminRoleBindingsAsync(
@@ -1243,6 +1290,7 @@ public sealed class ThreadService(
         var adminRoles = await dataContext.Query<IdentityRole>()
             .Where(r => r.CredentialId == credentialId)
             .Where(r => r.TypeId == IdentityConstants.RoleType.Admin)
+            .Where(r => r.TenantId == member.TenantId)
             .Where(r => !r.IsDeleted && r.IsEnabled)
             .ToListAsync(ct);
 

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Services/ThreadService.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Services/ThreadService.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text.Json;
+using IdentityServer.Domain.Shared;
 using Messaging.Domain.Shared;
 using Messaging.Domain.Shared.Contracts.Requests.Attachments;
 using Messaging.Domain.Shared.Contracts.Requests.Delete;
@@ -7,23 +9,30 @@ using Messaging.Domain.Shared.Contracts.Requests.Reactions;
 using Messaging.Domain.Shared.Contracts.Requests.Threads;
 using Messaging.Domain.Shared.Contracts.Responses;
 using XFramework.Core.Patterns;
-using XFramework.Core.Services;
 using XFramework.Domain.Shared.DataContext;
 
 namespace Messaging.Api.Services;
 public sealed class ThreadService(
     IDataContext dataContext,
-    ITenantResolver tenantService,
+    IMessagingRequestContextResolver requestContextResolver,
     ILogger<ThreadService> logger
 ) : IThreadService
 {
+    private static readonly JsonSerializerOptions OutboxJsonOptions = new(JsonSerializerDefaults.Web);
+
     public async Task<Result<CreateThreadResponse>> CreateThreadAsync(CreateThreadRequest request, CancellationToken ct = default)
     {
         try
         {
-            var tenant = await tenantService.GetTenant(request.Metadata.TenantId);
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CreateThreadResponse>(callerResult);
 
-            var allMemberIds = request.InitialMemberCredentialIds.Distinct().ToList();
+            var caller = callerResult.Data!;
+            var allMemberIds = request.InitialMemberCredentialIds
+                .Append(caller.CredentialId)
+                .Distinct()
+                .ToList();
 
             var threadTypeExists = await dataContext.Query<MessageThreadType>()
                 .Where(t => t.Id == request.TypeId)
@@ -44,7 +53,7 @@ public sealed class ThreadService(
             var thread = new MessageThread
             {
                 Id = Guid.NewGuid(),
-                TenantId = tenant.Id,
+                TenantId = caller.TenantId,
                 Name = request.Name,
                 Description = request.Description ?? string.Empty,
                 TypeId = request.TypeId,
@@ -55,7 +64,7 @@ public sealed class ThreadService(
 
             dataContext.Add(thread);
 
-            var defaultGroup = CreateDefaultThreadMemberGroup(thread.Id, tenant.Id);
+            var defaultGroup = CreateDefaultThreadMemberGroup(thread.Id, caller.TenantId);
             dataContext.Add(defaultGroup);
 
             foreach (var credentialId in allMemberIds)
@@ -63,7 +72,7 @@ public sealed class ThreadService(
                 var member = new MessageThreadMember
                 {
                     Id = Guid.NewGuid(),
-                    TenantId = tenant.Id,
+                    TenantId = caller.TenantId,
                     MessageThreadId = thread.Id,
                     CredentialId = credentialId,
                     GroupId = defaultGroup.Id,
@@ -77,7 +86,24 @@ public sealed class ThreadService(
                 };
 
                 dataContext.Add(member);
+
+                if (credentialId == caller.CredentialId)
+                    await AddAdminRoleBindingsAsync(member, caller.CredentialId, ct);
             }
+
+            AddOutboxEvent(
+                MessageRealtimeEvents.ThreadCreated,
+                caller.TenantId,
+                thread.Id,
+                thread.Id,
+                nameof(MessageThread),
+                caller.CredentialId,
+                new
+                {
+                    thread.Id,
+                    thread.Name,
+                    MemberCredentialIds = allMemberIds
+                });
 
             await dataContext.SaveChangesAsync(ct);
 
@@ -97,12 +123,17 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<GetThreadListResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var pageIndex = request.PageIndex < 0 ? 0 : request.PageIndex;
             var pageSize = request.PageSize <= 0 ? 20 : Math.Min(request.PageSize, 100);
 
             // Get memberships for this credential
             var memberships = await dataContext.Query<MessageThreadMember>()
-                .Where(m => m.CredentialId == request.CredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted)
                 .ToListAsync(ct);
 
@@ -168,7 +199,7 @@ public sealed class ThreadService(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error getting thread list for credential: {CredentialId}", request.CredentialId);
+            logger.LogError(ex, "Error getting thread list");
             return Result<GetThreadListResponse>.Failure($"Error getting thread list: {ex.Message}");
         }
     }
@@ -177,8 +208,11 @@ public sealed class ThreadService(
     {
         try
         {
-            if (request.RequesterCredentialId == Guid.Empty)
-                return Result<GetThreadResponse>.Failure("Requester credential ID is required");
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<GetThreadResponse>(callerResult);
+
+            var caller = callerResult.Data!;
 
             var thread = await dataContext.Query<MessageThread>()
                 .Where(t => t.Id == request.Id)
@@ -192,7 +226,7 @@ public sealed class ThreadService(
 
             var requesterMember = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == thread.Id)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -232,6 +266,11 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var thread = await dataContext.Query<MessageThread>()
                 .Where(t => t.Id == request.ThreadId)
                 .Where(t => !t.IsDeleted)
@@ -242,12 +281,15 @@ public sealed class ThreadService(
 
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
-                .Where(m => !m.IsDeleted)
+                .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
             if (member is null)
                 return Result<CmdResponse>.Failure("Requester is not a member of this thread", 403);
+
+            if (!await CanManageThreadAsync(member, ct))
+                return Result<CmdResponse>.Forbidden("Only thread admins can update this thread");
 
             if (request.Name is not null)
                 thread.Name = request.Name;
@@ -256,6 +298,20 @@ public sealed class ThreadService(
                 thread.Description = request.Description;
 
             thread.ModifiedAt = DateTime.UtcNow;
+
+            AddOutboxEvent(
+                MessageRealtimeEvents.ThreadUpdated,
+                thread.TenantId,
+                thread.Id,
+                thread.Id,
+                nameof(MessageThread),
+                caller.CredentialId,
+                new
+                {
+                    thread.Id,
+                    thread.Name,
+                    thread.Description
+                });
 
             dataContext.Update(thread);
             await dataContext.SaveChangesAsync(ct);
@@ -277,7 +333,11 @@ public sealed class ThreadService(
     {
         try
         {
-            var tenant = await tenantService.GetTenant(request.Metadata.TenantId);
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
 
             // Validate thread exists
             var thread = await dataContext.Query<MessageThread>()
@@ -289,6 +349,13 @@ public sealed class ThreadService(
             {
                 return Result<CmdResponse>.NotFound("Thread not found");
             }
+
+            var actorMember = await GetActiveMemberAsync(request.ThreadId, caller.CredentialId, ct);
+            if (actorMember is null)
+                return Result<CmdResponse>.Failure("Requester is not a member of this thread", 403);
+
+            if (!await CanManageThreadAsync(actorMember, ct))
+                return Result<CmdResponse>.Forbidden("Only thread admins can add members");
 
             // Validate credential exists
             var credential = await dataContext.Query<IdentityCredential>()
@@ -321,14 +388,14 @@ public sealed class ThreadService(
 
             if (group is null)
             {
-                group = CreateDefaultThreadMemberGroup(request.ThreadId, tenant.Id);
+                group = CreateDefaultThreadMemberGroup(request.ThreadId, thread.TenantId);
                 dataContext.Add(group);
             }
 
             var member = new MessageThreadMember
             {
                 Id = Guid.NewGuid(),
-                TenantId = tenant.Id,
+                TenantId = thread.TenantId,
                 MessageThreadId = request.ThreadId,
                 CredentialId = request.CredentialId,
                 GroupId = group.Id,
@@ -342,6 +409,20 @@ public sealed class ThreadService(
             };
 
             dataContext.Add(member);
+            AddOutboxEvent(
+                MessageRealtimeEvents.ThreadMemberAdded,
+                thread.TenantId,
+                thread.Id,
+                member.Id,
+                nameof(MessageThreadMember),
+                caller.CredentialId,
+                new
+                {
+                    ThreadId = thread.Id,
+                    MemberId = member.Id,
+                    member.CredentialId
+                });
+
             await dataContext.SaveChangesAsync(ct);
 
             return Result<CmdResponse>.Success(new CmdResponse
@@ -361,6 +442,15 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
+            var actorMember = await GetActiveMemberAsync(request.ThreadId, caller.CredentialId, ct);
+            if (actorMember is null)
+                return Result<CmdResponse>.Failure("Requester is not a member of this thread", 403);
+
             // Find the member
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
@@ -372,6 +462,9 @@ public sealed class ThreadService(
             {
                 return Result<CmdResponse>.NotFound("Member not found in this thread");
             }
+
+            if (member.Id != actorMember.Id && !await CanManageThreadAsync(actorMember, ct))
+                return Result<CmdResponse>.Forbidden("Only thread admins can remove other members");
 
             // Validate can't remove if they are the last member
             var memberCount = await dataContext.Query<MessageThreadMember>()
@@ -388,6 +481,21 @@ public sealed class ThreadService(
             member.IsDeleted = true;
             member.DeletedAt = DateTime.UtcNow;
             dataContext.Update(member);
+
+            AddOutboxEvent(
+                MessageRealtimeEvents.ThreadMemberRemoved,
+                member.TenantId,
+                request.ThreadId,
+                member.Id,
+                nameof(MessageThreadMember),
+                caller.CredentialId,
+                new
+                {
+                    request.ThreadId,
+                    MemberId = member.Id,
+                    member.CredentialId
+                });
+
             await dataContext.SaveChangesAsync(ct);
 
             return Result<CmdResponse>.Success(new CmdResponse
@@ -407,7 +515,11 @@ public sealed class ThreadService(
     {
         try
         {
-            var tenant = await tenantService.GetTenant(request.Metadata.TenantId);
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CreateThreadMessageResponse>(callerResult);
+
+            var caller = callerResult.Data!;
 
             // Validate thread exists
             var thread = await dataContext.Query<MessageThread>()
@@ -423,8 +535,8 @@ public sealed class ThreadService(
             // Validate sender is a member of the thread
             var senderMember = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.SenderCredentialId)
-                .Where(m => !m.IsDeleted)
+                .Where(m => m.CredentialId == caller.CredentialId)
+                .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
             if (senderMember is null)
@@ -435,7 +547,7 @@ public sealed class ThreadService(
             var message = new Message
             {
                 Id = Guid.NewGuid(),
-                TenantId = tenant.Id,
+                TenantId = thread.TenantId,
                 MessageThreadId = request.ThreadId,
                 MessageThreadMemberId = senderMember.Id,
                 Text = request.Text,
@@ -445,6 +557,20 @@ public sealed class ThreadService(
             };
 
             dataContext.Add(message);
+            AddOutboxEvent(
+                MessageRealtimeEvents.MessageCreated,
+                thread.TenantId,
+                thread.Id,
+                message.Id,
+                nameof(Message),
+                caller.CredentialId,
+                new
+                {
+                    ThreadId = thread.Id,
+                    MessageId = message.Id,
+                    SenderMemberId = senderMember.Id
+                });
+
             await dataContext.SaveChangesAsync(ct);
 
             return Result<CreateThreadMessageResponse>.Success(new CreateThreadMessageResponse
@@ -463,13 +589,18 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<GetThreadMessagesResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var pageIndex = request.PageIndex < 0 ? 0 : request.PageIndex;
             var pageSize = request.PageSize <= 0 ? 20 : Math.Min(request.PageSize, 100);
 
             // Validate requester is a member
             var requesterMember = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted)
                 .FirstOrDefaultAsync(ct);
 
@@ -560,9 +691,14 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -578,7 +714,7 @@ public sealed class ThreadService(
             if (message is null)
                 return Result<CmdResponse>.NotFound("Message not found");
 
-            if (message.MessageThreadMemberId != member.Id)
+            if (message.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.Id, ct))
                 return Result<CmdResponse>.Failure("You can only delete your own messages", 403);
 
             message.IsDeleted = true;
@@ -587,6 +723,19 @@ public sealed class ThreadService(
             message.ModifiedAt = DateTime.UtcNow;
 
             dataContext.Update(message);
+            AddOutboxEvent(
+                MessageRealtimeEvents.MessageDeleted,
+                message.TenantId,
+                message.MessageThreadId,
+                message.Id,
+                nameof(Message),
+                caller.CredentialId,
+                new
+                {
+                    request.ThreadId,
+                    request.MessageId
+                });
+
             await dataContext.SaveChangesAsync(ct);
 
             return Result<CmdResponse>.Success(new CmdResponse
@@ -606,9 +755,14 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -624,13 +778,26 @@ public sealed class ThreadService(
             if (message is null)
                 return Result<CmdResponse>.NotFound("Message not found");
 
-            if (message.MessageThreadMemberId != member.Id)
+            if (message.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.Id, ct))
                 return Result<CmdResponse>.Failure("You can only edit your own messages", 403);
 
             message.Text = request.Text;
             message.ModifiedAt = DateTime.UtcNow;
 
             dataContext.Update(message);
+            AddOutboxEvent(
+                MessageRealtimeEvents.MessageEdited,
+                message.TenantId,
+                message.MessageThreadId,
+                message.Id,
+                nameof(Message),
+                caller.CredentialId,
+                new
+                {
+                    request.ThreadId,
+                    request.MessageId
+                });
+
             await dataContext.SaveChangesAsync(ct);
 
             return Result<CmdResponse>.Success(new CmdResponse
@@ -650,9 +817,14 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -699,9 +871,14 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<List<MessageFileResponse>>(callerResult);
+
+            var caller = callerResult.Data!;
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -743,9 +920,14 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -785,6 +967,21 @@ public sealed class ThreadService(
             };
 
             dataContext.Add(reaction);
+            AddOutboxEvent(
+                MessageRealtimeEvents.ReactionCreated,
+                message.TenantId,
+                message.MessageThreadId,
+                reaction.Id,
+                nameof(MessageReaction),
+                caller.CredentialId,
+                new
+                {
+                    ReactionId = reaction.Id,
+                    request.MessageId,
+                    request.TypeId,
+                    MemberId = member.Id
+                });
+
             await dataContext.SaveChangesAsync(ct);
 
             return Result<CmdResponse>.Success(new CmdResponse
@@ -804,6 +1001,11 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var reaction = await dataContext.Query<MessageReaction>()
                 .Where(r => r.Id == request.ReactionId)
                 .Where(r => !r.IsDeleted)
@@ -823,14 +1025,14 @@ public sealed class ThreadService(
 
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == message.MessageThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
             if (member is null)
                 return Result<CmdResponse>.Failure("Requester is not a member of this thread", 403);
 
-            if (reaction.MessageThreadMemberId != member.Id)
+            if (reaction.MessageThreadMemberId != member.Id && !await MemberHasAdminRoleAsync(member.Id, ct))
                 return Result<CmdResponse>.Forbidden("You can only delete your own reactions");
 
             reaction.IsDeleted = true;
@@ -839,6 +1041,20 @@ public sealed class ThreadService(
             reaction.ModifiedAt = DateTime.UtcNow;
 
             dataContext.Update(reaction);
+            AddOutboxEvent(
+                MessageRealtimeEvents.ReactionDeleted,
+                reaction.TenantId,
+                message.MessageThreadId,
+                reaction.Id,
+                nameof(MessageReaction),
+                caller.CredentialId,
+                new
+                {
+                    ReactionId = reaction.Id,
+                    reaction.MessageId,
+                    reaction.TypeId
+                });
+
             await dataContext.SaveChangesAsync(ct);
 
             return Result<CmdResponse>.Success(new CmdResponse
@@ -858,9 +1074,14 @@ public sealed class ThreadService(
     {
         try
         {
+            var callerResult = ResolveCaller(request.Metadata);
+            if (!callerResult.IsSuccess)
+                return CallerFailure<CmdResponse>(callerResult);
+
+            var caller = callerResult.Data!;
             var member = await dataContext.Query<MessageThreadMember>()
                 .Where(m => m.MessageThreadId == request.ThreadId)
-                .Where(m => m.CredentialId == request.RequesterCredentialId)
+                .Where(m => m.CredentialId == caller.CredentialId)
                 .Where(m => !m.IsDeleted && m.IsEnabled)
                 .FirstOrDefaultAsync(ct);
 
@@ -917,6 +1138,24 @@ public sealed class ThreadService(
                 }
             }
 
+            if (markedCount > 0)
+            {
+                AddOutboxEvent(
+                    MessageRealtimeEvents.MessagesRead,
+                    member.TenantId,
+                    request.ThreadId,
+                    member.Id,
+                    nameof(MessageDelivery),
+                    caller.CredentialId,
+                    new
+                    {
+                        request.ThreadId,
+                        MemberId = member.Id,
+                        MessageIds = requestedMessageIds,
+                        Count = markedCount
+                    });
+            }
+
             await dataContext.SaveChangesAsync(ct);
 
             return Result<CmdResponse>.Success(new CmdResponse
@@ -930,6 +1169,123 @@ public sealed class ThreadService(
             logger.LogError(ex, "Error marking messages as read in thread {ThreadId}", request.ThreadId);
             return Result<CmdResponse>.Failure($"Error marking messages as read: {ex.Message}");
         }
+    }
+
+    private Result<MessagingRequestContext> ResolveCaller(RequestMetadata? metadata) =>
+        requestContextResolver.Resolve(metadata);
+
+    private static Result<T> CallerFailure<T>(Result<MessagingRequestContext> caller) =>
+        caller.StatusCode switch
+        {
+            401 => Result<T>.Unauthorized(caller.Message),
+            403 => Result<T>.Forbidden(caller.Message),
+            _ => Result<T>.Failure(caller.Message ?? "Caller context could not be resolved", caller.StatusCode)
+        };
+
+    private async Task<MessageThreadMember?> GetActiveMemberAsync(
+        Guid threadId,
+        Guid credentialId,
+        CancellationToken ct) =>
+        await dataContext.Query<MessageThreadMember>()
+            .Where(m => m.MessageThreadId == threadId)
+            .Where(m => m.CredentialId == credentialId)
+            .Where(m => !m.IsDeleted && m.IsEnabled)
+            .FirstOrDefaultAsync(ct);
+
+    private async Task<bool> ThreadHasExplicitRolesAsync(Guid threadId, CancellationToken ct)
+    {
+        var members = await dataContext.Query<MessageThreadMember>()
+            .Where(m => m.MessageThreadId == threadId)
+            .Where(m => !m.IsDeleted && m.IsEnabled)
+            .ToListAsync(ct);
+
+        var memberIds = members.Select(m => m.Id).ToList();
+        if (memberIds.Count == 0)
+            return false;
+
+        return await dataContext.Query<MessageThreadMemberRole>()
+            .Where(r => memberIds.Contains(r.MessageThreadMemberId))
+            .Where(r => !r.IsDeleted && r.IsEnabled)
+            .AnyAsync(ct);
+    }
+
+    private async Task<bool> MemberHasAdminRoleAsync(Guid memberId, CancellationToken ct)
+    {
+        var memberRoles = await dataContext.Query<MessageThreadMemberRole>()
+            .Where(r => r.MessageThreadMemberId == memberId)
+            .Where(r => !r.IsDeleted && r.IsEnabled)
+            .ToListAsync(ct);
+
+        var roleIds = memberRoles.Select(r => r.RoleId).ToList();
+        if (roleIds.Count == 0)
+            return false;
+
+        return await dataContext.Query<IdentityRole>()
+            .Where(r => roleIds.Contains(r.Id))
+            .Where(r => r.TypeId == IdentityConstants.RoleType.Admin)
+            .Where(r => !r.IsDeleted && r.IsEnabled)
+            .AnyAsync(ct);
+    }
+
+    private async Task<bool> CanManageThreadAsync(MessageThreadMember member, CancellationToken ct)
+    {
+        if (await MemberHasAdminRoleAsync(member.Id, ct))
+            return true;
+
+        return !await ThreadHasExplicitRolesAsync(member.MessageThreadId, ct);
+    }
+
+    private async Task AddAdminRoleBindingsAsync(
+        MessageThreadMember member,
+        Guid credentialId,
+        CancellationToken ct)
+    {
+        var adminRoles = await dataContext.Query<IdentityRole>()
+            .Where(r => r.CredentialId == credentialId)
+            .Where(r => r.TypeId == IdentityConstants.RoleType.Admin)
+            .Where(r => !r.IsDeleted && r.IsEnabled)
+            .ToListAsync(ct);
+
+        foreach (var role in adminRoles)
+        {
+            dataContext.Add(new MessageThreadMemberRole
+            {
+                Id = Guid.NewGuid(),
+                TenantId = member.TenantId,
+                MessageThreadMemberId = member.Id,
+                RoleId = role.Id,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow,
+                ConcurrencyStamp = Guid.NewGuid()
+            });
+        }
+    }
+
+    private void AddOutboxEvent(
+        string eventType,
+        Guid tenantId,
+        Guid? threadId,
+        Guid aggregateId,
+        string aggregateType,
+        Guid actorCredentialId,
+        object payload)
+    {
+        var now = DateTime.UtcNow;
+        dataContext.Add(new MessageOutboxEvent
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            EventType = eventType,
+            AggregateType = aggregateType,
+            AggregateId = aggregateId,
+            ThreadId = threadId,
+            ActorCredentialId = actorCredentialId,
+            PayloadJson = JsonSerializer.Serialize(payload, OutboxJsonOptions),
+            OccurredAt = now,
+            IsEnabled = true,
+            CreatedAt = now,
+            ConcurrencyStamp = Guid.NewGuid()
+        });
     }
 
     private static MessageThreadMemberGroup CreateDefaultThreadMemberGroup(Guid threadId, Guid tenantId) => new()

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageConfiguration.cs
@@ -23,6 +23,12 @@ public class MessageConfiguration : IEntityTypeConfiguration<Message>
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
         entity.Property(e => e.Text).HasColumnType("character varying");
 
+        entity.HasIndex(e => new { e.MessageThreadId, e.CreatedAt, e.Id })
+            .HasDatabaseName("IX_Message_Thread_CreatedAt_Id");
+
+        entity.HasIndex(e => new { e.MessageThreadMemberId, e.CreatedAt })
+            .HasDatabaseName("IX_Message_Member_CreatedAt");
+
         entity.HasOne(d => d.MessageThread).WithMany(p => p.Messages)
             .HasForeignKey(d => d.MessageThreadId)
             .OnDelete(DeleteBehavior.ClientSetNull)

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageDeliveryConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageDeliveryConfiguration.cs
@@ -22,6 +22,14 @@ public class MessageDeliveryConfiguration : IEntityTypeConfiguration<MessageDeli
             .HasDefaultValueSql("true");
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
 
+        entity.HasIndex(e => new { e.MessageThreadMemberId, e.MessageId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false")
+            .HasDatabaseName("UX_MessageDelivery_Member_Message_Active");
+
+        entity.HasIndex(e => new { e.MessageId, e.TypeId })
+            .HasDatabaseName("IX_MessageDelivery_Message_Type");
+
         entity.HasOne(d => d.Type).WithMany(p => p.MessageDeliveries)
             .HasForeignKey(d => d.TypeId)
             .OnDelete(DeleteBehavior.ClientSetNull)

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageOutboxEventConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageOutboxEventConfiguration.cs
@@ -1,0 +1,42 @@
+using Messaging.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Messaging.Domain.Shared.Configurations;
+
+public sealed class MessageOutboxEventConfiguration : IEntityTypeConfiguration<MessageOutboxEvent>
+{
+    public void Configure(EntityTypeBuilder<MessageOutboxEvent> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("messageoutboxevent_pk");
+
+        entity.ToTable("MessageOutboxEvent", "Messaging");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+        entity.Property(e => e.EventType)
+            .HasColumnType("character varying")
+            .HasMaxLength(128);
+        entity.Property(e => e.AggregateType)
+            .HasColumnType("character varying")
+            .HasMaxLength(128);
+        entity.Property(e => e.PayloadJson).HasColumnType("jsonb");
+        entity.Property(e => e.LastError).HasColumnType("character varying");
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.OccurredAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.IsEnabled)
+            .IsRequired()
+            .HasDefaultValueSql("true");
+
+        entity.HasIndex(e => new { e.TenantId, e.ProcessedAt, e.OccurredAt })
+            .HasDatabaseName("IX_MessageOutboxEvent_Tenant_Processed_Occurred");
+
+        entity.HasIndex(e => new { e.ThreadId, e.OccurredAt })
+            .HasDatabaseName("IX_MessageOutboxEvent_Thread_Occurred");
+
+        entity.HasIndex(e => new { e.EventType, e.OccurredAt })
+            .HasDatabaseName("IX_MessageOutboxEvent_EventType_Occurred");
+    }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageReactionConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageReactionConfiguration.cs
@@ -21,6 +21,14 @@ public class MessageReactionConfiguration : IEntityTypeConfiguration<MessageReac
             .HasDefaultValueSql("true");
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
 
+        entity.HasIndex(e => new { e.MessageId, e.TypeId, e.MessageThreadMemberId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false")
+            .HasDatabaseName("UX_MessageReaction_Message_Type_Member_Active");
+
+        entity.HasIndex(e => new { e.MessageThreadMemberId, e.MessageId })
+            .HasDatabaseName("IX_MessageReaction_Member_Message");
+
         entity.HasOne(d => d.Type).WithMany(p => p.MessageReactions)
             .HasForeignKey(d => d.TypeId)
             .OnDelete(DeleteBehavior.ClientSetNull)

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageThreadConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageThreadConfiguration.cs
@@ -24,6 +24,9 @@ public class MessageThreadConfiguration : IEntityTypeConfiguration<MessageThread
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
         entity.Property(e => e.Name).HasColumnType("character varying");
 
+        entity.HasIndex(e => new { e.TenantId, e.CreatedAt })
+            .HasDatabaseName("IX_MessageThread_Tenant_CreatedAt");
+
         entity.HasOne(d => d.Type).WithMany(p => p.MessageThreads)
             .HasForeignKey(d => d.TypeId)
             .OnDelete(DeleteBehavior.ClientSetNull)

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageThreadMemberConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageThreadMemberConfiguration.cs
@@ -25,6 +25,14 @@ public class MessageThreadMemberConfiguration : IEntityTypeConfiguration<Message
             .HasDefaultValueSql("true");
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
 
+        entity.HasIndex(e => new { e.MessageThreadId, e.CredentialId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false")
+            .HasDatabaseName("UX_MessageThreadMember_Thread_Credential_Active");
+
+        entity.HasIndex(e => new { e.CredentialId, e.MessageThreadId })
+            .HasDatabaseName("IX_MessageThreadMember_Credential_Thread");
+
         entity.HasOne(d => d.Group).WithMany()
             .HasForeignKey(d => d.GroupId)
             .OnDelete(DeleteBehavior.ClientSetNull)

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageThreadMemberRoleConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageThreadMemberRoleConfiguration.cs
@@ -22,6 +22,14 @@ public class MessageThreadMemberRoleConfiguration : IEntityTypeConfiguration<Mes
             .HasDefaultValueSql("true");
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
 
+        entity.HasIndex(e => new { e.MessageThreadMemberId, e.RoleId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false")
+            .HasDatabaseName("UX_MessageThreadMemberRole_Member_Role_Active");
+
+        entity.HasIndex(e => e.RoleId)
+            .HasDatabaseName("IX_MessageThreadMemberRole_RoleId");
+
         entity.HasOne(d => d.MessageThreadMember).WithMany()
             .HasForeignKey(d => d.MessageThreadMemberId)
             .OnDelete(DeleteBehavior.ClientSetNull)

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Constants.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Constants.cs
@@ -23,6 +23,22 @@ public static class MessageEvents
     public static readonly string ChatReceived = nameof(ChatReceived);
 }
 
+public static class MessageRealtimeEvents
+{
+    public static readonly string ThreadCreated = nameof(ThreadCreated);
+    public static readonly string ThreadUpdated = nameof(ThreadUpdated);
+    public static readonly string ThreadMemberAdded = nameof(ThreadMemberAdded);
+    public static readonly string ThreadMemberRemoved = nameof(ThreadMemberRemoved);
+    public static readonly string MessageCreated = nameof(MessageCreated);
+    public static readonly string MessageEdited = nameof(MessageEdited);
+    public static readonly string MessageDeleted = nameof(MessageDeleted);
+    public static readonly string ReactionCreated = nameof(ReactionCreated);
+    public static readonly string ReactionDeleted = nameof(ReactionDeleted);
+    public static readonly string MessagesRead = nameof(MessagesRead);
+
+    // TODO: Add audio/video call event types only after call/session feature flags exist in Messaging.
+}
+
 
 public static class GenericSender
 {

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/MessageOutboxEvent.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/MessageOutboxEvent.cs
@@ -1,0 +1,35 @@
+namespace Messaging.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+public partial class MessageOutboxEvent : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public string EventType { get; set; } = null!;
+
+    [MemoryPackOrder(1)]
+    public string AggregateType { get; set; } = null!;
+
+    [MemoryPackOrder(2)]
+    public Guid AggregateId { get; set; }
+
+    [MemoryPackOrder(3)]
+    public Guid? ThreadId { get; set; }
+
+    [MemoryPackOrder(4)]
+    public Guid? ActorCredentialId { get; set; }
+
+    [MemoryPackOrder(5)]
+    public string PayloadJson { get; set; } = "{}";
+
+    [MemoryPackOrder(6)]
+    public DateTime OccurredAt { get; set; }
+
+    [MemoryPackOrder(7)]
+    public DateTime? ProcessedAt { get; set; }
+
+    [MemoryPackOrder(8)]
+    public int Attempts { get; set; }
+
+    [MemoryPackOrder(9)]
+    public string? LastError { get; set; }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Tests/Domain/MessageModelConfigurationTests.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Tests/Domain/MessageModelConfigurationTests.cs
@@ -1,0 +1,96 @@
+using Messaging.Domain.Shared.Contracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using XFramework.Domain.Contexts;
+
+namespace Messaging.Tests.Domain;
+
+public sealed class MessageModelConfigurationTests
+{
+    [Test]
+    public void MessagingModel_MembershipDeliveryAndReactionUniqueness_Configured()
+    {
+        using var db = CreateDbContext();
+
+        AssertUniqueIndex<MessageThreadMember>(
+            db,
+            "UX_MessageThreadMember_Thread_Credential_Active",
+            "\"IsDeleted\" = false");
+
+        AssertUniqueIndex<MessageDelivery>(
+            db,
+            "UX_MessageDelivery_Member_Message_Active",
+            "\"IsDeleted\" = false");
+
+        AssertUniqueIndex<MessageReaction>(
+            db,
+            "UX_MessageReaction_Message_Type_Member_Active",
+            "\"IsDeleted\" = false");
+    }
+
+    [Test]
+    public void MessagingModel_TimelineAndOutboxIndexes_Configured()
+    {
+        using var db = CreateDbContext();
+
+        AssertIndex<Message>(
+            db,
+            "IX_Message_Thread_CreatedAt_Id");
+
+        AssertIndex<MessageOutboxEvent>(
+            db,
+            "IX_MessageOutboxEvent_Tenant_Processed_Occurred");
+    }
+
+    private static AppDbContext CreateDbContext()
+    {
+        _ = typeof(MessageThread).Assembly;
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql("Host=localhost;Database=xframework_model_test")
+            .Options;
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tenant:DefaultId"] = Guid.NewGuid().ToString()
+            })
+            .Build();
+
+        return new AppDbContext(options, new HttpContextAccessor(), config);
+    }
+
+    private static void AssertUniqueIndex<TEntity>(
+        AppDbContext db,
+        string indexName,
+        string filter)
+        where TEntity : class
+    {
+        var index = FindIndex<TEntity>(db, indexName);
+
+        Assert.That(index.IsUnique, Is.True);
+        Assert.That(index.GetFilter(), Is.EqualTo(filter));
+    }
+
+    private static void AssertIndex<TEntity>(AppDbContext db, string indexName)
+        where TEntity : class
+    {
+        _ = FindIndex<TEntity>(db, indexName);
+    }
+
+    private static IIndex FindIndex<TEntity>(AppDbContext db, string indexName)
+        where TEntity : class
+    {
+        var entityType = db.Model.FindEntityType(typeof(TEntity));
+        Assert.That(entityType, Is.Not.Null);
+
+        var index = entityType!.GetIndexes()
+            .SingleOrDefault(i => i.GetDatabaseName() == indexName);
+
+        Assert.That(index, Is.Not.Null, $"Missing index {indexName} on {typeof(TEntity).Name}");
+        return index!;
+    }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Tests/Features/Threads/Get/GetThreadValidatorTests.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Tests/Features/Threads/Get/GetThreadValidatorTests.cs
@@ -22,7 +22,7 @@ public sealed class GetThreadValidatorTests
     }
 
     [Test]
-    public void Validate_MissingRequesterCredentialId_ReturnsInvalidResult()
+    public void Validate_MissingRequesterCredentialId_ReturnsValidResult()
     {
         var validator = new GetThreadValidator();
         var request = new GetThreadRequest
@@ -33,7 +33,6 @@ public sealed class GetThreadValidatorTests
 
         var result = validator.Validate(request);
 
-        Assert.That(result.IsValid, Is.False);
-        Assert.That(result.Errors.Any(e => e.PropertyName == nameof(GetThreadRequest.RequesterCredentialId)), Is.True);
+        Assert.That(result.IsValid, Is.True);
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Tests/Infrastructure/InMemoryDataContext.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Tests/Infrastructure/InMemoryDataContext.cs
@@ -1,0 +1,211 @@
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using XFramework.Domain.Shared.DataContext;
+
+namespace Messaging.Tests.Infrastructure;
+
+internal sealed class InMemoryDataContext : IDataContext
+{
+    private readonly Dictionary<Type, IList<object>> _sets = [];
+
+    public List<T> Set<T>() where T : class
+    {
+        var type = typeof(T);
+        if (!_sets.TryGetValue(type, out var set))
+        {
+            set = new List<object>();
+            _sets[type] = set;
+        }
+
+        return set.Cast<T>().ToList();
+    }
+
+    public void Seed<T>(params T[] entities) where T : class
+    {
+        foreach (var entity in entities)
+            Add(entity);
+    }
+
+    public void Seed(params object[] entities)
+    {
+        foreach (var entity in entities)
+        {
+            var type = entity.GetType();
+            if (!_sets.TryGetValue(type, out var set))
+            {
+                set = new List<object>();
+                _sets[type] = set;
+            }
+
+            set.Add(entity);
+        }
+    }
+
+    public IRemoteQuery<T> Query<T>() where T : class => new InMemoryRemoteQuery<T>(Set<T>().AsQueryable());
+
+    public void Add<T>(T entity) where T : class
+    {
+        var type = typeof(T);
+        if (!_sets.TryGetValue(type, out var set))
+        {
+            set = new List<object>();
+            _sets[type] = set;
+        }
+
+        set.Add(entity);
+    }
+
+    public void Update<T>(T entity) where T : class
+    {
+    }
+
+    public void Remove<T>(T entity) where T : class
+    {
+        if (_sets.TryGetValue(typeof(T), out var set))
+            set.Remove(entity);
+    }
+
+    public Task<DataContextResult> SaveChangesAsync(CancellationToken ct = default) =>
+        Task.FromResult(DataContextResult.Success());
+}
+
+internal sealed class InMemoryRemoteQuery<T>(IQueryable<T> queryable) : IRemoteQuery<T>
+    where T : class
+{
+    private IQueryable<T> _queryable = queryable;
+    private bool _isOrdered;
+
+    public IRemoteQuery<T> Where(Expression<Func<T, bool>> predicate)
+    {
+        _queryable = _queryable.Where(predicate);
+        return this;
+    }
+
+    public IRemoteQuery<T> OrderBy<TKey>(Expression<Func<T, TKey>> keySelector)
+    {
+        _queryable = _queryable.OrderBy(keySelector);
+        _isOrdered = true;
+        return this;
+    }
+
+    public IRemoteQuery<T> OrderByDescending<TKey>(Expression<Func<T, TKey>> keySelector)
+    {
+        _queryable = _queryable.OrderByDescending(keySelector);
+        _isOrdered = true;
+        return this;
+    }
+
+    public IRemoteQuery<T> ThenBy<TKey>(Expression<Func<T, TKey>> keySelector)
+    {
+        if (!_isOrdered)
+            throw new InvalidOperationException("ThenBy can only be called after OrderBy or OrderByDescending.");
+
+        _queryable = ((IOrderedQueryable<T>)_queryable).ThenBy(keySelector);
+        return this;
+    }
+
+    public IRemoteQuery<T> ThenByDescending<TKey>(Expression<Func<T, TKey>> keySelector)
+    {
+        if (!_isOrdered)
+            throw new InvalidOperationException("ThenByDescending can only be called after OrderBy or OrderByDescending.");
+
+        _queryable = ((IOrderedQueryable<T>)_queryable).ThenByDescending(keySelector);
+        return this;
+    }
+
+    public IRemoteQuery<T> Skip(int count)
+    {
+        _queryable = _queryable.Skip(count);
+        return this;
+    }
+
+    public IRemoteQuery<T> Take(int count)
+    {
+        _queryable = _queryable.Take(count);
+        return this;
+    }
+
+    public IRemoteQuery<T> Include<TProperty>(Expression<Func<T, TProperty>> navigationSelector) => this;
+
+    public IRemoteQuery<T> Distinct()
+    {
+        _queryable = _queryable.Distinct();
+        return this;
+    }
+
+    public IRemoteQuery<T> DistinctBy<TKey>(Expression<Func<T, TKey>> keySelector)
+    {
+        var key = keySelector.Compile();
+        _queryable = _queryable.AsEnumerable().DistinctBy(key).AsQueryable();
+        return this;
+    }
+
+    public IRemoteQuery<T> NoCache() => this;
+
+    public Task<List<T>> ToListAsync(CancellationToken ct = default) =>
+        Task.FromResult(_queryable.ToList());
+
+    public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) =>
+        Task.FromResult(_queryable.FirstOrDefault());
+
+    public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default) =>
+        Task.FromResult(_queryable.SingleOrDefault());
+
+    public async IAsyncEnumerable<T> ToAsyncEnumerable(
+        int chunkSize = 100,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var item in _queryable)
+            yield return item;
+
+        await Task.CompletedTask;
+    }
+
+    public Task<int> CountAsync(CancellationToken ct = default) =>
+        Task.FromResult(_queryable.Count());
+
+    public Task<bool> AnyAsync(CancellationToken ct = default) =>
+        Task.FromResult(_queryable.Any());
+
+    public Task<bool> AnyAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) =>
+        Task.FromResult(_queryable.Any(predicate));
+
+    public Task<bool> AllAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) =>
+        Task.FromResult(_queryable.All(predicate));
+
+    public Task<TResult?> MinAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) =>
+        Task.FromResult(_queryable.Min(selector));
+
+    public Task<TResult?> MaxAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) =>
+        Task.FromResult(_queryable.Max(selector));
+
+    public Task<T?> MinByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) =>
+        Task.FromResult(_queryable.AsEnumerable().MinBy(keySelector.Compile()));
+
+    public Task<T?> MaxByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) =>
+        Task.FromResult(_queryable.AsEnumerable().MaxBy(keySelector.Compile()));
+
+    public Task<decimal> SumAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) =>
+        Task.FromResult(_queryable.Sum(selector));
+
+    public Task<double> AverageAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) =>
+        Task.FromResult((double)_queryable.Average(selector));
+
+    public Task<List<GroupResult<TKey, T>>> GroupByAsync<TKey>(
+        Expression<Func<T, TKey>> keySelector,
+        CancellationToken ct = default)
+    {
+        var key = keySelector.Compile();
+        var groups = _queryable
+            .AsEnumerable()
+            .GroupBy(key)
+            .Select(g => new GroupResult<TKey, T>
+            {
+                Key = g.Key,
+                Items = g.ToList()
+            })
+            .ToList();
+
+        return Task.FromResult(groups);
+    }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Tests/Services/ThreadServiceSecurityTests.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Tests/Services/ThreadServiceSecurityTests.cs
@@ -1,0 +1,207 @@
+using IdentityServer.Domain.Shared;
+using IdentityServer.Domain.Shared.Contracts;
+using Messaging.Api.Services;
+using Messaging.Domain.Shared;
+using Messaging.Domain.Shared.Contracts;
+using Messaging.Domain.Shared.Contracts.Requests.Threads;
+using Messaging.Tests.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using XFramework.Domain.Shared.BusinessObjects;
+
+namespace Messaging.Tests.Services;
+
+public sealed class ThreadServiceSecurityTests
+{
+    [Test]
+    public async Task CreateThreadMessageAsync_SpoofedSenderCredential_UsesAuthenticatedCaller()
+    {
+        var tenantId = Guid.NewGuid();
+        var threadId = Guid.NewGuid();
+        var callerCredentialId = Guid.NewGuid();
+        var spoofedCredentialId = Guid.NewGuid();
+        var callerMemberId = Guid.NewGuid();
+
+        var dataContext = new InMemoryDataContext();
+        dataContext.Seed(
+            Thread(threadId, tenantId),
+            Member(callerMemberId, threadId, callerCredentialId, tenantId),
+            Member(Guid.NewGuid(), threadId, spoofedCredentialId, tenantId));
+
+        var service = CreateService(dataContext);
+        var request = new CreateThreadMessageRequest
+        {
+            ThreadId = threadId,
+            SenderCredentialId = spoofedCredentialId,
+            Text = "spoof attempt",
+            Metadata = Metadata(callerCredentialId, tenantId)
+        };
+
+        var result = await service.CreateThreadMessageAsync(request);
+
+        Assert.That(result.IsSuccess, Is.True, result.Message);
+        var message = dataContext.Set<Message>().Single();
+        Assert.That(message.MessageThreadMemberId, Is.EqualTo(callerMemberId));
+        Assert.That(dataContext.Set<MessageOutboxEvent>().Single().ActorCredentialId, Is.EqualTo(callerCredentialId));
+    }
+
+    [Test]
+    public async Task AddThreadMemberAsync_ExplicitRolesWithoutAdmin_ReturnsForbidden()
+    {
+        var tenantId = Guid.NewGuid();
+        var threadId = Guid.NewGuid();
+        var actorCredentialId = Guid.NewGuid();
+        var targetCredentialId = Guid.NewGuid();
+        var actorMemberId = Guid.NewGuid();
+        var userRoleId = Guid.NewGuid();
+
+        var dataContext = new InMemoryDataContext();
+        dataContext.Seed(
+            Thread(threadId, tenantId),
+            Group(Guid.NewGuid(), threadId, tenantId),
+            Member(actorMemberId, threadId, actorCredentialId, tenantId),
+            Credential(targetCredentialId, tenantId),
+            IdentityRole(userRoleId, actorCredentialId, Guid.NewGuid(), tenantId),
+            ThreadRole(Guid.NewGuid(), actorMemberId, userRoleId, tenantId));
+
+        var service = CreateService(dataContext);
+        var request = new AddThreadMemberRequest
+        {
+            ThreadId = threadId,
+            CredentialId = targetCredentialId,
+            Metadata = Metadata(actorCredentialId, tenantId)
+        };
+
+        var result = await service.AddThreadMemberAsync(request);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.StatusCode, Is.EqualTo(403));
+        Assert.That(dataContext.Set<MessageThreadMember>().Any(m => m.CredentialId == targetCredentialId), Is.False);
+        Assert.That(dataContext.Set<MessageOutboxEvent>(), Is.Empty);
+    }
+
+    [Test]
+    public async Task AddThreadMemberAsync_AdminRole_AddsMember()
+    {
+        var tenantId = Guid.NewGuid();
+        var threadId = Guid.NewGuid();
+        var actorCredentialId = Guid.NewGuid();
+        var targetCredentialId = Guid.NewGuid();
+        var actorMemberId = Guid.NewGuid();
+        var adminRoleId = Guid.NewGuid();
+
+        var dataContext = new InMemoryDataContext();
+        dataContext.Seed(
+            Thread(threadId, tenantId),
+            Group(Guid.NewGuid(), threadId, tenantId),
+            Member(actorMemberId, threadId, actorCredentialId, tenantId),
+            Credential(targetCredentialId, tenantId),
+            IdentityRole(adminRoleId, actorCredentialId, IdentityConstants.RoleType.Admin, tenantId),
+            ThreadRole(Guid.NewGuid(), actorMemberId, adminRoleId, tenantId));
+
+        var service = CreateService(dataContext);
+        var request = new AddThreadMemberRequest
+        {
+            ThreadId = threadId,
+            CredentialId = targetCredentialId,
+            Metadata = Metadata(actorCredentialId, tenantId)
+        };
+
+        var result = await service.AddThreadMemberAsync(request);
+
+        Assert.That(result.IsSuccess, Is.True, result.Message);
+        Assert.That(dataContext.Set<MessageThreadMember>().Any(m => m.CredentialId == targetCredentialId), Is.True);
+        Assert.That(dataContext.Set<MessageOutboxEvent>().Single().EventType, Is.EqualTo(MessageRealtimeEvents.ThreadMemberAdded));
+    }
+
+    private static ThreadService CreateService(InMemoryDataContext dataContext) =>
+        new(
+            dataContext,
+            new MessagingRequestContextResolver(new HttpContextAccessor()),
+            NullLogger<ThreadService>.Instance);
+
+    private static RequestMetadata Metadata(Guid credentialId, Guid tenantId) => new()
+    {
+        CredentialId = credentialId,
+        TenantId = tenantId
+    };
+
+    private static MessageThread Thread(Guid id, Guid tenantId) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        TypeId = Guid.NewGuid(),
+        Name = "Thread",
+        Description = string.Empty,
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private static MessageThreadMemberGroup Group(Guid id, Guid threadId, Guid tenantId) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        MessageThreadId = threadId,
+        Alias = "Default",
+        Emoji = string.Empty,
+        Description = string.Empty,
+        Status = 1,
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private static MessageThreadMember Member(Guid id, Guid threadId, Guid credentialId, Guid tenantId) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        MessageThreadId = threadId,
+        CredentialId = credentialId,
+        GroupId = Guid.NewGuid(),
+        Alias = string.Empty,
+        Emoji = string.Empty,
+        Description = string.Empty,
+        Status = 1,
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private static IdentityCredential Credential(Guid id, Guid tenantId) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        UserName = $"user-{id:N}",
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private static IdentityRole IdentityRole(Guid id, Guid credentialId, Guid roleTypeId, Guid tenantId) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        CredentialId = credentialId,
+        TypeId = roleTypeId,
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private static MessageThreadMemberRole ThreadRole(
+        Guid id,
+        Guid memberId,
+        Guid roleId,
+        Guid tenantId) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        MessageThreadMemberId = memberId,
+        RoleId = roleId,
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Tests/Services/ThreadServiceSecurityTests.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Tests/Services/ThreadServiceSecurityTests.cs
@@ -47,6 +47,36 @@ public sealed class ThreadServiceSecurityTests
     }
 
     [Test]
+    public async Task CreateThreadMessageAsync_CrossTenantThreadId_ReturnsNotFound()
+    {
+        var threadTenantId = Guid.NewGuid();
+        var callerTenantId = Guid.NewGuid();
+        var threadId = Guid.NewGuid();
+        var callerCredentialId = Guid.NewGuid();
+
+        var dataContext = new InMemoryDataContext();
+        dataContext.Seed(
+            Thread(threadId, threadTenantId),
+            Member(Guid.NewGuid(), threadId, callerCredentialId, threadTenantId));
+
+        var service = CreateService(dataContext);
+        var request = new CreateThreadMessageRequest
+        {
+            ThreadId = threadId,
+            SenderCredentialId = callerCredentialId,
+            Text = "cross tenant attempt",
+            Metadata = Metadata(callerCredentialId, callerTenantId)
+        };
+
+        var result = await service.CreateThreadMessageAsync(request);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.StatusCode, Is.EqualTo(404));
+        Assert.That(dataContext.Set<Message>(), Is.Empty);
+        Assert.That(dataContext.Set<MessageOutboxEvent>(), Is.Empty);
+    }
+
+    [Test]
     public async Task AddThreadMemberAsync_ExplicitRolesWithoutAdmin_ReturnsForbidden()
     {
         var tenantId = Guid.NewGuid();

--- a/src/Shared/XFramework.Domain.Shared/BusinessObjects/RequestMetadata.cs
+++ b/src/Shared/XFramework.Domain.Shared/BusinessObjects/RequestMetadata.cs
@@ -6,6 +6,7 @@ public partial class RequestMetadata
 {
     public Guid? SessionId { get; set; }
     public Guid? TenantId { get; set; }
+    public Guid? CredentialId { get; set; }
     public string? Name { get; set; }
     public string? DeviceName { get; set; }
     public string? DeviceAgent { get; set; }


### PR DESCRIPTION
## Summary
- Requires authorization on Messaging generated endpoints.
- Resolves caller credential/tenant from auth metadata and blocks spoofed sender behavior.
- Adds role-aware thread/message/reaction/read-state checks.
- Adds database model constraints/indexes and a durable message outbox event entity for future realtime fan-out.
- Lead review added explicit tenant filters and a cross-tenant regression test.

## Verification
- dotnet test src\Modules\XFramework.Messaging\Messaging.Tests\Messaging.Tests.csproj -m:1 /nr:false
- git diff --check