### PR TITLE
Add Notifications module baseline

### DIFF
--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -35,6 +35,12 @@
     <Project Path="src\Modules\XFramework.Messaging\Messaging.Domain.Shared\Messaging.Domain.Shared.csproj" />
     <Project Path="src\Modules\XFramework.Messaging\Messaging.Integration\Messaging.Integration.csproj" />
   </Folder>
+  <Folder Name="/Services/Notifications/">
+    <Project Path="src\Modules\XFramework.Notifications\Notifications.Api\Notifications.Api.csproj" />
+    <Project Path="src\Modules\XFramework.Notifications\Notifications.Domain.Shared\Notifications.Domain.Shared.csproj" />
+    <Project Path="src\Modules\XFramework.Notifications\Notifications.Integration\Notifications.Integration.csproj" />
+    <Project Path="src\Modules\XFramework.Notifications\Notifications.Tests\Notifications.Tests.csproj" />
+  </Folder>
   <Folder Name="/Services/Payments/">
     <Project Path="src\Modules\XFramework.Payments\Payments.Core\Payments.Core.csproj" />
     <Project Path="src\Modules\XFramework.Payments\Payments.Domain.Shared\Payments.Domain.Shared.csproj" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,27 @@ services:
       retries: 15
       start_period: 15s
 
+  # ── Notifications Server ────────────────────────────────────
+  notifications:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT_PATH: src/Modules/XFramework.Notifications/Notifications.Api/Notifications.Api.csproj
+    environment:
+      <<: *common-env
+    ports:
+      - "${NOTIFICATIONS_EXPOSE_PORT:-5166}:8080"
+    depends_on:
+      bolt-hub:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 15s
+
   # ── SMS Gateway ─────────────────────────────────────────────
   smsgateway:
     build:

