### PR TITLE
Add Inventario ControlPanel module pages

### DIFF
--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -29,6 +29,7 @@
   <Folder Name="/Services/Inventario/">
     <Project Path="src\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj" />
     <Project Path="src\Modules\XFramework.Inventario\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
+    <Project Path="src\Modules\XFramework.Inventario\Inventario.Integration\Inventario.Integration.csproj" />
   </Folder>
   <Folder Name="/Services/Messaging/">
     <Project Path="src\Modules\XFramework.Messaging\Messaging.Api\Messaging.Api.csproj" />

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Product.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Product.cs
@@ -1,25 +1,55 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-using XFramework.Domain.Shared.Contracts.Base;
-
-public class Product : BaseModel, IProduct
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/products",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-products"
+)]
+public partial class Product : BaseModel, IProduct
 {
+    [MemoryPackOrder(0)]
     public string? Name { get; set; }
+    [MemoryPackOrder(1)]
     public string? Description { get; set; }
+    [MemoryPackOrder(2)]
     public decimal Price { get; set; }
+    [MemoryPackOrder(3)]
     public int StockQuantity { get; set; }
+    [MemoryPackOrder(4)]
     public Guid CategoryId { get; set; }
+    [MemoryPackOrder(5)]
     public ProductCategory? Category { get; set; }
+    [MemoryPackOrder(6)]
     public List<ProductVariation>? Variations { get; set; } = new();
+    [MemoryPackOrder(7)]
     public List<ProductTransaction>? Transactions { get; set; } = new();
+    [MemoryPackOrder(8)]
     public string? Image { get; set; }
+    [MemoryPackOrder(9)]
     public string? SKU { get; set; }
+    [MemoryPackOrder(10)]
     public string? Brand { get; set; }
+    [MemoryPackOrder(11)]
     public decimal? Weight { get; set; }
+    [MemoryPackOrder(12)]
+    [MemoryPackIgnore]
     public (string Length, string Width, string Height)? Dimensions { get; set; }
+    [MemoryPackOrder(13)]
+    [MemoryPackIgnore]
     public List<string>? Tags { get; set; } = new();
+    [MemoryPackOrder(14)]
     public decimal? Rating { get; set; }
+    [MemoryPackOrder(15)]
+    [MemoryPackIgnore]
     public List<string>? Reviews { get; set; } = new();
+    [MemoryPackOrder(16)]
     public decimal? Discount { get; set; }
+    [MemoryPackOrder(17)]
     public bool IsAvailable { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductCategory.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductCategory.cs
@@ -1,10 +1,22 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-using XFramework.Domain.Shared.Contracts.Base;
-
-public class ProductCategory : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/product-categories",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-product-categories"
+)]
+public partial class ProductCategory : BaseModel
 {
+    [MemoryPackOrder(0)]
     public string? Name { get; set; }
+    [MemoryPackOrder(1)]
     public string? Description { get; set; }
+    [MemoryPackOrder(2)]
     public List<Product>? Products { get; set; } = new();
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductTransaction.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductTransaction.cs
@@ -1,12 +1,26 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-using XFramework.Domain.Shared.Contracts.Base;
-
-public class ProductTransaction : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/product-transactions",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-product-transactions"
+)]
+public partial class ProductTransaction : BaseModel
 {
+    [MemoryPackOrder(0)]
     public Guid ProductId { get; set; }
+    [MemoryPackOrder(1)]
     public Product? Product { get; set; }
+    [MemoryPackOrder(2)]
     public int Quantity { get; set; }
+    [MemoryPackOrder(3)]
     public decimal TotalPrice { get; set; }
+    [MemoryPackOrder(4)]
     public DateTime TransactionDate { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductVariation.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductVariation.cs
@@ -1,11 +1,24 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-using XFramework.Domain.Shared.Contracts.Base;
-
-public class ProductVariation : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/product-variations",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-product-variations"
+)]
+public partial class ProductVariation : BaseModel
 {
+    [MemoryPackOrder(0)]
     public string? Name { get; set; }
+    [MemoryPackOrder(1)]
     public decimal AdditionalPrice { get; set; }
+    [MemoryPackOrder(2)]
     public Guid ProductId { get; set; }
+    [MemoryPackOrder(3)]
     public Product? Product { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/GlobalUsings.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using MemoryPack;
+global using XFramework.Domain.Shared.Contracts.Base;

--- a/src/Modules/XFramework.Inventario/Inventario.Integration/Drivers/InventarioServiceWrapper.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Integration/Drivers/InventarioServiceWrapper.cs
@@ -1,0 +1,2 @@
+// CRUD and IDataContext wrapper members are source-generated from Inventario.Domain.Shared
+// [GenerateEndpoints] contracts. See ServiceWrapperGenerator.

--- a/src/Modules/XFramework.Inventario/Inventario.Integration/Inventario.Integration.csproj
+++ b/src/Modules/XFramework.Inventario/Inventario.Integration/Inventario.Integration.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackageId>XFramework.Inventario.Integration</PackageId>
+        <Version>$(XFrameworkVersion)</Version>
+        <Description>XFramework Inventario service wrapper for ControlPanel and cross-module Bolt RPC calls.</Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\SourceGenerators\XFramework.SourceGenerators\XFramework.SourceGenerators.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
+        <ProjectReference Include="..\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -1,3 +1,6 @@
+@implements IDisposable
+@inject TenantModuleNavigationService ModuleNavigation
+
 @* Dashboard *@
 <div class="space-y-1">
     <NavLink href="/" Match="NavLinkMatch.All"
@@ -24,6 +27,28 @@
     </div>
 </div>
 
+@if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario))
+{
+    @* Inventario *@
+    <div class="mt-4">
+        <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Inventario</p>
+        <div class="space-y-0.5">
+            <NavLink href="/inventario/products" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="package" class="h-4 w-4" /> Products
+            </NavLink>
+            <NavLink href="/inventario/categories" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="folders" class="h-4 w-4" /> Categories
+            </NavLink>
+            <NavLink href="/inventario/transactions" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="arrow-left-right" class="h-4 w-4" /> Transactions
+            </NavLink>
+            <NavLink href="/inventario/settings" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="settings" class="h-4 w-4" /> Settings
+            </NavLink>
+        </div>
+    </div>
+}
+
 @* Finance *@
 <div class="mt-4">
     <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Finance</p>
