### PR TITLE
Split xeon-dev service deploy workflows

### DIFF
--- a/.github/workflows/deploy-xeon-dev-bolt-hub.yml
+++ b/.github/workflows/deploy-xeon-dev-bolt-hub.yml
@@ -1,0 +1,20 @@
+name: Deploy Xeon Dev - Bolt Hub
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Modules/XFramework.Bolt/Bolt.Hub/**
+      - src/Modules/XFramework.Bolt/Bolt.Domain.Shared/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: bolt-hub
+      health_url: http://localhost:7000/health/ready
+      diagnostics_services: migrate bolt-hub

--- a/.github/workflows/deploy-xeon-dev-controlpanel.yml
+++ b/.github/workflows/deploy-xeon-dev-controlpanel.yml
@@ -1,0 +1,29 @@
+name: Deploy Xeon Dev - ControlPanel
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Presentation/ControlPanel.Server/**
+      - src/Modules/XFramework.Community/Community.Domain.Shared/**
+      - src/Modules/XFramework.Community/Community.Integration/**
+      - src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/**
+      - src/Modules/XFramework.IdentityServer/IdentityServer.Integration/**
+      - src/Modules/XFramework.Inventario/Inventario.Domain.Shared/**
+      - src/Modules/XFramework.Inventario/Inventario.Integration/**
+      - src/Modules/XFramework.Messaging/Messaging.Domain.Shared/**
+      - src/Modules/XFramework.Messaging/Messaging.Integration/**
+      - src/Modules/XFramework.Wallets/Wallets.Domain.Shared/**
+      - src/Modules/XFramework.Wallets/Wallets.Integration/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: controlpanel
+      health_url: http://localhost:5000/health/ready
+      diagnostics_services: bolt-hub identityserver messaging wallets inventario controlpanel

--- a/.github/workflows/deploy-xeon-dev-identityserver.yml
+++ b/.github/workflows/deploy-xeon-dev-identityserver.yml
@@ -1,0 +1,22 @@
+name: Deploy Xeon Dev - IdentityServer
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Modules/XFramework.IdentityServer/IdentityServer.Api/**
+      - src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/**
+      - src/Modules/XFramework.Messaging/Messaging.Domain.Shared/**
+      - src/Modules/XFramework.Messaging/Messaging.Integration/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: identityserver
+      health_url: http://localhost:8261/health/ready
+      diagnostics_services: bolt-hub identityserver

--- a/.github/workflows/deploy-xeon-dev-inventario.yml
+++ b/.github/workflows/deploy-xeon-dev-inventario.yml
@@ -1,0 +1,22 @@
+name: Deploy Xeon Dev - Inventario
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Modules/XFramework.Inventario/Inventario.Api/**
+      - src/Modules/XFramework.Inventario/Inventario.Domain.Shared/**
+      - src/Modules/XFramework.Messaging/Messaging.Domain.Shared/**
+      - src/Modules/XFramework.Messaging/Messaging.Integration/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: inventario
+      health_url: http://localhost:8105/health/ready
+      diagnostics_services: bolt-hub messaging inventario

--- a/.github/workflows/deploy-xeon-dev-messaging.yml
+++ b/.github/workflows/deploy-xeon-dev-messaging.yml
@@ -1,0 +1,22 @@
+name: Deploy Xeon Dev - Messaging
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Modules/XFramework.Messaging/Messaging.Api/**
+      - src/Modules/XFramework.Messaging/Messaging.Domain.Shared/**
+      - src/Modules/XFramework.SmsGateway/SmsGateway.Domain.Shared/**
+      - src/Modules/XFramework.SmsGateway/SmsGateway.Integration/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: messaging
+      health_url: http://localhost:5148/health/ready
+      diagnostics_services: bolt-hub smsgateway messaging

--- a/.github/workflows/deploy-xeon-dev-notifications.yml
+++ b/.github/workflows/deploy-xeon-dev-notifications.yml
@@ -1,0 +1,20 @@
+name: Deploy Xeon Dev - Notifications
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Modules/XFramework.Notifications/Notifications.Api/**
+      - src/Modules/XFramework.Notifications/Notifications.Domain.Shared/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: notifications
+      health_url: http://localhost:5166/health/ready
+      diagnostics_services: bolt-hub notifications

--- a/.github/workflows/deploy-xeon-dev-service.yml
+++ b/.github/workflows/deploy-xeon-dev-service.yml
@@ -1,0 +1,139 @@
+name: Deploy Xeon Dev - Service
+
+on:
+  workflow_call:
+    inputs:
+      service:
+        required: true
+        type: string
+      health_url:
+        required: true
+        type: string
+      diagnostics_services:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: xeon-dev-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.service }} to xeon-dev
+    runs-on: [self-hosted, Linux, xeon-dev-deploy]
+    timeout-minutes: 45
+    env:
+      COMPOSE_FILE_PATH: docker-compose.yml
+      XFRAMEWORK_ENV_FILE: /opt/xframework/xeon-dev.env
+      SERVICE_NAME: ${{ inputs.service }}
+      HEALTH_URL: ${{ inputs.health_url }}
+      DIAGNOSTICS_SERVICES: ${{ inputs.diagnostics_services }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          has_shared=false
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            base_sha="${{ github.event.before }}"
+
+            if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+              base_sha="$(git rev-list --max-parents=0 HEAD)"
+            fi
+
+            git diff --name-only "$base_sha" "$GITHUB_SHA" > /tmp/xframework-changed-files.txt
+
+            while IFS= read -r path; do
+              case "$path" in
+                Dockerfile|docker-compose.yml|Directory.Build.props|Directory.Build.targets|Directory.Packages.props|Version.props|XFramework.slnx|global.json|NuGet.config|src/Kernel/*|src/Infrastructure/*|src/Shared/*|src/SourceGenerators/*|src/Libraries/*|src/Tools/XFramework.MigrationRunner/*|src/Modules/XFramework.Bolt/Bolt.Domain.Shared/*)
+                  has_shared=true
+                  echo "Shared deployment path changed: $path"
+                  ;;
+              esac
+            done < /tmp/xframework-changed-files.txt
+          fi
+
+          echo "has_shared=$has_shared" >> "$GITHUB_OUTPUT"
+
+      - name: Skip service deploy for shared changes
+        if: steps.shared.outputs.has_shared == 'true'
+        shell: bash
+        run: |
+          echo "Shared paths changed in this push; the all-services deploy workflow owns this deployment."
+
+      - name: Verify runner and Docker
+        if: steps.shared.outputs.has_shared != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Runner host: $(hostname)"
+          uname -a
+          docker --version
+          docker compose version
+          curl --version
+
+          test -r "$XFRAMEWORK_ENV_FILE"
+          test -S /var/run/docker.sock
+          docker info --format 'Docker daemon: {{.Name}} {{.ServerVersion}}'
+
+      - name: Validate compose
+        if: steps.shared.outputs.has_shared != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" config
+
+      - name: Deploy service
+        if: steps.shared.outputs.has_shared != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" up --build -d --no-deps "$SERVICE_NAME"
+          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps "$SERVICE_NAME"
+
+      - name: Wait for readiness
+        if: steps.shared.outputs.has_shared != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          body="/tmp/xframework-${SERVICE_NAME}-health.json"
+          echo "Waiting for ${SERVICE_NAME}: ${HEALTH_URL}"
+
+          ready=0
+          for attempt in {1..60}; do
+            status="$(curl -fsS -o "$body" -w "%{http_code}" "$HEALTH_URL" || true)"
+            if [ "$status" = "200" ]; then
+              ready=1
+              break
+            fi
+
+            echo "${SERVICE_NAME} not ready yet; attempt ${attempt}/60 returned ${status:-no response}"
+            sleep 5
+          done
+
+          if [ "$ready" -ne 1 ]; then
+            echo "::error::${SERVICE_NAME} failed readiness check at ${HEALTH_URL}"
+            cat "$body" || true
+            exit 1
+          fi
+
+      - name: Deployment diagnostics
+        if: failure() && steps.shared.outputs.has_shared != 'true'
+        shell: bash
+        run: |
+          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps || true
+          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 $DIAGNOSTICS_SERVICES || true

--- a/.github/workflows/deploy-xeon-dev-smsgateway.yml
+++ b/.github/workflows/deploy-xeon-dev-smsgateway.yml
@@ -1,0 +1,20 @@
+name: Deploy Xeon Dev - SmsGateway
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Modules/XFramework.SmsGateway/SmsGateway.Api/**
+      - src/Modules/XFramework.SmsGateway/SmsGateway.Domain.Shared/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: smsgateway
+      health_url: http://localhost:5274/health/ready
+      diagnostics_services: bolt-hub smsgateway

--- a/.github/workflows/deploy-xeon-dev-wallets.yml
+++ b/.github/workflows/deploy-xeon-dev-wallets.yml
@@ -1,0 +1,20 @@
+name: Deploy Xeon Dev - Wallets
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Modules/XFramework.Wallets/Wallets.Api/**
+      - src/Modules/XFramework.Wallets/Wallets.Domain.Shared/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: wallets
+      health_url: http://localhost:9696/health/ready
+      diagnostics_services: bolt-hub wallets

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -1,8 +1,25 @@
-name: Deploy Xeon Dev
+name: Deploy Xeon Dev - All Services
 
 on:
   push:
     branches: [develop]
+    paths:
+      - Dockerfile
+      - docker-compose.yml
+      - Directory.Build.props
+      - Directory.Build.targets
+      - Directory.Packages.props
+      - Version.props
+      - XFramework.slnx
+      - global.json
+      - NuGet.config
+      - src/Kernel/**
+      - src/Infrastructure/**
+      - src/Shared/**
+      - src/SourceGenerators/**
+      - src/Libraries/**
+      - src/Tools/XFramework.MigrationRunner/**
+      - src/Modules/XFramework.Bolt/Bolt.Domain.Shared/**
   workflow_dispatch:
 
 permissions:
@@ -14,7 +31,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy to xeon-dev
+    name: Deploy all services to xeon-dev
     runs-on: [self-hosted, Linux, xeon-dev-deploy]
     timeout-minutes: 60
     env:
@@ -64,8 +81,10 @@ jobs:
             "bolt-hub=http://localhost:7000/health/ready"
             "identityserver=http://localhost:8261/health/ready"
             "messaging=http://localhost:5148/health/ready"
+            "notifications=http://localhost:5166/health/ready"
             "smsgateway=http://localhost:5274/health/ready"
             "wallets=http://localhost:9696/health/ready"
+            "inventario=http://localhost:8105/health/ready"
             "controlpanel=http://localhost:5000/health/ready"
           )
 
@@ -99,4 +118,4 @@ jobs:
         shell: bash
         run: |
           docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps || true
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 migrate bolt-hub identityserver messaging smsgateway wallets controlpanel || true
+          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 migrate bolt-hub identityserver messaging notifications smsgateway wallets inventario controlpanel || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,27 @@ services:
       retries: 15
       start_period: 15s
 
+  # ── Inventario Server ───────────────────────────────────────
+  inventario:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT_PATH: src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj
+    environment:
+      <<: *common-env
+    ports:
+      - "${INVENTARIO_EXPOSE_PORT:-8105}:8080"
+    depends_on:
+      bolt-hub:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 15s
+
   # ── Control Panel ───────────────────────────────────────────
   controlpanel:
     build:
@@ -192,6 +213,10 @@ services:
       bolt-hub:
         condition: service_healthy
       identityserver:
+        condition: service_healthy
+      messaging:
+        condition: service_healthy
+      inventario:
         condition: service_healthy
       wallets:
         condition: service_healthy

--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Docker.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Docker.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultDatabaseConnection": "Host=postgres;Port=5432;Database=XFramework;Username=dbAdmin;Password=CHANGE_ME_DB_PASSWORD_USE_ENVIRONMENT"
+  },
+  "BoltConfiguration": {
+    "ServerUrls": ["ws://bolt-hub:8080/bolt/ws"]
+  },
+  "Seq": {
+    "Url": "http://seq:80"
+  },
+  "SKIP_DB_MIGRATION": true
+}


### PR DESCRIPTION
## Summary
- Split xeon-dev deployment into per-service GitHub Actions backed by a reusable workflow
- Keep the existing full-stack deploy for shared infrastructure/framework changes
- Add Inventario compose deployment and Docker appsettings, and include ControlPanel in dependency-aware deploys

## Validation
- python YAML parse for all .github/workflows/*.yml
- docker-compose -f docker-compose.yml config --quiet with placeholder secrets
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -c Release --no-restore
- git diff --cached --check