### PR TITLE
Refine ControlPanel tenant admin navigation

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -20,7 +20,18 @@
 
             @* Scrollable nav *@
             <nav class="flex-1 overflow-y-auto p-3">
-                <NavMenu />
+                @if (IsTenantListRoute)
+                {
+                    <TenantListSidebar />
+                }
+                else if (TryGetTenantDetailRoute(out var tenantRouteId, out _))
+                {
+                    <TenantDetailSidebar TenantId="@tenantRouteId" />
+                }
+                else
+                {
+                    <NavMenu />
+                }
             </nav>
 
             @* Footer *@
@@ -56,49 +67,58 @@
             <div class="flex items-center gap-2">
                 <BbDarkModeToggle Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" />
                 <BbThemeSwitcher />
-                <details class="profile-menu">
-                    <summary class="profile-trigger" aria-label="Open profile menu">
-                        <span class="profile-avatar">@_userInitials</span>
-                        <span class="profile-trigger-text">
-                            <span class="profile-name">@_displayName</span>
-                            <span class="profile-tenant">@ActiveTenantLabel</span>
-                        </span>
-                        <LucideIcon Name="chevron-down" class="h-4 w-4 text-muted-foreground" />
-                    </summary>
-                    <div class="profile-menu-panel">
-                        <div class="profile-menu-user">
-                            <span class="profile-avatar profile-avatar-large">@_userInitials</span>
-                            <div class="min-w-0">
-                                <div class="profile-menu-name">@_displayName</div>
-                                <div class="profile-menu-username">@_userName</div>
+                <div class="profile-menu">
+                    <BbPopover @bind-Open="_profileMenuOpen"
+                               CloseOnClickOutside="true"
+                               CloseOnEscape="true"
+                               RestoreFocusOnClose="true">
+                        <BbPopoverTrigger AsChild>
+                            <button type="button" class="profile-trigger" aria-label="Open profile menu">
+                                <span class="profile-avatar">@_userInitials</span>
+                                <span class="profile-trigger-text">
+                                    <span class="profile-name">@_displayName</span>
+                                    <span class="profile-tenant">@ActiveTenantLabel</span>
+                                </span>
+                                <LucideIcon Name="chevron-down" class="h-4 w-4 text-muted-foreground" />
+                            </button>
+                        </BbPopoverTrigger>
+                        <BbPopoverContent Side="PopoverSide.Bottom"
+                                          Align="PopoverAlign.End"
+                                          Class="profile-menu-panel">
+                            <div class="profile-menu-user">
+                                <span class="profile-avatar profile-avatar-large">@_userInitials</span>
+                                <div class="min-w-0">
+                                    <div class="profile-menu-name">@_displayName</div>
+                                    <div class="profile-menu-username">@_userName</div>
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="profile-menu-section">
-                            <label class="profile-menu-label">Active Tenant</label>
-                            <BbCombobox TValue="string"
-                                         Value="@_selectedTenantId"
-                                         ValueChanged="@OnTenantSelectionChanged"
-                                         Options="@TenantOptions"
-                                         Placeholder="All Tenants"
-                                         SearchPlaceholder="Search tenants..."
-                                         EmptyMessage="No tenants found."
-                                         Class="tenant-filter-combobox profile-tenant-combobox"
-                                         MatchTriggerWidth="true" />
-                        </div>
+                            <div class="profile-menu-section">
+                                <label class="profile-menu-label">Active Tenant</label>
+                                <BbCombobox TValue="string"
+                                             Value="@_selectedTenantId"
+                                             ValueChanged="@OnTenantSelectionChanged"
+                                             Options="@TenantOptions"
+                                             Placeholder="All Tenants"
+                                             SearchPlaceholder="Search tenants..."
+                                             EmptyMessage="No tenants found."
+                                             Class="tenant-filter-combobox profile-tenant-combobox"
+                                             MatchTriggerWidth="true" />
+                            </div>
 
