### PR TITLE
Add ControlPanel tenant module toggles

### DIFF
--- a/src/Modules/XFramework.Notifications/Notifications.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Installers/ServicesInstaller.cs
@@ -12,6 +12,7 @@ public sealed class ServicesInstaller : IInstaller
         IHostEnvironment hostEnvironment)
     {
         services.AddTenantResolver();
+        services.AddTenantModuleFeatures();
         services.AddScoped<NotificationService>();
     }
 }

--- a/src/Modules/XFramework.Notifications/Notifications.Api/Program.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Api/Program.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using IdentityServer.Domain.Shared.Contracts;
 using Notifications.Api.Generated;
 using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
@@ -23,6 +24,8 @@ var app = (WebApplication)builder.Build();
 
 app.UseCorrelationId();
 app.UseXFrameworkRateLimiting();
+app.UseTenantModuleFeatureGate(options =>
+    options.RequireFeature(TenantModuleFeatureKeys.Notifications, "/api/notifications"));
 app.EnsureDatabase<AppDbContext>();
 
 app.MapXFrameworkHealthChecks("Notifications");

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -65,6 +65,7 @@ else
         <BbTabs DefaultValue="summary">
             <BbTabsList>
                 <BbTabsTrigger Value="summary">Tenant Summary</BbTabsTrigger>
+                <BbTabsTrigger Value="modules">Modules (@_moduleFeatureRows.Count)</BbTabsTrigger>
                 <BbTabsTrigger Value="users">Users (@_detailUsers.Count)</BbTabsTrigger>
                 <BbTabsTrigger Value="configurations">Configurations (@_detailConfigs.Count)</BbTabsTrigger>
                 <BbTabsTrigger Value="roletypes">Role Types (@_detailRoleTypes.Count)</BbTabsTrigger>
@@ -103,6 +104,66 @@ else
                         <EditableField Label="Configurations" DisplayValue="@_detailConfigs.Count.ToString()" ReadOnly="true" />
                     </div>
                 </EditableForm>
+            </BbTabsContent>
+
+            <BbTabsContent Value="modules" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <div class="flex items-start justify-between gap-4">
+                            <div>
+                                <BbCardTitle>Tenant Modules</BbCardTitle>
+                                <BbTypographyMuted>Enable or disable tenant access to backend modules and planned module flags.</BbTypographyMuted>
+                            </div>
+                            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadModuleFeatures">
+                                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                                Refresh
+                            </BbButton>
+                        </div>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        @if (_moduleFeaturesLoading)
+                        {
+                            <CenteredSpinner />
+                        }
+                        else if (_moduleFeatureRows.Count == 0)
+                        {
+                            <BbAlert Variant="AlertVariant.Info">No module features found for this tenant.</BbAlert>
+                        }
+                        else
+                        {
+                            <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                                @foreach (var row in _moduleFeatureRows)
+                                {
+                                    <div class="rounded-lg border bg-card p-4 shadow-sm">
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div class="flex min-w-0 gap-3">
+                                                <div class="grid h-9 w-9 shrink-0 place-items-center rounded-md border bg-muted">
+                                                    <LucideIcon Name="@row.Icon" class="h-4 w-4" />
+                                                </div>
+                                                <div class="min-w-0">
+                                                    <div class="flex flex-wrap items-center gap-2">
+                                                        <div class="font-semibold">@row.DisplayName</div>
+                                                        <StatusBadge Text="@GetModuleFeatureCoverageText(row)" Status="@GetModuleFeatureCoverageStatus(row)" />
+                                                    </div>
+                                                    <div class="mt-1 text-sm text-muted-foreground">@row.Description</div>
+                                                    <div class="mt-2 font-mono text-xs text-muted-foreground">@row.Key</div>
+                                                </div>
+                                            </div>
+                                            <StatusBadge Text="@(row.IsEnabled ? "Enabled" : "Disabled")"
+                                                         Status="@(row.IsEnabled ? "active" : "inactive")" />
+                                        </div>
+                                        <div class="mt-4 border-t pt-3">
+                                            <BbFormFieldSwitch Checked="@row.IsEnabled"
+                                                               CheckedChanged="@((bool enabled) => ToggleModuleFeature(row, enabled))"
+                                                               Disabled="@(_savingModuleFeatureIds.Contains(row.Id))"
+                                                               Label="Module enabled" />
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </BbCardContent>
+                </BbCard>
             </BbTabsContent>
 
             <BbTabsContent Value="users" Class="xf-fade-in">
@@ -309,6 +370,10 @@ else
     private List<IdentityInformation> _detailUsers = [];
     private List<RegistryConfiguration> _detailConfigs = [];
     private List<IdentityRoleType> _detailRoleTypes = [];
+    private List<TenantModuleFeature> _detailModuleFeatures = [];
+    private List<ModuleFeatureRow> _moduleFeatureRows = [];
+    private HashSet<Guid> _savingModuleFeatureIds = [];
+    private bool _moduleFeaturesLoading;
 
     // -- Config dialog --
     private bool _configDialogOpen;
@@ -381,6 +446,8 @@ else
         _detailUsers = [];
         _detailConfigs = [];
         _detailRoleTypes = [];
+        _detailModuleFeatures = [];
+        _moduleFeatureRows = [];
     }
 
     private void SyncEditFields()
@@ -428,6 +495,8 @@ else
                     .ToListAsync())
                 .ToList();
 
