### PR TITLE
Add ControlPanel xeon-dev appsettings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@
 #   Production:           podman-compose --env-file .env.production up --build
 #
 # Service config lives in appsettings.Docker.json per service.
+# ControlPanel uses appsettings.dev.json for the xeon-dev admin surface.
 # Only secrets and infra overrides go in env vars / .env files.
 
 x-common-env: &common-env
@@ -184,10 +185,7 @@ services:
         PROJECT_PATH: src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
     environment:
       <<: *common-env
-      ControlPanel__BootstrapAdmin__Password: ${ControlPanel__BootstrapAdmin__Password:-}
-      ControlPanel__BootstrapAdmin__UserName: ${ControlPanel__BootstrapAdmin__UserName:-superadmin}
-      ControlPanel__BootstrapAdmin__TenantName: ${ControlPanel__BootstrapAdmin__TenantName:-XFramework Admin}
-      ControlPanel__BootstrapAdmin__DisplayName: ${ControlPanel__BootstrapAdmin__DisplayName:-Super Admin}
+      ASPNETCORE_ENVIRONMENT: ${CONTROLPANEL_ASPNETCORE_ENVIRONMENT:-dev}
     ports:
       - "${CONTROLPANEL_EXPOSE_PORT:-5000}:8080"
     depends_on:

--- a/src/Presentation/ControlPanel.Server/appsettings.dev.json
+++ b/src/Presentation/ControlPanel.Server/appsettings.dev.json
@@ -1,0 +1,16 @@
+{
+  "BoltConfiguration": {
+    "ServerUrls": ["ws://bolt-hub:8080/bolt/ws"]
+  },
+  "Seq": {
+    "Url": "http://seq:80"
+  },
+  "ControlPanel": {
+    "BootstrapAdmin": {
+      "UserName": "superadmin",
+      "Password": "XFrameworkDevAdmin!2026",
+      "TenantName": "XFramework Admin",
+      "DisplayName": "Super Admin"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `appsettings.dev.json` for the xeon-dev ControlPanel Docker deployment
- move the dev bootstrap admin credential into that dev-specific appsettings file
- set the ControlPanel compose service to `ASPNETCORE_ENVIRONMENT=dev` by default so the file is loaded

## Tests
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false -v minimal`
- `git diff --check`

Note: local Docker has no Compose plugin installed, so local `docker compose config` could not be run from this workstation.