### PR TITLE
Resolve tenant lookup through data context

### DIFF
--- a/src/Kernel/XFramework.Core/Services/TenantResolver.cs
+++ b/src/Kernel/XFramework.Core/Services/TenantResolver.cs
@@ -1,5 +1,6 @@
 using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.Extensions.Caching.Memory;
+using XFramework.Domain.Shared.DataContext;
 
 namespace XFramework.Core.Services;
 
@@ -18,24 +19,35 @@ public interface ITenantResolver
 
 /// <summary>
 /// Implementation of ITenantResolver with memory caching.
-/// Tenant lookup is parked until IdentityServer.Api exposes a tenant lookup contract.
 /// </summary>
-public sealed class TenantResolver(IMemoryCache cache) : ITenantResolver
+public sealed class TenantResolver(
+    IDataContext dataContext,
+    IMemoryCache cache) : ITenantResolver
 {
-    private const string UnsupportedTenantLookupMessage =
-        "Tenant lookup is not supported by the default TenantResolver. " +
-        "Configure a concrete ITenantResolver once IdentityServer.Api exposes a tenant endpoint or service wrapper.";
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(15);
 
     /// <inheritdoc />
-    public Task<Tenant> GetTenant(Guid? id)
+    public async Task<Tenant> GetTenant(Guid? id)
     {
         if (id is null || id == Guid.Empty) throw new ArgumentNullException(nameof(id));
 
-        if (cache.TryGetValue($"GetTenant-{id}", out Tenant? entity) && entity is not null)
+        var cacheKey = $"GetTenant-{id}";
+        if (cache.TryGetValue(cacheKey, out Tenant? entity) && entity is not null)
         {
-            return Task.FromResult(entity);
+            return entity;
         }
 
-        throw new NotSupportedException($"{UnsupportedTenantLookupMessage} Tenant id: '{id}'.");
+        var tenant = await dataContext.Query<Tenant>()
+            .IgnoreQueryFilters()
+            .Where(i => i.Id == id)
+            .FirstOrDefaultAsync();
+
+        if (tenant is null)
+        {
+            throw new InvalidOperationException($"Tenant '{id}' could not be found.");
+        }
+
+        cache.Set(cacheKey, tenant, CacheDuration);
+        return tenant;
     }
 }

--- a/src/Tests/XFramework.Core.Tests/Services/TenantResolverTests.cs
+++ b/src/Tests/XFramework.Core.Tests/Services/TenantResolverTests.cs
@@ -2,9 +2,12 @@ using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using NUnit.Framework;
+using XFramework.Core.DataContext;
 using XFramework.Core.Services;
+using XFramework.Domain.Contexts;
 
 namespace XFramework.Core.Tests.Services;
 
@@ -14,12 +17,13 @@ public sealed class TenantResolverTests
     [Test]
     public async Task GetTenant_CachedTenant_ReturnsCachedTenant()
     {
+        await using var db = CreateDbContext();
         using var cache = new MemoryCache(new MemoryCacheOptions());
         var tenantId = Guid.NewGuid();
         var tenant = new Tenant { Id = tenantId, Name = "Cached tenant" };
         cache.Set($"GetTenant-{tenantId}", tenant);
 
-        var resolver = new TenantResolver(cache);
+        var resolver = new TenantResolver(new ServerDataContext<AppDbContext>(db), cache);
 
         var result = await resolver.GetTenant(tenantId);
 
@@ -27,26 +31,60 @@ public sealed class TenantResolverTests
     }
 
     [Test]
-    public async Task GetTenant_MissingTenant_ThrowsExplicitUnsupportedError()
+    public async Task GetTenant_ExistingTenant_ReturnsAndCachesTenant()
     {
+        await using var db = CreateDbContext();
         using var cache = new MemoryCache(new MemoryCacheOptions());
-        var resolver = new TenantResolver(cache);
+        var tenantId = Guid.NewGuid();
+        var tenant = new Tenant { Id = tenantId, TenantId = tenantId, Name = "Database tenant" };
+        db.Set<Tenant>().Add(tenant);
+        await db.SaveChangesAsync();
+
+        var resolver = new TenantResolver(new ServerDataContext<AppDbContext>(db), cache);
+
+        var result = await resolver.GetTenant(tenantId);
+
+        result.Id.Should().Be(tenantId);
+        result.Name.Should().Be("Database tenant");
+        cache.TryGetValue($"GetTenant-{tenantId}", out Tenant? cachedTenant).Should().BeTrue();
+        cachedTenant.Should().NotBeNull();
+        cachedTenant!.Id.Should().Be(tenantId);
+    }
+
+    [Test]
+    public async Task GetTenant_MissingTenant_ThrowsInvalidOperationException()
+    {
+        await using var db = CreateDbContext();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var resolver = new TenantResolver(new ServerDataContext<AppDbContext>(db), cache);
 
         Func<Task> act = () => resolver.GetTenant(Guid.NewGuid());
 
         await act.Should()
-            .ThrowAsync<NotSupportedException>()
-            .WithMessage("*Tenant lookup is not supported*");
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*could not be found*");
     }
 
     [Test]
     public async Task GetTenant_EmptyTenantId_ThrowsArgumentNullException()
     {
+        await using var db = CreateDbContext();
         using var cache = new MemoryCache(new MemoryCacheOptions());
-        var resolver = new TenantResolver(cache);
+        var resolver = new TenantResolver(new ServerDataContext<AppDbContext>(db), cache);
 
         Func<Task> act = () => resolver.GetTenant(Guid.Empty);
 
         await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private static AppDbContext CreateDbContext()
+    {
+        _ = typeof(Tenant);
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        return new AppDbContext(options);
     }
 }


### PR DESCRIPTION
## Summary
- resolve `ITenantResolver` tenants through `IDataContext` instead of the unsupported fallback
- cache resolved tenants for repeated auth/service lookups
- update tenant resolver tests for cache, data-context lookup, missing tenant, and invalid id behavior

## Tests
- `dotnet test src\Tests\XFramework.Core.Tests\XFramework.Core.Tests.csproj -m:1 /nr:false -v minimal`
- `dotnet build src\Modules\XFramework.IdentityServer\IdentityServer.Api\IdentityServer.Api.csproj -m:1 /nr:false -v minimal`
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false -v minimal`