+            await LoadModuleFeatures();
+
             _configGroups = (await DataContext.Query<RegistryConfigurationGroup>()
                     .IgnoreQueryFilters()
                     .NoCache()
@@ -437,6 +506,144 @@ else
                 .ToList();
         }
         catch (Exception ex) { ToastService.Show($"Failed to load tenant details: {ex.Message}"); }
+    }
+
+    private async Task LoadModuleFeatures()
+    {
+        _moduleFeaturesLoading = true;
+        try
+        {
+            _detailModuleFeatures = (await DataContext.Query<TenantModuleFeature>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == Id)
+                    .OrderBy(x => x.ModuleKey)
+                    .ThenBy(x => x.SubFeatureKey)
+                    .ToListAsync())
+                .ToList();
+
+            var missingDefinitions = TenantModuleFeatureKeys.All
+                .Where(definition => _detailModuleFeatures.All(feature =>
+                    !string.Equals(feature.Key, definition.Key, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+
+            if (missingDefinitions.Count > 0)
+            {
+                foreach (var definition in missingDefinitions)
+                {
+                    DataContext.Add(new TenantModuleFeature
+                    {
+                        Id = Guid.NewGuid(),
+                        TenantId = Id,
+                        ModuleKey = definition.ModuleKey,
+                        SubFeatureKey = definition.SubFeatureKey,
+                        DisplayName = definition.DisplayName,
+                        Description = definition.Description,
+                        IsEnabled = true,
+                        CreatedAt = DateTime.UtcNow
+                    });
+                }
+
+                var seedResult = await DataContext.SaveChangesAsync();
+                if (!seedResult.IsSuccess)
+                {
+                    ToastService.Show($"Failed to initialize module toggles: {seedResult.Message}");
+                }
+
+                _detailModuleFeatures = (await DataContext.Query<TenantModuleFeature>()
+                        .IgnoreQueryFilters()
+                        .NoCache()
+                        .Where(x => x.TenantId == Id)
+                        .OrderBy(x => x.ModuleKey)
+                        .ThenBy(x => x.SubFeatureKey)
+                        .ToListAsync())
+                    .ToList();
+            }
+
+            _moduleFeatureRows = TenantModuleFeatureKeys.All
+                .Select(definition =>
+                {
+                    var feature = _detailModuleFeatures.FirstOrDefault(item =>
+                        string.Equals(item.Key, definition.Key, StringComparison.OrdinalIgnoreCase));
+
+                    return new ModuleFeatureRow(
+                        feature?.Id ?? Guid.Empty,
+                        definition.Key,
+                        definition.ModuleKey,
+                        definition.SubFeatureKey,
+                        feature?.DisplayName ?? definition.DisplayName,
+                        feature?.Description ?? definition.Description,
+                        definition.IconName,
+                        feature?.IsEnabled ?? false);
+                })
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load module toggles: {ex.Message}");
+        }
+        finally
+        {
+            _moduleFeaturesLoading = false;
+        }
+    }
+
+    private async Task ToggleModuleFeature(ModuleFeatureRow row, bool enabled)
+    {
+        if (row.Id == Guid.Empty)
+        {
+            ToastService.Show("Module toggle is still initializing. Refresh the page and try again.");
+            return;
+        }
+
+        _savingModuleFeatureIds.Add(row.Id);
+        try
+        {
+            var feature = await DataContext.Query<TenantModuleFeature>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == row.Id)
+                .FirstOrDefaultAsync();
+
+            if (feature is null)
+            {
+                ToastService.Show("Module toggle not found.");
+                await LoadModuleFeatures();
+                return;
+            }
+
+            feature.IsEnabled = enabled;
+            feature.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(feature);
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                row.IsEnabled = enabled;
+                var cachedFeature = _detailModuleFeatures.FirstOrDefault(item => item.Id == row.Id);
+                if (cachedFeature is not null)
+                {
+                    cachedFeature.IsEnabled = enabled;
+                    cachedFeature.ModifiedAt = feature.ModifiedAt;
+                }
+
+                ToastService.Show($"{row.DisplayName} {(enabled ? "enabled" : "disabled")}.");
+            }
+            else
+            {
+                ToastService.Show($"Failed to update {row.DisplayName}: {result.Message}");
+                await LoadModuleFeatures();
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error: {ex.Message}");
+            await LoadModuleFeatures();
+        }
+        finally
+        {
+            _savingModuleFeatureIds.Remove(row.Id);
+        }
     }
 
     private async Task SaveTenant()
@@ -495,6 +702,32 @@ else
 
     private static string GetStatusText(short? status) => status switch { 0 => "Pending", 1 => "Active", 2 => "Suspended", 3 => "Inactive", _ => "Unknown" };
     private static string GetStatusKey(short? status) => status switch { 0 => "pending", 1 => "active", 2 => "suspended", 3 => "inactive", _ => "inactive" };
+
+    private static string GetModuleFeatureCoverageText(ModuleFeatureRow row) =>
+        row.Key switch
+        {
+            TenantModuleFeatureKeys.Wallets or
+            TenantModuleFeatureKeys.Inventario or
+            TenantModuleFeatureKeys.MessagingChat or
+            TenantModuleFeatureKeys.Community or
+            TenantModuleFeatureKeys.Notifications => "API gated",
+            TenantModuleFeatureKeys.MessagingAudioVideo => "Planned flag",
+            TenantModuleFeatureKeys.Payments => "No API yet",
+            _ => "Stored"
+        };
+
+    private static string GetModuleFeatureCoverageStatus(ModuleFeatureRow row) =>
+        row.Key switch
+        {
+            TenantModuleFeatureKeys.Wallets or
+            TenantModuleFeatureKeys.Inventario or
+            TenantModuleFeatureKeys.MessagingChat or
+            TenantModuleFeatureKeys.Community or
+            TenantModuleFeatureKeys.Notifications => "active",
+            TenantModuleFeatureKeys.MessagingAudioVideo => "pending",
+            TenantModuleFeatureKeys.Payments => "inactive",
+            _ => "inactive"
+        };
 
     private void OpenUserDetail(IdentityInformation user) =>
         Navigation.NavigateTo($"/identity/users/{user.Id}");
@@ -561,6 +794,26 @@ else
         public string? Value { get; set; }
         public string? Unit { get; set; }
         public string GroupIdString { get; set; } = "";
+    }
+
+    private sealed class ModuleFeatureRow(
+        Guid id,
+        string key,
+        string moduleKey,
+        string subFeatureKey,
+        string displayName,
+        string description,
+        string icon,
+        bool isEnabled)
+    {
+        public Guid Id { get; } = id;
+        public string Key { get; } = key;
+        public string ModuleKey { get; } = moduleKey;
+        public string SubFeatureKey { get; } = subFeatureKey;
+        public string DisplayName { get; } = displayName;
+        public string Description { get; } = description;
+        public string Icon { get; } = icon;
+        public bool IsEnabled { get; set; } = isEnabled;
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- add a Modules tab to tenant detail so admins can enable/disable tenant module features
- initialize missing tenant module feature rows from the shared registry
- add Notifications API tenant-module gate registration

## Verification
- dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false -v minimal -clp:ErrorsOnly
- dotnet build src\Modules\XFramework.Notifications\Notifications.Api\Notifications.Api.csproj -m:1 /nr:false -v minimal -clp:ErrorsOnly
- git diff --check