@@ -33,6 +58,25 @@
         </NavLink>
     </div>
 </div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        ModuleNavigation.Initialize();
+        ModuleNavigation.OnChanged += OnModuleNavigationChanged;
+        await ModuleNavigation.EnsureLoadedAsync();
+    }
+
+    private void OnModuleNavigationChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        ModuleNavigation.OnChanged -= OnModuleNavigationChanged;
+    }
+}
 
 @* System *@
 <div class="mt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
@@ -1,0 +1,277 @@
+@page "/inventario/categories"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Categories - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <BbTypographyH3>Product Categories</BbTypographyH3>
+                    <BbTypographyMuted>Manage catalog categories for the selected tenant.</BbTypographyMuted>
+                </div>
+                <BbButton OnClick="@OpenCreateDialog">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    Create Category
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Categories</BbCardTitle>
+                    <BbCardDescription>@_categories.Count category(s) loaded</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_categories" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" />
+                            <BbDataGridTemplateColumn Title="Products">
+                                <ChildContent Context="item">@GetProductCount(item.Id)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <div class="flex items-center gap-1">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => OpenEditDialog(item))">
+                                            <LucideIcon Name="pencil" class="h-4 w-4" />
+                                        </BbButton>
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => OpenDeleteDialog(item))">
+                                            <LucideIcon Name="trash-2" class="h-4 w-4" />
+                                        </BbButton>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_dialogOpen" OpenChanged="@(v => _dialogOpen = v)">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>@(_editingCategory is null ? "Create Category" : "Edit Category")</BbDialogTitle>
+            <BbDialogDescription>Categories organize products in this tenant.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <BbFormFieldInput TValue="string" @bind-Value="_name" Label="Name" Required="true" />
+            <BbFormFieldInput TValue="string" @bind-Value="_description" Label="Description" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _dialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@SaveCategory" Disabled="@_saving">@(_editingCategory is null ? "Create" : "Save")</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+<ConfirmDeleteDialog Open="@_deleteDialogOpen"
+                     OpenChanged="@(v => _deleteDialogOpen = v)"
+                     Message="@($"Delete category \"{_deletingCategory?.Name}\"? Products using this category will not be changed.")"
+                     OnConfirm="@DeleteCategory" />
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private List<ProductCategory> _categories = [];
+    private Dictionary<Guid, int> _productCounts = [];
+    private bool _loading = true;
+    private bool _saving;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private bool _dialogOpen;
+    private bool _deleteDialogOpen;
+    private ProductCategory? _editingCategory;
+    private ProductCategory? _deletingCategory;
+    private string _name = "";
+    private string _description = "";
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _categories = [];
+            _productCounts = [];
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _categories = await DataContext.Query<ProductCategory>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(200)
+                .ToListAsync();
+
+            var products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(1000)
+                .ToListAsync();
+            _productCounts = products.GroupBy(x => x.CategoryId).ToDictionary(x => x.Key, x => x.Count());
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load categories: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private int GetProductCount(Guid categoryId) =>
+        _productCounts.TryGetValue(categoryId, out var count) ? count : 0;
+
+    private void OpenCreateDialog()
+    {
+        _editingCategory = null;
+        _name = "";
+        _description = "";
+        _dialogOpen = true;
+    }
+
+    private void OpenEditDialog(ProductCategory category)
+    {
+        _editingCategory = category;
+        _name = category.Name ?? "";
+        _description = category.Description ?? "";
+        _dialogOpen = true;
+    }
+
+    private void OpenDeleteDialog(ProductCategory category)
+    {
+        _deletingCategory = category;
+        _deleteDialogOpen = true;
+    }
+
+    private async Task SaveCategory()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid tenantId) return;
+        if (string.IsNullOrWhiteSpace(_name))
+        {
+            ToastService.Show("Category name is required.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            if (_editingCategory is null)
+            {
+                DataContext.Add(new ProductCategory
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    Name = _name.Trim(),
+                    Description = string.IsNullOrWhiteSpace(_description) ? null : _description.Trim(),
+                    CreatedAt = DateTime.UtcNow,
+                    IsEnabled = true
+                });
+            }
+            else
+            {
+                var fresh = await DataContext.Query<ProductCategory>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.Id == _editingCategory.Id && x.TenantId == tenantId)
+                    .FirstOrDefaultAsync();
+                if (fresh is null)
+                {
+                    ToastService.Show("Category not found.");
+                    return;
+                }
+
+                fresh.Name = _name.Trim();
+                fresh.Description = string.IsNullOrWhiteSpace(_description) ? null : _description.Trim();
+                fresh.ModifiedAt = DateTime.UtcNow;
+                DataContext.Update(fresh);
+            }
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show(_editingCategory is null ? "Category created." : "Category updated.");
+                _dialogOpen = false;
+                await Reload();
+            }
+            else
+            {
+                ToastService.Show($"Failed to save category: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving category: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task DeleteCategory()
+    {
+        if (_deletingCategory is null) return;
+        try
+        {
+            _deletingCategory.IsDeleted = true;
+            _deletingCategory.IsEnabled = false;
+            _deletingCategory.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(_deletingCategory);
+            var result = await DataContext.SaveChangesAsync();
+            ToastService.Show(result.IsSuccess ? "Category deleted." : $"Failed: {result.Message}");
+            _deleteDialogOpen = false;
+            _deletingCategory = null;
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error deleting category: {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -1,0 +1,302 @@
+@page "/inventario/products/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Product - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Products
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Product Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this product's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_product is null)
+{
+    <BbTypographyMuted>Product not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <BbTypographyH3>@(_product.Name ?? "Unnamed Product")</BbTypographyH3>
+                        <StatusBadge Text="@(_product.IsAvailable ? "Available" : "Unavailable")"
+                                     Status="@(_product.IsAvailable ? "active" : "inactive")" />
+                    </div>
+                    <BbTypographyMuted>SKU: @(_product.SKU ?? "N/A") — Category: @(_product.Category?.Name ?? "Uncategorized")</BbTypographyMuted>
+                </div>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Product Summary</BbCardTitle>
+                    <BbCardDescription>Catalog and stock snapshot for this tenant.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Price</BbTypographyMuted><BbTypographyH3>@_product.Price.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
+                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Stock</BbTypographyMuted><BbTypographyH3>@_product.StockQuantity</BbTypographyH3></div></BbCardContent></BbCard>
+                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Variations</BbTypographyMuted><BbTypographyH3>@_variations.Count</BbTypographyH3></div></BbCardContent></BbCard>
+                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Transactions</BbTypographyMuted><BbTypographyH3>@_transactions.Count</BbTypographyH3></div></BbCardContent></BbCard>
+                    </div>
+                    <div class="mt-4 grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Description</BbTypographyMuted>
+                            <div>@(_product.Description ?? "No description")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Brand</BbTypographyMuted>
+                            <div>@(_product.Brand ?? "N/A")</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <BbCardTitle>Variations</BbCardTitle>
+                            <BbCardDescription>Optional product options and price adjustments.</BbCardDescription>
+                        </div>
+                        <BbButton Size="ButtonSize.Small" OnClick="@OpenVariationDialog">
+                            <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                            Add Variation
+                        </BbButton>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_variations" ShowPagination="true" InitialPageSize="10">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Additional Price">
+                                <ChildContent Context="item">@item.AdditionalPrice.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Transaction History</BbCardTitle>
+                    <BbCardDescription>Read-only product transaction history.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="10">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Quantity">
+                                <ChildContent Context="item">@item.Quantity</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Total">
+                                <ChildContent Context="item">@item.TotalPrice.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_variationDialogOpen" OpenChanged="@(v => _variationDialogOpen = v)">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>Add Variation</BbDialogTitle>
+            <BbDialogDescription>Add an option for this product.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <BbFormFieldInput TValue="string" @bind-Value="_variationName" Label="Name" Required="true" />
+            <BbFormFieldInput TValue="string" @bind-Value="_variationAdditionalPrice" Label="Additional Price" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _variationDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@SaveVariation" Disabled="@_saving">Create</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private Product? _product;
+    private List<ProductVariation> _variations = [];
+    private List<ProductTransaction> _transactions = [];
+    private bool _loading = true;
+    private bool _saving;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private bool _outsideTenantContext;
+    private bool _variationDialogOpen;
+    private string _variationName = "";
+    private string _variationAdditionalPrice = "0";
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged()
+    {
+        _ = InvokeAsync(Reload);
+    }
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _outsideTenantContext = false;
+            _product = null;
+            _variations = [];
+            _transactions = [];
+
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            _product = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Category)
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _product is not null && _product.TenantId != TenantFilter.SelectedTenantId;
+            if (_product is null || _outsideTenantContext) return;
+
+            _variations = await DataContext.Query<ProductVariation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.ProductId == Id && x.TenantId == _product.TenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(100)
+                .ToListAsync();
+
+            _transactions = await DataContext.Query<ProductTransaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.ProductId == Id && x.TenantId == _product.TenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.TransactionDate)
+                .Take(100)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load product: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OpenVariationDialog()
+    {
+        _variationName = "";
+        _variationAdditionalPrice = "0";
+        _variationDialogOpen = true;
+    }
+
+    private async Task SaveVariation()
+    {
+        if (_product is null) return;
+        if (string.IsNullOrWhiteSpace(_variationName))
+        {
+            ToastService.Show("Variation name is required.");
+            return;
+        }
+
+        if (!decimal.TryParse(_variationAdditionalPrice, out var additionalPrice))
+        {
+            ToastService.Show("Additional price must be a valid number.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            DataContext.Add(new ProductVariation
+            {
+                Id = Guid.NewGuid(),
+                TenantId = _product.TenantId,
+                ProductId = _product.Id,
+                Name = _variationName.Trim(),
+                AdditionalPrice = additionalPrice,
+                CreatedAt = DateTime.UtcNow,
+                IsEnabled = true
+            });
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show("Variation added.");
+                _variationDialogOpen = false;
+                await Reload();
+            }
+            else
+            {
+                ToastService.Show($"Failed to add variation: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error adding variation: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
@@ -1,0 +1,432 @@
+@page "/inventario/products"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Products - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Products</BbTypographyH3>
+                    <BbTypographyMuted>Manage the selected tenant's product catalog and stock snapshot.</BbTypographyMuted>
+                </div>
+                <BbButton OnClick="@OpenCreateDialog">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    Create Product
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Total Products</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_products.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Available</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_products.Count(x => x.IsAvailable)</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Low Stock</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_products.Count(x => x.StockQuantity <= _lowStockThreshold)</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Categories</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_categories.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                        <div>
+                            <BbCardTitle>Product Catalog</BbCardTitle>
+                            <BbCardDescription>@_filteredProducts.Count product(s) shown</BbCardDescription>
+                        </div>
+                        <div class="flex flex-col gap-2 md:w-[28rem] md:flex-row">
+                            <BbInput @bind-Value="_search" Placeholder="Search products..." @oninput="OnSearchChanged" />
+                            <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                                Refresh
+                            </BbButton>
+                        </div>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_filteredProducts" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((Product item) => Navigation.NavigateTo($"/inventario/products/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="SKU">
+                                <ChildContent Context="item">
+                                    <span class="font-mono text-xs">@(item.SKU ?? "N/A")</span>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Category">
+                                <ChildContent Context="item">@GetCategoryName(item.CategoryId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Price" Sortable="true">
+                                <ChildContent Context="item">@item.Price.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Stock" Sortable="true">
+                                <ChildContent Context="item">
+                                    <span class="@(item.StockQuantity <= _lowStockThreshold ? "font-semibold text-yellow-600" : "")">
+                                        @item.StockQuantity
+                                    </span>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsAvailable ? "Available" : "Unavailable")"
+                                                 Status="@(item.IsAvailable ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <div class="flex items-center gap-1">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/inventario/products/{item.Id}"))">
+                                            <LucideIcon Name="eye" class="h-4 w-4" />
+                                        </BbButton>
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => OpenEditDialog(item))">
+                                            <LucideIcon Name="pencil" class="h-4 w-4" />
+                                        </BbButton>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_productDialogOpen" OpenChanged="@(v => _productDialogOpen = v)">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>@(_editingProduct is null ? "Create Product" : "Edit Product")</BbDialogTitle>
+            <BbDialogDescription>Catalog data belongs to the selected tenant.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <BbFormFieldInput TValue="string" @bind-Value="_form.Name" Label="Name" Required="true" />
+            <BbFormFieldInput TValue="string" @bind-Value="_form.Sku" Label="SKU" />
+            <BbFormFieldSelect TValue="string" @bind-Value="_form.CategoryId" Label="Category" Placeholder="Select category">
+                @foreach (var category in _categories)
+                {
+                    <BbSelectItem Value="@category.Id.ToString()">@(category.Name ?? category.Id.ToString()[..8])</BbSelectItem>
+                }
+            </BbFormFieldSelect>
+            <div class="grid gap-4 md:grid-cols-3">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Price" Label="Price" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.StockQuantity" Label="Stock Quantity" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Brand" Label="Brand" />
+            </div>
+            <BbFormFieldInput TValue="string" @bind-Value="_form.Description" Label="Description" />
+            <BbFormFieldSwitch Checked="@_form.IsAvailable"
+                               CheckedChanged="@((bool value) => _form.IsAvailable = value)"
+                               Label="Available" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _productDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@SaveProduct" Disabled="@_saving">
+                @(_editingProduct is null ? "Create" : "Save")
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private readonly ProductForm _form = new();
+    private List<Product> _products = [];
+    private List<Product> _filteredProducts = [];
+    private List<ProductCategory> _categories = [];
+    private bool _loading = true;
+    private bool _saving;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private bool _productDialogOpen;
+    private Product? _editingProduct;
+    private string _search = "";
+    private int _lowStockThreshold = 5;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Reload();
+    }
+
+    private void OnTenantChanged()
+    {
+        _ = InvokeAsync(Reload);
+    }
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _products = [];
+            _categories = [];
+
+            if (!_hasTenant || !_moduleEnabled)
+            {
+                ApplySearch();
+                return;
+            }
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _categories = await DataContext.Query<ProductCategory>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(200)
+                .ToListAsync();
+
+            _products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(250)
+                .ToListAsync();
+
+            await LoadSettings();
+            ApplySearch();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load products: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task LoadSettings()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid tenantId) return;
+        var key = "Settings:Inventario:LowStockThreshold";
+        var config = await DataContext.Query<RegistryConfiguration>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && x.Key == key && !x.IsDeleted)
+            .FirstOrDefaultAsync();
+        if (int.TryParse(config?.Value, out var threshold) && threshold >= 0)
+        {
+            _lowStockThreshold = threshold;
+        }
+    }
+
+    private void OnSearchChanged(ChangeEventArgs args)
+    {
+        _search = args.Value?.ToString() ?? "";
+        ApplySearch();
+    }
+
+    private void ApplySearch()
+    {
+        var search = _search.Trim();
+        _filteredProducts = string.IsNullOrWhiteSpace(search)
+            ? _products
+            : _products.Where(x =>
+                    (x.Name?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || (x.SKU?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || (x.Brand?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || GetCategoryName(x.CategoryId).Contains(search, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+    }
+
+    private string GetCategoryName(Guid categoryId) =>
+        _categories.FirstOrDefault(x => x.Id == categoryId)?.Name ?? "Uncategorized";
+
+    private void OpenCreateDialog()
+    {
+        _editingProduct = null;
+        _form.Reset();
+        _form.IsAvailable = true;
+        _form.CategoryId = _categories.FirstOrDefault()?.Id.ToString() ?? "";
+        _productDialogOpen = true;
+    }
+
+    private void OpenEditDialog(Product product)
+    {
+        _editingProduct = product;
+        _form.Name = product.Name ?? "";
+        _form.Sku = product.SKU ?? "";
+        _form.CategoryId = product.CategoryId.ToString();
+        _form.Price = product.Price.ToString("0.##");
+        _form.StockQuantity = product.StockQuantity.ToString();
+        _form.Brand = product.Brand ?? "";
+        _form.Description = product.Description ?? "";
+        _form.IsAvailable = product.IsAvailable;
+        _productDialogOpen = true;
+    }
+
+    private async Task SaveProduct()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            ToastService.Show("Select a tenant before saving products.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_form.Name))
+        {
+            ToastService.Show("Product name is required.");
+            return;
+        }
+
+        if (!Guid.TryParse(_form.CategoryId, out var categoryId))
+        {
+            ToastService.Show("Select a category.");
+            return;
+        }
+
+        if (!decimal.TryParse(_form.Price, out var price) || price < 0)
+        {
+            ToastService.Show("Price must be a non-negative number.");
+            return;
+        }
+
+        if (!int.TryParse(_form.StockQuantity, out var quantity) || quantity < 0)
+        {
+            ToastService.Show("Stock quantity must be a non-negative whole number.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            if (_editingProduct is null)
+            {
+                DataContext.Add(new Product
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    Name = _form.Name.Trim(),
+                    SKU = NullIfEmpty(_form.Sku),
+                    CategoryId = categoryId,
+                    Price = price,
+                    StockQuantity = quantity,
+                    Brand = NullIfEmpty(_form.Brand),
+                    Description = NullIfEmpty(_form.Description),
+                    IsAvailable = _form.IsAvailable,
+                    CreatedAt = DateTime.UtcNow,
+                    IsEnabled = true
+                });
+            }
+            else
+            {
+                var fresh = await DataContext.Query<Product>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.Id == _editingProduct.Id && x.TenantId == tenantId)
+                    .FirstOrDefaultAsync();
+                if (fresh is null)
+                {
+                    ToastService.Show("Product not found.");
+                    return;
+                }
+
+                fresh.Name = _form.Name.Trim();
+                fresh.SKU = NullIfEmpty(_form.Sku);
+                fresh.CategoryId = categoryId;
+                fresh.Price = price;
+                fresh.StockQuantity = quantity;
+                fresh.Brand = NullIfEmpty(_form.Brand);
+                fresh.Description = NullIfEmpty(_form.Description);
+                fresh.IsAvailable = _form.IsAvailable;
+                fresh.ModifiedAt = DateTime.UtcNow;
+                DataContext.Update(fresh);
+            }
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show(_editingProduct is null ? "Product created." : "Product updated.");
+                _productDialogOpen = false;
+                await Reload();
+            }
+            else
+            {
+                ToastService.Show($"Failed to save product: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving product: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class ProductForm
+    {
+        public string Name { get; set; } = "";
+        public string Sku { get; set; } = "";
+        public string CategoryId { get; set; } = "";
+        public string Price { get; set; } = "0";
+        public string StockQuantity { get; set; } = "0";
+        public string Brand { get; set; } = "";
+        public string Description { get; set; } = "";
+        public bool IsAvailable { get; set; } = true;
+
+        public void Reset()
+        {
+            Name = "";
+            Sku = "";
+            CategoryId = "";
+            Price = "0";
+            StockQuantity = "0";
+            Brand = "";
+            Description = "";
+            IsAvailable = true;
+        }
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Settings.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Settings.razor
@@ -1,0 +1,235 @@
+@page "/inventario/settings"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Settings - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div>
+                <BbTypographyH3>Inventario Settings</BbTypographyH3>
+                <BbTypographyMuted>Tenant-level inventory settings stored as registry configuration.</BbTypographyMuted>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Catalog Behavior</BbCardTitle>
+                    <BbCardDescription>These settings are reserved for inventory workflows and future UI defaults.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <BbFormFieldInput TValue="string" @bind-Value="_lowStockThreshold" Label="Low Stock Threshold" />
+                        <BbFormFieldInput TValue="string" @bind-Value="_defaultCurrency" Label="Default Currency" />
+                        <BbFormFieldSwitch Checked="@_skuRequired"
+                                           CheckedChanged="@((bool value) => _skuRequired = value)"
+                                           Label="Require SKU" />
+                        <BbFormFieldSwitch Checked="@_allowNegativeStock"
+                                           CheckedChanged="@((bool value) => _allowNegativeStock = value)"
+                                           Label="Allow Negative Stock" />
+                    </div>
+                    <div class="mt-6 flex justify-end">
+                        <BbButton OnClick="@SaveSettings" Disabled="@_saving">
+                            @if (_saving)
+                            {
+                                <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                            }
+                            Save Settings
+                        </BbButton>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private const string LowStockThresholdKey = "Settings:Inventario:LowStockThreshold";
+    private const string DefaultCurrencyKey = "Settings:Inventario:DefaultCurrency";
+    private const string SkuRequiredKey = "Settings:Inventario:SkuRequired";
+    private const string AllowNegativeStockKey = "Settings:Inventario:AllowNegativeStock";
+
+    private bool _loading = true;
+    private bool _saving;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private Guid _settingsGroupId;
+    private string _lowStockThreshold = "5";
+    private string _defaultCurrency = "PHP";
+    private bool _skuRequired = true;
+    private bool _allowNegativeStock;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            _settingsGroupId = await EnsureSettingsGroup();
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            var configs = await DataContext.Query<RegistryConfiguration>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.Key.StartsWith("Settings:Inventario:"))
+                .Take(50)
+                .ToListAsync();
+
+            _lowStockThreshold = GetValue(configs, LowStockThresholdKey, "5");
+            _defaultCurrency = GetValue(configs, DefaultCurrencyKey, "PHP");
+            _skuRequired = bool.TryParse(GetValue(configs, SkuRequiredKey, "true"), out var skuRequired) && skuRequired;
+            _allowNegativeStock = bool.TryParse(GetValue(configs, AllowNegativeStockKey, "false"), out var allowNegative) && allowNegative;
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Inventario settings: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task SaveSettings()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid tenantId) return;
+        if (!int.TryParse(_lowStockThreshold, out var threshold) || threshold < 0)
+        {
+            ToastService.Show("Low stock threshold must be a non-negative whole number.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            _settingsGroupId = _settingsGroupId == Guid.Empty ? await EnsureSettingsGroup() : _settingsGroupId;
+            await UpsertSetting(tenantId, LowStockThresholdKey, threshold.ToString(), "quantity");
+            await UpsertSetting(tenantId, DefaultCurrencyKey, _defaultCurrency.Trim(), "code");
+            await UpsertSetting(tenantId, SkuRequiredKey, _skuRequired.ToString(), "boolean");
+            await UpsertSetting(tenantId, AllowNegativeStockKey, _allowNegativeStock.ToString(), "boolean");
+
+            var result = await DataContext.SaveChangesAsync();
+            ToastService.Show(result.IsSuccess ? "Inventario settings saved." : $"Failed: {result.Message}");
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving Inventario settings: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task<Guid> EnsureSettingsGroup()
+    {
+        var groups = await DataContext.Query<RegistryConfigurationGroup>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => !x.IsDeleted)
+            .Take(100)
+            .ToListAsync();
+
+        var group = groups.FirstOrDefault(x =>
+                string.Equals(x.Name, "Inventario", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x.Name, "Settings", StringComparison.OrdinalIgnoreCase))
+            ?? groups.FirstOrDefault();
+
+        if (group is not null)
+        {
+            return group.Id;
+        }
+
+        var created = new RegistryConfigurationGroup
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
+            Name = "Inventario",
+            Description = "Inventario module settings",
+            SystemReferenceId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            IsEnabled = true
+        };
+        DataContext.Add(created);
+        var result = await DataContext.SaveChangesAsync();
+        if (!result.IsSuccess)
+        {
+            throw new InvalidOperationException(result.Message ?? "Unable to create settings group.");
+        }
+
+        return created.Id;
+    }
+
+    private async Task UpsertSetting(Guid tenantId, string key, string? value, string unit)
+    {
+        var config = await DataContext.Query<RegistryConfiguration>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && x.Key == key && !x.IsDeleted)
+            .FirstOrDefaultAsync();
+
+        if (config is null)
+        {
+            DataContext.Add(new RegistryConfiguration
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                GroupId = _settingsGroupId,
+                Key = key,
+                Value = value,
+                Unit = unit,
+                CreatedAt = DateTime.UtcNow,
+                IsEnabled = true
+            });
+        }
+        else
+        {
+            config.Value = value;
+            config.Unit = unit;
+            config.GroupId = _settingsGroupId;
+            config.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(config);
+        }
+    }
+
+    private static string GetValue(IEnumerable<RegistryConfiguration> configs, string key, string fallback) =>
+        configs.FirstOrDefault(x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase))?.Value ?? fallback;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
@@ -1,0 +1,129 @@
+@page "/inventario/transactions"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Transactions - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <BbTypographyH3>Inventory Transactions</BbTypographyH3>
+                    <BbTypographyMuted>Read-only stock and sales movement history for the selected tenant.</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Transactions</BbCardTitle>
+                    <BbCardDescription>@_transactions.Count transaction(s) loaded</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Quantity" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Total">
+                                <ChildContent Context="item">@item.TotalPrice.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private List<ProductTransaction> _transactions = [];
+    private Dictionary<Guid, string> _productNames = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _transactions = [];
+            _productNames = [];
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            var products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(1000)
+                .ToListAsync();
+            _productNames = products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]);
+
+            _transactions = await DataContext.Query<ProductTransaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.TransactionDate)
+                .Take(250)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load inventory transactions: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private string GetProductName(Guid productId) =>
+        _productNames.TryGetValue(productId, out var name) ? name : productId.ToString()[..8];
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Shared/ModuleUnavailable.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/ModuleUnavailable.razor
@@ -1,0 +1,17 @@
+<BbAlert Variant="AlertVariant.Warning">
+    <BbAlertTitle>@Title</BbAlertTitle>
+    <BbAlertDescription>@Message</BbAlertDescription>
+</BbAlert>
+
+@code {
+    [Parameter] public string ModuleName { get; set; } = "Module";
+    [Parameter] public bool RequiresTenant { get; set; }
+
+    private string Title => RequiresTenant
+        ? "Select a tenant"
+        : $"{ModuleName} disabled";
+
+    private string Message => RequiresTenant
+        ? "Select a specific active tenant from the profile menu to manage tenant module pages."
+        : $"{ModuleName} is not enabled for the selected tenant. Enable it from the tenant Modules page first.";
+}