-                        <div class="profile-menu-actions">
-                            <BbButton Variant="ButtonVariant.Outline" OnClick="@ManageTenants" Class="profile-menu-button">
-                                <LucideIcon Name="building-2" class="mr-2 h-4 w-4" />
-                                Manage Tenants
-                            </BbButton>
-                            <BbButton Variant="ButtonVariant.Ghost" OnClick="@Logout" Class="profile-menu-button">
-                                <LucideIcon Name="log-out" class="mr-2 h-4 w-4" />
-                                Sign Out
-                            </BbButton>
-                        </div>
-                    </div>
-                </details>
+                            <div class="profile-menu-actions">
+                                <BbButton Variant="ButtonVariant.Outline" OnClick="@ManageTenants" Class="profile-menu-button">
+                                    <LucideIcon Name="building-2" class="mr-2 h-4 w-4" />
+                                    Manage Tenants
+                                </BbButton>
+                                <BbButton Variant="ButtonVariant.Ghost" OnClick="@Logout" Class="profile-menu-button">
+                                    <LucideIcon Name="log-out" class="mr-2 h-4 w-4" />
+                                    Sign Out
+                                </BbButton>
+                            </div>
+                        </BbPopoverContent>
+                    </BbPopover>
+                </div>
             </div>
         </header>
         <main class="app-main flex-1 min-w-0 p-6 overflow-y-auto">
@@ -127,8 +147,11 @@
     private string _displayName = "Administrator";
     private string _userName = "";
     private string _userInitials = "A";
+    private bool _profileMenuOpen;
     private string _selectedTenantName => TenantFilter.SelectedTenantName ?? "";
     private string ActiveTenantLabel => string.IsNullOrWhiteSpace(_selectedTenantName) ? "All Tenants" : _selectedTenantName;
