### PR TITLE
Fix ControlPanel login auth log IP length

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260618023000_ExpandAuthorizationLogIpAddress.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260618023000_ExpandAuthorizationLogIpAddress.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260618023000_ExpandAuthorizationLogIpAddress")]
+    public partial class ExpandAuthorizationLogIpAddress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "IPAddress",
+                schema: "Audit",
+                table: "AuthorizationLog",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(18)",
+                oldMaxLength: 18,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "IPAddress",
+                schema: "Audit",
+                table: "AuthorizationLog",
+                type: "character varying(18)",
+                maxLength: 18,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Kernel/XFramework.Domain/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/AppDbContextModelSnapshot.cs
@@ -955,8 +955,8 @@ namespace XFramework.Domain.Migrations
                         .HasColumnType("character varying(50)");
 
                     b.Property<string>("Ipaddress")
-                        .HasMaxLength(18)
-                        .HasColumnType("character varying(18)")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)")
                         .HasColumnName("IPAddress");
 
                     b.Property<bool>("IsDeleted")

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/AuthorizationLogConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/AuthorizationLogConfiguration.cs
@@ -22,7 +22,7 @@ public class AuthorizationLogConfiguration : IEntityTypeConfiguration<Authorizat
         entity.Property(e => e.DeviceName).HasMaxLength(50);
 
         entity.Property(e => e.Ipaddress)
-            .HasMaxLength(18)
+            .HasMaxLength(64)
             .HasColumnName("IPAddress");
         entity.Property(e => e.LoginSource).HasMaxLength(50);
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/AuthenticationTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/AuthenticationTests.cs
@@ -289,6 +289,31 @@ public class AuthenticationTests : IntegrationTestBase
         LogTiming("Bolt", elapsed);
     }
 
+    [Test]
+    public async Task Bolt_Authenticate_WithLongIpAddress_PersistsAuthorizationLog()
+    {
+        var username = UniqueUsername();
+        var password = "ValidPassword123!";
+        var credential = await SeedCredentialWithRole(username, password);
+        var request = CreateAuthRequest(username, password);
+        request.Metadata.IpAddress = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+
+        var (result, elapsed) = await TimedBoltCall(request);
+
+        result.Should().NotBeNull();
+        result!.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDbContext();
+        var log = await db.Set<AuthorizationLog>()
+            .Where(l => l.CredentialId == credential.Id)
+            .OrderByDescending(l => l.CreatedAt)
+            .FirstOrDefaultAsync();
+
+        log.Should().NotBeNull();
+        log!.Ipaddress.Should().Be(request.Metadata.IpAddress);
+        LogTiming("Bolt", elapsed);
+    }
+
     #endregion
 
     #region Helpers


### PR DESCRIPTION
﻿## Summary
- widen `Audit.AuthorizationLog.IPAddress` from `varchar(18)` to `varchar(64)`
- add EF migration and model snapshot update
- add IdentityServer Bolt authentication regression for long IPv6 metadata IPs

## Verification
- `dotnet build src\Modules\XFramework.IdentityServer\IdentityServer.Domain.Shared\IdentityServer.Domain.Shared.csproj -m:1 /nr:false -v minimal`
- `dotnet build src\Tests\IdentityServer.IntegrationTests\IdentityServer.IntegrationTests.csproj -m:1 /nr:false -v minimal`
- `dotnet test src\Tests\IdentityServer.IntegrationTests\IdentityServer.IntegrationTests.csproj --filter "FullyQualifiedName~Bolt_Authenticate_WithLongIpAddress_PersistsAuthorizationLog" --logger "console;verbosity=minimal" -m:1 /nr:false`

## Notes
Root cause: ControlPanel login authenticated successfully, then IdentityServer failed to persist the authorization log because the recorded remote IP exceeded `varchar(18)`.