--- a/src/Kernel/XFramework.Domain/Migrations/20260617000000_AddNotificationsBaseline.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260617000000_AddNotificationsBaseline.cs
@@ -1,0 +1,152 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260617000000_AddNotificationsBaseline")]
+    public partial class AddNotificationsBaseline : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(name: "Notifications");
+
+            migrationBuilder.CreateTable(
+                name: "NotificationInboxItem",
+                schema: "Notifications",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    RecipientCredentialId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceCredentialId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TemplateKey = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Title = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Body = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    DeliveryChannels = table.Column<int>(type: "integer", nullable: false),
+                    CorrelationId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    DataJson = table.Column<string>(type: "text", nullable: true),
+                    IsRead = table.Column<bool>(type: "boolean", nullable: false),
+                    ReadAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("notificationinboxitem_pk", x => x.ID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NotificationPreference",
+                schema: "Notifications",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CredentialId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EnabledChannels = table.Column<int>(type: "integer", nullable: false),
+                    DisabledTemplateKeys = table.Column<string>(type: "text", nullable: true),
+                    DigestEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("notificationpreference_pk", x => x.ID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NotificationDeliveryStatus",
+                schema: "Notifications",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    NotificationInboxItemId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Channel = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    ProviderMessageId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ErrorCode = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    ErrorMessage = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    AttemptNumber = table.Column<int>(type: "integer", nullable: false),
+                    RecordedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("notificationdeliverystatus_pk", x => x.ID);
+                    table.ForeignKey(
+                        name: "notificationdeliverystatus_inboxitem_id_fk",
+                        column: x => x.NotificationInboxItemId,
+                        principalSchema: "Notifications",
+                        principalTable: "NotificationInboxItem",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notificationinboxitem_tenant_correlation",
+                schema: "Notifications",
+                table: "NotificationInboxItem",
+                columns: new[] { "TenantId", "CorrelationId" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notificationinboxitem_tenant_recipient_read_created",
+                schema: "Notifications",
+                table: "NotificationInboxItem",
+                columns: new[] { "TenantId", "RecipientCredentialId", "IsRead", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notificationinboxitem_tenant_template",
+                schema: "Notifications",
+                table: "NotificationInboxItem",
+                columns: new[] { "TenantId", "TemplateKey" });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_notificationpreference_tenant_credential",
+                schema: "Notifications",
+                table: "NotificationPreference",
+                columns: new[] { "TenantId", "CredentialId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ux_notificationdeliverystatus_tenant_item_channel",
+                schema: "Notifications",
+                table: "NotificationDeliveryStatus",
+                columns: new[] { "TenantId", "NotificationInboxItemId", "Channel" },
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NotificationDeliveryStatus",
+                schema: "Notifications");
+
+            migrationBuilder.DropTable(
+                name: "NotificationPreference",
+                schema: "Notifications");
+
+            migrationBuilder.DropTable(
+                name: "NotificationInboxItem",
+                schema: "Notifications");
+        }
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/Create/CreateNotificationValidator.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/Create/CreateNotificationValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+
+namespace Notifications.Api.Features.Notifications.Create;
+
+public sealed class CreateNotificationValidator : AbstractValidator<CreateNotificationRequest>
+{
+    public CreateNotificationValidator()
+    {
+        RuleFor(x => x.RecipientCredentialId)
+            .NotEmpty().WithMessage("Recipient credential ID is required");
+
+        RuleFor(x => x.TemplateKey)
+            .NotEmpty().WithMessage("Template key is required")
+            .MaximumLength(128).WithMessage("Template key must not exceed 128 characters");
+
+        RuleFor(x => x.Title)
+            .NotEmpty().WithMessage("Title is required")
+            .MaximumLength(256).WithMessage("Title must not exceed 256 characters");
+
+        RuleFor(x => x.Body)
+            .NotEmpty().WithMessage("Body is required")
+            .MaximumLength(4000).WithMessage("Body must not exceed 4000 characters");
+
+        RuleFor(x => x.DeliveryChannels)
+            .Must(channels => channels != NotificationDeliveryChannel.None)
+            .WithMessage("At least one delivery channel is required")
+            .Must(channels => (channels & ~NotificationDeliveryChannel.All) == 0)
+            .WithMessage("Delivery channels contain an unsupported value");
+
+        RuleFor(x => x.CorrelationId)
+            .MaximumLength(128).WithMessage("Correlation ID must not exceed 128 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.CorrelationId));
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/Create/Endpoint.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/Create/Endpoint.cs
@@ -1,0 +1,18 @@
+using Notifications.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+namespace Notifications.Api.Features.Notifications.Create;
+
+public static class CreateNotificationEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/notifications", Tags = ["Notifications"],
+        Summary = "Create notification",
+        Description = "Creates a tenant-scoped notification inbox item for a credential.")]
+    public static Task<Result<NotificationInboxItemResponse>> Handle(
+        CreateNotificationRequest request,
+        NotificationService notificationService,
+        CancellationToken ct) =>
+        notificationService.CreateNotificationAsync(request, ct);
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/GetInbox/Endpoint.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/GetInbox/Endpoint.cs
@@ -1,0 +1,18 @@
+using Notifications.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+namespace Notifications.Api.Features.Notifications.GetInbox;
+
+public static class GetNotificationInboxEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/notifications/inbox", Tags = ["Notifications"],
+        Summary = "Get notification inbox",
+        Description = "Retrieves tenant-scoped notification inbox items for a credential.")]
+    public static Task<Result<GetNotificationInboxResponse>> Handle(
+        GetNotificationInboxRequest request,
+        NotificationService notificationService,
+        CancellationToken ct) =>
+        notificationService.GetInboxAsync(request, ct);
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/GetInbox/GetNotificationInboxValidator.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/GetInbox/GetNotificationInboxValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace Notifications.Api.Features.Notifications.GetInbox;
+
+public sealed class GetNotificationInboxValidator : AbstractValidator<GetNotificationInboxRequest>
+{
+    public GetNotificationInboxValidator()
+    {
+        RuleFor(x => x.RecipientCredentialId)
+            .NotEmpty().WithMessage("Recipient credential ID is required");
+
+        RuleFor(x => x.Page)
+            .GreaterThan(0).WithMessage("Page must be greater than zero");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100).WithMessage("Page size must be between 1 and 100");
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/MarkRead/Endpoint.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/MarkRead/Endpoint.cs
@@ -1,0 +1,18 @@
+using Notifications.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+namespace Notifications.Api.Features.Notifications.MarkRead;
+
+public static class MarkNotificationReadEndpoint
+{
+    [BoltHandler]
+    [MapPatch("/api/notifications/inbox/read", Tags = ["Notifications"],
+        Summary = "Mark notifications read",
+        Description = "Marks notification inbox items read for the requesting credential.")]
+    public static Task<Result> Handle(
+        MarkNotificationReadRequest request,
+        NotificationService notificationService,
+        CancellationToken ct) =>
+        notificationService.MarkReadAsync(request, ct);
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/MarkRead/MarkNotificationReadValidator.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/MarkRead/MarkNotificationReadValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace Notifications.Api.Features.Notifications.MarkRead;
+
+public sealed class MarkNotificationReadValidator : AbstractValidator<MarkNotificationReadRequest>
+{
+    public MarkNotificationReadValidator()
+    {
+        RuleFor(x => x.RecipientCredentialId)
+            .NotEmpty().WithMessage("Recipient credential ID is required");
+
+        RuleFor(x => x.NotificationIds)
+            .NotEmpty().WithMessage("At least one notification ID is required")
+            .Must(ids => ids.Distinct().Count() == ids.Count)
+            .WithMessage("Notification IDs must be unique");
+
+        RuleForEach(x => x.NotificationIds)
+            .NotEmpty().WithMessage("Notification ID cannot be empty");
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/RecordDeliveryStatus/Endpoint.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/RecordDeliveryStatus/Endpoint.cs
@@ -1,0 +1,18 @@
+using Notifications.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+namespace Notifications.Api.Features.Notifications.RecordDeliveryStatus;
+
+public static class RecordNotificationDeliveryStatusEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/notifications/delivery-status", Tags = ["Notifications"],
+        Summary = "Record notification delivery status",
+        Description = "Records or advances delivery status for a notification and channel.")]
+    public static Task<Result<NotificationDeliveryStatusResponse>> Handle(
+        RecordNotificationDeliveryStatusRequest request,
+        NotificationService notificationService,
+        CancellationToken ct) =>
+        notificationService.RecordDeliveryStatusAsync(request, ct);
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/RecordDeliveryStatus/RecordNotificationDeliveryStatusValidator.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/RecordDeliveryStatus/RecordNotificationDeliveryStatusValidator.cs
@@ -1,0 +1,42 @@
+using FluentValidation;
+
+namespace Notifications.Api.Features.Notifications.RecordDeliveryStatus;
+
+public sealed class RecordNotificationDeliveryStatusValidator : AbstractValidator<RecordNotificationDeliveryStatusRequest>
+{
+    public RecordNotificationDeliveryStatusValidator()
+    {
+        RuleFor(x => x.NotificationInboxItemId)
+            .NotEmpty().WithMessage("Notification inbox item ID is required");
+
+        RuleFor(x => x.Channel)
+            .Must(channel => channel is not NotificationDeliveryChannel.None &&
+                             (channel & ~NotificationDeliveryChannel.All) == 0 &&
+                             IsSingleChannel(channel))
+            .WithMessage("A single supported delivery channel is required");
+
+        RuleFor(x => x.Status)
+            .IsInEnum().WithMessage("Delivery status is invalid");
+
+        RuleFor(x => x.ProviderMessageId)
+            .MaximumLength(256).WithMessage("Provider message ID must not exceed 256 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.ProviderMessageId));
+
+        RuleFor(x => x.ErrorCode)
+            .MaximumLength(128).WithMessage("Error code must not exceed 128 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.ErrorCode));
+
+        RuleFor(x => x.ErrorMessage)
+            .MaximumLength(2000).WithMessage("Error message must not exceed 2000 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.ErrorMessage));
+
+        RuleFor(x => x.AttemptNumber)
+            .GreaterThanOrEqualTo(0).WithMessage("Attempt number cannot be negative");
+    }
+
+    private static bool IsSingleChannel(NotificationDeliveryChannel channel)
+    {
+        var value = (int)channel;
+        return (value & (value - 1)) == 0;
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/UpdatePreferences/Endpoint.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/UpdatePreferences/Endpoint.cs
@@ -1,0 +1,18 @@
+using Notifications.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+namespace Notifications.Api.Features.Notifications.UpdatePreferences;
+
+public static class UpdateNotificationPreferencesEndpoint
+{
+    [BoltHandler]
+    [MapPut("/api/notifications/preferences", Tags = ["Notifications"],
+        Summary = "Update notification preferences",
+        Description = "Creates or updates delivery-channel and template preferences for a credential.")]
+    public static Task<Result<NotificationPreferencesResponse>> Handle(
+        UpdateNotificationPreferencesRequest request,
+        NotificationService notificationService,
+        CancellationToken ct) =>
+        notificationService.UpdatePreferencesAsync(request, ct);
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/UpdatePreferences/UpdateNotificationPreferencesValidator.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Features/Notifications/UpdatePreferences/UpdateNotificationPreferencesValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace Notifications.Api.Features.Notifications.UpdatePreferences;
+
+public sealed class UpdateNotificationPreferencesValidator : AbstractValidator<UpdateNotificationPreferencesRequest>
+{
+    public UpdateNotificationPreferencesValidator()
+    {
+        RuleFor(x => x.CredentialId)
+            .NotEmpty().WithMessage("Credential ID is required");
+
+        RuleFor(x => x.EnabledChannels)
+            .Must(channels => (channels & ~NotificationDeliveryChannel.All) == 0)
+            .WithMessage("Enabled channels contain an unsupported value");
+
+        RuleForEach(x => x.DisabledTemplateKeys)
+            .NotEmpty().WithMessage("Disabled template key cannot be empty")
+            .MaximumLength(128).WithMessage("Disabled template key must not exceed 128 characters");
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/GlobalUsings.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/GlobalUsings.cs
@@ -1,0 +1,7 @@
+global using Microsoft.EntityFrameworkCore;
+global using Notifications.Domain.Shared.Contracts;
+global using Notifications.Domain.Shared.Contracts.Requests;
+global using Notifications.Domain.Shared.Contracts.Responses;
+global using Notifications.Domain.Shared.Enums;
+global using XFramework.Domain.Contexts;
+global using XFramework.Extensions;

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Installers/DbInstaller.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Installers/DbInstaller.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using XFramework.Core.DataContext;
+using XFramework.Domain.Interceptors;
+using XFramework.Domain.Shared.Interfaces;
+
+namespace Notifications.Api.Installers;
+
+public sealed class DbInstaller : IInstaller
+{
+    public void InstallServices<TAssembly>(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment)
+    {
+        services.AddHttpContextAccessor();
+        services.AddScoped<AuditInterceptor>();
+
+        services.AddDbContext<DbContext, AppDbContext>((serviceProvider, options) => options
+            .UseNpgsql(string.IsNullOrEmpty(configuration["DefaultDatabaseConnection"])
+                    ? configuration.GetConnectionString("DefaultDatabaseConnection")
+                    : configuration["DefaultDatabaseConnection"],
+                npgsqlOptions => npgsqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery))
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(warnings => warnings.Ignore(
+                RelationalEventId.BoolWithDefaultWarning,
+                RelationalEventId.PendingModelChangesWarning))
+            .AddInterceptors(serviceProvider.GetRequiredService<AuditInterceptor>()));
+
+        services.AddServerDataContext<AppDbContext>();
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Installers/ServicesInstaller.cs
@@ -1,0 +1,17 @@
+using Notifications.Api.Services;
+using XFramework.Core.Extensions;
+using XFramework.Domain.Shared.Interfaces;
+
+namespace Notifications.Api.Installers;
+
+public sealed class ServicesInstaller : IInstaller
+{
+    public void InstallServices<TAssembly>(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment)
+    {
+        services.AddTenantResolver();
+        services.AddScoped<NotificationService>();
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Installers/WrapperInstaller.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Installers/WrapperInstaller.cs
@@ -1,0 +1,15 @@
+using XFramework.Domain.Shared.Interfaces;
+using XFramework.Integration.Extensions;
+
+namespace Notifications.Api.Installers;
+
+public sealed class WrapperInstaller : IInstaller
+{
+    public void InstallServices<TAssembly>(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment)
+    {
+        services.AddXFrameworkBoltClient(configuration);
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Notifications.Api.csproj
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Notifications.Api.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\SourceGenerators\XFramework.SourceGenerators\XFramework.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
+        <ProjectReference Include="..\..\..\Kernel\XFramework.Core\XFramework.Core.csproj" />
+        <ProjectReference Include="..\..\..\Kernel\XFramework.Domain\XFramework.Domain.csproj" />
+        <ProjectReference Include="..\Notifications.Domain.Shared\Notifications.Domain.Shared.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="OpenTelemetry" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    </ItemGroup>
+
+</Project>

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Program.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Program.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using Notifications.Api.Generated;
+using XFramework.Core.DataContext;
+using XFramework.Core.Extensions;
+using XFramework.Core.Health;
+using XFramework.Core.Middlewares;
+using XFramework.Core.RateLimiting;
+using XFramework.Integration.Extensions;
+
+var builder = XApplication.Configure<Program>();
+builder.Logging.AddXFrameworkLogging(builder.Configuration);
+
+builder.Services.InstallOpenTelemetry(builder.Configuration, "XFramework.Notifications.Api");
+builder.Services.AddXFrameworkHealthChecks<AppDbContext>(
+    builder.Configuration,
+    "Notifications");
+
+builder.Services.AddValidatorsFromAssemblyContaining<Program>();
+builder.Services.AddDataContextHandler(typeof(Program).Assembly);
+builder.Services.AddXFrameworkRateLimiting();
+
+var app = (WebApplication)builder.Build();
+
+app.UseCorrelationId();
+app.UseXFrameworkRateLimiting();
+app.EnsureDatabase<AppDbContext>();
+
+app.MapXFrameworkHealthChecks("Notifications");
+app.MapGeneratedEndpoints();
+app.MapApiDocumentation();
+
+app.Run();
+
+public partial class Program;

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Program.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Program.cs
@@ -26,7 +26,8 @@ app.UseXFrameworkRateLimiting();
 app.EnsureDatabase<AppDbContext>();
 
 app.MapXFrameworkHealthChecks("Notifications");
-app.MapGeneratedEndpoints();
+var securedNotificationEndpoints = app.MapGroup(string.Empty).RequireAuthorization();
+securedNotificationEndpoints.MapGeneratedEndpoints();
 app.MapApiDocumentation();
 
 app.Run();

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Services/NotificationService.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Services/NotificationService.cs
@@ -1,0 +1,373 @@
+using System.Text.Json;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.BusinessObjects;
+
+namespace Notifications.Api.Services;
+
+public sealed class NotificationService(AppDbContext db, ILogger<NotificationService> logger)
+{
+    private const char TemplateKeySeparator = '\n';
+
+    public async Task<Result<NotificationInboxItemResponse>> CreateNotificationAsync(
+        CreateNotificationRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
+            return Result<NotificationInboxItemResponse>.Failure("Tenant ID is required", 400);
+
+        var preferences = await GetPreferenceEntityAsync(tenantId, request.RecipientCredentialId, ct);
+        var enabledChannels = preferences?.EnabledChannels ?? NotificationPreferenceDefaults.EnabledChannels;
+        var requestedChannels = NotificationPreferenceDefaults.Normalize(request.DeliveryChannels);
+        var effectiveChannels = requestedChannels & enabledChannels;
+
+        if (effectiveChannels == NotificationDeliveryChannel.None)
+        {
+            logger.LogInformation(
+                "Notification suppressed because no requested channels are enabled. TenantId={TenantId} RecipientCredentialId={CredentialId} TemplateKey={TemplateKey}",
+                tenantId,
+                request.RecipientCredentialId,
+                request.TemplateKey);
+            return Result<NotificationInboxItemResponse>.Conflict("No enabled delivery channels are available for this recipient");
+        }
+
+        if (IsTemplateDisabled(preferences, request.TemplateKey))
+            return Result<NotificationInboxItemResponse>.Conflict("Notification template is disabled for this recipient");
+
+        var item = new NotificationInboxItem
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            RecipientCredentialId = request.RecipientCredentialId,
+            SourceCredentialId = request.SourceCredentialId,
+            TemplateKey = request.TemplateKey.Trim(),
+            Title = request.Title.Trim(),
+            Body = request.Body.Trim(),
+            DeliveryChannels = effectiveChannels,
+            CorrelationId = string.IsNullOrWhiteSpace(request.CorrelationId) ? null : request.CorrelationId.Trim(),
+            DataJson = request.Data is null ? null : JsonSerializer.Serialize(request.Data),
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid(),
+            IsEnabled = true
+        };
+
+        db.Set<NotificationInboxItem>().Add(item);
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Notification {NotificationId} created for credential {CredentialId} in tenant {TenantId}",
+            item.Id,
+            item.RecipientCredentialId,
+            tenantId);
+
+        return Result<NotificationInboxItemResponse>.Success(ToInboxResponse(item), 201, "Notification created");
+    }
+
+    public async Task<Result<GetNotificationInboxResponse>> GetInboxAsync(
+        GetNotificationInboxRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
+            return Result<GetNotificationInboxResponse>.Failure("Tenant ID is required", 400);
+
+        var page = request.Page <= 0 ? 1 : request.Page;
+        var pageSize = request.PageSize <= 0 ? 20 : Math.Min(request.PageSize, 100);
+
+        var query = db.Set<NotificationInboxItem>()
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.RecipientCredentialId == request.RecipientCredentialId);
+
+        if (request.IsRead.HasValue)
+            query = query.Where(item => item.IsRead == request.IsRead.Value);
+
+        var totalCount = await query.CountAsync(ct);
+        var items = await query
+            .OrderByDescending(item => item.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(item => new NotificationInboxItemResponse
+            {
+                Id = item.Id,
+                TenantId = item.TenantId,
+                RecipientCredentialId = item.RecipientCredentialId,
+                SourceCredentialId = item.SourceCredentialId,
+                TemplateKey = item.TemplateKey,
+                Title = item.Title,
+                Body = item.Body,
+                DeliveryChannels = item.DeliveryChannels,
+                CorrelationId = item.CorrelationId,
+                DataJson = item.DataJson,
+                IsRead = item.IsRead,
+                ReadAt = item.ReadAt,
+                CreatedAt = item.CreatedAt
+            })
+            .ToListAsync(ct);
+
+        var response = new GetNotificationInboxResponse
+        {
+            Items = items,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = totalCount,
+            TotalPages = totalCount == 0 ? 0 : (int)Math.Ceiling(totalCount / (double)pageSize)
+        };
+
+        return Result<GetNotificationInboxResponse>.Success(response);
+    }
+
+    public async Task<Result> MarkReadAsync(MarkNotificationReadRequest request, CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
+            return Result.Failure("Tenant ID is required", 400);
+
+        var items = await db.Set<NotificationInboxItem>()
+            .AsTracking()
+            .Where(item =>
+                item.TenantId == tenantId &&
+                item.RecipientCredentialId == request.RecipientCredentialId &&
+                request.NotificationIds.Contains(item.Id))
+            .ToListAsync(ct);
+
+        if (items.Count == 0)
+            return Result.NotFound("No matching notifications were found");
+
+        var readAt = DateTime.UtcNow;
+        foreach (var item in items.Where(item => !item.IsRead))
+        {
+            item.IsRead = true;
+            item.ReadAt = readAt;
+            item.ModifiedAt = readAt;
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        return Result.Success($"Marked {items.Count} notification(s) as read");
+    }
+
+    public async Task<Result<NotificationPreferencesResponse>> GetPreferencesAsync(
+        Guid tenantId,
+        Guid credentialId,
+        CancellationToken ct)
+    {
+        if (tenantId == Guid.Empty)
+            return Result<NotificationPreferencesResponse>.Failure("Tenant ID is required", 400);
+
+        var preferences = await GetPreferenceEntityAsync(tenantId, credentialId, ct);
+        return Result<NotificationPreferencesResponse>.Success(ToPreferencesResponse(tenantId, credentialId, preferences));
+    }
+
+    public async Task<Result<NotificationPreferencesResponse>> UpdatePreferencesAsync(
+        UpdateNotificationPreferencesRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
+            return Result<NotificationPreferencesResponse>.Failure("Tenant ID is required", 400);
+
+        var normalizedTemplateKeys = request.DisabledTemplateKeys
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .Select(key => key.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var preferences = await db.Set<NotificationPreference>()
+            .AsTracking()
+            .FirstOrDefaultAsync(
+                pref => pref.TenantId == tenantId && pref.CredentialId == request.CredentialId,
+                ct);
+
+        if (preferences is null)
+        {
+            preferences = new NotificationPreference
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                CredentialId = request.CredentialId,
+                CreatedAt = DateTime.UtcNow,
+                ConcurrencyStamp = Guid.NewGuid(),
+                IsEnabled = true
+            };
+            db.Set<NotificationPreference>().Add(preferences);
+        }
+
+        preferences.EnabledChannels = NotificationPreferenceDefaults.Normalize(request.EnabledChannels);
+        preferences.DisabledTemplateKeys = SerializeTemplateKeys(normalizedTemplateKeys);
+        preferences.DigestEnabled = request.DigestEnabled;
+        preferences.ModifiedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+
+        return Result<NotificationPreferencesResponse>.Success(
+            ToPreferencesResponse(tenantId, request.CredentialId, preferences),
+            "Notification preferences updated");
+    }
+
+    public async Task<Result<NotificationDeliveryStatusResponse>> RecordDeliveryStatusAsync(
+        RecordNotificationDeliveryStatusRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
+            return Result<NotificationDeliveryStatusResponse>.Failure("Tenant ID is required", 400);
+
+        var notificationExists = await db.Set<NotificationInboxItem>()
+            .AsNoTracking()
+            .AnyAsync(
+                item => item.TenantId == tenantId && item.Id == request.NotificationInboxItemId,
+                ct);
+
+        if (!notificationExists)
+            return Result<NotificationDeliveryStatusResponse>.NotFound("Notification was not found");
+
+        var record = await db.Set<NotificationDeliveryStatusRecord>()
+            .AsTracking()
+            .FirstOrDefaultAsync(
+                status =>
+                    status.TenantId == tenantId &&
+                    status.NotificationInboxItemId == request.NotificationInboxItemId &&
+                    status.Channel == request.Channel,
+                ct);
+
+        if (record is not null && !CanTransition(record.Status, request.Status))
+        {
+            return Result<NotificationDeliveryStatusResponse>.Conflict(
+                $"Cannot transition delivery status from {record.Status} to {request.Status}");
+        }
+
+        var recordedAt = request.RecordedAt ?? DateTime.UtcNow;
+        if (record is null)
+        {
+            record = new NotificationDeliveryStatusRecord
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                NotificationInboxItemId = request.NotificationInboxItemId,
+                Channel = request.Channel,
+                CreatedAt = recordedAt,
+                ConcurrencyStamp = Guid.NewGuid(),
+                IsEnabled = true
+            };
+            db.Set<NotificationDeliveryStatusRecord>().Add(record);
+        }
+
+        record.Status = request.Status;
+        record.ProviderMessageId = string.IsNullOrWhiteSpace(request.ProviderMessageId)
+            ? record.ProviderMessageId
+            : request.ProviderMessageId.Trim();
+        record.ErrorCode = string.IsNullOrWhiteSpace(request.ErrorCode) ? null : request.ErrorCode.Trim();
+        record.ErrorMessage = string.IsNullOrWhiteSpace(request.ErrorMessage) ? null : request.ErrorMessage.Trim();
+        record.AttemptNumber = request.AttemptNumber <= 0 ? record.AttemptNumber : request.AttemptNumber;
+        record.RecordedAt = recordedAt;
+        record.ModifiedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+
+        return Result<NotificationDeliveryStatusResponse>.Success(
+            ToDeliveryStatusResponse(record),
+            "Notification delivery status recorded");
+    }
+
+    private async Task<NotificationPreference?> GetPreferenceEntityAsync(
+        Guid tenantId,
+        Guid credentialId,
+        CancellationToken ct) =>
+        await db.Set<NotificationPreference>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                pref => pref.TenantId == tenantId && pref.CredentialId == credentialId,
+                ct);
+
+    private static bool TryResolveTenantId(Guid? requestTenantId, RequestMetadata metadata, out Guid tenantId)
+    {
+        tenantId = requestTenantId ?? metadata.TenantId ?? Guid.Empty;
+        return tenantId != Guid.Empty;
+    }
+
+    private static bool IsTemplateDisabled(NotificationPreference? preference, string templateKey)
+    {
+        if (preference?.DisabledTemplateKeys is null)
+            return false;
+
+        return DeserializeTemplateKeys(preference.DisabledTemplateKeys)
+            .Contains(templateKey.Trim(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string? SerializeTemplateKeys(IReadOnlyCollection<string> keys) =>
+        keys.Count == 0 ? null : string.Join(TemplateKeySeparator, keys);
+
+    private static List<string> DeserializeTemplateKeys(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? []
+            : value.Split(TemplateKeySeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+    private static NotificationInboxItemResponse ToInboxResponse(NotificationInboxItem item) => new()
+    {
+        Id = item.Id,
+        TenantId = item.TenantId,
+        RecipientCredentialId = item.RecipientCredentialId,
+        SourceCredentialId = item.SourceCredentialId,
+        TemplateKey = item.TemplateKey,
+        Title = item.Title,
+        Body = item.Body,
+        DeliveryChannels = item.DeliveryChannels,
+        CorrelationId = item.CorrelationId,
+        DataJson = item.DataJson,
+        IsRead = item.IsRead,
+        ReadAt = item.ReadAt,
+        CreatedAt = item.CreatedAt
+    };
+
+    private static NotificationPreferencesResponse ToPreferencesResponse(
+        Guid tenantId,
+        Guid credentialId,
+        NotificationPreference? preference) => new()
+    {
+        Id = preference?.Id,
+        TenantId = tenantId,
+        CredentialId = credentialId,
+        EnabledChannels = preference?.EnabledChannels ?? NotificationPreferenceDefaults.EnabledChannels,
+        DisabledTemplateKeys = DeserializeTemplateKeys(preference?.DisabledTemplateKeys),
+        DigestEnabled = preference?.DigestEnabled ?? false,
+        IsDefault = preference is null
+    };
+
+    private static NotificationDeliveryStatusResponse ToDeliveryStatusResponse(NotificationDeliveryStatusRecord status) =>
+        new()
+        {
+            Id = status.Id,
+            TenantId = status.TenantId,
+            NotificationInboxItemId = status.NotificationInboxItemId,
+            Channel = status.Channel,
+            Status = status.Status,
+            ProviderMessageId = status.ProviderMessageId,
+            ErrorCode = status.ErrorCode,
+            ErrorMessage = status.ErrorMessage,
+            AttemptNumber = status.AttemptNumber,
+            RecordedAt = status.RecordedAt
+        };
+
+    private static bool CanTransition(NotificationDeliveryStatus current, NotificationDeliveryStatus next) =>
+        current == next ||
+        current switch
+        {
+            NotificationDeliveryStatus.Pending => next is
+                NotificationDeliveryStatus.Queued or
+                NotificationDeliveryStatus.Sent or
+                NotificationDeliveryStatus.Failed or
+                NotificationDeliveryStatus.Suppressed or
+                NotificationDeliveryStatus.Cancelled,
+            NotificationDeliveryStatus.Queued => next is
+                NotificationDeliveryStatus.Sent or
+                NotificationDeliveryStatus.Failed or
+                NotificationDeliveryStatus.Cancelled,
+            NotificationDeliveryStatus.Sent => next is
+                NotificationDeliveryStatus.Delivered or
+                NotificationDeliveryStatus.Failed,
+            NotificationDeliveryStatus.Delivered => false,
+            NotificationDeliveryStatus.Failed => next is NotificationDeliveryStatus.Queued,
+            NotificationDeliveryStatus.Suppressed => false,
+            NotificationDeliveryStatus.Cancelled => false,
+            _ => false
+        };
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/appsettings.Docker.json
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/appsettings.Docker.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
+  },
+  "BoltConfiguration": {
+    "ServerUrls": [ "ws://bolt-hub:8080/bolt/ws" ]
+  },
+  "Seq": {
+    "Url": "http://seq:80"
+  },
+  "SKIP_DB_MIGRATION": true
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Api/appsettings.json
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/appsettings.json
@@ -1,0 +1,29 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Tenant": {
+    "DefaultId": "7602c2d3-01df-4bdb-9a67-02c144e4a2ac"
+  },
+  "JwtOptions": {
+    "ValidAudience": "http://localhost:5001",
+    "ValidIssuer": "http://localhost:5001",
+    "Secret": "CHANGE_ME_JWT_SECRET_USE_ENVIRONMENT",
+    "AccessTokenLifespan": "00:30:00",
+    "RefreshTokenLifespan": "00:30:00"
+  },
+  "BoltConfiguration": {
+    "ServerUrls": [ "ws://localhost:7000/bolt/ws" ],
+    "ClientGuid": "364314df-8747-44c9-b91e-ad20b3596183",
+    "ClientName": "Notifications",
+    "ClientDescription": "Notifications",
+    "ReconnectDelay": 1500,
+    "MaxRetry": 3,
+    "Signature": "kxtEZ])e;#S8bb7R"
+  }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Configurations/NotificationDeliveryStatusRecordConfiguration.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Configurations/NotificationDeliveryStatusRecordConfiguration.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Notifications.Domain.Shared.Contracts;
+
+namespace Notifications.Domain.Shared.Configurations;
+
+public sealed class NotificationDeliveryStatusRecordConfiguration :
+    IEntityTypeConfiguration<NotificationDeliveryStatusRecord>
+{
+    public void Configure(EntityTypeBuilder<NotificationDeliveryStatusRecord> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("notificationdeliverystatus_pk");
+        entity.ToTable("NotificationDeliveryStatus", "Notifications");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.IsEnabled).IsRequired().HasDefaultValueSql("true");
+        entity.Property(e => e.IsDeleted).IsRequired().HasDefaultValueSql("false");
+        entity.Property(e => e.Channel).HasConversion<int>();
+        entity.Property(e => e.Status).HasConversion<int>();
+        entity.Property(e => e.ProviderMessageId).HasMaxLength(256);
+        entity.Property(e => e.ErrorCode).HasMaxLength(128);
+        entity.Property(e => e.ErrorMessage).HasMaxLength(2000);
+        entity.Property(e => e.RecordedAt).HasDefaultValueSql("now()");
+
+        entity.HasIndex(e => new { e.TenantId, e.NotificationInboxItemId, e.Channel })
+            .IsUnique()
+            .HasDatabaseName("ux_notificationdeliverystatus_tenant_item_channel");
+
+        entity.HasOne(e => e.NotificationInboxItem)
+            .WithMany(e => e.DeliveryStatuses)
+            .HasForeignKey(e => e.NotificationInboxItemId)
+            .OnDelete(DeleteBehavior.Cascade)
+            .HasConstraintName("notificationdeliverystatus_inboxitem_id_fk");
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Configurations/NotificationInboxItemConfiguration.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Configurations/NotificationInboxItemConfiguration.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Notifications.Domain.Shared.Contracts;
+
+namespace Notifications.Domain.Shared.Configurations;
+
+public sealed class NotificationInboxItemConfiguration : IEntityTypeConfiguration<NotificationInboxItem>
+{
+    public void Configure(EntityTypeBuilder<NotificationInboxItem> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("notificationinboxitem_pk");
+        entity.ToTable("NotificationInboxItem", "Notifications");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.IsEnabled).IsRequired().HasDefaultValueSql("true");
+        entity.Property(e => e.IsDeleted).IsRequired().HasDefaultValueSql("false");
+        entity.Property(e => e.TemplateKey).HasMaxLength(128);
+        entity.Property(e => e.Title).HasMaxLength(256);
+        entity.Property(e => e.Body).HasMaxLength(4000);
+        entity.Property(e => e.CorrelationId).HasMaxLength(128);
+        entity.Property(e => e.DataJson).HasColumnType("text");
+        entity.Property(e => e.DeliveryChannels).HasConversion<int>();
+
+        entity.HasIndex(e => new { e.TenantId, e.RecipientCredentialId, e.IsRead, e.CreatedAt })
+            .HasDatabaseName("ix_notificationinboxitem_tenant_recipient_read_created");
+        entity.HasIndex(e => new { e.TenantId, e.CorrelationId })
+            .HasDatabaseName("ix_notificationinboxitem_tenant_correlation");
+        entity.HasIndex(e => new { e.TenantId, e.TemplateKey })
+            .HasDatabaseName("ix_notificationinboxitem_tenant_template");
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Configurations/NotificationPreferenceConfiguration.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Configurations/NotificationPreferenceConfiguration.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Notifications.Domain.Shared.Contracts;
+
+namespace Notifications.Domain.Shared.Configurations;
+
+public sealed class NotificationPreferenceConfiguration : IEntityTypeConfiguration<NotificationPreference>
+{
+    public void Configure(EntityTypeBuilder<NotificationPreference> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("notificationpreference_pk");
+        entity.ToTable("NotificationPreference", "Notifications");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.IsEnabled).IsRequired().HasDefaultValueSql("true");
+        entity.Property(e => e.IsDeleted).IsRequired().HasDefaultValueSql("false");
+        entity.Property(e => e.EnabledChannels).HasConversion<int>();
+        entity.Property(e => e.DisabledTemplateKeys).HasColumnType("text");
+
+        entity.HasIndex(e => new { e.TenantId, e.CredentialId })
+            .IsUnique()
+            .HasDatabaseName("ux_notificationpreference_tenant_credential");
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationDeliveryStatusRecord.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationDeliveryStatusRecord.cs
@@ -1,0 +1,32 @@
+namespace Notifications.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+public partial class NotificationDeliveryStatusRecord : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid NotificationInboxItemId { get; set; }
+
+    [MemoryPackOrder(1)]
+    public NotificationDeliveryChannel Channel { get; set; }
+
+    [MemoryPackOrder(2)]
+    public NotificationDeliveryStatus Status { get; set; }
+
+    [MemoryPackOrder(3)]
+    public string? ProviderMessageId { get; set; }
+
+    [MemoryPackOrder(4)]
+    public string? ErrorCode { get; set; }
+
+    [MemoryPackOrder(5)]
+    public string? ErrorMessage { get; set; }
+
+    [MemoryPackOrder(6)]
+    public int AttemptNumber { get; set; }
+
+    [MemoryPackOrder(7)]
+    public DateTime RecordedAt { get; set; }
+
+    [MemoryPackOrder(8)]
+    public virtual NotificationInboxItem NotificationInboxItem { get; set; } = null!;
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationInboxItem.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationInboxItem.cs
@@ -1,0 +1,39 @@
+namespace Notifications.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+public partial class NotificationInboxItem : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid RecipientCredentialId { get; set; }
+
+    [MemoryPackOrder(1)]
+    public Guid? SourceCredentialId { get; set; }
+
+    [MemoryPackOrder(2)]
+    public string TemplateKey { get; set; } = NotificationTemplateKeys.SystemGeneric;
+
+    [MemoryPackOrder(3)]
+    public string Title { get; set; } = string.Empty;
+
+    [MemoryPackOrder(4)]
+    public string Body { get; set; } = string.Empty;
+
+    [MemoryPackOrder(5)]
+    public NotificationDeliveryChannel DeliveryChannels { get; set; } = NotificationPreferenceDefaults.EnabledChannels;
+
+    [MemoryPackOrder(6)]
+    public string? CorrelationId { get; set; }
+
+    [MemoryPackOrder(7)]
+    public string? DataJson { get; set; }
+
+    [MemoryPackOrder(8)]
+    public bool IsRead { get; set; }
+
+    [MemoryPackOrder(9)]
+    public DateTime? ReadAt { get; set; }
+
+    [MemoryPackOrder(10)]
+    public virtual ICollection<NotificationDeliveryStatusRecord> DeliveryStatuses { get; set; } =
+        new List<NotificationDeliveryStatusRecord>();
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationPreference.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationPreference.cs
@@ -1,0 +1,17 @@
+namespace Notifications.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+public partial class NotificationPreference : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid CredentialId { get; set; }
+
+    [MemoryPackOrder(1)]
+    public NotificationDeliveryChannel EnabledChannels { get; set; } = NotificationPreferenceDefaults.EnabledChannels;
+
+    [MemoryPackOrder(2)]
+    public string? DisabledTemplateKeys { get; set; }
+
+    [MemoryPackOrder(3)]
+    public bool DigestEnabled { get; set; }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationPreferenceDefaults.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationPreferenceDefaults.cs
@@ -1,0 +1,9 @@
+namespace Notifications.Domain.Shared.Contracts;
+
+public static class NotificationPreferenceDefaults
+{
+    public const NotificationDeliveryChannel EnabledChannels = NotificationDeliveryChannel.InApp;
+
+    public static NotificationDeliveryChannel Normalize(NotificationDeliveryChannel channels) =>
+        channels == NotificationDeliveryChannel.None ? EnabledChannels : channels & NotificationDeliveryChannel.All;
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationTemplateKeys.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/NotificationTemplateKeys.cs
@@ -1,0 +1,21 @@
+namespace Notifications.Domain.Shared.Contracts;
+
+public static class NotificationTemplateKeys
+{
+    public const string SystemGeneric = "notifications.system.generic";
+    public const string MessageReceived = "notifications.message.received";
+    public const string CommunityMention = "notifications.community.mention";
+    public const string CommunityReaction = "notifications.community.reaction";
+    public const string WalletTransaction = "notifications.wallet.transaction";
+    public const string VerificationCode = "notifications.identity.verification-code";
+
+    public static readonly IReadOnlySet<string> KnownKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        SystemGeneric,
+        MessageReceived,
+        CommunityMention,
+        CommunityReaction,
+        WalletTransaction,
+        VerificationCode
+    };
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/CreateNotificationRequest.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/CreateNotificationRequest.cs
@@ -1,0 +1,18 @@
+namespace Notifications.Domain.Shared.Contracts.Requests;
+
+[MemoryPackable]
+public partial record CreateNotificationRequest : RequestBase,
+    ICommand<QueryResponse<NotificationInboxItemResponse>>,
+    IBoltRequest<CreateNotificationRequest, QueryResponse<NotificationInboxItemResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public Guid RecipientCredentialId { get; set; }
+    public Guid? SourceCredentialId { get; set; }
+    public string TemplateKey { get; set; } = Notifications.Domain.Shared.Contracts.NotificationTemplateKeys.SystemGeneric;
+    public string Title { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public NotificationDeliveryChannel DeliveryChannels { get; set; } =
+        Notifications.Domain.Shared.Contracts.NotificationPreferenceDefaults.EnabledChannels;
+    public string? CorrelationId { get; set; }
+    public Dictionary<string, string>? Data { get; set; }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/GetNotificationInboxRequest.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/GetNotificationInboxRequest.cs
@@ -1,0 +1,13 @@
+namespace Notifications.Domain.Shared.Contracts.Requests;
+
+[MemoryPackable]
+public partial record GetNotificationInboxRequest : RequestBase,
+    IQuery<QueryResponse<GetNotificationInboxResponse>>,
+    IBoltRequest<GetNotificationInboxRequest, QueryResponse<GetNotificationInboxResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public Guid RecipientCredentialId { get; set; }
+    public bool? IsRead { get; set; }
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/MarkNotificationReadRequest.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/MarkNotificationReadRequest.cs
@@ -1,0 +1,11 @@
+namespace Notifications.Domain.Shared.Contracts.Requests;
+
+[MemoryPackable]
+public partial record MarkNotificationReadRequest : RequestBase,
+    ICommand<CmdResponse>,
+    IBoltRequest<MarkNotificationReadRequest, CmdResponse>
+{
+    public Guid? TenantId { get; set; }
+    public Guid RecipientCredentialId { get; set; }
+    public List<Guid> NotificationIds { get; set; } = [];
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/RecordNotificationDeliveryStatusRequest.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/RecordNotificationDeliveryStatusRequest.cs
@@ -1,0 +1,17 @@
+namespace Notifications.Domain.Shared.Contracts.Requests;
+
+[MemoryPackable]
+public partial record RecordNotificationDeliveryStatusRequest : RequestBase,
+    ICommand<QueryResponse<NotificationDeliveryStatusResponse>>,
+    IBoltRequest<RecordNotificationDeliveryStatusRequest, QueryResponse<NotificationDeliveryStatusResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public Guid NotificationInboxItemId { get; set; }
+    public NotificationDeliveryChannel Channel { get; set; }
+    public NotificationDeliveryStatus Status { get; set; }
+    public string? ProviderMessageId { get; set; }
+    public string? ErrorCode { get; set; }
+    public string? ErrorMessage { get; set; }
+    public int AttemptNumber { get; set; }
+    public DateTime? RecordedAt { get; set; }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/UpdateNotificationPreferencesRequest.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Requests/UpdateNotificationPreferencesRequest.cs
@@ -1,0 +1,14 @@
+namespace Notifications.Domain.Shared.Contracts.Requests;
+
+[MemoryPackable]
+public partial record UpdateNotificationPreferencesRequest : RequestBase,
+    ICommand<QueryResponse<NotificationPreferencesResponse>>,
+    IBoltRequest<UpdateNotificationPreferencesRequest, QueryResponse<NotificationPreferencesResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public Guid CredentialId { get; set; }
+    public NotificationDeliveryChannel EnabledChannels { get; set; } =
+        Notifications.Domain.Shared.Contracts.NotificationPreferenceDefaults.EnabledChannels;
+    public List<string> DisabledTemplateKeys { get; set; } = [];
+    public bool DigestEnabled { get; set; }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Responses/GetNotificationInboxResponse.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Responses/GetNotificationInboxResponse.cs
@@ -1,0 +1,11 @@
+namespace Notifications.Domain.Shared.Contracts.Responses;
+
+[MemoryPackable]
+public partial record GetNotificationInboxResponse
+{
+    public List<NotificationInboxItemResponse> Items { get; set; } = [];
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public int TotalCount { get; set; }
+    public int TotalPages { get; set; }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Responses/NotificationDeliveryStatusResponse.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Responses/NotificationDeliveryStatusResponse.cs
@@ -1,0 +1,16 @@
+namespace Notifications.Domain.Shared.Contracts.Responses;
+
+[MemoryPackable]
+public partial record NotificationDeliveryStatusResponse
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }
+    public Guid NotificationInboxItemId { get; set; }
+    public NotificationDeliveryChannel Channel { get; set; }
+    public NotificationDeliveryStatus Status { get; set; }
+    public string? ProviderMessageId { get; set; }
+    public string? ErrorCode { get; set; }
+    public string? ErrorMessage { get; set; }
+    public int AttemptNumber { get; set; }
+    public DateTime RecordedAt { get; set; }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Responses/NotificationInboxItemResponse.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Responses/NotificationInboxItemResponse.cs
@@ -1,0 +1,19 @@
+namespace Notifications.Domain.Shared.Contracts.Responses;
+
+[MemoryPackable]
+public partial record NotificationInboxItemResponse
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }
+    public Guid RecipientCredentialId { get; set; }
+    public Guid? SourceCredentialId { get; set; }
+    public string TemplateKey { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public NotificationDeliveryChannel DeliveryChannels { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? DataJson { get; set; }
+    public bool IsRead { get; set; }
+    public DateTime? ReadAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Responses/NotificationPreferencesResponse.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Contracts/Responses/NotificationPreferencesResponse.cs
@@ -1,0 +1,13 @@
+namespace Notifications.Domain.Shared.Contracts.Responses;
+
+[MemoryPackable]
+public partial record NotificationPreferencesResponse
+{
+    public Guid? Id { get; set; }
+    public Guid TenantId { get; set; }
+    public Guid CredentialId { get; set; }
+    public NotificationDeliveryChannel EnabledChannels { get; set; }
+    public List<string> DisabledTemplateKeys { get; set; } = [];
+    public bool DigestEnabled { get; set; }
+    public bool IsDefault { get; set; }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Enums/NotificationDeliveryChannel.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Enums/NotificationDeliveryChannel.cs
@@ -1,0 +1,13 @@
+namespace Notifications.Domain.Shared.Enums;
+
+[Flags]
+public enum NotificationDeliveryChannel
+{
+    None = 0,
+    InApp = 1,
+    Email = 2,
+    Sms = 4,
+    Push = 8,
+    Webhook = 16,
+    All = InApp | Email | Sms | Push | Webhook
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Enums/NotificationDeliveryStatus.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Enums/NotificationDeliveryStatus.cs
@@ -1,0 +1,12 @@
+namespace Notifications.Domain.Shared.Enums;
+
+public enum NotificationDeliveryStatus
+{
+    Pending = 0,
+    Queued = 1,
+    Sent = 2,
+    Delivered = 3,
+    Failed = 4,
+    Suppressed = 5,
+    Cancelled = 6
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/GlobalUsings.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/GlobalUsings.cs
@@ -1,0 +1,7 @@
+global using Bolt.Domain.Shared.Contracts.Requests;
+global using MemoryPack;
+global using Notifications.Domain.Shared.Contracts.Responses;
+global using Notifications.Domain.Shared.Enums;
+global using XFramework.Domain.Shared.BusinessObjects;
+global using XFramework.Domain.Shared.Contracts.Base;
+global using XFramework.Domain.Shared.Contracts.Requests;

--- a/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Notifications.Domain.Shared.csproj
+++ b/src/Modules/XFramework.Notifications/Notifications.Domain.Shared/Notifications.Domain.Shared.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackageId>XFramework.Notifications.Domain.Shared</PackageId>
+        <Version>$(XFrameworkVersion)</Version>
+        <Description>XFramework Notifications domain contracts, preference models, and delivery status contracts.</Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Shared\XFramework.Domain.Shared\XFramework.Domain.Shared.csproj" />
+        <ProjectReference Include="..\..\XFramework.Bolt\Bolt.Domain.Shared\Bolt.Domain.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Modules/XFramework.Notifications/Notifications.Integration/Drivers/NotificationsServiceWrapper.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Integration/Drivers/NotificationsServiceWrapper.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Notifications.Domain.Shared.Contracts.Requests;
+using Notifications.Domain.Shared.Contracts.Responses;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Integration.Abstractions.Wrappers;
+using XFramework.Integration.Drivers;
+using XFramework.Integration.Security;
+
+namespace Notifications.Integration.Drivers;
+
+public interface INotificationsServiceWrapper : IServiceWrapper
+{
+    Task<QueryResponse<NotificationInboxItemResponse>> CreateNotification(CreateNotificationRequest request);
+    Task<QueryResponse<GetNotificationInboxResponse>> GetNotificationInbox(GetNotificationInboxRequest request);
+    Task<CmdResponse> MarkNotificationRead(MarkNotificationReadRequest request);
+    Task<QueryResponse<NotificationPreferencesResponse>> UpdateNotificationPreferences(UpdateNotificationPreferencesRequest request);
+    Task<QueryResponse<NotificationDeliveryStatusResponse>> RecordNotificationDeliveryStatus(
+        RecordNotificationDeliveryStatusRequest request);
+}
+
+public sealed record NotificationsServiceWrapper(
+    IMessageBusWrapper messageBusDriver,
+    IConfiguration configuration
+) : DriverBase(messageBusDriver, configuration), INotificationsServiceWrapper
+{
+    public override void Initialize()
+    {
+        TargetClient = "Notifications".ToSha256();
+    }
+
+    public Task<QueryResponse<NotificationInboxItemResponse>> CreateNotification(CreateNotificationRequest request) =>
+        SendAsync<CreateNotificationRequest, NotificationInboxItemResponse>(request);
+
+    public Task<QueryResponse<GetNotificationInboxResponse>> GetNotificationInbox(GetNotificationInboxRequest request) =>
+        SendAsync<GetNotificationInboxRequest, GetNotificationInboxResponse>(request);
+
+    public Task<CmdResponse> MarkNotificationRead(MarkNotificationReadRequest request) =>
+        SendVoidAsync(request);
+
+    public Task<QueryResponse<NotificationPreferencesResponse>> UpdateNotificationPreferences(
+        UpdateNotificationPreferencesRequest request) =>
+        SendAsync<UpdateNotificationPreferencesRequest, NotificationPreferencesResponse>(request);
+
+    public Task<QueryResponse<NotificationDeliveryStatusResponse>> RecordNotificationDeliveryStatus(
+        RecordNotificationDeliveryStatusRequest request) =>
+        SendAsync<RecordNotificationDeliveryStatusRequest, NotificationDeliveryStatusResponse>(request);
+}
+
+public static class NotificationsServiceWrapperExtensions
+{
+    public static void AddNotificationsWrapperServices(this IServiceCollection services)
+    {
+        services.AddSingleton<INotificationsServiceWrapper, NotificationsServiceWrapper>();
+    }
+}

--- a/src/Modules/XFramework.Notifications/Notifications.Integration/Notifications.Integration.csproj
+++ b/src/Modules/XFramework.Notifications/Notifications.Integration/Notifications.Integration.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackageId>XFramework.Notifications.Integration</PackageId>
+        <Version>$(XFrameworkVersion)</Version>
+        <Description>XFramework Notifications service wrapper for cross-module Bolt RPC calls.</Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\SourceGenerators\XFramework.SourceGenerators\XFramework.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
+        <ProjectReference Include="..\Notifications.Domain.Shared\Notifications.Domain.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Modules/XFramework.Notifications/Notifications.Tests/Notifications.Tests.csproj
+++ b/src/Modules/XFramework.Notifications/Notifications.Tests/Notifications.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <AssemblyName>Notifications.Tests</AssemblyName>
+        <RootNamespace>Notifications.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="coverlet.collector" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Notifications.Api\Notifications.Api.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Modules/XFramework.Notifications/Notifications.Tests/Services/NotificationServiceTests.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Tests/Services/NotificationServiceTests.cs
@@ -1,0 +1,223 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Notifications.Api.Services;
+using Notifications.Domain.Shared.Contracts;
+using Notifications.Domain.Shared.Contracts.Requests;
+using Notifications.Domain.Shared.Enums;
+using NUnit.Framework;
+using XFramework.Domain.Contexts;
+
+namespace Notifications.Tests.Services;
+
+public sealed class NotificationServiceTests
+{
+    [Test]
+    public async Task GetPreferencesAsync_MissingPreference_ReturnsDefaultInAppPreference()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var credentialId = Guid.NewGuid();
+        var service = CreateService(database.Context);
+
+        var result = await service.GetPreferencesAsync(database.TenantId, credentialId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.CredentialId.Should().Be(credentialId);
+        result.Data.EnabledChannels.Should().Be(NotificationDeliveryChannel.InApp);
+        result.Data.DisabledTemplateKeys.Should().BeEmpty();
+        result.Data.IsDefault.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetInboxAsync_DifferentTenantRows_ReturnsOnlyRequestedTenantNotifications()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var credentialId = Guid.NewGuid();
+        var otherTenantId = Guid.NewGuid();
+        var service = CreateService(database.Context);
+
+        database.Context.Set<NotificationInboxItem>().AddRange(
+            CreateInboxItem(database.TenantId, credentialId, "Current tenant"),
+            CreateInboxItem(otherTenantId, credentialId, "Other tenant"));
+        await database.Context.SaveChangesAsync();
+
+        var result = await service.GetInboxAsync(new GetNotificationInboxRequest
+        {
+            TenantId = database.TenantId,
+            RecipientCredentialId = credentialId
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.TotalCount.Should().Be(1);
+        result.Data.Items.Should().ContainSingle();
+        result.Data.Items[0].Title.Should().Be("Current tenant");
+        result.Data.Items[0].TenantId.Should().Be(database.TenantId);
+    }
+
+    [Test]
+    public async Task MarkReadAsync_UnreadNotification_MarksReadAndSetsReadAt()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var credentialId = Guid.NewGuid();
+        var item = CreateInboxItem(database.TenantId, credentialId, "Unread");
+        database.Context.Set<NotificationInboxItem>().Add(item);
+        await database.Context.SaveChangesAsync();
+
+        var service = CreateService(database.Context);
+        var result = await service.MarkReadAsync(new MarkNotificationReadRequest
+        {
+            TenantId = database.TenantId,
+            RecipientCredentialId = credentialId,
+            NotificationIds = [item.Id]
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var updated = await database.Context.Set<NotificationInboxItem>()
+            .AsNoTracking()
+            .SingleAsync(notification => notification.Id == item.Id);
+
+        updated.IsRead.Should().BeTrue();
+        updated.ReadAt.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task RecordDeliveryStatusAsync_ValidTransitions_AdvancesDeliveryStatus()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var item = CreateInboxItem(database.TenantId, Guid.NewGuid(), "Delivery");
+        database.Context.Set<NotificationInboxItem>().Add(item);
+        await database.Context.SaveChangesAsync();
+
+        var service = CreateService(database.Context);
+
+        foreach (var status in new[]
+                 {
+                     NotificationDeliveryStatus.Pending,
+                     NotificationDeliveryStatus.Queued,
+                     NotificationDeliveryStatus.Sent,
+                     NotificationDeliveryStatus.Delivered
+                 })
+        {
+            var result = await service.RecordDeliveryStatusAsync(new RecordNotificationDeliveryStatusRequest
+            {
+                TenantId = database.TenantId,
+                NotificationInboxItemId = item.Id,
+                Channel = NotificationDeliveryChannel.Email,
+                Status = status,
+                AttemptNumber = 1
+            }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Data!.Status.Should().Be(status);
+        }
+
+        var record = await database.Context.Set<NotificationDeliveryStatusRecord>()
+            .AsNoTracking()
+            .SingleAsync(status => status.NotificationInboxItemId == item.Id);
+        record.Status.Should().Be(NotificationDeliveryStatus.Delivered);
+    }
+
+    [Test]
+    public async Task RecordDeliveryStatusAsync_TerminalDeliveredToPending_ReturnsConflict()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var item = CreateInboxItem(database.TenantId, Guid.NewGuid(), "Terminal");
+        database.Context.Set<NotificationInboxItem>().Add(item);
+        database.Context.Set<NotificationDeliveryStatusRecord>().Add(new NotificationDeliveryStatusRecord
+        {
+            Id = Guid.NewGuid(),
+            TenantId = database.TenantId,
+            NotificationInboxItemId = item.Id,
+            Channel = NotificationDeliveryChannel.Email,
+            Status = NotificationDeliveryStatus.Delivered,
+            AttemptNumber = 1,
+            RecordedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid(),
+            IsEnabled = true
+        });
+        await database.Context.SaveChangesAsync();
+
+        var service = CreateService(database.Context);
+        var result = await service.RecordDeliveryStatusAsync(new RecordNotificationDeliveryStatusRequest
+        {
+            TenantId = database.TenantId,
+            NotificationInboxItemId = item.Id,
+            Channel = NotificationDeliveryChannel.Email,
+            Status = NotificationDeliveryStatus.Pending
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        result.Message.Should().Contain("Cannot transition");
+    }
+
+    private static NotificationService CreateService(AppDbContext db) =>
+        new(db, NullLogger<NotificationService>.Instance);
+
+    private static NotificationInboxItem CreateInboxItem(Guid tenantId, Guid credentialId, string title) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = tenantId,
+        RecipientCredentialId = credentialId,
+        TemplateKey = NotificationTemplateKeys.SystemGeneric,
+        Title = title,
+        Body = "Body",
+        DeliveryChannels = NotificationDeliveryChannel.InApp,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid(),
+        IsEnabled = true
+    };
+
+    private sealed class TestDatabase : IAsyncDisposable
+    {
+        private readonly SqliteConnection connection;
+
+        private TestDatabase(SqliteConnection connection, AppDbContext context, Guid tenantId)
+        {
+            this.connection = connection;
+            Context = context;
+            TenantId = tenantId;
+        }
+
+        public AppDbContext Context { get; }
+        public Guid TenantId { get; }
+
+        public static async Task<TestDatabase> CreateAsync()
+        {
+            var tenantId = Guid.NewGuid();
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+            connection.CreateFunction("now", () => DateTime.UtcNow);
+            connection.CreateFunction("uuid_generate_v4", () => Guid.NewGuid());
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Tenant:DefaultId"] = tenantId.ToString()
+                })
+                .Build();
+
+            var context = new AppDbContext(options, new Microsoft.AspNetCore.Http.HttpContextAccessor(), configuration);
+
+            _ = typeof(NotificationInboxItem).Assembly;
+            await context.Database.EnsureCreatedAsync();
+
+            return new TestDatabase(connection, context, tenantId);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            await connection.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Notifications Domain.Shared, API, Integration wrapper, Docker service, migration, and tests.
- Adds notification inbox, delivery channels/status records, preferences, and template keys.
- Requires authorization on generated Notifications endpoints.

## Verification
- dotnet build src\Modules\XFramework.Notifications\Notifications.Api\Notifications.Api.csproj -m:1 /nr:false
- dotnet build src\Modules\XFramework.Notifications\Notifications.Integration\Notifications.Integration.csproj
- dotnet test src\Modules\XFramework.Notifications\Notifications.Tests\Notifications.Tests.csproj -m:1 /nr:false
- dotnet sln XFramework.slnx list
- git diff --check

## Notes
- Migration is scoped manually to Notifications tables to avoid unrelated cross-module EF snapshot churn.