--- a/src/Presentation/ControlPanel.Server/Components/_Imports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/_Imports.razor
@@ -22,6 +22,8 @@
 @using XFramework.Domain.Shared.Contracts.Responses
 @using IdentityServer.Domain.Shared.Contracts
 @using IdentityServer.Integration.Drivers
+@using XFramework.Inventario.Domain.Shared.Contracts
+@using global::Inventario.Integration.Drivers
 @using global::Wallets.Domain.Shared.Contracts
 @using global::Wallets.Integration.Drivers
 

--- a/src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
+++ b/src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
@@ -19,9 +19,11 @@
     <ItemGroup>
         <!-- Domain.Shared for entity types -->
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Domain.Shared\IdentityServer.Domain.Shared.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Domain.Shared\Wallets.Domain.Shared.csproj" />
         <!-- Service wrappers (Bolt CRUD + custom operations) -->
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Integration\IdentityServer.Integration.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Integration\Inventario.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Integration\Wallets.Integration.csproj" />
         <!-- Bolt client infrastructure (BoltClient, BoltDriver, IMessageBusWrapper) -->
         <ProjectReference Include="..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -6,6 +6,7 @@ using ControlPanel.Server.Health;
 using ControlPanel.Server.Services;
 using XFramework.Integration.Extensions;
 using IdentityServer.Integration.Drivers;
