### PR TITLE
Fix ControlPanel profile menu toggle

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -68,21 +68,25 @@
                 <BbDarkModeToggle Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" />
                 <BbThemeSwitcher />
                 <div class="profile-menu">
-                    <BbPopover @bind-Open="_profileMenuOpen"
-                               RestoreFocusOnClose="true">
-                        <BbPopoverTrigger AsChild>
-                            <button type="button" class="profile-trigger" aria-label="Open profile menu">
-                                <span class="profile-avatar">@_userInitials</span>
-                                <span class="profile-trigger-text">
-                                    <span class="profile-name">@_displayName</span>
-                                    <span class="profile-tenant">@ActiveTenantLabel</span>
-                                </span>
-                                <LucideIcon Name="chevron-down" class="h-4 w-4 text-muted-foreground" />
-                            </button>
-                        </BbPopoverTrigger>
-                        <BbPopoverContent Side="PopoverSide.Bottom"
-                                          Align="PopoverAlign.End"
-                                          Class="profile-menu-panel">
+                    <button type="button"
+                            class="profile-trigger"
+                            aria-label="Open profile menu"
+                            aria-expanded="@(_profileMenuOpen ? "true" : "false")"
+                            @onclick="ToggleProfileMenu">
+                        <span class="profile-avatar">@_userInitials</span>
+                        <span class="profile-trigger-text">
+                            <span class="profile-name">@_displayName</span>
+                            <span class="profile-tenant">@ActiveTenantLabel</span>
+                        </span>
+                        <LucideIcon Name="chevron-down" class="h-4 w-4 text-muted-foreground" />
+                    </button>
+                    @if (_profileMenuOpen)
+                    {
+                        <button type="button"
+                                class="profile-menu-backdrop"
+                                aria-label="Close profile menu"
+                                @onclick="CloseProfileMenu"></button>
+                        <div class="profile-menu-panel" @onclick:stopPropagation="true">
                             <div class="profile-menu-user">
                                 <span class="profile-avatar profile-avatar-large">@_userInitials</span>
                                 <div class="min-w-0">
@@ -114,8 +118,8 @@
                                     Sign Out
                                 </BbButton>
                             </div>
-                        </BbPopoverContent>
-                    </BbPopover>
+                        </div>
+                    }
                 </div>
             </div>
         </header>
@@ -156,6 +160,10 @@
         new(AllTenantsValue, "All Tenants"),
         .. _tenants.Select(t => new SelectOption<string>(t.Id.ToString(), t.Name ?? t.Id.ToString()[..8]))
     ];
+
+    private void ToggleProfileMenu() => _profileMenuOpen = !_profileMenuOpen;
+
+    private void CloseProfileMenu() => _profileMenuOpen = false;
 
     private List<string> GetBreadcrumbs()
     {

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -285,6 +285,15 @@
     position: relative;
 }
 
+.profile-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 59;
+    border: 0;
+    background: transparent;
+    cursor: default;
+}
+
 .profile-trigger {
     display: flex;
     align-items: center;
@@ -356,6 +365,9 @@
 }
 
 .profile-menu-panel {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
     z-index: 60;
     display: flex;
     width: min(22rem, calc(100vw - 2rem));


### PR DESCRIPTION
## Summary
- replace the profile switcher popover wrapper with a controlled Blazor menu button
- add an outside-click backdrop so the profile menu closes when clicking outside
- keep existing tenant combobox and profile actions inside the menu

## Tests
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false -v minimal -clp:ErrorsOnly
- dotnet build src/Modules/XFramework.Blazor/XFramework.Blazor.csproj -m:1 /nr:false -v minimal -clp:ErrorsOnly
- browser smoke on http://localhost:5001/identity/tenants: profile menu opens, shows Manage Tenants/Sign Out, and closes on outside click