+    private string CurrentPath => new Uri(Nav.Uri).AbsolutePath.TrimEnd('/');
+    private bool IsTenantListRoute => string.Equals(CurrentPath, "/identity/tenants", StringComparison.OrdinalIgnoreCase);
 
     private List<SelectOption<string>> TenantOptions =>
     [
@@ -219,16 +242,45 @@
         {
             TenantFilter.Clear();
         }
+
+        _profileMenuOpen = false;
     }
 
     private void ManageTenants()
     {
+        _profileMenuOpen = false;
         Nav.NavigateTo("/identity/tenants");
     }
 
     private void Logout()
     {
+        _profileMenuOpen = false;
         Nav.NavigateTo("/auth/logout", forceLoad: true);
+    }
+
+    private bool TryGetTenantDetailRoute(out Guid tenantId, out string section)
+    {
+        tenantId = Guid.Empty;
+        section = "summary";
+
+        var segments = CurrentPath
+            .Trim('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (segments.Length < 3
+            || !string.Equals(segments[0], "identity", StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(segments[1], "tenants", StringComparison.OrdinalIgnoreCase)
+            || !Guid.TryParse(segments[2], out tenantId))
+        {
+            return false;
+        }
+
+        if (segments.Length >= 4)
+        {
+            section = segments[3];
+        }
+
+        return true;
     }
 
     private static string BuildInitials(string displayName)

--- a/src/Presentation/ControlPanel.Server/Components/Layout/TenantDetailSidebar.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/TenantDetailSidebar.razor
@@ -1,0 +1,66 @@
+@* Tenant detail section navigation *@
+@inject NavigationManager Navigation
+
+<div class="space-y-1">
+    <NavLink href="/identity/tenants"
+             Match="NavLinkMatch.All"
+             class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground">
+        <LucideIcon Name="arrow-left" class="h-4 w-4" />
+        Tenant List
+    </NavLink>
+</div>
+
+<div class="mt-4">
+    <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Tenant Detail</p>
+    <div class="space-y-0.5">
+        <a href="@SectionHref("summary")" class="@SectionClass("summary")">
+            <LucideIcon Name="file-text" class="h-4 w-4" />
+            Summary
+        </a>
+        <a href="@SectionHref("modules")" class="@SectionClass("modules")">
+            <LucideIcon Name="blocks" class="h-4 w-4" />
+            Modules
+        </a>
+        <a href="@SectionHref("users")" class="@SectionClass("users")">
+            <LucideIcon Name="users" class="h-4 w-4" />
+            Users
+        </a>
+        <a href="@SectionHref("configurations")" class="@SectionClass("configurations")">
+            <LucideIcon Name="settings" class="h-4 w-4" />
+            Configurations
+        </a>
+        <a href="@SectionHref("role-types")" class="@SectionClass("role-types")">
+            <LucideIcon Name="shield" class="h-4 w-4" />
+            Role Types
+        </a>
+    </div>
+</div>
+
+@code {
+    [Parameter] public Guid TenantId { get; set; }
+
+    private string CurrentPath => new Uri(Navigation.Uri).AbsolutePath.TrimEnd('/');
+    private string BaseHref => $"/identity/tenants/{TenantId}";
+
+    private string CurrentSection
+    {
+        get
+        {
+            var segments = CurrentPath
+                .Trim('/')
+                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            return segments.Length >= 4 ? NormalizeSection(segments[3]) : "summary";
+        }
+    }
+
+    private string SectionHref(string section) =>
+        section == "summary" ? BaseHref : $"{BaseHref}/{section}";
+
+    private string SectionClass(string section) =>
+        "flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent "
+        + (CurrentSection == section ? "bg-sidebar-accent text-sidebar-accent-foreground" : "");
+
+    private static string NormalizeSection(string section) =>
+        section.Equals("roletypes", StringComparison.OrdinalIgnoreCase) ? "role-types" : section.ToLowerInvariant();
+}

--- a/src/Presentation/ControlPanel.Server/Components/Layout/TenantListSidebar.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/TenantListSidebar.razor
@@ -1,0 +1,11 @@
+@* Tenant administration list navigation *@
+<div class="space-y-1">
+    <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Tenant Admin</p>
+    <NavLink href="/identity/tenants"
+             Match="NavLinkMatch.All"
+             class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+             ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+        <LucideIcon Name="building-2" class="h-4 w-4" />
+        Tenant List
+    </NavLink>
+</div>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -1,4 +1,5 @@
 @page "/identity/tenants/{Id:guid}"
+@page "/identity/tenants/{Id:guid}/{Section}"
 @implements IDisposable
 
 <PageTitle>Tenant Detail - Control Panel</PageTitle>
@@ -61,15 +62,8 @@ else
             </BbButton>
         </div>
 
-        @* -- Detail Tabs -- *@
-        <BbTabs DefaultValue="summary">
-            <BbTabsList>
-                <BbTabsTrigger Value="summary">Tenant Summary</BbTabsTrigger>
-                <BbTabsTrigger Value="modules">Modules (@_moduleFeatureRows.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="users">Users (@_detailUsers.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="configurations">Configurations (@_detailConfigs.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="roletypes">Role Types (@_detailRoleTypes.Count)</BbTabsTrigger>
-            </BbTabsList>
+        @* -- Detail section selected by the tenant detail sidebar route -- *@
+        <BbTabs @key="CurrentSection" DefaultValue="@CurrentSection">
 
             <BbTabsContent Value="summary" Class="xf-fade-in">
                 <EditableForm @ref="_editableForm" TModel="Tenant" Model="_tenant"
@@ -137,8 +131,8 @@ else
                                     <div class="rounded-lg border bg-card p-4 shadow-sm">
                                         <div class="flex items-start justify-between gap-3">
                                             <div class="flex min-w-0 gap-3">
-                                                <div class="grid h-9 w-9 shrink-0 place-items-center rounded-md border bg-muted">
-                                                    <LucideIcon Name="@row.Icon" class="h-4 w-4" />
+                                                <div class="tenant-module-icon">
+                                                    <LucideIcon Name="@row.Icon" class="h-5 w-5" />
                                                 </div>
                                                 <div class="min-w-0">
                                                     <div class="flex flex-wrap items-center gap-2">
@@ -253,7 +247,7 @@ else
                 </BbCard>
             </BbTabsContent>
 
-            <BbTabsContent Value="roletypes" Class="xf-fade-in">
+            <BbTabsContent Value="role-types" Class="xf-fade-in">
                 <BbCard>
                     <BbCardContent>
                         @if (_detailRoleTypes.Count == 0)
@@ -336,6 +330,7 @@ else
 
 @code {
     [Parameter] public Guid Id { get; set; }
+    [Parameter] public string? Section { get; set; }
 
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
@@ -374,6 +369,7 @@ else
     private List<ModuleFeatureRow> _moduleFeatureRows = [];
     private HashSet<Guid> _savingModuleFeatureIds = [];
     private bool _moduleFeaturesLoading;
+    private string CurrentSection => NormalizeSection(Section);
 
     // -- Config dialog --
     private bool _configDialogOpen;
@@ -391,6 +387,12 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        if (!IsValidSection(Section))
+        {
+            Navigation.NavigateTo($"/identity/tenants/{Id}", replace: true);
+            return;
+        }
+
         if (_loadedId == Id)
         {
             return;
@@ -728,6 +730,22 @@ else
             TenantModuleFeatureKeys.Payments => "inactive",
             _ => "inactive"
         };
+
+    private static string NormalizeSection(string? section)
+    {
+        if (string.IsNullOrWhiteSpace(section))
+        {
+            return "summary";
+        }
+
+        return section.Equals("roletypes", StringComparison.OrdinalIgnoreCase)
+            ? "role-types"
+            : section.ToLowerInvariant();
+    }
+
+    private static bool IsValidSection(string? section) =>
+        string.IsNullOrWhiteSpace(section)
+        || NormalizeSection(section) is "summary" or "modules" or "users" or "configurations" or "role-types";
 
     private void OpenUserDetail(IdentityInformation user) =>
         Navigation.NavigateTo($"/identity/users/{user.Id}");

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -285,14 +285,6 @@
     position: relative;
 }
 
-.profile-menu > summary {
-    list-style: none;
-}
-
-.profile-menu > summary::-webkit-details-marker {
-    display: none;
-}
-
 .profile-trigger {
     display: flex;
     align-items: center;
@@ -364,9 +356,6 @@
 }
 
 .profile-menu-panel {
-    position: absolute;
-    top: calc(100% + 0.5rem);
-    right: 0;
     z-index: 60;
     display: flex;
     width: min(22rem, calc(100vw - 2rem));
@@ -421,6 +410,24 @@
 
 .profile-tenant-combobox {
     width: 100%;
+}
+
+.tenant-module-icon {
+    display: grid;
+    width: 3rem;
+    height: 3rem;
+    flex: 0 0 3rem;
+    place-items: center;
+    align-self: flex-start;
+    border: 1px solid var(--border);
+    border-radius: calc(var(--radius) - 2px);
+    background: var(--muted);
+    color: var(--foreground);
+}
+
+.tenant-module-icon svg {
+    width: 1.35rem;
+    height: 1.35rem;
 }
 
 [role="row"][tabindex="0"]:focus,


### PR DESCRIPTION
## Summary
- replace the profile details menu with a BlazorBlueprint popover that dismisses on outside click
- add route-aware tenant admin sidebars for tenant list and tenant detail pages
- convert tenant detail sections from visible horizontal tabs to sidebar-driven routes
- center and enlarge tenant module icons

## Verification
- dotnet build src\\Presentation\\ControlPanel.Server\\ControlPanel.Server.csproj -m:1 /nr:false -v minimal -clp:ErrorsOnly
- dotnet build src\\Modules\\XFramework.Blazor\\XFramework.Blazor.csproj -m:1 /nr:false -v minimal -clp:ErrorsOnly
- git diff --cached --check

## Notes
- Local browser opened http://localhost:5001/identity/tenants, but smoke testing stopped at the login page rather than submitting credentials through the browser.