+using Inventario.Integration.Drivers;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Wallets.Integration.Drivers;
@@ -63,6 +64,7 @@ builder.Services.AddHealthChecks()
 
 // Service wrappers — auto-generated CRUD + custom operations for each microservice
 builder.Services.AddIdentityServerWrapperServices();
+builder.Services.AddInventarioWrapperServices();
 builder.Services.AddWalletsWrapperServices();
 
 // IDataContext — universal query layer routed through service wrappers
@@ -86,6 +88,7 @@ builder.Services.AddRemoteDataContext();
 
 // Tenant filter state (sidebar selection)
 builder.Services.AddScoped<TenantFilterService>();
+builder.Services.AddScoped<TenantModuleNavigationService>();
 builder.Services.AddScoped<NavigationHistoryService>();
 builder.Services.AddScoped<ControlPanelAuthService>();
 builder.Services.AddScoped<ControlPanelBootstrapSeeder>();

--- a/src/Presentation/ControlPanel.Server/Services/TenantModuleNavigationService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/TenantModuleNavigationService.cs
@@ -1,0 +1,88 @@
+using IdentityServer.Domain.Shared.Contracts;
+using XFramework.Domain.Shared.DataContext;
+
+namespace ControlPanel.Server.Services;
+
+public sealed class TenantModuleNavigationService(
+    TenantFilterService tenantFilter,
+    IDataContext dataContext) : IDisposable
+{
+    private readonly Dictionary<string, bool> _features = new(StringComparer.OrdinalIgnoreCase);
+    private Guid? _loadedTenantId;
+    private bool _loading;
+
+    public event Action? OnChanged;
+
+    public Guid? ActiveTenantId => tenantFilter.SelectedTenantId;
+    public bool HasConcreteTenant => tenantFilter.SelectedTenantId is Guid;
+    public bool IsLoading => _loading;
+
+    public async Task EnsureLoadedAsync(CancellationToken ct = default)
+    {
+        if (_loadedTenantId == tenantFilter.SelectedTenantId)
+        {
+            return;
+        }
+
+        await LoadAsync(ct);
+    }
+
+    public bool IsFeatureEnabled(string moduleKey, string? subFeatureKey = null)
+    {
+        var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+        return tenantFilter.SelectedTenantId is Guid && _features.TryGetValue(key, out var enabled) && enabled;
+    }
+
+    public async Task ReloadAsync(CancellationToken ct = default) => await LoadAsync(ct);
+
+    public void Initialize()
+    {
+        tenantFilter.OnChanged -= OnTenantFilterChanged;
+        tenantFilter.OnChanged += OnTenantFilterChanged;
+        _ = LoadAsync();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = LoadAsync();
+    }
+
+    private async Task LoadAsync(CancellationToken ct = default)
+    {
+        _loading = true;
+        OnChanged?.Invoke();
+
+        try
+        {
+            _features.Clear();
+            _loadedTenantId = tenantFilter.SelectedTenantId;
+
+            if (tenantFilter.SelectedTenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            var rows = await dataContext.Query<TenantModuleFeature>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.IsEnabled)
+                .Take(50)
+                .ToListAsync(ct);
+
+            foreach (var row in rows)
+            {
+                _features[row.Key] = true;
+            }
+        }
+        finally
+        {
+            _loading = false;
+            OnChanged?.Invoke();
+        }
+    }
+
+    public void Dispose()
+    {
+        tenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
@@ -307,6 +307,8 @@ public sealed class ProductServiceTests
 
         public IRemoteQuery<T> NoCache() => this;
 
+        public IRemoteQuery<T> IgnoreQueryFilters() => this;
+
         public Task<List<T>> ToListAsync(CancellationToken ct = default) =>
             Task.FromResult(query.ToList());
 


### PR DESCRIPTION
## Summary
- Adds shared tenant-module-aware ControlPanel navigation using `TenantModuleNavigationService`.
- Adds Inventario ControlPanel pages for products, product detail, categories, transactions, and tenant settings.
- Adds Inventario integration wrapper support and registers Inventario entities for remote data-context routing without generating new Inventario API CRUD endpoints.
- Repairs the Inventario API test fake for the current `IRemoteQuery<T>` contract.

## Merge order
1. Merge this PR first.
2. Then merge the Messaging ControlPanel PR.
3. Then merge the Community ControlPanel PR.

## Verification
- `dotnet build src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj -m:1 /nr:false -clp:ErrorsOnly`
- `dotnet build src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false -clp:ErrorsOnly`
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false -clp:ErrorsOnly`
- `dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false -clp:ErrorsOnly`
- `dotnet build XFramework.slnx -m:1 /nr:false -clp:ErrorsOnly` verified on the full stacked branch.