### PR TITLE
Add Community ControlPanel module pages

### DIFF
--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -20,6 +20,7 @@
   <Folder Name="/Services/Community/">
     <Project Path="src\Modules\XFramework.Community\Community.Api\Community.Api.csproj" />
     <Project Path="src\Modules\XFramework.Community\Community.Domain.Shared\Community.Domain.Shared.csproj" />
+    <Project Path="src\Modules\XFramework.Community\Community.Integration\Community.Integration.csproj" />
   </Folder>
   <Folder Name="/Services/IdentityServer/">
     <Project Path="src\Modules\XFramework.IdentityServer\IdentityServer.Api\IdentityServer.Api.csproj" />

--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -29,6 +29,7 @@
   <Folder Name="/Services/Inventario/">
     <Project Path="src\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj" />
     <Project Path="src\Modules\XFramework.Inventario\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
+    <Project Path="src\Modules\XFramework.Inventario\Inventario.Integration\Inventario.Integration.csproj" />
   </Folder>
   <Folder Name="/Services/Messaging/">
     <Project Path="src\Modules\XFramework.Messaging\Messaging.Api\Messaging.Api.csproj" />

--- a/src/Modules/XFramework.Community/Community.Api/Program.cs
+++ b/src/Modules/XFramework.Community/Community.Api/Program.cs
@@ -32,6 +32,7 @@ app.UseXFrameworkRateLimiting();
 app.UseTenantModuleFeatureGate(options =>
 {
     options.RequireFeature(TenantModuleFeatureKeys.Notifications, "/api/community/notifications");
+    options.RequireFeature(TenantModuleFeatureKeys.Notifications, "/api/community-notifications");
     options.RequireFeature(TenantModuleFeatureKeys.Community, "/api/community");
     options.RequireFeature(TenantModuleFeatureKeys.Community, "/api/community-identities");
     options.RequireFeature(TenantModuleFeatureKeys.Community, "/api/community-identity-types");
@@ -42,6 +43,7 @@ app.UseTenantModuleFeatureGate(options =>
     options.RequireFeature(TenantModuleFeatureKeys.Community, "/api/community-content-files");
     options.RequireFeature(TenantModuleFeatureKeys.Community, "/api/community-content-reactions");
     options.RequireFeature(TenantModuleFeatureKeys.Community, "/api/community-content-reaction-types");
+    options.RequireFeature(TenantModuleFeatureKeys.Community, "/api/community-connections");
     options.RequireFeature(TenantModuleFeatureKeys.Community, "/api/community-connection-types");
 });
 app.EnsureDatabase<AppDbContext>();

--- a/src/Modules/XFramework.Community/Community.Domain.Shared/Contracts/CommunityConnection.cs
+++ b/src/Modules/XFramework.Community/Community.Domain.Shared/Contracts/CommunityConnection.cs
@@ -1,11 +1,18 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace Community.Domain.Shared.Contracts;
 
-
 [MemoryPackable(GenerateType.CircularReference)]
-// [GenerateEndpoints] disabled — has manual endpoints in Features/Connections/ with custom request types
+[GenerateEndpoints(
+    Type = EndpointType.Both,
+    Actions = EndpointActions.ReadOnly,
+    RoutePrefix = "api/community-connections",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "community-connections"
+)]
 public partial class CommunityConnection : BaseModel
 {
-    
     [MemoryPackOrder(0)]
     public Guid SourceSocialMediaIdentityId { get; set; }
 
@@ -14,7 +21,6 @@ public partial class CommunityConnection : BaseModel
 
     [MemoryPackOrder(2)]
     public Guid TypeId { get; set; }
-
 
     [MemoryPackOrder(3)]
     public virtual CommunityConnectionType Type { get; set; } = null!;
@@ -26,4 +32,4 @@ public partial class CommunityConnection : BaseModel
     public virtual CommunityIdentity TargetSocialMediaIdentity { get; set; } = null!;
 }
 
-// Create/Update/GetList handled by manual endpoints in Features/Connections/
+// Create/Update flows are handled by manual endpoints in Features/Connections/.

--- a/src/Modules/XFramework.Community/Community.Domain.Shared/Contracts/CommunityNotification.cs
+++ b/src/Modules/XFramework.Community/Community.Domain.Shared/Contracts/CommunityNotification.cs
@@ -1,6 +1,16 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace Community.Domain.Shared.Contracts;
 
 [MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Both,
+    Actions = EndpointActions.ReadOnly,
+    RoutePrefix = "api/community-notifications",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "community-notifications"
+)]
 public partial class CommunityNotification : BaseModel
 {
     [MemoryPackOrder(0)]
@@ -29,4 +39,14 @@ public partial class CommunityNotification : BaseModel
 
     [MemoryPackOrder(8)]
     public virtual CommunityContent? Content { get; set; }
+}
+
+public class GetCommunityNotificationListRequest
+{
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
+    public Guid? RecipientIdentityId { get; set; }
+    public Guid? ActorIdentityId { get; set; }
+    public bool? IsRead { get; set; }
+    public string? Type { get; set; }
 }

--- a/src/Modules/XFramework.Community/Community.Domain.Shared/Contracts/Requests/GetCommunityConnectionListRequest.cs
+++ b/src/Modules/XFramework.Community/Community.Domain.Shared/Contracts/Requests/GetCommunityConnectionListRequest.cs
@@ -10,6 +10,8 @@ public partial record GetCommunityConnectionListRequest : RequestBase,
     IQuery<TResponse>,
     IBoltRequest<TRequest, TResponse>
 {
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
     public Guid ConnectionTypeId { get; set; }
     public Guid CommunityIdentityId { get; set; }
     public int Limit { get; set; } = 20;

--- a/src/Modules/XFramework.Community/Community.Integration/Community.Integration.csproj
+++ b/src/Modules/XFramework.Community/Community.Integration/Community.Integration.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackageId>XFramework.Community.Integration</PackageId>
+        <Version>$(XFrameworkVersion)</Version>
+        <Description>XFramework Community service wrapper for cross-module Bolt RPC calls.</Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\SourceGenerators\XFramework.SourceGenerators\XFramework.SourceGenerators.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
+        <ProjectReference Include="..\Community.Domain.Shared\Community.Domain.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Modules/XFramework.Community/Community.Integration/Drivers/CommunityServiceWrapper.cs
+++ b/src/Modules/XFramework.Community/Community.Integration/Drivers/CommunityServiceWrapper.cs
@@ -1,0 +1,3 @@
+// Custom Bolt wrapper methods and data-context wrapper registrations are source-generated
+// from IBoltRequest and GenerateEndpoints types in Community.Domain.Shared.
+// See ServiceWrapperGenerator.

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Product.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Product.cs
@@ -1,25 +1,55 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-using XFramework.Domain.Shared.Contracts.Base;
-
-public class Product : BaseModel, IProduct
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/products",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-products"
+)]
+public partial class Product : BaseModel, IProduct
 {
+    [MemoryPackOrder(0)]
     public string? Name { get; set; }
+    [MemoryPackOrder(1)]
     public string? Description { get; set; }
+    [MemoryPackOrder(2)]
     public decimal Price { get; set; }
+    [MemoryPackOrder(3)]
     public int StockQuantity { get; set; }
+    [MemoryPackOrder(4)]
     public Guid CategoryId { get; set; }
+    [MemoryPackOrder(5)]
     public ProductCategory? Category { get; set; }
+    [MemoryPackOrder(6)]
     public List<ProductVariation>? Variations { get; set; } = new();
+    [MemoryPackOrder(7)]
     public List<ProductTransaction>? Transactions { get; set; } = new();
+    [MemoryPackOrder(8)]
     public string? Image { get; set; }
+    [MemoryPackOrder(9)]
     public string? SKU { get; set; }
+    [MemoryPackOrder(10)]
     public string? Brand { get; set; }
+    [MemoryPackOrder(11)]
     public decimal? Weight { get; set; }
+    [MemoryPackOrder(12)]
+    [MemoryPackIgnore]
     public (string Length, string Width, string Height)? Dimensions { get; set; }
+    [MemoryPackOrder(13)]
+    [MemoryPackIgnore]
     public List<string>? Tags { get; set; } = new();
+    [MemoryPackOrder(14)]
     public decimal? Rating { get; set; }
+    [MemoryPackOrder(15)]
+    [MemoryPackIgnore]
     public List<string>? Reviews { get; set; } = new();
+    [MemoryPackOrder(16)]
     public decimal? Discount { get; set; }
+    [MemoryPackOrder(17)]
     public bool IsAvailable { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductCategory.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductCategory.cs
@@ -1,10 +1,22 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-using XFramework.Domain.Shared.Contracts.Base;
-
-public class ProductCategory : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/product-categories",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-product-categories"
+)]
+public partial class ProductCategory : BaseModel
 {
+    [MemoryPackOrder(0)]
     public string? Name { get; set; }
+    [MemoryPackOrder(1)]
     public string? Description { get; set; }
+    [MemoryPackOrder(2)]
     public List<Product>? Products { get; set; } = new();
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductTransaction.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductTransaction.cs
@@ -1,12 +1,26 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-using XFramework.Domain.Shared.Contracts.Base;
-
-public class ProductTransaction : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/product-transactions",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-product-transactions"
+)]
+public partial class ProductTransaction : BaseModel
 {
+    [MemoryPackOrder(0)]
     public Guid ProductId { get; set; }
+    [MemoryPackOrder(1)]
     public Product? Product { get; set; }
+    [MemoryPackOrder(2)]
     public int Quantity { get; set; }
+    [MemoryPackOrder(3)]
     public decimal TotalPrice { get; set; }
+    [MemoryPackOrder(4)]
     public DateTime TransactionDate { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductVariation.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductVariation.cs
@@ -1,11 +1,24 @@
+using XFramework.Domain.Shared.Attributes;
+
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-using XFramework.Domain.Shared.Contracts.Base;
-
-public class ProductVariation : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/product-variations",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-product-variations"
+)]
+public partial class ProductVariation : BaseModel
 {
+    [MemoryPackOrder(0)]
     public string? Name { get; set; }
+    [MemoryPackOrder(1)]
     public decimal AdditionalPrice { get; set; }
+    [MemoryPackOrder(2)]
     public Guid ProductId { get; set; }
+    [MemoryPackOrder(3)]
     public Product? Product { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/GlobalUsings.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using MemoryPack;
+global using XFramework.Domain.Shared.Contracts.Base;

--- a/src/Modules/XFramework.Inventario/Inventario.Integration/Drivers/InventarioServiceWrapper.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Integration/Drivers/InventarioServiceWrapper.cs
@@ -1,0 +1,2 @@
+// CRUD and IDataContext wrapper members are source-generated from Inventario.Domain.Shared
+// [GenerateEndpoints] contracts. See ServiceWrapperGenerator.

--- a/src/Modules/XFramework.Inventario/Inventario.Integration/Inventario.Integration.csproj
+++ b/src/Modules/XFramework.Inventario/Inventario.Integration/Inventario.Integration.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackageId>XFramework.Inventario.Integration</PackageId>
+        <Version>$(XFrameworkVersion)</Version>
+        <Description>XFramework Inventario service wrapper for ControlPanel and cross-module Bolt RPC calls.</Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\SourceGenerators\XFramework.SourceGenerators\XFramework.SourceGenerators.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
+        <ProjectReference Include="..\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -1,3 +1,6 @@
+@implements IDisposable
+@inject TenantModuleNavigationService ModuleNavigation
+
 @* Dashboard *@
 <div class="space-y-1">
     <NavLink href="/" Match="NavLinkMatch.All"
@@ -24,6 +27,28 @@
     </div>
 </div>
 
+@if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario))
+{
+    @* Inventario *@
+    <div class="mt-4">
+        <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Inventario</p>
+        <div class="space-y-0.5">
+            <NavLink href="/inventario/products" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="package" class="h-4 w-4" /> Products
+            </NavLink>
+            <NavLink href="/inventario/categories" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="folders" class="h-4 w-4" /> Categories
+            </NavLink>
+            <NavLink href="/inventario/transactions" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="arrow-left-right" class="h-4 w-4" /> Transactions
+            </NavLink>
+            <NavLink href="/inventario/settings" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="settings" class="h-4 w-4" /> Settings
+            </NavLink>
+        </div>
+    </div>
+}
+
 @* Finance *@
 <div class="mt-4">
     <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Finance</p>
@@ -33,6 +58,25 @@
         </NavLink>
     </div>
 </div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        ModuleNavigation.Initialize();
+        ModuleNavigation.OnChanged += OnModuleNavigationChanged;
+        await ModuleNavigation.EnsureLoadedAsync();
+    }
+
+    private void OnModuleNavigationChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        ModuleNavigation.OnChanged -= OnModuleNavigationChanged;
+    }
+}
 
 @* System *@
 <div class="mt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -68,6 +68,31 @@
     </div>
 }
 
+@if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Community))
+{
+    @* Community *@
+    <div class="mt-4">
+        <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Community</p>
+        <div class="space-y-0.5">
+            <NavLink href="/community/identities" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="user-round" class="h-4 w-4" /> Identities
+            </NavLink>
+            <NavLink href="/community/content" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="newspaper" class="h-4 w-4" /> Content
+            </NavLink>
+            <NavLink href="/community/connections" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="network" class="h-4 w-4" /> Connections
+            </NavLink>
+            <NavLink href="/community/notifications" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="bell" class="h-4 w-4" /> Notifications
+            </NavLink>
+            <NavLink href="/community/settings" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="settings" class="h-4 w-4" /> Settings
+            </NavLink>
+        </div>
+    </div>
+}
+
 @* Finance *@
 <div class="mt-4">
     <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Finance</p>

--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -49,6 +49,25 @@
     </div>
 }
 
+@if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.MessagingChat))
+{
+    @* Messaging *@
+    <div class="mt-4">
+        <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Messaging</p>
+        <div class="space-y-0.5">
+            <NavLink href="/messaging/threads" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="messages-square" class="h-4 w-4" /> Threads
+            </NavLink>
+            <NavLink href="/messaging/direct-messages" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="send" class="h-4 w-4" /> Direct Messages
+            </NavLink>
+            <NavLink href="/messaging/settings" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                <LucideIcon Name="settings" class="h-4 w-4" /> Settings
+            </NavLink>
+        </div>
+    </div>
+}
+
 @* Finance *@
 <div class="mt-4">
     <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Finance</p>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Community/Connections.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Community/Connections.razor
