### PR TITLE
Fix ControlPanel profile popover parameters

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -69,8 +69,6 @@
                 <BbThemeSwitcher />
                 <div class="profile-menu">
                     <BbPopover @bind-Open="_profileMenuOpen"
-                               CloseOnClickOutside="true"
-                               CloseOnEscape="true"
                                RestoreFocusOnClose="true">
                         <BbPopoverTrigger AsChild>
                             <button type="button" class="profile-trigger" aria-label="Open profile menu">


### PR DESCRIPTION
## Summary
- remove unsupported BbPopover CloseOnClickOutside and CloseOnEscape parameters that crash authenticated ControlPanel rendering

## Tests
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false -v minimal -clp:ErrorsOnly
- dotnet build src/Modules/XFramework.Blazor/XFramework.Blazor.csproj -m:1 /nr:false -v minimal -clp:ErrorsOnly