@@ -1,0 +1,304 @@
+@page "/community/connections"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Community Connections - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_access.HasTenant)
+{
+    <BbAlert>
+        <BbAlertTitle>Select a Tenant</BbAlertTitle>
+        <BbAlertDescription>Choose a tenant in the sidebar to review Community connections.</BbAlertDescription>
+    </BbAlert>
+}
+else if (!_access.CanUseCommunity)
+{
+    <BbAlert Variant="AlertVariant.Warning">
+        <BbAlertTitle>Community Module Disabled</BbAlertTitle>
+        <BbAlertDescription>Enable the Community module for this tenant before reviewing connections.</BbAlertDescription>
+    </BbAlert>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Community Connections</BbTypographyH3>
+                    <BbTypographyMuted>@_access.TenantName - relationship moderation overview</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Total</BbCardTitle><BbCardDescription>Loaded connections</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_items.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Enabled</BbCardTitle><BbCardDescription>Active relationships</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_enabledCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Disabled</BbCardTitle><BbCardDescription>Moderated relationships</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_disabledCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Types</BbCardTitle><BbCardDescription>Connection categories</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_typeNames.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                        <div>
+                            <BbCardTitle>Connections</BbCardTitle>
+                            <BbCardDescription>@FilteredItems.Count connection(s)</BbCardDescription>
+                        </div>
+                        <div class="grid w-full gap-2 md:w-auto md:grid-cols-[18rem_14rem_12rem]">
+                            <BbFormFieldInput TValue="string" @bind-Value="_search" Label="Search" Placeholder="Source or target identity" />
+                            <BbFormFieldSelect TValue="string" @bind-Value="_typeFilter" Label="Type">
+                                <BbSelectItem Value="@("all")">All types</BbSelectItem>
+                                @foreach (var type in _typeNames.OrderBy(x => x.Value))
+                                {
+                                    <BbSelectItem Value="@type.Key.ToString()">@type.Value</BbSelectItem>
+                                }
+                            </BbFormFieldSelect>
+                            <BbFormFieldSelect TValue="string" @bind-Value="_enabledFilter" Label="Status">
+                                <BbSelectItem Value="@("all")">All</BbSelectItem>
+                                <BbSelectItem Value="@("enabled")">Enabled</BbSelectItem>
+                                <BbSelectItem Value="@("disabled")">Disabled</BbSelectItem>
+                            </BbFormFieldSelect>
+                        </div>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@FilteredItems" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Source">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost"
+                                              OnClick="@(() => Navigation.NavigateTo($"/community/identities/{item.SourceSocialMediaIdentityId}"))">
+                                        @GetIdentityLabel(item.SourceSocialMediaIdentityId)
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Target">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost"
+                                              OnClick="@(() => Navigation.NavigateTo($"/community/identities/{item.TargetSocialMediaIdentityId}"))">
+                                        @GetIdentityLabel(item.TargetSocialMediaIdentityId)
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Type">
+                                <ChildContent Context="item">@(item.Type?.Name ?? GetTypeName(item.TypeId))</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Enabled">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")"
+                                                 Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              OnClick="@(() => ToggleEnabled(item))">
+                                        <LucideIcon Name="@(item.IsEnabled ? "ban" : "check")" class="h-4 w-4" />
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private CommunityControlPanelAccessService AccessService { get; set; } = default!;
+
+    private CommunityControlPanelAccessState _access = new(null, null, false, null);
+    private List<CommunityConnection> _items = [];
+    private Dictionary<Guid, string> _identityLabels = [];
+    private Dictionary<Guid, string> _typeNames = [];
+    private bool _loading = true;
+    private string _search = "";
+    private string _typeFilter = "all";
+    private string _enabledFilter = "all";
+    private int _enabledCount;
+    private int _disabledCount;
+
+    private List<CommunityConnection> FilteredItems
+    {
+        get
+        {
+            var items = _items.AsEnumerable();
+
+            if (Guid.TryParse(_typeFilter, out var typeId))
+            {
+                items = items.Where(x => x.TypeId == typeId);
+            }
+
+            if (_enabledFilter == "enabled")
+            {
+                items = items.Where(x => x.IsEnabled);
+            }
+            else if (_enabledFilter == "disabled")
+            {
+                items = items.Where(x => !x.IsEnabled);
+            }
+
+            if (!string.IsNullOrWhiteSpace(_search))
+            {
+                var search = _search.Trim();
+                items = items.Where(x =>
+                    Contains(GetIdentityLabel(x.SourceSocialMediaIdentityId), search) ||
+                    Contains(GetIdentityLabel(x.TargetSocialMediaIdentityId), search));
+            }
+
+            return items.ToList();
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        try
+        {
+            _access = await AccessService.GetStateAsync();
+            _items = [];
+            _identityLabels = [];
+            _typeNames = [];
+
+            if (!_access.CanUseCommunity || _access.TenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            _items = await DataContext.Query<CommunityConnection>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(500)
+                .ToListAsync();
+
+            var identities = await DataContext.Query<CommunityIdentity>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Take(500)
+                .ToListAsync();
+            _identityLabels = identities.ToDictionary(x => x.Id, BuildIdentityLabel);
+
+            var types = await DataContext.Query<CommunityConnectionType>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .OrderBy(x => x.Name)
+                .Take(100)
+                .ToListAsync();
+            _typeNames = types.ToDictionary(x => x.Id, x => x.Name);
+
+            _enabledCount = _items.Count(x => x.IsEnabled);
+            _disabledCount = _items.Count(x => !x.IsEnabled);
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Community connections: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task ToggleEnabled(CommunityConnection item)
+    {
+        try
+        {
+            var fresh = await DataContext.Query<CommunityConnection>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == item.Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null || fresh.TenantId != _access.TenantId)
+            {
+                ToastService.Show("Connection was not found in the selected tenant.");
+                return;
+            }
+
+            fresh.IsEnabled = !fresh.IsEnabled;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+
+            if (result.IsSuccess)
+            {
+                ToastService.Show(fresh.IsEnabled ? "Connection enabled." : "Connection disabled.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to update connection: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error updating connection: {ex.Message}");
+        }
+    }
+
+    private string GetIdentityLabel(Guid identityId) =>
+        _identityLabels.TryGetValue(identityId, out var label)
+            ? label
+            : $"{identityId.ToString()[..8]}...";
+
+    private string GetTypeName(Guid typeId) =>
+        _typeNames.TryGetValue(typeId, out var name)
+            ? name
+            : $"{typeId.ToString()[..8]}...";
+
+    private static string BuildIdentityLabel(CommunityIdentity identity) =>
+        identity.HandleName ?? identity.Alias ?? $"{identity.Id.ToString()[..8]}...";
+
+    private static bool Contains(string? value, string search) =>
+        value?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Community/Content.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Community/Content.razor
@@ -1,0 +1,325 @@
+@page "/community/content"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Community Content - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_access.HasTenant)
+{
+    <BbAlert>
+        <BbAlertTitle>Select a Tenant</BbAlertTitle>
+        <BbAlertDescription>Choose a tenant in the sidebar to review Community content.</BbAlertDescription>
+    </BbAlert>
+}
+else if (!_access.CanUseCommunity)
+{
+    <BbAlert Variant="AlertVariant.Warning">
+        <BbAlertTitle>Community Module Disabled</BbAlertTitle>
+        <BbAlertDescription>Enable the Community module for this tenant before reviewing content.</BbAlertDescription>
+    </BbAlert>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Community Content</BbTypographyH3>
+                    <BbTypographyMuted>@_access.TenantName - read and moderation overview</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Total</BbCardTitle><BbCardDescription>Loaded content</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_items.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Published</BbCardTitle><BbCardDescription>Enabled records</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_publishedCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Hidden</BbCardTitle><BbCardDescription>Disabled records</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_hiddenCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Comments</BbCardTitle><BbCardDescription>Has parent content</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_commentCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                        <div>
+                            <BbCardTitle>Content Records</BbCardTitle>
+                            <BbCardDescription>@FilteredItems.Count item(s)</BbCardDescription>
+                        </div>
+                        <div class="grid w-full gap-2 md:w-auto md:grid-cols-[18rem_12rem]">
+                            <BbFormFieldInput TValue="string" @bind-Value="_search" Label="Search" Placeholder="Title, body, or author" />
+                            <BbFormFieldSelect TValue="string" @bind-Value="_visibilityFilter" Label="Visibility">
+                                <BbSelectItem Value="@("all")">All</BbSelectItem>
+                                <BbSelectItem Value="@("visible")">Published</BbSelectItem>
+                                <BbSelectItem Value="@("hidden")">Hidden</BbSelectItem>
+                            </BbFormFieldSelect>
+                        </div>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@FilteredItems" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((CommunityContent item) => Navigation.NavigateTo($"/community/content/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Content" Sortable="true">
+                                <ChildContent Context="item">
+                                    <div>
+                                        <div class="font-medium">@(item.Title ?? Truncate(item.Text, 72))</div>
+                                        <div class="text-xs text-muted-foreground">@Truncate(item.Text, 96)</div>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Author">
+                                <ChildContent Context="item">@GetIdentityLabel(item.SocialMediaIdentityId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Type">
+                                <ChildContent Context="item">@(item.Type?.Name ?? GetTypeName(item.TypeId))</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Reactions">
+                                <ChildContent Context="item">@GetReactionCount(item.Id)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsEnabled ? "Published" : "Hidden")"
+                                                 Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <div class="flex items-center gap-1">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/community/content/{item.Id}"))">
+                                            <LucideIcon Name="eye" class="h-4 w-4" />
+                                        </BbButton>
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => ToggleEnabled(item))">
+                                            <LucideIcon Name="@(item.IsEnabled ? "eye-off" : "eye")" class="h-4 w-4" />
+                                        </BbButton>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private CommunityControlPanelAccessService AccessService { get; set; } = default!;
+
+    private CommunityControlPanelAccessState _access = new(null, null, false, null);
+    private List<CommunityContent> _items = [];
+    private Dictionary<Guid, string> _identityLabels = [];
+    private Dictionary<Guid, string> _typeNames = [];
+    private Dictionary<Guid, int> _reactionCounts = [];
+    private bool _loading = true;
+    private string _search = "";
+    private string _visibilityFilter = "all";
+    private int _publishedCount;
+    private int _hiddenCount;
+    private int _commentCount;
+
+    private List<CommunityContent> FilteredItems
+    {
+        get
+        {
+            var items = _items.AsEnumerable();
+
+            if (_visibilityFilter == "visible")
+            {
+                items = items.Where(x => x.IsEnabled);
+            }
+            else if (_visibilityFilter == "hidden")
+            {
+                items = items.Where(x => !x.IsEnabled);
+            }
+
+            if (!string.IsNullOrWhiteSpace(_search))
+            {
+                var search = _search.Trim();
+                items = items.Where(x =>
+                    Contains(x.Title, search) ||
+                    Contains(x.Text, search) ||
+                    Contains(GetIdentityLabel(x.SocialMediaIdentityId), search));
+            }
+
+            return items.ToList();
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        try
+        {
+            _access = await AccessService.GetStateAsync();
+            _items = [];
+            _identityLabels = [];
+            _typeNames = [];
+            _reactionCounts = [];
+
+            if (!_access.CanUseCommunity || _access.TenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            _items = await DataContext.Query<CommunityContent>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(250)
+                .ToListAsync();
+
+            var identities = await DataContext.Query<CommunityIdentity>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .OrderBy(x => x.HandleName)
+                .Take(500)
+                .ToListAsync();
+            _identityLabels = identities.ToDictionary(x => x.Id, BuildIdentityLabel);
+
+            var types = await DataContext.Query<CommunityContentType>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .OrderBy(x => x.Name)
+                .Take(100)
+                .ToListAsync();
+            _typeNames = types.ToDictionary(x => x.Id, x => x.Name);
+
+            var reactions = await DataContext.Query<CommunityContentReaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(1000)
+                .ToListAsync();
+            _reactionCounts = reactions
+                .GroupBy(x => x.ContentId)
+                .ToDictionary(x => x.Key, x => x.Count());
+
+            _publishedCount = _items.Count(x => x.IsEnabled);
+            _hiddenCount = _items.Count(x => !x.IsEnabled);
+            _commentCount = _items.Count(x => x.ParentContentId is not null);
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Community content: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task ToggleEnabled(CommunityContent item)
+    {
+        try
+        {
+            var fresh = await DataContext.Query<CommunityContent>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == item.Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null || fresh.TenantId != _access.TenantId)
+            {
+                ToastService.Show("Content was not found in the selected tenant.");
+                return;
+            }
+
+            fresh.IsEnabled = !fresh.IsEnabled;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+
+            if (result.IsSuccess)
+            {
+                ToastService.Show(fresh.IsEnabled ? "Content published." : "Content hidden.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to update content: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error updating content: {ex.Message}");
+        }
+    }
+
+    private int GetReactionCount(Guid contentId) =>
+        _reactionCounts.TryGetValue(contentId, out var count) ? count : 0;
+
+    private string GetIdentityLabel(Guid identityId) =>
+        _identityLabels.TryGetValue(identityId, out var label)
+            ? label
+            : $"{identityId.ToString()[..8]}...";
+
+    private string GetTypeName(Guid typeId) =>
+        _typeNames.TryGetValue(typeId, out var name) ? name : $"{typeId.ToString()[..8]}...";
+
+    private static string BuildIdentityLabel(CommunityIdentity identity) =>
+        identity.HandleName ?? identity.Alias ?? $"{identity.Id.ToString()[..8]}...";
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Untitled";
+        }
+
+        return value.Length <= maxLength ? value : $"{value[..maxLength]}...";
+    }
+
+    private static bool Contains(string? value, string search) =>
+        value?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Community/ContentDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Community/ContentDetail.razor
@@ -1,0 +1,439 @@
+@page "/community/content/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Community Content Detail - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_access.HasTenant)
+{
+    <BbAlert>
+        <BbAlertTitle>Select a Tenant</BbAlertTitle>
+        <BbAlertDescription>Choose a tenant in the sidebar to review this Community content.</BbAlertDescription>
+    </BbAlert>
+}
+else if (!_access.CanUseCommunity)
+{
+    <BbAlert Variant="AlertVariant.Warning">
+        <BbAlertTitle>Community Module Disabled</BbAlertTitle>
+        <BbAlertDescription>Enable the Community module for this tenant before reviewing content.</BbAlertDescription>
+    </BbAlert>
+}
+else if (_content is null)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@GoBack">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Content
+        </BbButton>
+        <BbAlert Variant="AlertVariant.Danger">
+            <BbAlertTitle>Content Not Found</BbAlertTitle>
+            <BbAlertDescription>No Community content was found for the selected tenant.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@GoBack">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Content
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Content Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to the content tenant to view this record.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div class="flex items-center gap-4">
+                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" OnClick="@GoBack">
+                        <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                    </BbButton>
+                    <div>
+                        <div class="flex flex-wrap items-center gap-2">
+                            <BbTypographyH3>@(_content.Title ?? "Untitled content")</BbTypographyH3>
+                            <StatusBadge Text="@(_content.IsEnabled ? "Published" : "Hidden")"
+                                         Status="@(_content.IsEnabled ? "active" : "inactive")" />
+                        </div>
+                        <BbTypographyMuted>ID: @_content.Id - Author: @GetIdentityLabel(_content.SocialMediaIdentityId)</BbTypographyMuted>
+                    </div>
+                </div>
+                <div class="flex items-center gap-2">
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ToggleEnabled">
+                        <LucideIcon Name="@(_content.IsEnabled ? "eye-off" : "eye")" class="mr-2 h-4 w-4" />
+                        @(_content.IsEnabled ? "Hide" : "Publish")
+                    </BbButton>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Reactions</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_reactions.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Files</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_files.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Comments</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_comments.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Type</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyLarge>@(_content.Type?.Name ?? GetContentTypeName(_content.TypeId))</BbTypographyLarge></BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Content Body</BbCardTitle>
+                    <BbCardDescription>Read-only content text and ownership references</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Author</BbTypographyMuted>
+                            <BbTypographyLarge>@GetIdentityLabel(_content.SocialMediaIdentityId)</BbTypographyLarge>
+                        </div>
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Community Group</BbTypographyMuted>
+                            <BbTypographyLarge>@GetIdentityLabel(_content.CommunityGroupId)</BbTypographyLarge>
+                        </div>
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Parent Content</BbTypographyMuted>
+                            @if (_content.ParentContentId is Guid parentId)
+                            {
+                                <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo($"/community/content/{parentId}"))">
+                                    @parentId.ToString()[..8]...
+                                </BbButton>
+                            }
+                            else
+                            {
+                                <BbTypographyLarge>N/A</BbTypographyLarge>
+                            }
+                        </div>
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <BbTypographyLarge>@_content.CreatedAt.ToString("g")</BbTypographyLarge>
+                        </div>
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Modified</BbTypographyMuted>
+                            <BbTypographyLarge>@(_content.ModifiedAt?.ToString("g") ?? "N/A")</BbTypographyLarge>
+                        </div>
+                    </div>
+                    <div class="mt-6 space-y-2">
+                        <BbTypographyMuted>Text</BbTypographyMuted>
+                        <div class="rounded-md border border-border bg-muted/30 p-4 text-sm leading-6 whitespace-pre-wrap">
+                            @(_content.Text ?? "No text.")
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbTabs DefaultValue="reactions">
+                <BbTabsList>
+                    <BbTabsTrigger Value="reactions">Reactions (@_reactions.Count)</BbTabsTrigger>
+                    <BbTabsTrigger Value="files">Files (@_files.Count)</BbTabsTrigger>
+                    <BbTabsTrigger Value="comments">Comments (@_comments.Count)</BbTabsTrigger>
+                </BbTabsList>
+
+                <BbTabsContent Value="reactions" Class="xf-fade-in">
+                    <BbCard>
+                        <BbCardContent>
+                            <BbDataGrid Items="@_reactions" ShowPagination="true" InitialPageSize="10">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Identity">
+                                        <ChildContent Context="item">@GetIdentityLabel(item.SocialMediaIdentityId)</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Type">
+                                        <ChildContent Context="item">@(item.Type?.Name ?? GetReactionTypeName(item.TypeId))</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        </BbCardContent>
+                    </BbCard>
+                </BbTabsContent>
+
+                <BbTabsContent Value="files" Class="xf-fade-in">
+                    <BbCard>
+                        <BbCardContent>
+                            <BbDataGrid Items="@_files" ShowPagination="true" InitialPageSize="10">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Storage ID">
+                                        <ChildContent Context="item"><span class="font-mono text-xs">@item.StorageId</span></ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Enabled">
+                                        <ChildContent Context="item">
+                                            <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")"
+                                                         Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        </BbCardContent>
+                    </BbCard>
+                </BbTabsContent>
+
+                <BbTabsContent Value="comments" Class="xf-fade-in">
+                    <BbCard>
+                        <BbCardContent>
+                            <BbDataGrid Items="@_comments" ShowPagination="true" InitialPageSize="10"
+                                        OnRowClick="@((CommunityContent item) => Navigation.NavigateTo($"/community/content/{item.Id}"))"
+                                        Class="cursor-pointer">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Comment">
+                                        <ChildContent Context="item">@(item.Title ?? Truncate(item.Text, 90))</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Author">
+                                        <ChildContent Context="item">@GetIdentityLabel(item.SocialMediaIdentityId)</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Enabled">
+                                        <ChildContent Context="item">
+                                            <StatusBadge Text="@(item.IsEnabled ? "Published" : "Hidden")"
+                                                         Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        </BbCardContent>
+                    </BbCard>
+                </BbTabsContent>
+            </BbTabs>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private CommunityControlPanelAccessService AccessService { get; set; } = default!;
+
+    private CommunityControlPanelAccessState _access = new(null, null, false, null);
+    private CommunityContent? _content;
+    private List<CommunityContentReaction> _reactions = [];
+    private List<CommunityContentFile> _files = [];
+    private List<CommunityContent> _comments = [];
+    private Dictionary<Guid, string> _identityLabels = [];
+    private Dictionary<Guid, string> _contentTypeNames = [];
+    private Dictionary<Guid, string> _reactionTypeNames = [];
+    private bool _loading = true;
+    private bool _outsideTenantContext;
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!_loading)
+        {
+            await LoadData();
+        }
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        try
+        {
+            _access = await AccessService.GetStateAsync();
+            ClearData();
+
+            if (!_access.CanUseCommunity || _access.TenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            _content = await DataContext.Query<CommunityContent>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _content is not null && _content.TenantId != tenantId;
+            if (_content is null || _outsideTenantContext)
+            {
+                return;
+            }
+
+            await LoadLookups(tenantId);
+
+            _reactions = await DataContext.Query<CommunityContentReaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId && x.ContentId == Id)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+
+            _files = await DataContext.Query<CommunityContentFile>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.ContentId == Id)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+
+            _comments = await DataContext.Query<CommunityContent>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.ParentContentId == Id)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Community content: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task LoadLookups(Guid tenantId)
+    {
+        var identities = await DataContext.Query<CommunityIdentity>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Take(500)
+            .ToListAsync();
+        _identityLabels = identities.ToDictionary(x => x.Id, BuildIdentityLabel);
+
+        var contentTypes = await DataContext.Query<CommunityContentType>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Take(100)
+            .ToListAsync();
+        _contentTypeNames = contentTypes.ToDictionary(x => x.Id, x => x.Name);
+
+        var reactionTypes = await DataContext.Query<CommunityContentReactionType>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Take(100)
+            .ToListAsync();
+        _reactionTypeNames = reactionTypes.ToDictionary(x => x.Id, x => x.Name);
+    }
+
+    private async Task ToggleEnabled()
+    {
+        if (_content is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var fresh = await DataContext.Query<CommunityContent>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null || fresh.TenantId != _access.TenantId)
+            {
+                ToastService.Show("Content was not found in the selected tenant.");
+                return;
+            }
+
+            fresh.IsEnabled = !fresh.IsEnabled;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+
+            if (result.IsSuccess)
+            {
+                ToastService.Show(fresh.IsEnabled ? "Content published." : "Content hidden.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to update content: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error updating content: {ex.Message}");
+        }
+    }
+
+    private void ClearData()
+    {
+        _content = null;
+        _reactions = [];
+        _files = [];
+        _comments = [];
+        _identityLabels = [];
+        _contentTypeNames = [];
+        _reactionTypeNames = [];
+        _outsideTenantContext = false;
+    }
+
+    private void GoBack() => Navigation.NavigateTo("/community/content");
+
+    private string GetIdentityLabel(Guid identityId) =>
+        _identityLabels.TryGetValue(identityId, out var label)
+            ? label
+            : $"{identityId.ToString()[..8]}...";
+
+    private string GetContentTypeName(Guid typeId) =>
+        _contentTypeNames.TryGetValue(typeId, out var name) ? name : $"{typeId.ToString()[..8]}...";
+
+    private string GetReactionTypeName(Guid typeId) =>
+        _reactionTypeNames.TryGetValue(typeId, out var name) ? name : $"{typeId.ToString()[..8]}...";
+
+    private static string BuildIdentityLabel(CommunityIdentity identity) =>
+        identity.HandleName ?? identity.Alias ?? $"{identity.Id.ToString()[..8]}...";
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Untitled";
+        }
+
+        return value.Length <= maxLength ? value : $"{value[..maxLength]}...";
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Community/Identities.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Community/Identities.razor
@@ -1,0 +1,344 @@
+@page "/community/identities"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Community Identities - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_access.HasTenant)
+{
+    <BbAlert>
+        <BbAlertTitle>Select a Tenant</BbAlertTitle>
+        <BbAlertDescription>Choose a tenant in the sidebar to review Community identities.</BbAlertDescription>
+    </BbAlert>
+}
+else if (!_access.CanUseCommunity)
+{
+    <BbAlert Variant="AlertVariant.Warning">
+        <BbAlertTitle>Community Module Disabled</BbAlertTitle>
+        <BbAlertDescription>Enable the Community module for this tenant before reviewing identities.</BbAlertDescription>
+    </BbAlert>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Community Identities</BbTypographyH3>
+                    <BbTypographyMuted>@_access.TenantName - admin moderation overview</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Total</BbCardTitle>
+                        <BbCardDescription>Loaded identities</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_items.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Active</BbCardTitle>
+                        <BbCardDescription>Status is active</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_activeCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Suspended</BbCardTitle>
+                        <BbCardDescription>Status is suspended</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_suspendedCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Disabled</BbCardTitle>
+                        <BbCardDescription>Moderation disabled</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_disabledCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                        <div>
+                            <BbCardTitle>Identity Records</BbCardTitle>
+                            <BbCardDescription>@FilteredItems.Count identity record(s)</BbCardDescription>
+                        </div>
+                        <div class="grid w-full gap-2 md:w-auto md:grid-cols-[18rem_12rem]">
+                            <BbFormFieldInput TValue="string"
+                                              @bind-Value="_search"
+                                              Label="Search"
+                                              Placeholder="Handle, alias, or credential" />
+                            <BbFormFieldSelect TValue="string"
+                                               @bind-Value="_statusFilter"
+                                               Label="Status"
+                                               Placeholder="All statuses">
+                                <BbSelectItem Value="@("all")">All statuses</BbSelectItem>
+                                @foreach (var status in Enum.GetValues<CommunityIdentityStatus>())
+                                {
+                                    var statusValue = ((int)status).ToString();
+                                    <BbSelectItem Value="@statusValue">@status.ToString()</BbSelectItem>
+                                }
+                            </BbFormFieldSelect>
+                        </div>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@FilteredItems" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((CommunityIdentity item) => Navigation.NavigateTo($"/community/identities/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Identity" Sortable="true">
+                                <ChildContent Context="item">
+                                    <div>
+                                        <div class="font-medium">@(item.HandleName ?? item.Alias ?? "Unnamed identity")</div>
+                                        <div class="text-xs text-muted-foreground">@GetCredentialLabel(item.CredentialId)</div>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Type">
+                                <ChildContent Context="item">@(item.Type?.Name ?? GetTypeName(item.TypeId))</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@GetIdentityStatusText(item.Status)" Status="@GetIdentityStatusKey(item.Status)" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Enabled">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")"
+                                                 Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.LastActive)" Title="Last Active" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <div class="flex items-center gap-1">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/community/identities/{item.Id}"))">
+                                            <LucideIcon Name="eye" class="h-4 w-4" />
+                                        </BbButton>
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => ToggleEnabled(item))">
+                                            <LucideIcon Name="@(item.IsEnabled ? "ban" : "check")" class="h-4 w-4" />
+                                        </BbButton>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private CommunityControlPanelAccessService AccessService { get; set; } = default!;
+
+    private CommunityControlPanelAccessState _access = new(null, null, false, null);
+    private List<CommunityIdentity> _items = [];
+    private Dictionary<Guid, string> _credentialLabels = [];
+    private Dictionary<Guid, string> _typeNames = [];
+    private bool _loading = true;
+    private string _search = "";
+    private string _statusFilter = "all";
+    private int _activeCount;
+    private int _suspendedCount;
+    private int _disabledCount;
+
+    private List<CommunityIdentity> FilteredItems
+    {
+        get
+        {
+            var items = _items.AsEnumerable();
+
+            if (int.TryParse(_statusFilter, out var status))
+            {
+                items = items.Where(x => x.Status == status);
+            }
+
+            if (!string.IsNullOrWhiteSpace(_search))
+            {
+                var search = _search.Trim();
+                items = items.Where(x =>
+                    Contains(x.HandleName, search) ||
+                    Contains(x.Alias, search) ||
+                    Contains(x.Tagline, search) ||
+                    Contains(GetCredentialLabel(x.CredentialId), search));
+            }
+
+            return items.ToList();
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        try
+        {
+            _access = await AccessService.GetStateAsync();
+            _items = [];
+            _credentialLabels = [];
+            _typeNames = [];
+
+            if (!_access.CanUseCommunity || _access.TenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            _items = await DataContext.Query<CommunityIdentity>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(250)
+                .ToListAsync();
+
+            var types = await DataContext.Query<CommunityIdentityType>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .OrderBy(x => x.Name)
+                .Take(100)
+                .ToListAsync();
+            _typeNames = types.ToDictionary(x => x.Id, x => x.Name);
+
+            var credentials = await DataContext.Query<IdentityCredential>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.IdentityInfo)
+                .Where(x => x.TenantId == tenantId)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(500)
+                .ToListAsync();
+            _credentialLabels = credentials.ToDictionary(x => x.Id, BuildCredentialLabel);
+
+            _activeCount = _items.Count(x => x.Status == (int)CommunityIdentityStatus.Active);
+            _suspendedCount = _items.Count(x => x.Status == (int)CommunityIdentityStatus.Suspended);
+            _disabledCount = _items.Count(x => !x.IsEnabled);
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Community identities: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task ToggleEnabled(CommunityIdentity item)
+    {
+        try
+        {
+            var fresh = await DataContext.Query<CommunityIdentity>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == item.Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null || fresh.TenantId != _access.TenantId)
+            {
+                ToastService.Show("Identity not found in the selected tenant.");
+                return;
+            }
+
+            fresh.IsEnabled = !fresh.IsEnabled;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+
+            if (result.IsSuccess)
+            {
+                ToastService.Show(fresh.IsEnabled ? "Identity enabled." : "Identity disabled.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to update identity: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error updating identity: {ex.Message}");
+        }
+    }
+
+    private string GetCredentialLabel(Guid credentialId) =>
+        _credentialLabels.TryGetValue(credentialId, out var label)
+            ? label
+            : $"{credentialId.ToString()[..8]}...";
+
+    private string GetTypeName(Guid typeId) =>
+        _typeNames.TryGetValue(typeId, out var name)
+            ? name
+            : $"{typeId.ToString()[..8]}...";
+
+    private static string BuildCredentialLabel(IdentityCredential credential)
+    {
+        var displayName = credential.IdentityInfo?.FullName;
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = credential.IdentityInfo?.IdentityName;
+        }
+
+        var username = credential.UserName ?? credential.UserAlias;
+        return string.IsNullOrWhiteSpace(username)
+            ? displayName ?? credential.Id.ToString()[..8]
+            : $"{displayName ?? "Credential"} ({username})";
+    }
+
+    private static string GetIdentityStatusText(int status) =>
+        Enum.IsDefined(typeof(CommunityIdentityStatus), status)
+            ? ((CommunityIdentityStatus)status).ToString()
+            : status.ToString();
+
+    private static string GetIdentityStatusKey(int status) => (CommunityIdentityStatus)status switch
+    {
+        CommunityIdentityStatus.Active => "active",
+        CommunityIdentityStatus.Suspended => "suspended",
+        CommunityIdentityStatus.Inactive => "inactive",
+        _ => "inactive"
+    };
+
+    private static bool Contains(string? value, string search) =>
+        value?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Community/IdentityDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Community/IdentityDetail.razor
@@ -1,0 +1,584 @@
+@page "/community/identities/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Community Identity Detail - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_access.HasTenant)
+{
+    <BbAlert>
+        <BbAlertTitle>Select a Tenant</BbAlertTitle>
+        <BbAlertDescription>Choose a tenant in the sidebar to review this Community identity.</BbAlertDescription>
+    </BbAlert>
+}
+else if (!_access.CanUseCommunity)
+{
+    <BbAlert Variant="AlertVariant.Warning">
+        <BbAlertTitle>Community Module Disabled</BbAlertTitle>
+        <BbAlertDescription>Enable the Community module for this tenant before reviewing identities.</BbAlertDescription>
+    </BbAlert>
+}
+else if (_identity is null)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@GoBack">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Identities
+        </BbButton>
+        <BbAlert Variant="AlertVariant.Danger">
+            <BbAlertTitle>Identity Not Found</BbAlertTitle>
+            <BbAlertDescription>No Community identity was found for the selected tenant.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@GoBack">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Identities
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Identity Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to the identity's tenant to view this record.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div class="flex items-center gap-4">
+                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" OnClick="@GoBack">
+                        <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                    </BbButton>
+                    <div>
+                        <div class="flex flex-wrap items-center gap-2">
+                            <BbTypographyH3>@(_identity.HandleName ?? _identity.Alias ?? "Unnamed identity")</BbTypographyH3>
+                            <StatusBadge Text="@GetIdentityStatusText(_identity.Status)" Status="@GetIdentityStatusKey(_identity.Status)" />
+                            <StatusBadge Text="@(_identity.IsEnabled ? "Enabled" : "Disabled")"
+                                         Status="@(_identity.IsEnabled ? "active" : "inactive")" />
+                        </div>
+                        <BbTypographyMuted>ID: @_identity.Id - Credential: @GetCredentialLabel(_identity.CredentialId)</BbTypographyMuted>
+                    </div>
+                </div>
+                <div class="flex items-center gap-2">
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ToggleEnabled">
+                        <LucideIcon Name="@(_identity.IsEnabled ? "ban" : "check")" class="mr-2 h-4 w-4" />
+                        @(_identity.IsEnabled ? "Disable" : "Enable")
+                    </BbButton>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Content</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_content.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Followers</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_followers</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Following</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_following</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Reactions</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_reactions.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Identity Summary</BbCardTitle>
+                    <BbCardDescription>Read-only owner data with admin moderation controls</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Handle</BbTypographyMuted>
+                            <BbTypographyLarge>@(_identity.HandleName ?? "N/A")</BbTypographyLarge>
+                        </div>
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Alias</BbTypographyMuted>
+                            <BbTypographyLarge>@(_identity.Alias ?? "N/A")</BbTypographyLarge>
+                        </div>
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Type</BbTypographyMuted>
+                            <BbTypographyLarge>@(_identity.Type?.Name ?? GetTypeName(_identity.TypeId))</BbTypographyLarge>
+                        </div>
+                        <div class="space-y-1 md:col-span-2">
+                            <BbTypographyMuted>Tagline</BbTypographyMuted>
+                            <BbTypographyP>@(_identity.Tagline ?? "N/A")</BbTypographyP>
+                        </div>
+                        <div class="space-y-1">
+                            <BbTypographyMuted>Last Active</BbTypographyMuted>
+                            <BbTypographyLarge>@FormatDate(_identity.LastActive)</BbTypographyLarge>
+                        </div>
+                    </div>
+
+                    <div class="mt-6 grid gap-3 md:grid-cols-[16rem_auto] md:items-end">
+                        <BbFormFieldSelect TValue="string" @bind-Value="_statusEdit" Label="Moderation Status">
+                            @foreach (var status in Enum.GetValues<CommunityIdentityStatus>())
+                            {
+                                var statusValue = ((int)status).ToString();
+                                <BbSelectItem Value="@statusValue">@status.ToString()</BbSelectItem>
+                            }
+                        </BbFormFieldSelect>
+                        <div>
+                            <BbButton OnClick="@SaveStatus" Disabled="@_savingStatus">
+                                @if (_savingStatus)
+                                {
+                                    <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                                }
+                                Save Status
+                            </BbButton>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbTabs DefaultValue="content">
+                <BbTabsList>
+                    <BbTabsTrigger Value="content">Content (@_content.Count)</BbTabsTrigger>
+                    <BbTabsTrigger Value="connections">Connections (@_connections.Count)</BbTabsTrigger>
+                    <BbTabsTrigger Value="reactions">Reactions (@_reactions.Count)</BbTabsTrigger>
+                </BbTabsList>
+
+                <BbTabsContent Value="content" Class="xf-fade-in">
+                    <BbCard>
+                        <BbCardHeader><BbCardTitle>Recent Content</BbCardTitle></BbCardHeader>
+                        <BbCardContent>
+                            <BbDataGrid Items="@_content" ShowPagination="true" InitialPageSize="10"
+                                        OnRowClick="@((CommunityContent item) => Navigation.NavigateTo($"/community/content/{item.Id}"))"
+                                        Class="cursor-pointer">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Title">
+                                        <ChildContent Context="item">@(item.Title ?? Truncate(item.Text, 60))</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Type">
+                                        <ChildContent Context="item">@(item.Type?.Name ?? GetContentTypeName(item.TypeId))</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Enabled">
+                                        <ChildContent Context="item">
+                                            <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Hidden")"
+                                                         Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        </BbCardContent>
+                    </BbCard>
+                </BbTabsContent>
+
+                <BbTabsContent Value="connections" Class="xf-fade-in">
+                    <BbCard>
+                        <BbCardHeader><BbCardTitle>Recent Connections</BbCardTitle></BbCardHeader>
+                        <BbCardContent>
+                            <BbDataGrid Items="@_connections" ShowPagination="true" InitialPageSize="10">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Source">
+                                        <ChildContent Context="item">@GetIdentityLabel(item.SourceSocialMediaIdentityId)</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Target">
+                                        <ChildContent Context="item">@GetIdentityLabel(item.TargetSocialMediaIdentityId)</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Type">
+                                        <ChildContent Context="item">@(item.Type?.Name ?? GetConnectionTypeName(item.TypeId))</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        </BbCardContent>
+                    </BbCard>
+                </BbTabsContent>
+
+                <BbTabsContent Value="reactions" Class="xf-fade-in">
+                    <BbCard>
+                        <BbCardHeader><BbCardTitle>Recent Reactions</BbCardTitle></BbCardHeader>
+                        <BbCardContent>
+                            <BbDataGrid Items="@_reactions" ShowPagination="true" InitialPageSize="10">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Content">
+                                        <ChildContent Context="item">
+                                            <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo($"/community/content/{item.ContentId}"))">
+                                                @item.ContentId.ToString()[..8]...
+                                            </BbButton>
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Type">
+                                        <ChildContent Context="item">@(item.Type?.Name ?? item.TypeId.ToString()[..8])</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        </BbCardContent>
+                    </BbCard>
+                </BbTabsContent>
+            </BbTabs>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private CommunityControlPanelAccessService AccessService { get; set; } = default!;
+
+    private CommunityControlPanelAccessState _access = new(null, null, false, null);
+    private CommunityIdentity? _identity;
+    private List<CommunityContent> _content = [];
+    private List<CommunityConnection> _connections = [];
+    private List<CommunityContentReaction> _reactions = [];
+    private Dictionary<Guid, string> _identityLabels = [];
+    private Dictionary<Guid, string> _credentialLabels = [];
+    private Dictionary<Guid, string> _typeNames = [];
+    private Dictionary<Guid, string> _contentTypeNames = [];
+    private Dictionary<Guid, string> _connectionTypeNames = [];
+    private bool _loading = true;
+    private bool _outsideTenantContext;
+    private bool _savingStatus;
+    private string _statusEdit = "";
+    private int _followers;
+    private int _following;
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!_loading)
+        {
+            await LoadData();
+        }
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        try
+        {
+            _access = await AccessService.GetStateAsync();
+            ClearData();
+
+            if (!_access.CanUseCommunity || _access.TenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            _identity = await DataContext.Query<CommunityIdentity>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _identity is not null && _identity.TenantId != tenantId;
+            if (_identity is null || _outsideTenantContext)
+            {
+                return;
+            }
+
+            _statusEdit = _identity.Status.ToString();
+
+            await LoadLookups(tenantId);
+
+            _content = await DataContext.Query<CommunityContent>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId && x.SocialMediaIdentityId == Id)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+
+            var outgoingConnections = await DataContext.Query<CommunityConnection>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId && x.SourceSocialMediaIdentityId == Id)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+
+            var incomingConnections = await DataContext.Query<CommunityConnection>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId && x.TargetSocialMediaIdentityId == Id)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+
+            _connections = outgoingConnections
+                .Concat(incomingConnections)
+                .GroupBy(x => x.Id)
+                .Select(x => x.First())
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToList();
+
+            _reactions = await DataContext.Query<CommunityContentReaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId && x.SocialMediaIdentityId == Id)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+
+            _followers = _connections.Count(x => x.TargetSocialMediaIdentityId == Id);
+            _following = _connections.Count(x => x.SourceSocialMediaIdentityId == Id);
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Community identity: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task LoadLookups(Guid tenantId)
+    {
+        var identities = await DataContext.Query<CommunityIdentity>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .OrderBy(x => x.HandleName)
+            .Take(500)
+            .ToListAsync();
+        _identityLabels = identities.ToDictionary(x => x.Id, BuildIdentityLabel);
+
+        var credentials = await DataContext.Query<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Include(x => x.IdentityInfo)
+            .Where(x => x.TenantId == tenantId)
+            .Take(500)
+            .ToListAsync();
+        _credentialLabels = credentials.ToDictionary(x => x.Id, BuildCredentialLabel);
+
+        var identityTypes = await DataContext.Query<CommunityIdentityType>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Take(100)
+            .ToListAsync();
+        _typeNames = identityTypes.ToDictionary(x => x.Id, x => x.Name);
+
+        var contentTypes = await DataContext.Query<CommunityContentType>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Take(100)
+            .ToListAsync();
+        _contentTypeNames = contentTypes.ToDictionary(x => x.Id, x => x.Name);
+
+        var connectionTypes = await DataContext.Query<CommunityConnectionType>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Take(100)
+            .ToListAsync();
+        _connectionTypeNames = connectionTypes.ToDictionary(x => x.Id, x => x.Name);
+    }
+
+    private async Task ToggleEnabled()
+    {
+        if (_identity is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var fresh = await DataContext.Query<CommunityIdentity>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null || fresh.TenantId != _access.TenantId)
+            {
+                ToastService.Show("Identity not found in the selected tenant.");
+                return;
+            }
+
+            fresh.IsEnabled = !fresh.IsEnabled;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+
+            if (result.IsSuccess)
+            {
+                ToastService.Show(fresh.IsEnabled ? "Identity enabled." : "Identity disabled.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to update identity: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error updating identity: {ex.Message}");
+        }
+    }
+
+    private async Task SaveStatus()
+    {
+        if (!int.TryParse(_statusEdit, out var status))
+        {
+            ToastService.Show("Choose a valid status.");
+            return;
+        }
+
+        _savingStatus = true;
+        try
+        {
+            var fresh = await DataContext.Query<CommunityIdentity>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null || fresh.TenantId != _access.TenantId)
+            {
+                ToastService.Show("Identity not found in the selected tenant.");
+                return;
+            }
+
+            fresh.Status = status;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+
+            if (result.IsSuccess)
+            {
+                ToastService.Show("Identity status updated.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to update status: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error updating status: {ex.Message}");
+        }
+        finally
+        {
+            _savingStatus = false;
+        }
+    }
+
+    private void ClearData()
+    {
+        _identity = null;
+        _content = [];
+        _connections = [];
+        _reactions = [];
+        _identityLabels = [];
+        _credentialLabels = [];
+        _typeNames = [];
+        _contentTypeNames = [];
+        _connectionTypeNames = [];
+        _outsideTenantContext = false;
+        _followers = 0;
+        _following = 0;
+    }
+
+    private void GoBack() => Navigation.NavigateTo("/community/identities");
+
+    private string GetCredentialLabel(Guid credentialId) =>
+        _credentialLabels.TryGetValue(credentialId, out var label)
+            ? label
+            : $"{credentialId.ToString()[..8]}...";
+
+    private string GetIdentityLabel(Guid identityId) =>
+        _identityLabels.TryGetValue(identityId, out var label)
+            ? label
+            : $"{identityId.ToString()[..8]}...";
+
+    private string GetTypeName(Guid typeId) =>
+        _typeNames.TryGetValue(typeId, out var name) ? name : $"{typeId.ToString()[..8]}...";
+
+    private string GetContentTypeName(Guid typeId) =>
+        _contentTypeNames.TryGetValue(typeId, out var name) ? name : $"{typeId.ToString()[..8]}...";
+
+    private string GetConnectionTypeName(Guid typeId) =>
+        _connectionTypeNames.TryGetValue(typeId, out var name) ? name : $"{typeId.ToString()[..8]}...";
+
+    private static string BuildIdentityLabel(CommunityIdentity identity) =>
+        identity.HandleName ?? identity.Alias ?? $"{identity.Id.ToString()[..8]}...";
+
+    private static string BuildCredentialLabel(IdentityCredential credential)
+    {
+        var name = credential.IdentityInfo?.FullName ?? credential.IdentityInfo?.IdentityName;
+        var username = credential.UserName ?? credential.UserAlias;
+        return string.IsNullOrWhiteSpace(username)
+            ? name ?? credential.Id.ToString()[..8]
+            : $"{name ?? "Credential"} ({username})";
+    }
+
+    private static string GetIdentityStatusText(int status) =>
+        Enum.IsDefined(typeof(CommunityIdentityStatus), status)
+            ? ((CommunityIdentityStatus)status).ToString()
+            : status.ToString();
+
+    private static string GetIdentityStatusKey(int status) => (CommunityIdentityStatus)status switch
+    {
+        CommunityIdentityStatus.Active => "active",
+        CommunityIdentityStatus.Suspended => "suspended",
+        CommunityIdentityStatus.Inactive => "inactive",
+        _ => "inactive"
+    };
+
+    private static string FormatDate(DateTime value) =>
+        value == default ? "Never" : value.ToString("g");
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Untitled";
+        }
+
+        return value.Length <= maxLength ? value : $"{value[..maxLength]}...";
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Community/Notifications.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Community/Notifications.razor
@@ -1,0 +1,328 @@
+@page "/community/notifications"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Community Notifications - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_access.HasTenant)
+{
+    <BbAlert>
+        <BbAlertTitle>Select a Tenant</BbAlertTitle>
+        <BbAlertDescription>Choose a tenant in the sidebar to review Community notifications.</BbAlertDescription>
+    </BbAlert>
+}
+else if (!_access.CanUseCommunity)
+{
+    <BbAlert Variant="AlertVariant.Warning">
+        <BbAlertTitle>Community Module Disabled</BbAlertTitle>
+        <BbAlertDescription>Enable the Community module for this tenant before reviewing notifications.</BbAlertDescription>
+    </BbAlert>
+}
+else if (!_access.CanUseNotifications)
+{
+    <BbAlert Variant="AlertVariant.Warning">
+        <BbAlertTitle>Notifications Module Disabled</BbAlertTitle>
+        <BbAlertDescription>Enable the Notifications module for this tenant before reviewing Community notifications.</BbAlertDescription>
+    </BbAlert>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Community Notifications</BbTypographyH3>
+                    <BbTypographyMuted>@_access.TenantName - notification delivery and read-state overview</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Total</BbCardTitle><BbCardDescription>Loaded notifications</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_items.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Unread</BbCardTitle><BbCardDescription>Recipient has not read</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_unreadCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Read</BbCardTitle><BbCardDescription>Recipient read state</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_readCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Disabled</BbCardTitle><BbCardDescription>Moderated records</BbCardDescription></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_disabledCount</BbTypographyH2></BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                        <div>
+                            <BbCardTitle>Notifications</BbCardTitle>
+                            <BbCardDescription>@FilteredItems.Count notification(s)</BbCardDescription>
+                        </div>
+                        <div class="grid w-full gap-2 md:w-auto md:grid-cols-[18rem_12rem_12rem]">
+                            <BbFormFieldInput TValue="string" @bind-Value="_search" Label="Search" Placeholder="Message or identity" />
+                            <BbFormFieldSelect TValue="string" @bind-Value="_readFilter" Label="Read State">
+                                <BbSelectItem Value="@("all")">All</BbSelectItem>
+                                <BbSelectItem Value="@("unread")">Unread</BbSelectItem>
+                                <BbSelectItem Value="@("read")">Read</BbSelectItem>
+                            </BbFormFieldSelect>
+                            <BbFormFieldSelect TValue="string" @bind-Value="_enabledFilter" Label="Status">
+                                <BbSelectItem Value="@("all")">All</BbSelectItem>
+                                <BbSelectItem Value="@("enabled")">Enabled</BbSelectItem>
+                                <BbSelectItem Value="@("disabled")">Disabled</BbSelectItem>
+                            </BbFormFieldSelect>
+                        </div>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@FilteredItems" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Recipient">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost"
+                                              OnClick="@(() => Navigation.NavigateTo($"/community/identities/{item.RecipientIdentityId}"))">
+                                        @GetIdentityLabel(item.RecipientIdentityId)
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Actor">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost"
+                                              OnClick="@(() => Navigation.NavigateTo($"/community/identities/{item.ActorIdentityId}"))">
+                                        @GetIdentityLabel(item.ActorIdentityId)
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Type">
+                                <ChildContent Context="item">@(item.Type ?? "N/A")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Message">
+                                <ChildContent Context="item">@Truncate(item.Message, 96)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Read">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsRead ? "Read" : "Unread")"
+                                                 Status="@(item.IsRead ? "active" : "pending")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Enabled">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")"
+                                                 Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <div class="flex items-center gap-1">
+                                        @if (item.ContentId is Guid contentId)
+                                        {
+                                            <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                      OnClick="@(() => Navigation.NavigateTo($"/community/content/{contentId}"))">
+                                                <LucideIcon Name="file-text" class="h-4 w-4" />
+                                            </BbButton>
+                                        }
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => ToggleEnabled(item))">
+                                            <LucideIcon Name="@(item.IsEnabled ? "ban" : "check")" class="h-4 w-4" />
+                                        </BbButton>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private CommunityControlPanelAccessService AccessService { get; set; } = default!;
+
+    private CommunityControlPanelAccessState _access = new(null, null, false, null);
+    private List<CommunityNotification> _items = [];
+    private Dictionary<Guid, string> _identityLabels = [];
+    private bool _loading = true;
+    private string _search = "";
+    private string _readFilter = "all";
+    private string _enabledFilter = "all";
+    private int _unreadCount;
+    private int _readCount;
+    private int _disabledCount;
+
+    private List<CommunityNotification> FilteredItems
+    {
+        get
+        {
+            var items = _items.AsEnumerable();
+
+            if (_readFilter == "read")
+            {
+                items = items.Where(x => x.IsRead);
+            }
+            else if (_readFilter == "unread")
+            {
+                items = items.Where(x => !x.IsRead);
+            }
+
+            if (_enabledFilter == "enabled")
+            {
+                items = items.Where(x => x.IsEnabled);
+            }
+            else if (_enabledFilter == "disabled")
+            {
+                items = items.Where(x => !x.IsEnabled);
+            }
+
+            if (!string.IsNullOrWhiteSpace(_search))
+            {
+                var search = _search.Trim();
+                items = items.Where(x =>
+                    Contains(x.Message, search) ||
+                    Contains(x.Type, search) ||
+                    Contains(GetIdentityLabel(x.RecipientIdentityId), search) ||
+                    Contains(GetIdentityLabel(x.ActorIdentityId), search));
+            }
+
+            return items.ToList();
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        try
+        {
+            _access = await AccessService.GetStateAsync(includeNotifications: true);
+            _items = [];
+            _identityLabels = [];
+
+            if (!_access.CanUseNotifications || _access.TenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            _items = await DataContext.Query<CommunityNotification>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(500)
+                .ToListAsync();
+
+            var identities = await DataContext.Query<CommunityIdentity>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Take(500)
+                .ToListAsync();
+            _identityLabels = identities.ToDictionary(x => x.Id, BuildIdentityLabel);
+
+            _unreadCount = _items.Count(x => !x.IsRead);
+            _readCount = _items.Count(x => x.IsRead);
+            _disabledCount = _items.Count(x => !x.IsEnabled);
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Community notifications: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task ToggleEnabled(CommunityNotification item)
+    {
+        try
+        {
+            var fresh = await DataContext.Query<CommunityNotification>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == item.Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null || fresh.TenantId != _access.TenantId)
+            {
+                ToastService.Show("Notification was not found in the selected tenant.");
+                return;
+            }
+
+            fresh.IsEnabled = !fresh.IsEnabled;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+
+            if (result.IsSuccess)
+            {
+                ToastService.Show(fresh.IsEnabled ? "Notification enabled." : "Notification disabled.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to update notification: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error updating notification: {ex.Message}");
+        }
+    }
+
+    private string GetIdentityLabel(Guid identityId) =>
+        _identityLabels.TryGetValue(identityId, out var label)
+            ? label
+            : $"{identityId.ToString()[..8]}...";
+
+    private static string BuildIdentityLabel(CommunityIdentity identity) =>
+        identity.HandleName ?? identity.Alias ?? $"{identity.Id.ToString()[..8]}...";
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "N/A";
+        }
+
+        return value.Length <= maxLength ? value : $"{value[..maxLength]}...";
+    }
+
+    private static bool Contains(string? value, string search) =>
+        value?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Community/Settings.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Community/Settings.razor
@@ -1,0 +1,367 @@
+@page "/community/settings"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Community Settings - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_access.HasTenant)
+{
+    <BbAlert>
+        <BbAlertTitle>Select a Tenant</BbAlertTitle>
+        <BbAlertDescription>Choose a tenant in the sidebar to manage Community settings.</BbAlertDescription>
+    </BbAlert>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Community Settings</BbTypographyH3>
+                    <BbTypographyMuted>@_access.TenantName - registry-backed module configuration</BbTypographyMuted>
+                </div>
+                <div class="flex items-center gap-2">
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                    <BbButton OnClick="@SaveSettings" Disabled="@_saving">
+                        @if (_saving)
+                        {
+                            <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                        }
+                        Save Settings
+                    </BbButton>
+                </div>
+            </div>
+
+            @if (!_access.CanUseCommunity)
+            {
+                <BbAlert Variant="AlertVariant.Warning">
+                    <BbAlertTitle>Community Module Disabled</BbAlertTitle>
+                    <BbAlertDescription>These settings are stored for the selected tenant, but Community APIs remain gated until the tenant module feature is enabled.</BbAlertDescription>
+                </BbAlert>
+            }
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                        <div>
+                            <BbCardTitle>Registry Settings</BbCardTitle>
+                            <BbCardDescription>Keys are stored as tenant-scoped RegistryConfiguration records.</BbCardDescription>
+                        </div>
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@ResetFormToDefaults">
+                            <LucideIcon Name="rotate-ccw" class="mr-2 h-4 w-4" />
+                            Defaults
+                        </BbButton>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="space-y-5">
+                        @foreach (var row in _rows)
+                        {
+                            <div class="grid gap-3 border-b border-border pb-4 last:border-b-0 md:grid-cols-[minmax(12rem,1fr)_18rem_8rem] md:items-end">
+                                <div>
+                                    <div class="font-medium">@row.Definition.Label</div>
+                                    <div class="text-sm text-muted-foreground">@row.Definition.Description</div>
+                                    <div class="mt-1 font-mono text-xs text-muted-foreground">@row.Definition.Key</div>
+                                </div>
+                                @if (row.Definition.InputKind == CommunitySettingInputKind.Boolean)
+                                {
+                                    <BbFormFieldSelect TValue="string" @bind-Value="row.Value" Label="Value">
+                                        <BbSelectItem Value="@("true")">True</BbSelectItem>
+                                        <BbSelectItem Value="@("false")">False</BbSelectItem>
+                                    </BbFormFieldSelect>
+                                }
+                                else
+                                {
+                                    <BbFormFieldInput TValue="string" @bind-Value="row.Value" Label="Value" />
+                                }
+                                <div class="text-sm text-muted-foreground">
+                                    @(string.IsNullOrWhiteSpace(row.Definition.Unit) ? "Value" : row.Definition.Unit)
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Existing Community Registry Entries</BbCardTitle>
+                    <BbCardDescription>@_communityConfigs.Count stored key(s) with the community prefix</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_communityConfigs" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Key)" Title="Key" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Value)" Title="Value" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Unit)" Title="Unit" />
+                            <BbDataGridTemplateColumn Title="Enabled">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")"
+                                                 Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.ModifiedAt)" Title="Modified" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private CommunityControlPanelAccessService AccessService { get; set; } = default!;
+
+    private static readonly Guid CommunitySettingsGroupSystemReferenceId =
+        Guid.Parse("4e763322-b6c0-4609-8fd8-92f81425ccf0");
+
+    private static readonly IReadOnlyList<CommunitySettingDefinition> SettingDefinitions =
+    [
+        new("community.identities.allowPublicSearch", "Public identity search", "Allow community identities to appear in public search results.", "true", null, CommunitySettingInputKind.Boolean),
+        new("community.content.requireModeration", "Require content moderation", "Require new content to be reviewed before it is treated as published.", "false", null, CommunitySettingInputKind.Boolean),
+        new("community.content.maxTextLength", "Maximum content length", "Maximum text length accepted by Community content workflows.", "5000", "characters", CommunitySettingInputKind.Number),
+        new("community.content.maxFilesPerPost", "Maximum files per post", "Maximum number of files that may be attached to one content item.", "4", "files", CommunitySettingInputKind.Number),
+        new("community.connections.allowBlocking", "Allow blocking", "Allow identities to create block relationships.", "true", null, CommunitySettingInputKind.Boolean),
+        new("community.notifications.enabled", "Community notifications", "Enable notification creation for Community workflows.", "true", null, CommunitySettingInputKind.Boolean),
+        new("community.notifications.digestWindowMinutes", "Notification digest window", "Window used by digest-style notification aggregation.", "15", "minutes", CommunitySettingInputKind.Number)
+    ];
+
+    private CommunityControlPanelAccessState _access = new(null, null, false, null);
+    private List<CommunitySettingRow> _rows = [];
+    private List<RegistryConfiguration> _communityConfigs = [];
+    private bool _loading = true;
+    private bool _saving;
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        try
+        {
+            _access = await AccessService.GetStateAsync(includeNotifications: true);
+            _rows = [];
+            _communityConfigs = [];
+
+            if (_access.TenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            _communityConfigs = await DataContext.Query<RegistryConfiguration>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .OrderBy(x => x.Key)
+                .Take(500)
+                .ToListAsync();
+
+            _communityConfigs = _communityConfigs
+                .Where(x => x.Key.StartsWith("community.", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var configByKey = _communityConfigs.ToDictionary(x => x.Key, StringComparer.OrdinalIgnoreCase);
+            _rows = SettingDefinitions
+                .Select(definition =>
+                {
+                    configByKey.TryGetValue(definition.Key, out var config);
+                    return new CommunitySettingRow(definition, config?.Value ?? definition.DefaultValue);
+                })
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Community settings: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void ResetFormToDefaults()
+    {
+        foreach (var row in _rows)
+        {
+            row.Value = row.Definition.DefaultValue;
+        }
+    }
+
+    private async Task SaveSettings()
+    {
+        if (_access.TenantId is not Guid tenantId)
+        {
+            ToastService.Show("Select a tenant first.");
+            return;
+        }
+
+        if (!ValidateRows())
+        {
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var groupId = await EnsureCommunityGroupId(tenantId);
+            var existing = await DataContext.Query<RegistryConfiguration>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Take(500)
+                .ToListAsync();
+            var existingByKey = existing.ToDictionary(x => x.Key, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var row in _rows)
+            {
+                var value = string.IsNullOrWhiteSpace(row.Value)
+                    ? row.Definition.DefaultValue
+                    : row.Value.Trim();
+
+                if (existingByKey.TryGetValue(row.Definition.Key, out var config))
+                {
+                    config.Value = value;
+                    config.Unit = row.Definition.Unit;
+                    config.GroupId = groupId;
+                    config.IsEnabled = true;
+                    config.ModifiedAt = DateTime.UtcNow;
+                    DataContext.Update(config);
+                }
+                else
+                {
+                    DataContext.Add(new RegistryConfiguration
+                    {
+                        Id = Guid.NewGuid(),
+                        TenantId = tenantId,
+                        Key = row.Definition.Key,
+                        Value = value,
+                        Unit = row.Definition.Unit,
+                        GroupId = groupId,
+                        IsEnabled = true,
+                        CreatedAt = DateTime.UtcNow
+                    });
+                }
+            }
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show("Community settings saved.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to save settings: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving settings: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task<Guid> EnsureCommunityGroupId(Guid tenantId)
+    {
+        var group = await DataContext.Query<RegistryConfigurationGroup>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                x.SystemReferenceId == CommunitySettingsGroupSystemReferenceId &&
+                x.IsDeleted == false)
+            .FirstOrDefaultAsync();
+
+        if (group is not null)
+        {
+            return group.Id;
+        }
+
+        var groupId = Guid.NewGuid();
+        DataContext.Add(new RegistryConfigurationGroup
+        {
+            Id = groupId,
+            TenantId = tenantId,
+            Name = "Community",
+            Description = "Community control panel settings",
+            SystemReferenceId = CommunitySettingsGroupSystemReferenceId,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        return groupId;
+    }
+
+    private bool ValidateRows()
+    {
+        foreach (var row in _rows)
+        {
+            if (row.Definition.InputKind == CommunitySettingInputKind.Boolean &&
+                row.Value is not ("true" or "false"))
+            {
+                ToastService.Show($"{row.Definition.Label} must be true or false.");
+                return false;
+            }
+
+            if (row.Definition.InputKind == CommunitySettingInputKind.Number &&
+                (!int.TryParse(row.Value, out var value) || value < 0))
+            {
+                ToastService.Show($"{row.Definition.Label} must be a non-negative number.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+
+    private sealed record CommunitySettingDefinition(
+        string Key,
+        string Label,
+        string Description,
+        string DefaultValue,
+        string? Unit,
+        CommunitySettingInputKind InputKind);
+
+    private sealed class CommunitySettingRow(CommunitySettingDefinition definition, string value)
+    {
+        public CommunitySettingDefinition Definition { get; } = definition;
+        public string Value { get; set; } = value;
+    }
+
+    private enum CommunitySettingInputKind
+    {
+        Boolean,
+        Number
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
@@ -1,0 +1,277 @@
+@page "/inventario/categories"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Categories - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <BbTypographyH3>Product Categories</BbTypographyH3>
+                    <BbTypographyMuted>Manage catalog categories for the selected tenant.</BbTypographyMuted>
+                </div>
+                <BbButton OnClick="@OpenCreateDialog">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    Create Category
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Categories</BbCardTitle>
+                    <BbCardDescription>@_categories.Count category(s) loaded</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_categories" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" />
+                            <BbDataGridTemplateColumn Title="Products">
+                                <ChildContent Context="item">@GetProductCount(item.Id)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <div class="flex items-center gap-1">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => OpenEditDialog(item))">
+                                            <LucideIcon Name="pencil" class="h-4 w-4" />
+                                        </BbButton>
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => OpenDeleteDialog(item))">
+                                            <LucideIcon Name="trash-2" class="h-4 w-4" />
+                                        </BbButton>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_dialogOpen" OpenChanged="@(v => _dialogOpen = v)">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>@(_editingCategory is null ? "Create Category" : "Edit Category")</BbDialogTitle>
+            <BbDialogDescription>Categories organize products in this tenant.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <BbFormFieldInput TValue="string" @bind-Value="_name" Label="Name" Required="true" />
+            <BbFormFieldInput TValue="string" @bind-Value="_description" Label="Description" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _dialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@SaveCategory" Disabled="@_saving">@(_editingCategory is null ? "Create" : "Save")</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+<ConfirmDeleteDialog Open="@_deleteDialogOpen"
+                     OpenChanged="@(v => _deleteDialogOpen = v)"
+                     Message="@($"Delete category \"{_deletingCategory?.Name}\"? Products using this category will not be changed.")"
+                     OnConfirm="@DeleteCategory" />
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private List<ProductCategory> _categories = [];
+    private Dictionary<Guid, int> _productCounts = [];
+    private bool _loading = true;
+    private bool _saving;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private bool _dialogOpen;
+    private bool _deleteDialogOpen;
+    private ProductCategory? _editingCategory;
+    private ProductCategory? _deletingCategory;
+    private string _name = "";
+    private string _description = "";
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _categories = [];
+            _productCounts = [];
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _categories = await DataContext.Query<ProductCategory>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(200)
+                .ToListAsync();
+
+            var products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(1000)
+                .ToListAsync();
+            _productCounts = products.GroupBy(x => x.CategoryId).ToDictionary(x => x.Key, x => x.Count());
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load categories: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private int GetProductCount(Guid categoryId) =>
+        _productCounts.TryGetValue(categoryId, out var count) ? count : 0;
+
+    private void OpenCreateDialog()
+    {
+        _editingCategory = null;
+        _name = "";
+        _description = "";
+        _dialogOpen = true;
+    }
+
+    private void OpenEditDialog(ProductCategory category)
+    {
+        _editingCategory = category;
+        _name = category.Name ?? "";
+        _description = category.Description ?? "";
+        _dialogOpen = true;
+    }
+
+    private void OpenDeleteDialog(ProductCategory category)
+    {
+        _deletingCategory = category;
+        _deleteDialogOpen = true;
+    }
+
+    private async Task SaveCategory()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid tenantId) return;
+        if (string.IsNullOrWhiteSpace(_name))
+        {
+            ToastService.Show("Category name is required.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            if (_editingCategory is null)
+            {
+                DataContext.Add(new ProductCategory
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    Name = _name.Trim(),
+                    Description = string.IsNullOrWhiteSpace(_description) ? null : _description.Trim(),
+                    CreatedAt = DateTime.UtcNow,
+                    IsEnabled = true
+                });
+            }
+            else
+            {
+                var fresh = await DataContext.Query<ProductCategory>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.Id == _editingCategory.Id && x.TenantId == tenantId)
+                    .FirstOrDefaultAsync();
+                if (fresh is null)
+                {
+                    ToastService.Show("Category not found.");
+                    return;
+                }
+
+                fresh.Name = _name.Trim();
+                fresh.Description = string.IsNullOrWhiteSpace(_description) ? null : _description.Trim();
+                fresh.ModifiedAt = DateTime.UtcNow;
+                DataContext.Update(fresh);
+            }
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show(_editingCategory is null ? "Category created." : "Category updated.");
+                _dialogOpen = false;
+                await Reload();
+            }
+            else
+            {
+                ToastService.Show($"Failed to save category: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving category: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task DeleteCategory()
+    {
+        if (_deletingCategory is null) return;
+        try
+        {
+            _deletingCategory.IsDeleted = true;
+            _deletingCategory.IsEnabled = false;
+            _deletingCategory.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(_deletingCategory);
+            var result = await DataContext.SaveChangesAsync();
+            ToastService.Show(result.IsSuccess ? "Category deleted." : $"Failed: {result.Message}");
+            _deleteDialogOpen = false;
+            _deletingCategory = null;
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error deleting category: {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -1,0 +1,302 @@
+@page "/inventario/products/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Product - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Products
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Product Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this product's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_product is null)
+{
+    <BbTypographyMuted>Product not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <BbTypographyH3>@(_product.Name ?? "Unnamed Product")</BbTypographyH3>
+                        <StatusBadge Text="@(_product.IsAvailable ? "Available" : "Unavailable")"
+                                     Status="@(_product.IsAvailable ? "active" : "inactive")" />
+                    </div>
+                    <BbTypographyMuted>SKU: @(_product.SKU ?? "N/A") — Category: @(_product.Category?.Name ?? "Uncategorized")</BbTypographyMuted>
+                </div>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Product Summary</BbCardTitle>
+                    <BbCardDescription>Catalog and stock snapshot for this tenant.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Price</BbTypographyMuted><BbTypographyH3>@_product.Price.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
+                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Stock</BbTypographyMuted><BbTypographyH3>@_product.StockQuantity</BbTypographyH3></div></BbCardContent></BbCard>
+                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Variations</BbTypographyMuted><BbTypographyH3>@_variations.Count</BbTypographyH3></div></BbCardContent></BbCard>
+                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Transactions</BbTypographyMuted><BbTypographyH3>@_transactions.Count</BbTypographyH3></div></BbCardContent></BbCard>
+                    </div>
+                    <div class="mt-4 grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Description</BbTypographyMuted>
+                            <div>@(_product.Description ?? "No description")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Brand</BbTypographyMuted>
+                            <div>@(_product.Brand ?? "N/A")</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <BbCardTitle>Variations</BbCardTitle>
+                            <BbCardDescription>Optional product options and price adjustments.</BbCardDescription>
+                        </div>
+                        <BbButton Size="ButtonSize.Small" OnClick="@OpenVariationDialog">
+                            <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                            Add Variation
+                        </BbButton>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_variations" ShowPagination="true" InitialPageSize="10">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Additional Price">
+                                <ChildContent Context="item">@item.AdditionalPrice.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Transaction History</BbCardTitle>
+                    <BbCardDescription>Read-only product transaction history.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="10">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Quantity">
+                                <ChildContent Context="item">@item.Quantity</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Total">
+                                <ChildContent Context="item">@item.TotalPrice.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_variationDialogOpen" OpenChanged="@(v => _variationDialogOpen = v)">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>Add Variation</BbDialogTitle>
+            <BbDialogDescription>Add an option for this product.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <BbFormFieldInput TValue="string" @bind-Value="_variationName" Label="Name" Required="true" />
+            <BbFormFieldInput TValue="string" @bind-Value="_variationAdditionalPrice" Label="Additional Price" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _variationDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@SaveVariation" Disabled="@_saving">Create</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private Product? _product;
+    private List<ProductVariation> _variations = [];
+    private List<ProductTransaction> _transactions = [];
+    private bool _loading = true;
+    private bool _saving;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private bool _outsideTenantContext;
+    private bool _variationDialogOpen;
+    private string _variationName = "";
+    private string _variationAdditionalPrice = "0";
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged()
+    {
+        _ = InvokeAsync(Reload);
+    }
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _outsideTenantContext = false;
+            _product = null;
+            _variations = [];
+            _transactions = [];
+
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            _product = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Category)
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _product is not null && _product.TenantId != TenantFilter.SelectedTenantId;
+            if (_product is null || _outsideTenantContext) return;
+
+            _variations = await DataContext.Query<ProductVariation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.ProductId == Id && x.TenantId == _product.TenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(100)
+                .ToListAsync();
+
+            _transactions = await DataContext.Query<ProductTransaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.ProductId == Id && x.TenantId == _product.TenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.TransactionDate)
+                .Take(100)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load product: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OpenVariationDialog()
+    {
+        _variationName = "";
+        _variationAdditionalPrice = "0";
+        _variationDialogOpen = true;
+    }
+
+    private async Task SaveVariation()
+    {
+        if (_product is null) return;
+        if (string.IsNullOrWhiteSpace(_variationName))
+        {
+            ToastService.Show("Variation name is required.");
+            return;
+        }
+
+        if (!decimal.TryParse(_variationAdditionalPrice, out var additionalPrice))
+        {
+            ToastService.Show("Additional price must be a valid number.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            DataContext.Add(new ProductVariation
+            {
+                Id = Guid.NewGuid(),
+                TenantId = _product.TenantId,
+                ProductId = _product.Id,
+                Name = _variationName.Trim(),
+                AdditionalPrice = additionalPrice,
+                CreatedAt = DateTime.UtcNow,
+                IsEnabled = true
+            });
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show("Variation added.");
+                _variationDialogOpen = false;
+                await Reload();
+            }
+            else
+            {
+                ToastService.Show($"Failed to add variation: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error adding variation: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
@@ -1,0 +1,432 @@
+@page "/inventario/products"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Products - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Products</BbTypographyH3>
+                    <BbTypographyMuted>Manage the selected tenant's product catalog and stock snapshot.</BbTypographyMuted>
+                </div>
+                <BbButton OnClick="@OpenCreateDialog">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    Create Product
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Total Products</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_products.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Available</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_products.Count(x => x.IsAvailable)</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Low Stock</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_products.Count(x => x.StockQuantity <= _lowStockThreshold)</BbTypographyH2></BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardHeader><BbCardTitle>Categories</BbCardTitle></BbCardHeader>
+                    <BbCardContent><BbTypographyH2>@_categories.Count</BbTypographyH2></BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                        <div>
+                            <BbCardTitle>Product Catalog</BbCardTitle>
+                            <BbCardDescription>@_filteredProducts.Count product(s) shown</BbCardDescription>
+                        </div>
+                        <div class="flex flex-col gap-2 md:w-[28rem] md:flex-row">
+                            <BbInput @bind-Value="_search" Placeholder="Search products..." @oninput="OnSearchChanged" />
+                            <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                                Refresh
+                            </BbButton>
+                        </div>
+                    </div>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_filteredProducts" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((Product item) => Navigation.NavigateTo($"/inventario/products/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="SKU">
+                                <ChildContent Context="item">
+                                    <span class="font-mono text-xs">@(item.SKU ?? "N/A")</span>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Category">
+                                <ChildContent Context="item">@GetCategoryName(item.CategoryId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Price" Sortable="true">
+                                <ChildContent Context="item">@item.Price.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Stock" Sortable="true">
+                                <ChildContent Context="item">
+                                    <span class="@(item.StockQuantity <= _lowStockThreshold ? "font-semibold text-yellow-600" : "")">
+                                        @item.StockQuantity
+                                    </span>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsAvailable ? "Available" : "Unavailable")"
+                                                 Status="@(item.IsAvailable ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <div class="flex items-center gap-1">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/inventario/products/{item.Id}"))">
+                                            <LucideIcon Name="eye" class="h-4 w-4" />
+                                        </BbButton>
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => OpenEditDialog(item))">
+                                            <LucideIcon Name="pencil" class="h-4 w-4" />
+                                        </BbButton>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_productDialogOpen" OpenChanged="@(v => _productDialogOpen = v)">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>@(_editingProduct is null ? "Create Product" : "Edit Product")</BbDialogTitle>
+            <BbDialogDescription>Catalog data belongs to the selected tenant.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <BbFormFieldInput TValue="string" @bind-Value="_form.Name" Label="Name" Required="true" />
+            <BbFormFieldInput TValue="string" @bind-Value="_form.Sku" Label="SKU" />
+            <BbFormFieldSelect TValue="string" @bind-Value="_form.CategoryId" Label="Category" Placeholder="Select category">
+                @foreach (var category in _categories)
+                {
+                    <BbSelectItem Value="@category.Id.ToString()">@(category.Name ?? category.Id.ToString()[..8])</BbSelectItem>
+                }
+            </BbFormFieldSelect>
+            <div class="grid gap-4 md:grid-cols-3">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Price" Label="Price" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.StockQuantity" Label="Stock Quantity" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Brand" Label="Brand" />
+            </div>
+            <BbFormFieldInput TValue="string" @bind-Value="_form.Description" Label="Description" />
+            <BbFormFieldSwitch Checked="@_form.IsAvailable"
+                               CheckedChanged="@((bool value) => _form.IsAvailable = value)"
+                               Label="Available" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _productDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@SaveProduct" Disabled="@_saving">
+                @(_editingProduct is null ? "Create" : "Save")
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private readonly ProductForm _form = new();
+    private List<Product> _products = [];
+    private List<Product> _filteredProducts = [];
+    private List<ProductCategory> _categories = [];
+    private bool _loading = true;
+    private bool _saving;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private bool _productDialogOpen;
+    private Product? _editingProduct;
+    private string _search = "";
+    private int _lowStockThreshold = 5;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Reload();
+    }
+
+    private void OnTenantChanged()
+    {
+        _ = InvokeAsync(Reload);
+    }
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _products = [];
+            _categories = [];
+
+            if (!_hasTenant || !_moduleEnabled)
+            {
+                ApplySearch();
+                return;
+            }
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _categories = await DataContext.Query<ProductCategory>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(200)
+                .ToListAsync();
+
+            _products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(250)
+                .ToListAsync();
+
+            await LoadSettings();
+            ApplySearch();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load products: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task LoadSettings()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid tenantId) return;
+        var key = "Settings:Inventario:LowStockThreshold";
+        var config = await DataContext.Query<RegistryConfiguration>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && x.Key == key && !x.IsDeleted)
+            .FirstOrDefaultAsync();
+        if (int.TryParse(config?.Value, out var threshold) && threshold >= 0)
+        {
+            _lowStockThreshold = threshold;
+        }
+    }
+
+    private void OnSearchChanged(ChangeEventArgs args)
+    {
+        _search = args.Value?.ToString() ?? "";
+        ApplySearch();
+    }
+
+    private void ApplySearch()
+    {
+        var search = _search.Trim();
+        _filteredProducts = string.IsNullOrWhiteSpace(search)
+            ? _products
+            : _products.Where(x =>
+                    (x.Name?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || (x.SKU?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || (x.Brand?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || GetCategoryName(x.CategoryId).Contains(search, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+    }
+
+    private string GetCategoryName(Guid categoryId) =>
+        _categories.FirstOrDefault(x => x.Id == categoryId)?.Name ?? "Uncategorized";
+
+    private void OpenCreateDialog()
+    {
+        _editingProduct = null;
+        _form.Reset();
+        _form.IsAvailable = true;
+        _form.CategoryId = _categories.FirstOrDefault()?.Id.ToString() ?? "";
+        _productDialogOpen = true;
+    }
+
+    private void OpenEditDialog(Product product)
+    {
+        _editingProduct = product;
+        _form.Name = product.Name ?? "";
+        _form.Sku = product.SKU ?? "";
+        _form.CategoryId = product.CategoryId.ToString();
+        _form.Price = product.Price.ToString("0.##");
+        _form.StockQuantity = product.StockQuantity.ToString();
+        _form.Brand = product.Brand ?? "";
+        _form.Description = product.Description ?? "";
+        _form.IsAvailable = product.IsAvailable;
+        _productDialogOpen = true;
+    }
+
+    private async Task SaveProduct()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            ToastService.Show("Select a tenant before saving products.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_form.Name))
+        {
+            ToastService.Show("Product name is required.");
+            return;
+        }
+
+        if (!Guid.TryParse(_form.CategoryId, out var categoryId))
+        {
+            ToastService.Show("Select a category.");
+            return;
+        }
+
+        if (!decimal.TryParse(_form.Price, out var price) || price < 0)
+        {
+            ToastService.Show("Price must be a non-negative number.");
+            return;
+        }
+
+        if (!int.TryParse(_form.StockQuantity, out var quantity) || quantity < 0)
+        {
+            ToastService.Show("Stock quantity must be a non-negative whole number.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            if (_editingProduct is null)
+            {
+                DataContext.Add(new Product
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    Name = _form.Name.Trim(),
+                    SKU = NullIfEmpty(_form.Sku),
+                    CategoryId = categoryId,
+                    Price = price,
+                    StockQuantity = quantity,
+                    Brand = NullIfEmpty(_form.Brand),
+                    Description = NullIfEmpty(_form.Description),
+                    IsAvailable = _form.IsAvailable,
+                    CreatedAt = DateTime.UtcNow,
+                    IsEnabled = true
+                });
+            }
+            else
+            {
+                var fresh = await DataContext.Query<Product>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.Id == _editingProduct.Id && x.TenantId == tenantId)
+                    .FirstOrDefaultAsync();
+                if (fresh is null)
+                {
+                    ToastService.Show("Product not found.");
+                    return;
+                }
+
+                fresh.Name = _form.Name.Trim();
+                fresh.SKU = NullIfEmpty(_form.Sku);
+                fresh.CategoryId = categoryId;
+                fresh.Price = price;
+                fresh.StockQuantity = quantity;
+                fresh.Brand = NullIfEmpty(_form.Brand);
+                fresh.Description = NullIfEmpty(_form.Description);
+                fresh.IsAvailable = _form.IsAvailable;
+                fresh.ModifiedAt = DateTime.UtcNow;
+                DataContext.Update(fresh);
+            }
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show(_editingProduct is null ? "Product created." : "Product updated.");
+                _productDialogOpen = false;
+                await Reload();
+            }
+            else
+            {
+                ToastService.Show($"Failed to save product: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving product: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class ProductForm
+    {
+        public string Name { get; set; } = "";
+        public string Sku { get; set; } = "";
+        public string CategoryId { get; set; } = "";
+        public string Price { get; set; } = "0";
+        public string StockQuantity { get; set; } = "0";
+        public string Brand { get; set; } = "";
+        public string Description { get; set; } = "";
+        public bool IsAvailable { get; set; } = true;
+
+        public void Reset()
+        {
+            Name = "";
+            Sku = "";
+            CategoryId = "";
+            Price = "0";
+            StockQuantity = "0";
+            Brand = "";
+            Description = "";
+            IsAvailable = true;
+        }
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Settings.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Settings.razor
@@ -1,0 +1,235 @@
+@page "/inventario/settings"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Settings - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div>
+                <BbTypographyH3>Inventario Settings</BbTypographyH3>
+                <BbTypographyMuted>Tenant-level inventory settings stored as registry configuration.</BbTypographyMuted>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Catalog Behavior</BbCardTitle>
+                    <BbCardDescription>These settings are reserved for inventory workflows and future UI defaults.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <BbFormFieldInput TValue="string" @bind-Value="_lowStockThreshold" Label="Low Stock Threshold" />
+                        <BbFormFieldInput TValue="string" @bind-Value="_defaultCurrency" Label="Default Currency" />
+                        <BbFormFieldSwitch Checked="@_skuRequired"
+                                           CheckedChanged="@((bool value) => _skuRequired = value)"
+                                           Label="Require SKU" />
+                        <BbFormFieldSwitch Checked="@_allowNegativeStock"
+                                           CheckedChanged="@((bool value) => _allowNegativeStock = value)"
+                                           Label="Allow Negative Stock" />
+                    </div>
+                    <div class="mt-6 flex justify-end">
+                        <BbButton OnClick="@SaveSettings" Disabled="@_saving">
+                            @if (_saving)
+                            {
+                                <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                            }
+                            Save Settings
+                        </BbButton>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private const string LowStockThresholdKey = "Settings:Inventario:LowStockThreshold";
+    private const string DefaultCurrencyKey = "Settings:Inventario:DefaultCurrency";
+    private const string SkuRequiredKey = "Settings:Inventario:SkuRequired";
+    private const string AllowNegativeStockKey = "Settings:Inventario:AllowNegativeStock";
+
+    private bool _loading = true;
+    private bool _saving;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private Guid _settingsGroupId;
+    private string _lowStockThreshold = "5";
+    private string _defaultCurrency = "PHP";
+    private bool _skuRequired = true;
+    private bool _allowNegativeStock;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            _settingsGroupId = await EnsureSettingsGroup();
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            var configs = await DataContext.Query<RegistryConfiguration>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.Key.StartsWith("Settings:Inventario:"))
+                .Take(50)
+                .ToListAsync();
+
+            _lowStockThreshold = GetValue(configs, LowStockThresholdKey, "5");
+            _defaultCurrency = GetValue(configs, DefaultCurrencyKey, "PHP");
+            _skuRequired = bool.TryParse(GetValue(configs, SkuRequiredKey, "true"), out var skuRequired) && skuRequired;
+            _allowNegativeStock = bool.TryParse(GetValue(configs, AllowNegativeStockKey, "false"), out var allowNegative) && allowNegative;
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load Inventario settings: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task SaveSettings()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid tenantId) return;
+        if (!int.TryParse(_lowStockThreshold, out var threshold) || threshold < 0)
+        {
+            ToastService.Show("Low stock threshold must be a non-negative whole number.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            _settingsGroupId = _settingsGroupId == Guid.Empty ? await EnsureSettingsGroup() : _settingsGroupId;
+            await UpsertSetting(tenantId, LowStockThresholdKey, threshold.ToString(), "quantity");
+            await UpsertSetting(tenantId, DefaultCurrencyKey, _defaultCurrency.Trim(), "code");
+            await UpsertSetting(tenantId, SkuRequiredKey, _skuRequired.ToString(), "boolean");
+            await UpsertSetting(tenantId, AllowNegativeStockKey, _allowNegativeStock.ToString(), "boolean");
+
+            var result = await DataContext.SaveChangesAsync();
+            ToastService.Show(result.IsSuccess ? "Inventario settings saved." : $"Failed: {result.Message}");
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving Inventario settings: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task<Guid> EnsureSettingsGroup()
+    {
+        var groups = await DataContext.Query<RegistryConfigurationGroup>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => !x.IsDeleted)
+            .Take(100)
+            .ToListAsync();
+
+        var group = groups.FirstOrDefault(x =>
+                string.Equals(x.Name, "Inventario", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x.Name, "Settings", StringComparison.OrdinalIgnoreCase))
+            ?? groups.FirstOrDefault();
+
+        if (group is not null)
+        {
+            return group.Id;
+        }
+
+        var created = new RegistryConfigurationGroup
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
+            Name = "Inventario",
+            Description = "Inventario module settings",
+            SystemReferenceId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            IsEnabled = true
+        };
+        DataContext.Add(created);
+        var result = await DataContext.SaveChangesAsync();
+        if (!result.IsSuccess)
+        {
+            throw new InvalidOperationException(result.Message ?? "Unable to create settings group.");
+        }
+
+        return created.Id;
+    }
+
+    private async Task UpsertSetting(Guid tenantId, string key, string? value, string unit)
+    {
+        var config = await DataContext.Query<RegistryConfiguration>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && x.Key == key && !x.IsDeleted)
+            .FirstOrDefaultAsync();
+
+        if (config is null)
+        {
+            DataContext.Add(new RegistryConfiguration
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                GroupId = _settingsGroupId,
+                Key = key,
+                Value = value,
+                Unit = unit,
+                CreatedAt = DateTime.UtcNow,
+                IsEnabled = true
+            });
+        }
+        else
+        {
+            config.Value = value;
+            config.Unit = unit;
+            config.GroupId = _settingsGroupId;
+            config.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(config);
+        }
+    }
+
+    private static string GetValue(IEnumerable<RegistryConfiguration> configs, string key, string fallback) =>
+        configs.FirstOrDefault(x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase))?.Value ?? fallback;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
@@ -1,0 +1,129 @@
+@page "/inventario/transactions"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Transactions - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <BbTypographyH3>Inventory Transactions</BbTypographyH3>
+                    <BbTypographyMuted>Read-only stock and sales movement history for the selected tenant.</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Transactions</BbCardTitle>
+                    <BbCardDescription>@_transactions.Count transaction(s) loaded</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Quantity" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Total">
+                                <ChildContent Context="item">@item.TotalPrice.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private List<ProductTransaction> _transactions = [];
+    private Dictionary<Guid, string> _productNames = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _transactions = [];
+            _productNames = [];
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            var products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(1000)
+                .ToListAsync();
+            _productNames = products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]);
+
+            _transactions = await DataContext.Query<ProductTransaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.TransactionDate)
+                .Take(250)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load inventory transactions: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private string GetProductName(Guid productId) =>
+        _productNames.TryGetValue(productId, out var name) ? name : productId.ToString()[..8];
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/DirectMessages.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/DirectMessages.razor
@@ -1,0 +1,342 @@
+@page "/messaging/direct-messages"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Direct Messages - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (_guard is { IsEnabled: false })
+{
+    <div class="space-y-4">
+        <BbAlert Variant="@(_guard.HasSelectedTenant ? AlertVariant.Warning : AlertVariant.Info)">
+            <BbAlertTitle>@_guard.Title</BbAlertTitle>
+            <BbAlertDescription>@_guard.Description</BbAlertDescription>
+        </BbAlert>
+        @if (_guard.TenantId is Guid tenantId)
+        {
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => Navigation.NavigateTo($"/identity/tenants/{tenantId}/modules"))">
+                <LucideIcon Name="blocks" class="mr-2 h-4 w-4" />
+                Tenant Modules
+            </BbButton>
+        }
+    </div>
+}
+else
+{
+    <FadeInContent>
+    <div class="space-y-6">
+        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+                <BbTypographyH3>Direct Messages</BbTypographyH3>
+                <BbTypographyMuted>Outbound and inbound direct-message diagnostics for @(_guard?.TenantName ?? "selected tenant")</BbTypographyMuted>
+            </div>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
+
+        @if (_error is not null)
+        {
+            <BbAlert Variant="AlertVariant.Danger">
+                <BbAlertTitle>Messaging Query Error</BbAlertTitle>
+                <BbAlertDescription>@_error</BbAlertDescription>
+            </BbAlert>
+        }
+
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Direct Messages</BbCardTitle>
+                    <BbCardDescription>Total tenant records</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbTypographyH2>@_totalDirectMessages</BbTypographyH2>
+                </BbCardContent>
+            </BbCard>
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Queued</BbCardTitle>
+                    <BbCardDescription>Loaded sample in queue</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbTypographyH2>@_queuedCount</BbTypographyH2>
+                </BbCardContent>
+            </BbCard>
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Sent</BbCardTitle>
+                    <BbCardDescription>Loaded sample sent</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbTypographyH2>@_sentCount</BbTypographyH2>
+                </BbCardContent>
+            </BbCard>
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Failed</BbCardTitle>
+                    <BbCardDescription>Loaded sample failed or blocked</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbTypographyH2>@_failedCount</BbTypographyH2>
+                </BbCardContent>
+            </BbCard>
+        </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Recent Direct Messages</BbCardTitle>
+                <BbCardDescription>@_items.Count record(s) loaded. Message body is truncated for diagnostics.</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                @if (_items.Count == 0)
+                {
+                    <BbAlert Variant="AlertVariant.Info">No direct messages found for this tenant.</BbAlert>
+                }
+                else
+                {
+                    <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@item.Status.ToString()" Status="@GetStatusKey(item.Status)" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Transport">
+                                <ChildContent Context="item">
+                                    <BbBadge Variant="BadgeVariant.Outline">@item.MessageTransportType</BbBadge>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Intent">
+                                <ChildContent Context="item">
+                                    @(string.IsNullOrWhiteSpace(item.Intent) ? "N/A" : item.Intent)
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Subject">
+                                <ChildContent Context="item">
+                                    @(string.IsNullOrWhiteSpace(item.Subject) ? "N/A" : item.Subject)
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Sender">
+                                <ChildContent Context="item">
+                                    @GetParticipantLabel(item.Sender, item.ExternalSender, item.SenderId)
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Recipient">
+                                <ChildContent Context="item">
+                                    @GetParticipantLabel(item.Recipient, item.ExternalRecipient, item.RecipientId)
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Message">
+                                <ChildContent Context="item">
+                                    <span title="@item.Message">@Truncate(item.Message, 120)</span>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Sent">
+                                <ChildContent Context="item">
+                                    @(item.SentAt?.ToString("g") ?? "N/A")
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Received">
+                                <ChildContent Context="item">
+                                    @(item.ReceivedAt?.ToString("g") ?? "N/A")
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(item => item.CreatedAt)" Title="Created" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                }
+            </BbCardContent>
+        </BbCard>
+
+        <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Status Mix</BbCardTitle>
+                    <BbCardDescription>Counts from the loaded direct-message sample.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="space-y-2">
+                        @foreach (var statusGroup in _statusGroups)
+                        {
+                            <div class="flex items-center justify-between border-b py-2 last:border-b-0">
+                                <StatusBadge Text="@statusGroup.Status.ToString()" Status="@GetStatusKey(statusGroup.Status)" />
+                                <span class="font-semibold">@statusGroup.Count</span>
+                            </div>
+                        }
+                    </div>
+                </BbCardContent>
+            </BbCard>
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Transport Mix</BbCardTitle>
+                    <BbCardDescription>Counts from the loaded direct-message sample.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="space-y-2">
+                        @foreach (var transportGroup in _transportGroups)
+                        {
+                            <div class="flex items-center justify-between border-b py-2 last:border-b-0">
+                                <BbBadge Variant="BadgeVariant.Outline">@transportGroup.Transport</BbBadge>
+                                <span class="font-semibold">@transportGroup.Count</span>
+                            </div>
+                        }
+                    </div>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private MessagingControlPanelGuard Guard { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private MessagingControlPanelGuardResult? _guard;
+    private List<MessageDirect> _items = [];
+    private List<StatusGroup> _statusGroups = [];
+    private List<TransportGroup> _transportGroups = [];
+    private bool _loading = true;
+    private string? _error;
+    private int _totalDirectMessages;
+    private int _queuedCount;
+    private int _sentCount;
+    private int _failedCount;
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        _error = null;
+        _items = [];
+
+        try
+        {
+            _guard = await Guard.GetCurrentTenantStateAsync();
+            if (!_guard.IsEnabled || _guard.TenantId is not Guid tenantId)
+            {
+                ResetStats();
+                return;
+            }
+
+            _totalDirectMessages = await DirectMessageQuery(tenantId).CountAsync();
+
+            _items = await DirectMessageQuery(tenantId)
+                .Include(x => x.Type)
+                .Include(x => x.Sender)
+                .Include(x => x.Recipient)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(250)
+                .ToListAsync();
+
+            _queuedCount = _items.Count(x => x.Status is MessageStatus.Queued or MessageStatus.Processing or MessageStatus.Scheduled);
+            _sentCount = _items.Count(x => x.Status is MessageStatus.Sent or MessageStatus.Delivered);
+            _failedCount = _items.Count(x => x.Status is MessageStatus.Failed or MessageStatus.Blocked);
+
+            _statusGroups = _items
+                .GroupBy(x => x.Status)
+                .Select(group => new StatusGroup(group.Key, group.Count()))
+                .OrderByDescending(group => group.Count)
+                .ToList();
+
+            _transportGroups = _items
+                .GroupBy(x => x.MessageTransportType)
+                .Select(group => new TransportGroup(group.Key, group.Count()))
+                .OrderByDescending(group => group.Count)
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            ToastService.Show($"Failed to load direct messages: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private IRemoteQuery<MessageDirect> DirectMessageQuery(Guid tenantId) =>
+        DataContext.Query<MessageDirect>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Where(x => !x.IsDeleted);
+
+    private void ResetStats()
+    {
+        _totalDirectMessages = 0;
+        _queuedCount = 0;
+        _sentCount = 0;
+        _failedCount = 0;
+        _statusGroups = [];
+        _transportGroups = [];
+    }
+
+    private static string GetStatusKey(MessageStatus status) => status switch
+    {
+        MessageStatus.Queued or MessageStatus.Processing or MessageStatus.Scheduled => "pending",
+        MessageStatus.Sent or MessageStatus.Delivered => "active",
+        MessageStatus.Failed or MessageStatus.Blocked => "inactive",
+        _ => "inactive"
+    };
+
+    private static string GetParticipantLabel(
+        IdentityCredential? credential,
+        string? externalValue,
+        Guid? credentialId)
+    {
+        if (credential is not null)
+        {
+            return credential.UserName
+                ?? credential.UserAlias
+                ?? credential.Id.ToString()[..8];
+        }
+
+        if (!string.IsNullOrWhiteSpace(externalValue))
+        {
+            return externalValue;
+        }
+
+        return credentialId?.ToString()[..8] ?? "N/A";
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Empty message";
+        }
+
+        return value.Length <= maxLength ? value : $"{value[..maxLength]}...";
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+
+    private sealed record StatusGroup(MessageStatus Status, int Count);
+    private sealed record TransportGroup(MessageTransportType Transport, int Count);
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/Settings.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/Settings.razor
@@ -1,0 +1,501 @@
+@page "/messaging/settings"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Messaging Settings - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (_guard is { IsEnabled: false })
+{
+    <div class="space-y-4">
+        <BbAlert Variant="@(_guard.HasSelectedTenant ? AlertVariant.Warning : AlertVariant.Info)">
+            <BbAlertTitle>@_guard.Title</BbAlertTitle>
+            <BbAlertDescription>@_guard.Description</BbAlertDescription>
+        </BbAlert>
+        @if (_guard.TenantId is Guid tenantId)
+        {
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => Navigation.NavigateTo($"/identity/tenants/{tenantId}/modules"))">
+                <LucideIcon Name="blocks" class="mr-2 h-4 w-4" />
+                Tenant Modules
+            </BbButton>
+        }
+    </div>
+}
+else
+{
+    <FadeInContent>
+    <div class="space-y-6">
+        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+                <BbTypographyH3>Messaging Settings</BbTypographyH3>
+                <BbTypographyMuted>Tenant RegistryConfiguration values for @(_guard?.TenantName ?? "selected tenant")</BbTypographyMuted>
+            </div>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
+
+        @if (_error is not null)
+        {
+            <BbAlert Variant="AlertVariant.Danger">
+                <BbAlertTitle>Settings Query Error</BbAlertTitle>
+                <BbAlertDescription>@_error</BbAlertDescription>
+            </BbAlert>
+        }
+
+        <BbAlert Variant="AlertVariant.Info">
+            <BbAlertTitle>Registry Backed</BbAlertTitle>
+            <BbAlertDescription>Saving updates tenant RegistryConfiguration records only. Messaging thread and direct-message records are not changed from this page.</BbAlertDescription>
+        </BbAlert>
+
+        <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            @foreach (var row in _settings)
+            {
+                <BbCard>
+                    <BbCardHeader>
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <BbCardTitle>@row.Label</BbCardTitle>
+                                <BbCardDescription>@row.Description</BbCardDescription>
+                            </div>
+                            <StatusBadge Text="@(row.Exists ? "Stored" : "Default")"
+                                         Status="@(row.Exists ? "active" : "pending")" />
+                        </div>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <div class="space-y-4">
+                            <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+                                <div class="space-y-1">
+                                    <BbTypographyMuted>Group</BbTypographyMuted>
+                                    <div class="font-mono text-xs">@row.GroupName</div>
+                                </div>
+                                <div class="space-y-1">
+                                    <BbTypographyMuted>Key</BbTypographyMuted>
+                                    <div class="font-mono text-xs">@row.Key</div>
+                                </div>
+                            </div>
+
+                            <BbFormFieldTextarea Value="@row.Value"
+                                                 ValueChanged="@((string? value) => row.Value = value ?? string.Empty)"
+                                                 UpdateTiming="UpdateTiming.Immediate"
+                                                 Label="Value"
+                                                 Placeholder="@row.Placeholder" />
+
+                            <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+                                <BbFormFieldSwitch Checked="@row.IsEnabled"
+                                                   CheckedChanged="@((bool value) => row.IsEnabled = value)"
+                                                   Label="Enabled"
+                                                   Disabled="@row.IsSaving" />
+                                <div class="space-y-1">
+                                    <BbTypographyMuted>Unit</BbTypographyMuted>
+                                    <div class="font-mono text-xs">@(row.Unit ?? "N/A")</div>
+                                </div>
+                            </div>
+
+                            <div class="flex flex-col gap-3 border-t pt-3 md:flex-row md:items-center md:justify-between">
+                                <div class="text-xs text-muted-foreground">
+                                    Last updated: @(row.LastUpdated?.ToString("g") ?? "Not saved")
+                                </div>
+                                <BbButton OnClick="@(() => SaveSetting(row))" Disabled="@row.IsSaving">
+                                    @if (row.IsSaving)
+                                    {
+                                        <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                                    }
+                                    else
+                                    {
+                                        <LucideIcon Name="save" class="mr-2 h-4 w-4" />
+                                    }
+                                    Save
+                                </BbButton>
+                            </div>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            }
+        </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Loaded Registry Records</BbCardTitle>
+                <BbCardDescription>@_existingConfigs.Count matching messaging configuration record(s) found for this tenant.</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                @if (_existingConfigs.Count == 0)
+                {
+                    <BbAlert Variant="AlertVariant.Info">No matching messaging registry records are currently stored for this tenant.</BbAlert>
+                }
+                else
+                {
+                    <BbDataGrid Items="@_existingConfigs" ShowPagination="true" InitialPageSize="10">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(item => item.Key)" Title="Key" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Group">
+                                <ChildContent Context="item">
+                                    @(item.Group?.Name ?? item.GroupId.ToString()[..8])
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Value">
+                                <ChildContent Context="item">
+                                    @Truncate(item.Value, 120)
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(item => item.Unit)" Title="Unit" />
+                            <BbDataGridTemplateColumn Title="Enabled">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")"
+                                                 Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(item => item.ModifiedAt)" Title="Modified" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                }
+            </BbCardContent>
+        </BbCard>
+    </div>
+    </FadeInContent>
+}
+
+@code {
+    private static readonly IReadOnlyList<MessagingSettingDefinition> SettingDefinitions =
+    [
+        new(
+            "MessagingService_Otp",
+            "MessageTemplate",
+            "OTP Message Template",
+            "Template used when Identity sends one-time passwords through Messaging. Use |Value| for the generated code.",
+            "Your verification code is |Value|.",
+            "template",
+            MatchFirstConfigInGroup: true,
+            GroupSystemReferenceId: new Guid("b5e1da3f-c4ad-4dc2-9187-34f5781adf01")),
+        new(
+            "MessagingService_PasswordReset",
+            "MessageTemplate",
+            "Password Reset Template",
+            "Template used when Identity sends password reset tokens through Messaging. Use |Token| for the generated token.",
+            "Your password reset token is: |Token|. This token expires in 30 minutes.",
+            "template",
+            MatchFirstConfigInGroup: true,
+            GroupSystemReferenceId: new Guid("8dbef62d-f510-48ed-b970-76b51b9a5119")),
+        new(
+            "Messaging",
+            "DirectMessages.DefaultTransport",
+            "Default Direct Message Transport",
+            "Operational default recorded for direct-message diagnostics.",
+            MessageTransportType.Sms.ToString(),
+            "MessageTransportType",
+            MatchFirstConfigInGroup: false,
+            GroupSystemReferenceId: new Guid("651f06b1-b70e-4822-a638-06ad07b5307c")),
+        new(
+            "Messaging",
+            "Threads.DiagnosticsPageSize",
+            "Thread Diagnostics Page Size",
+            "Preferred diagnostic sample size for thread views.",
+            "100",
+            "count",
+            MatchFirstConfigInGroup: false,
+            GroupSystemReferenceId: new Guid("651f06b1-b70e-4822-a638-06ad07b5307c"))
+    ];
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private MessagingControlPanelGuard Guard { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private MessagingControlPanelGuardResult? _guard;
+    private List<MessagingSettingRow> _settings = [];
+    private List<RegistryConfiguration> _existingConfigs = [];
+    private bool _loading = true;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        _error = null;
+        _settings = [];
+        _existingConfigs = [];
+
+        try
+        {
+            _guard = await Guard.GetCurrentTenantStateAsync();
+            if (!_guard.IsEnabled || _guard.TenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            var groups = await DataContext.Query<RegistryConfigurationGroup>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(250)
+                .ToListAsync();
+
+            var groupNames = SettingDefinitions
+                .Select(x => x.GroupName)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var tenantConfigs = await DataContext.Query<RegistryConfiguration>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Group)
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => !x.IsDeleted)
+                .OrderBy(x => x.Key)
+                .Take(500)
+                .ToListAsync();
+
+            _existingConfigs = tenantConfigs
+                .Where(config => groupNames.Contains(GetGroupName(config, groups)))
+                .OrderBy(config => GetGroupName(config, groups))
+                .ThenBy(config => config.Key)
+                .ToList();
+
+            _settings = SettingDefinitions
+                .Select(definition =>
+                {
+                    var group = FindGroup(groups, definition.GroupName);
+                    var config = FindConfig(tenantConfigs, groups, definition);
+
+                    return new MessagingSettingRow(
+                        definition,
+                        config?.Id,
+                        config?.Key ?? definition.Key,
+                        config?.Value ?? definition.DefaultValue,
+                        config?.Unit ?? definition.Unit,
+                        config?.IsEnabled ?? true,
+                        config is not null,
+                        config?.ModifiedAt ?? config?.CreatedAt);
+                })
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            ToastService.Show($"Failed to load messaging settings: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task SaveSetting(MessagingSettingRow row)
+    {
+        if (_guard?.TenantId is not Guid tenantId)
+        {
+            ToastService.Show("Select a tenant before saving settings.");
+            return;
+        }
+
+        row.IsSaving = true;
+        try
+        {
+            var group = await DataContext.Query<RegistryConfigurationGroup>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Name == row.GroupName)
+                .FirstOrDefaultAsync();
+
+            if (group is null)
+            {
+                group = new RegistryConfigurationGroup
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    Name = row.GroupName,
+                    Description = $"Messaging control panel settings for {row.GroupName}.",
+                    SystemReferenceId = row.GroupSystemReferenceId,
+                    IsEnabled = true,
+                    CreatedAt = DateTime.UtcNow,
+                    ConcurrencyStamp = Guid.NewGuid()
+                };
+
+                DataContext.Add(group);
+            }
+
+            RegistryConfiguration? config = null;
+            if (row.ConfigId is Guid configId)
+            {
+                config = await DataContext.Query<RegistryConfiguration>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.Id == configId)
+                    .FirstOrDefaultAsync();
+            }
+
+            config ??= await DataContext.Query<RegistryConfiguration>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.GroupId == group.Id)
+                .Where(x => x.Key == row.Key)
+                .FirstOrDefaultAsync();
+
+            if (config is null && row.MatchFirstConfigInGroup)
+            {
+                config = await DataContext.Query<RegistryConfiguration>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId)
+                    .Where(x => x.GroupId == group.Id)
+                    .FirstOrDefaultAsync();
+            }
+
+            if (config is null)
+            {
+                config = new RegistryConfiguration
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    Key = row.Key,
+                    Value = row.Value,
+                    Unit = row.Unit,
+                    GroupId = group.Id,
+                    IsEnabled = row.IsEnabled,
+                    CreatedAt = DateTime.UtcNow,
+                    ConcurrencyStamp = Guid.NewGuid()
+                };
+
+                DataContext.Add(config);
+            }
+            else
+            {
+                config.Key = row.Key;
+                config.Value = row.Value;
+                config.Unit = row.Unit;
+                config.GroupId = group.Id;
+                config.IsEnabled = row.IsEnabled;
+                config.ModifiedAt = DateTime.UtcNow;
+                DataContext.Update(config);
+            }
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show($"{row.Label} saved.");
+                await LoadData();
+            }
+            else
+            {
+                ToastService.Show($"Failed to save {row.Label}: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving setting: {ex.Message}");
+        }
+        finally
+        {
+            row.IsSaving = false;
+        }
+    }
+
+    private static RegistryConfigurationGroup? FindGroup(
+        IEnumerable<RegistryConfigurationGroup> groups,
+        string groupName) =>
+        groups.FirstOrDefault(group =>
+            string.Equals(group.Name, groupName, StringComparison.OrdinalIgnoreCase));
+
+    private static RegistryConfiguration? FindConfig(
+        IEnumerable<RegistryConfiguration> configs,
+        IReadOnlyCollection<RegistryConfigurationGroup> groups,
+        MessagingSettingDefinition definition)
+    {
+        var exact = configs.FirstOrDefault(config =>
+            string.Equals(config.Key, definition.Key, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(GetGroupName(config, groups), definition.GroupName, StringComparison.OrdinalIgnoreCase));
+
+        if (exact is not null || !definition.MatchFirstConfigInGroup)
+        {
+            return exact;
+        }
+
+        return configs.FirstOrDefault(config =>
+            string.Equals(GetGroupName(config, groups), definition.GroupName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string GetGroupName(
+        RegistryConfiguration config,
+        IEnumerable<RegistryConfigurationGroup> groups)
+    {
+        if (!string.IsNullOrWhiteSpace(config.Group?.Name))
+        {
+            return config.Group.Name;
+        }
+
+        return groups.FirstOrDefault(group => group.Id == config.GroupId)?.Name ?? string.Empty;
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "N/A";
+        }
+
+        return value.Length <= maxLength ? value : $"{value[..maxLength]}...";
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+
+    private sealed record MessagingSettingDefinition(
+        string GroupName,
+        string Key,
+        string Label,
+        string Description,
+        string DefaultValue,
+        string? Unit,
+        bool MatchFirstConfigInGroup,
+        Guid GroupSystemReferenceId);
+
+    private sealed class MessagingSettingRow(
+        MessagingSettingDefinition definition,
+        Guid? configId,
+        string key,
+        string value,
+        string? unit,
+        bool isEnabled,
+        bool exists,
+        DateTime? lastUpdated)
+    {
+        public Guid? ConfigId { get; } = configId;
+        public string GroupName { get; } = definition.GroupName;
+        public Guid GroupSystemReferenceId { get; } = definition.GroupSystemReferenceId;
+        public string Key { get; } = key;
+        public string Label { get; } = definition.Label;
+        public string Description { get; } = definition.Description;
+        public string Placeholder { get; } = definition.DefaultValue;
+        public string? Unit { get; } = unit;
+        public bool MatchFirstConfigInGroup { get; } = definition.MatchFirstConfigInGroup;
+        public bool Exists { get; } = exists;
+        public DateTime? LastUpdated { get; } = lastUpdated;
+        public string Value { get; set; } = value;
+        public bool IsEnabled { get; set; } = isEnabled;
+        public bool IsSaving { get; set; }
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/ThreadDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/ThreadDetail.razor
@@ -1,0 +1,564 @@
+@page "/messaging/threads/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Messaging Thread Detail - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (_guard is { IsEnabled: false })
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@GoBack">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Threads
+        </BbButton>
+        <BbAlert Variant="@(_guard.HasSelectedTenant ? AlertVariant.Warning : AlertVariant.Info)">
+            <BbAlertTitle>@_guard.Title</BbAlertTitle>
+            <BbAlertDescription>@_guard.Description</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_thread is null)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@GoBack">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Threads
+        </BbButton>
+        <BbAlert Variant="AlertVariant.Danger">
+            <BbAlertTitle>Thread Not Found</BbAlertTitle>
+            <BbAlertDescription>No messaging thread was found with the specified ID.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@GoBack">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Threads
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Thread Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to the thread's tenant to view this record.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else
+{
+    <FadeInContent>
+    <div class="space-y-6">
+        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="flex items-start gap-3">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" OnClick="@GoBack">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div>
+                    <BbTypographyH3>@DisplayThreadName(_thread)</BbTypographyH3>
+                    <BbTypographyMuted>ID: @_thread.Id - Type: @(_thread.Type?.Name ?? "N/A")</BbTypographyMuted>
+                </div>
+            </div>
+            <div class="flex items-center gap-2">
+                <StatusBadge Text="@(_thread.IsEnabled ? "Enabled" : "Disabled")"
+                             Status="@(_thread.IsEnabled ? "active" : "inactive")" />
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+        </div>
+
+        @if (_error is not null)
+        {
+            <BbAlert Variant="AlertVariant.Danger">
+                <BbAlertTitle>Messaging Query Error</BbAlertTitle>
+                <BbAlertDescription>@_error</BbAlertDescription>
+            </BbAlert>
+        }
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Thread Summary</BbCardTitle>
+                <BbCardDescription>@(string.IsNullOrWhiteSpace(_thread.Description) ? "No description" : _thread.Description)</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
+                    <div class="space-y-1">
+                        <BbTypographyMuted>Members</BbTypographyMuted>
+                        <BbTypographyH3>@_members.Count</BbTypographyH3>
+                    </div>
+                    <div class="space-y-1">
+                        <BbTypographyMuted>Messages</BbTypographyMuted>
+                        <BbTypographyH3>@_messages.Count</BbTypographyH3>
+                    </div>
+                    <div class="space-y-1">
+                        <BbTypographyMuted>Deliveries</BbTypographyMuted>
+                        <BbTypographyH3>@_deliveries.Count</BbTypographyH3>
+                    </div>
+                    <div class="space-y-1">
+                        <BbTypographyMuted>Reactions</BbTypographyMuted>
+                        <BbTypographyH3>@_reactions.Count</BbTypographyH3>
+                    </div>
+                    <div class="space-y-1">
+                        <BbTypographyMuted>Files</BbTypographyMuted>
+                        <BbTypographyH3>@_files.Count</BbTypographyH3>
+                    </div>
+                </div>
+                <div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+                    <div class="space-y-1">
+                        <BbTypographyMuted>Created</BbTypographyMuted>
+                        <BbTypographyP>@_thread.CreatedAt.ToString("g")</BbTypographyP>
+                    </div>
+                    <div class="space-y-1">
+                        <BbTypographyMuted>Modified</BbTypographyMuted>
+                        <BbTypographyP>@(_thread.ModifiedAt?.ToString("g") ?? "N/A")</BbTypographyP>
+                    </div>
+                    <div class="space-y-1">
+                        <BbTypographyMuted>Last Message</BbTypographyMuted>
+                        <BbTypographyP>@(_messages.FirstOrDefault()?.CreatedAt.ToString("g") ?? "No sampled messages")</BbTypographyP>
+                    </div>
+                </div>
+            </BbCardContent>
+        </BbCard>
+
+        <BbTabs DefaultValue="messages">
+            <BbTabsList>
+                <BbTabsTrigger Value="messages">Messages (@_messages.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="members">Members (@_members.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="deliveries">Deliveries (@_deliveries.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="reactions">Reactions (@_reactions.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="files">Files (@_files.Count)</BbTabsTrigger>
+            </BbTabsList>
+
+            <BbTabsContent Value="messages" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Recent Messages</BbCardTitle>
+                        <BbCardDescription>Latest @_messages.Count messages for this thread.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        @if (_messages.Count == 0)
+                        {
+                            <BbAlert Variant="AlertVariant.Info">No messages found for this thread.</BbAlert>
+                        }
+                        else
+                        {
+                            <BbDataGrid Items="@_messages" ShowPagination="true" InitialPageSize="20">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Message">
+                                        <ChildContent Context="message">
+                                            <div>
+                                                <div>@Truncate(message.Text, 140)</div>
+                                                <div class="mt-1 font-mono text-xs text-muted-foreground">@message.Id</div>
+                                            </div>
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Member">
+                                        <ChildContent Context="message">
+                                            @GetMemberLabel(message.MessageThreadMemberId)
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Deliveries">
+                                        <ChildContent Context="message">
+                                            @_deliveries.Count(delivery => delivery.MessageId == message.Id)
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Reactions">
+                                        <ChildContent Context="message">
+                                            @_reactions.Count(reaction => reaction.MessageId == message.Id)
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Files">
+                                        <ChildContent Context="message">
+                                            @_files.Count(file => file.MessageId == message.Id)
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(message => message.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        }
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="members" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Thread Members</BbCardTitle>
+                        <BbCardDescription>@_members.Count member(s) loaded for this thread.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        @if (_members.Count == 0)
+                        {
+                            <BbAlert Variant="AlertVariant.Info">No members found for this thread.</BbAlert>
+                        }
+                        else
+                        {
+                            <BbDataGrid Items="@_members" ShowPagination="true" InitialPageSize="20">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Member">
+                                        <ChildContent Context="member">
+                                            <div>
+                                                <div class="font-medium">@GetCredentialLabel(member.Credential)</div>
+                                                <div class="text-xs text-muted-foreground">@member.CredentialId</div>
+                                            </div>
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Alias">
+                                        <ChildContent Context="member">
+                                            @(string.IsNullOrWhiteSpace(member.Alias) ? "N/A" : member.Alias)
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Group">
+                                        <ChildContent Context="member">
+                                            @(member.Group?.Alias ?? member.GroupId.ToString()[..8])
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(member => member.Status)" Title="Status" Sortable="true" />
+                                    <BbDataGridTemplateColumn Title="Enabled">
+                                        <ChildContent Context="member">
+                                            <StatusBadge Text="@(member.IsEnabled ? "Enabled" : "Disabled")"
+                                                         Status="@(member.IsEnabled ? "active" : "inactive")" />
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(member => member.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        }
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="deliveries" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Deliveries</BbCardTitle>
+                        <BbCardDescription>@_deliveries.Count delivery state records loaded.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        @if (_deliveries.Count == 0)
+                        {
+                            <BbAlert Variant="AlertVariant.Info">No deliveries found for sampled messages.</BbAlert>
+                        }
+                        else
+                        {
+                            <BbDataGrid Items="@_deliveries" ShowPagination="true" InitialPageSize="20">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Type">
+                                        <ChildContent Context="delivery">
+                                            @(delivery.Type?.Name ?? delivery.TypeId.ToString()[..8])
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Member">
+                                        <ChildContent Context="delivery">
+                                            @GetMemberLabel(delivery.MessageThreadMemberId)
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Message">
+                                        <ChildContent Context="delivery">
+                                            <span class="font-mono text-xs">@delivery.MessageId</span>
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(delivery => delivery.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        }
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="reactions" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Reactions</BbCardTitle>
+                        <BbCardDescription>@_reactions.Count reaction records loaded.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        @if (_reactions.Count == 0)
+                        {
+                            <BbAlert Variant="AlertVariant.Info">No reactions found for sampled messages.</BbAlert>
+                        }
+                        else
+                        {
+                            <BbDataGrid Items="@_reactions" ShowPagination="true" InitialPageSize="20">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Reaction">
+                                        <ChildContent Context="reaction">
+                                            @ReactionLabel(reaction)
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Member">
+                                        <ChildContent Context="reaction">
+                                            @GetMemberLabel(reaction.MessageThreadMemberId)
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Message">
+                                        <ChildContent Context="reaction">
+                                            <span class="font-mono text-xs">@reaction.MessageId</span>
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(reaction => reaction.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        }
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="files" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Attachments</BbCardTitle>
+                        <BbCardDescription>@_files.Count attachment records loaded.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        @if (_files.Count == 0)
+                        {
+                            <BbAlert Variant="AlertVariant.Info">No attachment records found for sampled messages.</BbAlert>
+                        }
+                        else
+                        {
+                            <BbDataGrid Items="@_files" ShowPagination="true" InitialPageSize="20">
+                                <Columns>
+                                    <BbDataGridTemplateColumn Title="Storage ID">
+                                        <ChildContent Context="file">
+                                            <span class="font-mono text-xs">@file.StorageId</span>
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Message">
+                                        <ChildContent Context="file">
+                                            <span class="font-mono text-xs">@file.MessageId</span>
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridTemplateColumn Title="Enabled">
+                                        <ChildContent Context="file">
+                                            <StatusBadge Text="@(file.IsEnabled ? "Enabled" : "Disabled")"
+                                                         Status="@(file.IsEnabled ? "active" : "inactive")" />
+                                        </ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                    <BbDataGridPropertyColumn Property="@(file => file.CreatedAt)" Title="Created" Sortable="true" />
+                                </Columns>
+                            </BbDataGrid>
+                        }
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+        </BbTabs>
+    </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private MessagingControlPanelGuard Guard { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private MessagingControlPanelGuardResult? _guard;
+    private MessageThread? _thread;
+    private List<Message> _messages = [];
+    private List<MessageThreadMember> _members = [];
+    private List<MessageDelivery> _deliveries = [];
+    private List<MessageReaction> _reactions = [];
+    private List<MessageFile> _files = [];
+    private bool _loading = true;
+    private bool _outsideTenantContext;
+    private string? _error;
+
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id)
+        {
+            return;
+        }
+
+        _loadedId = Id;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        _error = null;
+        _outsideTenantContext = false;
+        ClearRelatedData();
+
+        try
+        {
+            _guard = await Guard.GetCurrentTenantStateAsync();
+            if (!_guard.IsEnabled || _guard.TenantId is not Guid tenantId)
+            {
+                _thread = null;
+                return;
+            }
+
+            _thread = await DataContext.Query<MessageThread>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _thread is not null && _thread.TenantId != tenantId;
+            if (_thread is null || _outsideTenantContext)
+            {
+                return;
+            }
+
+            _members = await DataContext.Query<MessageThreadMember>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Credential)
+                .Include(x => x.Group)
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.MessageThreadId == Id)
+                .Where(x => !x.IsDeleted)
+                .OrderBy(x => x.Alias)
+                .Take(200)
+                .ToListAsync();
+
+            _messages = await DataContext.Query<Message>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.MessageThreadId == Id)
+                .Where(x => !x.IsDeleted)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+
+            _deliveries = await DataContext.Query<MessageDelivery>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.Message.MessageThreadId == Id)
+                .Where(x => !x.IsDeleted)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(500)
+                .ToListAsync();
+
+            _reactions = await DataContext.Query<MessageReaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.Message.MessageThreadId == Id)
+                .Where(x => !x.IsDeleted)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(500)
+                .ToListAsync();
+
+            _files = await DataContext.Query<MessageFile>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.Message.MessageThreadId == Id)
+                .Where(x => !x.IsDeleted)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(200)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            ToastService.Show($"Failed to load messaging thread: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void ClearRelatedData()
+    {
+        _messages = [];
+        _members = [];
+        _deliveries = [];
+        _reactions = [];
+        _files = [];
+    }
+
+    private void GoBack() => Navigation.NavigateTo("/messaging/threads");
+
+    private static string DisplayThreadName(MessageThread thread) =>
+        string.IsNullOrWhiteSpace(thread.Name) ? thread.Id.ToString()[..8] : thread.Name;
+
+    private string GetMemberLabel(Guid memberId)
+    {
+        var member = _members.FirstOrDefault(x => x.Id == memberId);
+        if (member is null)
+        {
+            return memberId.ToString()[..8];
+        }
+
+        if (!string.IsNullOrWhiteSpace(member.Alias))
+        {
+            return member.Alias;
+        }
+
+        return GetCredentialLabel(member.Credential);
+    }
+
+    private static string GetCredentialLabel(IdentityCredential? credential)
+    {
+        if (credential is null)
+        {
+            return "Unknown credential";
+        }
+
+        return credential.UserName
+            ?? credential.UserAlias
+            ?? credential.Id.ToString()[..8];
+    }
+
+    private static string ReactionLabel(MessageReaction reaction)
+    {
+        var type = reaction.Type;
+        if (type is null)
+        {
+            return reaction.TypeId.ToString()[..8];
+        }
+
+        return string.IsNullOrWhiteSpace(type.Emoji)
+            ? type.Name
+            : $"{type.Emoji} {type.Name}";
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Empty message";
+        }
+
+        return value.Length <= maxLength ? value : $"{value[..maxLength]}...";
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/Threads.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/Threads.razor
@@ -1,0 +1,307 @@
+@page "/messaging/threads"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Messaging Threads - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (_guard is { IsEnabled: false })
+{
+    <div class="space-y-4">
+        <BbAlert Variant="@(_guard.HasSelectedTenant ? AlertVariant.Warning : AlertVariant.Info)">
+            <BbAlertTitle>@_guard.Title</BbAlertTitle>
+            <BbAlertDescription>@_guard.Description</BbAlertDescription>
+        </BbAlert>
+        @if (_guard.TenantId is Guid tenantId)
+        {
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => Navigation.NavigateTo($"/identity/tenants/{tenantId}/modules"))">
+                <LucideIcon Name="blocks" class="mr-2 h-4 w-4" />
+                Tenant Modules
+            </BbButton>
+        }
+    </div>
+}
+else
+{
+    <FadeInContent>
+    <div class="space-y-6">
+        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+                <BbTypographyH3>Messaging Threads</BbTypographyH3>
+                <BbTypographyMuted>Thread diagnostics for @(_guard?.TenantName ?? "selected tenant")</BbTypographyMuted>
+            </div>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
+
+        @if (_error is not null)
+        {
+            <BbAlert Variant="AlertVariant.Danger">
+                <BbAlertTitle>Messaging Query Error</BbAlertTitle>
+                <BbAlertDescription>@_error</BbAlertDescription>
+            </BbAlert>
+        }
+
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Threads</BbCardTitle>
+                    <BbCardDescription>Total tenant threads</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbTypographyH2>@_totalThreads</BbTypographyH2>
+                </BbCardContent>
+            </BbCard>
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Messages</BbCardTitle>
+                    <BbCardDescription>Total thread messages</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbTypographyH2>@_totalMessages</BbTypographyH2>
+                </BbCardContent>
+            </BbCard>
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Members</BbCardTitle>
+                    <BbCardDescription>Total thread members</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbTypographyH2>@_totalMembers</BbTypographyH2>
+                </BbCardContent>
+            </BbCard>
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Recently Active</BbCardTitle>
+                    <BbCardDescription>Threads with sampled activity</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbTypographyH2>@_recentlyActiveThreads</BbTypographyH2>
+                </BbCardContent>
+            </BbCard>
+        </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Recent Threads</BbCardTitle>
+                <BbCardDescription>@_rows.Count thread(s) loaded; message and member columns use the current diagnostic sample.</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                @if (_rows.Count == 0)
+                {
+                    <BbAlert Variant="AlertVariant.Info">No messaging threads found for this tenant.</BbAlert>
+                }
+                else
+                {
+                    <BbDataGrid Items="@_rows" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((ThreadRow row) => Navigation.NavigateTo($"/messaging/threads/{row.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Thread" Sortable="true">
+                                <ChildContent Context="row">
+                                    <div>
+                                        <div class="font-medium">@row.Name</div>
+                                        <div class="text-xs text-muted-foreground">@row.Description</div>
+                                    </div>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Type">
+                                <ChildContent Context="row">
+                                    @(row.TypeName ?? "N/A")
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(row => row.MemberCount)" Title="Members" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(row => row.MessageCount)" Title="Messages" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="row">
+                                    <StatusBadge Text="@(row.IsEnabled ? "Enabled" : "Disabled")"
+                                                 Status="@(row.IsEnabled ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Last Message">
+                                <ChildContent Context="row">
+                                    @(row.LastMessageAt?.ToString("g") ?? "No sampled messages")
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(row => row.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="row">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              OnClick="@(() => Navigation.NavigateTo($"/messaging/threads/{row.Id}"))">
+                                        <LucideIcon Name="eye" class="h-4 w-4" />
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                }
+            </BbCardContent>
+        </BbCard>
+    </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private MessagingControlPanelGuard Guard { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private MessagingControlPanelGuardResult? _guard;
+    private List<ThreadRow> _rows = [];
+    private bool _loading = true;
+    private string? _error;
+    private int _totalThreads;
+    private int _totalMessages;
+    private int _totalMembers;
+    private int _recentlyActiveThreads;
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadData();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadData();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        _error = null;
+        _rows = [];
+
+        try
+        {
+            _guard = await Guard.GetCurrentTenantStateAsync();
+            if (!_guard.IsEnabled || _guard.TenantId is not Guid tenantId)
+            {
+                ResetStats();
+                return;
+            }
+
+            _totalThreads = await ThreadQuery(tenantId).CountAsync();
+            _totalMessages = await DataContext.Query<Message>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => !x.IsDeleted)
+                .CountAsync();
+            _totalMembers = await DataContext.Query<MessageThreadMember>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => !x.IsDeleted)
+                .CountAsync();
+
+            var threads = await ThreadQuery(tenantId)
+                .Include(x => x.Type)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(100)
+                .ToListAsync();
+
+            var sampledMessages = await DataContext.Query<Message>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => !x.IsDeleted)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(500)
+                .ToListAsync();
+
+            var sampledMembers = await DataContext.Query<MessageThreadMember>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => !x.IsDeleted)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(500)
+                .ToListAsync();
+
+            _rows = threads
+                .Select(thread =>
+                {
+                    var threadMessages = sampledMessages
+                        .Where(message => message.MessageThreadId == thread.Id)
+                        .ToList();
+
+                    return new ThreadRow(
+                        thread.Id,
+                        string.IsNullOrWhiteSpace(thread.Name) ? thread.Id.ToString()[..8] : thread.Name,
+                        Truncate(thread.Description, 90),
+                        thread.Type?.Name,
+                        sampledMembers.Count(member => member.MessageThreadId == thread.Id),
+                        threadMessages.Count,
+                        threadMessages.Select(message => (DateTime?)message.CreatedAt).Max(),
+                        thread.IsEnabled,
+                        thread.CreatedAt);
+                })
+                .OrderByDescending(row => row.LastMessageAt ?? row.CreatedAt)
+                .ToList();
+
+            _recentlyActiveThreads = _rows.Count(row => row.LastMessageAt is not null);
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            ToastService.Show($"Failed to load messaging threads: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private IRemoteQuery<MessageThread> ThreadQuery(Guid tenantId) =>
+        DataContext.Query<MessageThread>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Where(x => !x.IsDeleted);
+
+    private void ResetStats()
+    {
+        _totalThreads = 0;
+        _totalMessages = 0;
+        _totalMembers = 0;
+        _recentlyActiveThreads = 0;
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "No description";
+        }
+
+        return value.Length <= maxLength ? value : $"{value[..maxLength]}...";
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+
+    private sealed record ThreadRow(
+        Guid Id,
+        string Name,
+        string Description,
+        string? TypeName,
+        int MemberCount,
+        int MessageCount,
+        DateTime? LastMessageAt,
+        bool IsEnabled,
+        DateTime CreatedAt);
+}

--- a/src/Presentation/ControlPanel.Server/Components/Shared/ModuleUnavailable.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/ModuleUnavailable.razor
@@ -1,0 +1,17 @@
+<BbAlert Variant="AlertVariant.Warning">
+    <BbAlertTitle>@Title</BbAlertTitle>
+    <BbAlertDescription>@Message</BbAlertDescription>
+</BbAlert>
+
+@code {
+    [Parameter] public string ModuleName { get; set; } = "Module";
+    [Parameter] public bool RequiresTenant { get; set; }
+
+    private string Title => RequiresTenant
+        ? "Select a tenant"
+        : $"{ModuleName} disabled";
+
+    private string Message => RequiresTenant
+        ? "Select a specific active tenant from the profile menu to manage tenant module pages."
+        : $"{ModuleName} is not enabled for the selected tenant. Enable it from the tenant Modules page first.";
+}

--- a/src/Presentation/ControlPanel.Server/Components/_Imports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/_Imports.razor
@@ -24,6 +24,9 @@
 @using IdentityServer.Integration.Drivers
 @using XFramework.Inventario.Domain.Shared.Contracts
 @using global::Inventario.Integration.Drivers
+@using global::Messaging.Domain.Shared
+@using global::Messaging.Domain.Shared.Contracts
+@using global::Messaging.Integration.Drivers
 @using global::Wallets.Domain.Shared.Contracts
 @using global::Wallets.Integration.Drivers
 

--- a/src/Presentation/ControlPanel.Server/Components/_Imports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/_Imports.razor
@@ -13,6 +13,9 @@
 @using BlazorBlueprint.Primitives
 @using BlazorBlueprint.Primitives.Services
 @using BlazorBlueprint.Icons.Lucide.Components
+@using global::Community.Domain.Shared.Contracts
+@using global::Community.Domain.Shared.Enums
+@using global::Community.Integration.Drivers
 @using ControlPanel.Server.Components
 @using ControlPanel.Server.Components.Layout
 @using ControlPanel.Server.Components.Shared

--- a/src/Presentation/ControlPanel.Server/Components/_Imports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/_Imports.razor
@@ -22,6 +22,8 @@
 @using XFramework.Domain.Shared.Contracts.Responses
 @using IdentityServer.Domain.Shared.Contracts
 @using IdentityServer.Integration.Drivers
+@using XFramework.Inventario.Domain.Shared.Contracts
+@using global::Inventario.Integration.Drivers
 @using global::Wallets.Domain.Shared.Contracts
 @using global::Wallets.Integration.Drivers
 

--- a/src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
+++ b/src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
@@ -19,9 +19,11 @@
     <ItemGroup>
         <!-- Domain.Shared for entity types -->
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Domain.Shared\IdentityServer.Domain.Shared.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Domain.Shared\Wallets.Domain.Shared.csproj" />
         <!-- Service wrappers (Bolt CRUD + custom operations) -->
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Integration\IdentityServer.Integration.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Integration\Inventario.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Integration\Wallets.Integration.csproj" />
         <!-- Bolt client infrastructure (BoltClient, BoltDriver, IMessageBusWrapper) -->
         <ProjectReference Include="..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />

--- a/src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
+++ b/src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
@@ -18,11 +18,13 @@
 
     <ItemGroup>
         <!-- Domain.Shared for entity types -->
+        <ProjectReference Include="..\..\Modules\XFramework.Community\Community.Domain.Shared\Community.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Domain.Shared\IdentityServer.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Messaging\Messaging.Domain.Shared\Messaging.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Domain.Shared\Wallets.Domain.Shared.csproj" />
         <!-- Service wrappers (Bolt CRUD + custom operations) -->
+        <ProjectReference Include="..\..\Modules\XFramework.Community\Community.Integration\Community.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Integration\IdentityServer.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Integration\Inventario.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Messaging\Messaging.Integration\Messaging.Integration.csproj" />

--- a/src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
+++ b/src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj
@@ -20,10 +20,12 @@
         <!-- Domain.Shared for entity types -->
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Domain.Shared\IdentityServer.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Messaging\Messaging.Domain.Shared\Messaging.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Domain.Shared\Wallets.Domain.Shared.csproj" />
         <!-- Service wrappers (Bolt CRUD + custom operations) -->
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Integration\IdentityServer.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Integration\Inventario.Integration.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Messaging\Messaging.Integration\Messaging.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Integration\Wallets.Integration.csproj" />
         <!-- Bolt client infrastructure (BoltClient, BoltDriver, IMessageBusWrapper) -->
         <ProjectReference Include="..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -7,6 +7,7 @@ using ControlPanel.Server.Services;
 using XFramework.Integration.Extensions;
 using IdentityServer.Integration.Drivers;
 using Inventario.Integration.Drivers;
+using Messaging.Integration.Drivers;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Wallets.Integration.Drivers;
@@ -65,6 +66,7 @@ builder.Services.AddHealthChecks()
 // Service wrappers — auto-generated CRUD + custom operations for each microservice
 builder.Services.AddIdentityServerWrapperServices();
 builder.Services.AddInventarioWrapperServices();
+builder.Services.AddMessagingWrapperServices();
 builder.Services.AddWalletsWrapperServices();
 
 // IDataContext — universal query layer routed through service wrappers
@@ -89,6 +91,7 @@ builder.Services.AddRemoteDataContext();
 // Tenant filter state (sidebar selection)
 builder.Services.AddScoped<TenantFilterService>();
 builder.Services.AddScoped<TenantModuleNavigationService>();
+builder.Services.AddScoped<MessagingControlPanelGuard>();
 builder.Services.AddScoped<NavigationHistoryService>();
 builder.Services.AddScoped<ControlPanelAuthService>();
 builder.Services.AddScoped<ControlPanelBootstrapSeeder>();

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -1,6 +1,7 @@
 using BlazorBlueprint.Components;
 using System.Security.Claims;
 using System.Text.Json;
+using Community.Integration.Drivers;
 using ControlPanel.Server.Extensions;
 using ControlPanel.Server.Health;
 using ControlPanel.Server.Services;
@@ -64,6 +65,7 @@ builder.Services.AddHealthChecks()
         tags: ["ready"]);
 
 // Service wrappers — auto-generated CRUD + custom operations for each microservice
+builder.Services.AddCommunityWrapperServices();
 builder.Services.AddIdentityServerWrapperServices();
 builder.Services.AddInventarioWrapperServices();
 builder.Services.AddMessagingWrapperServices();
@@ -93,6 +95,7 @@ builder.Services.AddScoped<TenantFilterService>();
 builder.Services.AddScoped<TenantModuleNavigationService>();
 builder.Services.AddScoped<MessagingControlPanelGuard>();
 builder.Services.AddScoped<NavigationHistoryService>();
+builder.Services.AddScoped<CommunityControlPanelAccessService>();
 builder.Services.AddScoped<ControlPanelAuthService>();
 builder.Services.AddScoped<ControlPanelBootstrapSeeder>();
 builder.Services.AddHostedService<ControlPanelBootstrapHostedService>();

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -6,6 +6,7 @@ using ControlPanel.Server.Health;
 using ControlPanel.Server.Services;
 using XFramework.Integration.Extensions;
 using IdentityServer.Integration.Drivers;
+using Inventario.Integration.Drivers;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Wallets.Integration.Drivers;
@@ -63,6 +64,7 @@ builder.Services.AddHealthChecks()
 
 // Service wrappers — auto-generated CRUD + custom operations for each microservice
 builder.Services.AddIdentityServerWrapperServices();
+builder.Services.AddInventarioWrapperServices();
 builder.Services.AddWalletsWrapperServices();
 
 // IDataContext — universal query layer routed through service wrappers
@@ -86,6 +88,7 @@ builder.Services.AddRemoteDataContext();
 
 // Tenant filter state (sidebar selection)
 builder.Services.AddScoped<TenantFilterService>();
+builder.Services.AddScoped<TenantModuleNavigationService>();
 builder.Services.AddScoped<NavigationHistoryService>();
 builder.Services.AddScoped<ControlPanelAuthService>();
 builder.Services.AddScoped<ControlPanelBootstrapSeeder>();

--- a/src/Presentation/ControlPanel.Server/Services/CommunityControlPanelAccessService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/CommunityControlPanelAccessService.cs
@@ -1,0 +1,72 @@
+using IdentityServer.Domain.Shared.Contracts;
+using XFramework.Domain.Shared.DataContext;
+
+namespace ControlPanel.Server.Services;
+
+public sealed class CommunityControlPanelAccessService(
+    IDataContext dataContext,
+    TenantFilterService tenantFilter)
+{
+    public async Task<CommunityControlPanelAccessState> GetStateAsync(
+        bool includeNotifications = false,
+        CancellationToken ct = default)
+    {
+        if (tenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            return new CommunityControlPanelAccessState(null, null, false, null);
+        }
+
+        var communityEnabled = await IsFeatureEnabledAsync(
+            tenantId,
+            TenantModuleFeatureKeys.Community,
+            ct: ct);
+
+        bool? notificationsEnabled = null;
+        if (includeNotifications)
+        {
+            notificationsEnabled = await IsFeatureEnabledAsync(
+                tenantId,
+                TenantModuleFeatureKeys.Notifications,
+                ct: ct);
+        }
+
+        return new CommunityControlPanelAccessState(
+            tenantId,
+            tenantFilter.SelectedTenantName,
+            communityEnabled,
+            notificationsEnabled);
+    }
+
+    private async Task<bool> IsFeatureEnabledAsync(
+        Guid tenantId,
+        string moduleKey,
+        string? subFeatureKey = null,
+        CancellationToken ct = default)
+    {
+        var (normalizedModuleKey, normalizedSubFeatureKey) =
+            TenantModuleFeatureKeys.Normalize(moduleKey, subFeatureKey);
+
+        var feature = await dataContext.Query<TenantModuleFeature>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                x.ModuleKey == normalizedModuleKey &&
+                x.SubFeatureKey == normalizedSubFeatureKey &&
+                x.IsDeleted == false)
+            .FirstOrDefaultAsync(ct);
+
+        return feature?.IsEnabled == true;
+    }
+}
+
+public sealed record CommunityControlPanelAccessState(
+    Guid? TenantId,
+    string? TenantName,
+    bool CommunityEnabled,
+    bool? NotificationsEnabled)
+{
+    public bool HasTenant => TenantId is not null;
+    public bool CanUseCommunity => HasTenant && CommunityEnabled;
+    public bool CanUseNotifications => CanUseCommunity && NotificationsEnabled == true;
+}

--- a/src/Presentation/ControlPanel.Server/Services/MessagingControlPanelGuard.cs
+++ b/src/Presentation/ControlPanel.Server/Services/MessagingControlPanelGuard.cs
@@ -1,0 +1,77 @@
+using IdentityServer.Domain.Shared.Contracts;
+using XFramework.Domain.Shared.DataContext;
+
+namespace ControlPanel.Server.Services;
+
+public sealed class MessagingControlPanelGuard(
+    IDataContext dataContext,
+    TenantFilterService tenantFilter)
+{
+    public async Task<MessagingControlPanelGuardResult> GetCurrentTenantStateAsync(
+        CancellationToken ct = default)
+    {
+        if (tenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            return MessagingControlPanelGuardResult.NoTenantSelected();
+        }
+
+        var (moduleKey, subFeatureKey) = TenantModuleFeatureKeys.Normalize(
+            TenantModuleFeatureKeys.Messaging,
+            TenantModuleFeatureKeys.ChatSubFeature);
+
+        var feature = await dataContext.Query<TenantModuleFeature>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Where(x => x.ModuleKey == moduleKey)
+            .Where(x => x.SubFeatureKey == subFeatureKey)
+            .FirstOrDefaultAsync(ct);
+
+        if (feature is null or { IsEnabled: false } or { IsDeleted: true })
+        {
+            return MessagingControlPanelGuardResult.ModuleDisabled(
+                tenantId,
+                tenantFilter.SelectedTenantName);
+        }
+
+        return MessagingControlPanelGuardResult.Enabled(
+            tenantId,
+            tenantFilter.SelectedTenantName);
+    }
+}
+
+public sealed record MessagingControlPanelGuardResult(
+    Guid? TenantId,
+    string? TenantName,
+    bool HasSelectedTenant,
+    bool IsEnabled,
+    string Title,
+    string Description)
+{
+    public static MessagingControlPanelGuardResult Enabled(Guid tenantId, string? tenantName) =>
+        new(
+            tenantId,
+            tenantName,
+            HasSelectedTenant: true,
+            IsEnabled: true,
+            Title: "Messaging Enabled",
+            Description: "Messaging diagnostics are available for the selected tenant.");
+
+    public static MessagingControlPanelGuardResult NoTenantSelected() =>
+        new(
+            TenantId: null,
+            TenantName: null,
+            HasSelectedTenant: false,
+            IsEnabled: false,
+            Title: "Select a Tenant",
+            Description: "Choose a tenant from the sidebar to view Messaging control panel pages.");
+
+    public static MessagingControlPanelGuardResult ModuleDisabled(Guid tenantId, string? tenantName) =>
+        new(
+            tenantId,
+            tenantName,
+            HasSelectedTenant: true,
+            IsEnabled: false,
+            Title: "Messaging Disabled",
+            Description: "Messaging Chat is disabled or not initialized for this tenant. Enable it from the tenant Modules tab before viewing diagnostics.");
+}

--- a/src/Presentation/ControlPanel.Server/Services/TenantModuleNavigationService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/TenantModuleNavigationService.cs
@@ -1,0 +1,88 @@
+using IdentityServer.Domain.Shared.Contracts;
+using XFramework.Domain.Shared.DataContext;
+
+namespace ControlPanel.Server.Services;
+
+public sealed class TenantModuleNavigationService(
+    TenantFilterService tenantFilter,
+    IDataContext dataContext) : IDisposable
+{
+    private readonly Dictionary<string, bool> _features = new(StringComparer.OrdinalIgnoreCase);
+    private Guid? _loadedTenantId;
+    private bool _loading;
+
+    public event Action? OnChanged;
+
+    public Guid? ActiveTenantId => tenantFilter.SelectedTenantId;
+    public bool HasConcreteTenant => tenantFilter.SelectedTenantId is Guid;
+    public bool IsLoading => _loading;
+
+    public async Task EnsureLoadedAsync(CancellationToken ct = default)
+    {
+        if (_loadedTenantId == tenantFilter.SelectedTenantId)
+        {
+            return;
+        }
+
+        await LoadAsync(ct);
+    }
+
+    public bool IsFeatureEnabled(string moduleKey, string? subFeatureKey = null)
+    {
+        var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+        return tenantFilter.SelectedTenantId is Guid && _features.TryGetValue(key, out var enabled) && enabled;
+    }
+
+    public async Task ReloadAsync(CancellationToken ct = default) => await LoadAsync(ct);
+
+    public void Initialize()
+    {
+        tenantFilter.OnChanged -= OnTenantFilterChanged;
+        tenantFilter.OnChanged += OnTenantFilterChanged;
+        _ = LoadAsync();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = LoadAsync();
+    }
+
+    private async Task LoadAsync(CancellationToken ct = default)
+    {
+        _loading = true;
+        OnChanged?.Invoke();
+
+        try
+        {
+            _features.Clear();
+            _loadedTenantId = tenantFilter.SelectedTenantId;
+
+            if (tenantFilter.SelectedTenantId is not Guid tenantId)
+            {
+                return;
+            }
+
+            var rows = await dataContext.Query<TenantModuleFeature>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.IsEnabled)
+                .Take(50)
+                .ToListAsync(ct);
+
+            foreach (var row in rows)
+            {
+                _features[row.Key] = true;
+            }
+        }
+        finally
+        {
+            _loading = false;
+            OnChanged?.Invoke();
+        }
+    }
+
+    public void Dispose()
+    {
+        tenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+}

--- a/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
@@ -307,6 +307,8 @@ public sealed class ProductServiceTests
 
         public IRemoteQuery<T> NoCache() => this;
 
+        public IRemoteQuery<T> IgnoreQueryFilters() => this;
+
         public Task<List<T>> ToListAsync(CancellationToken ct = default) =>
             Task.FromResult(query.ToList());
 


### PR DESCRIPTION
## Summary
- Adds Community integration wrapper support and ControlPanel registration.
- Adds Community ControlPanel pages for identities, identity detail, content, content detail, connections, notifications, and tenant community settings.
- Adds Community sidebar links gated by the `community` tenant module toggle.
- Keeps pages as tenant-aware admin overview/moderation surfaces and uses RegistryConfiguration-backed settings.

## Merge order
Stacked after #224 and #225. Merge #224 first, then #225, then this PR.

## Verification
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false -clp:ErrorsOnly`
- `dotnet build src/Modules/XFramework.Community/Community.Api/Community.Api.csproj -m:1 /nr:false -v:minimal`
- `dotnet build XFramework.slnx -m:1 /nr:false -clp:ErrorsOnly`
- `dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false -clp:ErrorsOnly`
- `git diff --check`