### PR TITLE
identity: add Inventario sub-feature taxonomy

### DIFF
--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureDefinition.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureDefinition.cs
@@ -5,7 +5,8 @@ public sealed record TenantModuleFeatureDefinition(
     string SubFeatureKey,
     string DisplayName,
     string Description,
-    string IconName)
+    string IconName,
+    bool DefaultEnabled = true)
 {
     public string Key => TenantModuleFeatureKeys.Combine(ModuleKey, SubFeatureKey);
 }

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureKeys.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureKeys.cs
@@ -4,6 +4,20 @@ public static class TenantModuleFeatureKeys
 {
     public const string Wallets = "wallets";
     public const string Inventario = "inventario";
+    public const string InventarioCatalog = "inventario.catalog";
+    public const string InventarioVariations = "inventario.variations";
+    public const string InventarioTransactions = "inventario.transactions";
+    public const string InventarioLowStockAlerts = "inventario.low_stock_alerts";
+    public const string InventarioWarehousing = "inventario.warehousing";
+    public const string InventarioStockBalances = "inventario.stock_balances";
+    public const string InventarioMovements = "inventario.movements";
+    public const string InventarioReservations = "inventario.reservations";
+    public const string InventarioFulfillment = "inventario.fulfillment";
+    public const string InventarioPurchasing = "inventario.purchasing";
+    public const string InventarioTraceability = "inventario.traceability";
+    public const string InventarioPlanning = "inventario.planning";
+    public const string InventarioReporting = "inventario.reporting";
+    public const string InventarioNegativeStock = "inventario.negative_stock";
     public const string Messaging = "messaging";
     public const string MessagingChat = "messaging.chat";
     public const string MessagingAudioVideo = "messaging.audio_video";
@@ -11,6 +25,20 @@ public static class TenantModuleFeatureKeys
     public const string Payments = "payments";
     public const string Notifications = "notifications";
 
+    public const string CatalogSubFeature = "catalog";
+    public const string VariationsSubFeature = "variations";
+    public const string TransactionsSubFeature = "transactions";
+    public const string LowStockAlertsSubFeature = "low_stock_alerts";
+    public const string WarehousingSubFeature = "warehousing";
+    public const string StockBalancesSubFeature = "stock_balances";
+    public const string MovementsSubFeature = "movements";
+    public const string ReservationsSubFeature = "reservations";
+    public const string FulfillmentSubFeature = "fulfillment";
+    public const string PurchasingSubFeature = "purchasing";
+    public const string TraceabilitySubFeature = "traceability";
+    public const string PlanningSubFeature = "planning";
+    public const string ReportingSubFeature = "reporting";
+    public const string NegativeStockSubFeature = "negative_stock";
     public const string ChatSubFeature = "chat";
     public const string AudioVideoSubFeature = "audio_video";
 
@@ -18,6 +46,20 @@ public static class TenantModuleFeatureKeys
     [
         new(Wallets, string.Empty, "Wallets", "Wallet accounts, balances, transfers, deposits, and withdrawals.", "wallet"),
         new(Inventario, string.Empty, "Inventario", "Product catalog and inventory operations.", "boxes"),
+        new(Inventario, CatalogSubFeature, "Catalog", "Products, categories, SKUs, and catalog attributes.", "package"),
+        new(Inventario, VariationsSubFeature, "Variations", "Product options, variants, and variation-specific stock.", "git-branch"),
+        new(Inventario, TransactionsSubFeature, "Transactions", "Inventory receipts, adjustments, transfers, and issue records.", "arrow-left-right"),
+        new(Inventario, LowStockAlertsSubFeature, "Low Stock Alerts", "Low stock thresholds, alert review, and replenishment signals.", "bell"),
+        new(Inventario, WarehousingSubFeature, "Warehousing", "Warehouse, location, bin, and storage-area workflows.", "warehouse", false),
+        new(Inventario, StockBalancesSubFeature, "Stock Balances", "Stock-on-hand, available, allocated, and reserved balance views.", "scale", false),
+        new(Inventario, MovementsSubFeature, "Movements", "Physical stock movement tracking between locations and states.", "move", false),
+        new(Inventario, ReservationsSubFeature, "Reservations", "Stock reservations, holds, and allocation commitments.", "bookmark-check", false),
+        new(Inventario, FulfillmentSubFeature, "Fulfillment", "Pick, pack, ship, and order fulfillment operations.", "truck", false),
+        new(Inventario, PurchasingSubFeature, "Purchasing", "Purchase orders, receiving, and supplier replenishment workflows.", "shopping-cart", false),
+        new(Inventario, TraceabilitySubFeature, "Traceability", "Lot, serial, batch, and inventory lineage tracking.", "scan-line", false),
+        new(Inventario, PlanningSubFeature, "Planning", "Demand planning, reorder planning, and replenishment forecasting.", "calendar-clock", false),
+        new(Inventario, ReportingSubFeature, "Reporting", "Inventory analytics, valuation, audit, and operational reports.", "bar-chart-3", false),
+        new(Inventario, NegativeStockSubFeature, "Negative Stock", "Controls for allowing or blocking negative stock positions.", "minus-circle", false),
         new(Messaging, ChatSubFeature, "Messaging Chat", "Threads, direct messages, reactions, and attachments.", "message-circle"),
         new(Messaging, AudioVideoSubFeature, "Messaging Audio/Video", "Audio and video communication features.", "video"),
         new(Community, string.Empty, "Community", "Community identities, content, feed, and connections.", "users"),

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -126,9 +126,9 @@ else
                         else
                         {
                             <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                                @foreach (var row in _moduleFeatureRows)
+                                @foreach (var row in _rootModuleFeatureRows)
                                 {
-                                    <div class="rounded-lg border bg-card p-4 shadow-sm">
+                                    <div class="@GetModuleFeatureCardClass(row)">
                                         <div class="flex items-start justify-between gap-3">
                                             <div class="flex min-w-0 gap-3">
                                                 <div class="tenant-module-icon">
@@ -152,6 +152,48 @@ else
                                                                Disabled="@(_savingModuleFeatureIds.Contains(row.Id))"
                                                                Label="Module enabled" />
                                         </div>
+                                        @if (IsInventarioRootFeature(row) && _inventarioSubFeatureRows.Count > 0)
+                                        {
+                                            <div class="mt-4 border-t pt-4">
+                                                <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+                                                    <div>
+                                                        <div class="text-sm font-semibold">Inventario sub-features</div>
+                                                        <div class="text-xs text-muted-foreground">The root Inventario toggle remains the parent access gate.</div>
+                                                    </div>
+                                                    <StatusBadge Text="@($"{_inventarioSubFeatureRows.Count(child => child.IsEnabled)} enabled")" Status="active" />
+                                                </div>
+                                                <div class="grid gap-2 lg:grid-cols-2">
+                                                    @foreach (var childRow in _inventarioSubFeatureRows)
+                                                    {
+                                                        <div class="rounded-md border bg-muted/30 p-3">
+                                                            <div class="flex items-start justify-between gap-3">
+                                                                <div class="flex min-w-0 gap-3">
+                                                                    <div class="tenant-module-icon h-10 w-10 flex-[0_0_2.5rem]">
+                                                                        <LucideIcon Name="@childRow.Icon" class="h-4 w-4" />
+                                                                    </div>
+                                                                    <div class="min-w-0">
+                                                                        <div class="flex flex-wrap items-center gap-2">
+                                                                            <div class="font-medium">@childRow.DisplayName</div>
+                                                                            <StatusBadge Text="@GetModuleFeatureCoverageText(childRow)" Status="@GetModuleFeatureCoverageStatus(childRow)" />
+                                                                        </div>
+                                                                        <div class="mt-1 text-sm text-muted-foreground">@childRow.Description</div>
+                                                                        <div class="mt-2 font-mono text-xs text-muted-foreground">@childRow.Key</div>
+                                                                    </div>
+                                                                </div>
+                                                                <StatusBadge Text="@(childRow.IsEnabled ? "Enabled" : "Disabled")"
+                                                                             Status="@(childRow.IsEnabled ? "active" : "inactive")" />
+                                                            </div>
+                                                            <div class="mt-3 border-t pt-3">
+                                                                <BbFormFieldSwitch Checked="@childRow.IsEnabled"
+                                                                                   CheckedChanged="@((bool enabled) => ToggleModuleFeature(childRow, enabled))"
+                                                                                   Disabled="@(_savingModuleFeatureIds.Contains(childRow.Id))"
+                                                                                   Label="Feature enabled" />
+                                                            </div>
+                                                        </div>
+                                                    }
+                                                </div>
+                                            </div>
+                                        }
                                     </div>
                                 }
                             </div>
@@ -367,6 +409,8 @@ else
     private List<IdentityRoleType> _detailRoleTypes = [];
     private List<TenantModuleFeature> _detailModuleFeatures = [];
     private List<ModuleFeatureRow> _moduleFeatureRows = [];
+    private List<ModuleFeatureRow> _rootModuleFeatureRows = [];
+    private List<ModuleFeatureRow> _inventarioSubFeatureRows = [];
     private HashSet<Guid> _savingModuleFeatureIds = [];
     private bool _moduleFeaturesLoading;
     private string CurrentSection => NormalizeSection(Section);
@@ -450,6 +494,8 @@ else
         _detailRoleTypes = [];
         _detailModuleFeatures = [];
         _moduleFeatureRows = [];
+        _rootModuleFeatureRows = [];
+        _inventarioSubFeatureRows = [];
     }
 
     private void SyncEditFields()
@@ -541,7 +587,7 @@ else
                         SubFeatureKey = definition.SubFeatureKey,
                         DisplayName = definition.DisplayName,
                         Description = definition.Description,
-                        IsEnabled = true,
+                        IsEnabled = definition.DefaultEnabled,
                         CreatedAt = DateTime.UtcNow
                     });
                 }
@@ -579,6 +625,7 @@ else
                         feature?.IsEnabled ?? false);
                 })
                 .ToList();
+            ApplyModuleFeatureGrouping();
         }
         catch (Exception ex)
         {
@@ -588,6 +635,17 @@ else
         {
             _moduleFeaturesLoading = false;
         }
+    }
+
+    private void ApplyModuleFeatureGrouping()
+    {
+        _inventarioSubFeatureRows = _moduleFeatureRows
+            .Where(IsInventarioSubFeature)
+            .ToList();
+
+        _rootModuleFeatureRows = _moduleFeatureRows
+            .Where(row => !IsInventarioSubFeature(row))
+            .ToList();
     }
 
     private async Task ToggleModuleFeature(ModuleFeatureRow row, bool enabled)
@@ -710,9 +768,23 @@ else
         {
             TenantModuleFeatureKeys.Wallets or
             TenantModuleFeatureKeys.Inventario or
+            TenantModuleFeatureKeys.InventarioCatalog or
+            TenantModuleFeatureKeys.InventarioVariations or
+            TenantModuleFeatureKeys.InventarioTransactions or
+            TenantModuleFeatureKeys.InventarioLowStockAlerts or
+            TenantModuleFeatureKeys.InventarioWarehousing or
+            TenantModuleFeatureKeys.InventarioStockBalances or
+            TenantModuleFeatureKeys.InventarioMovements or
+            TenantModuleFeatureKeys.InventarioReservations or
             TenantModuleFeatureKeys.MessagingChat or
             TenantModuleFeatureKeys.Community or
             TenantModuleFeatureKeys.Notifications => "API gated",
+            TenantModuleFeatureKeys.InventarioFulfillment or
+            TenantModuleFeatureKeys.InventarioPurchasing or
+            TenantModuleFeatureKeys.InventarioTraceability or
+            TenantModuleFeatureKeys.InventarioPlanning or
+            TenantModuleFeatureKeys.InventarioReporting or
+            TenantModuleFeatureKeys.InventarioNegativeStock or
             TenantModuleFeatureKeys.MessagingAudioVideo => "Planned flag",
             TenantModuleFeatureKeys.Payments => "No API yet",
             _ => "Stored"
@@ -723,13 +795,40 @@ else
         {
             TenantModuleFeatureKeys.Wallets or
             TenantModuleFeatureKeys.Inventario or
+            TenantModuleFeatureKeys.InventarioCatalog or
+            TenantModuleFeatureKeys.InventarioVariations or
+            TenantModuleFeatureKeys.InventarioTransactions or
+            TenantModuleFeatureKeys.InventarioLowStockAlerts or
+            TenantModuleFeatureKeys.InventarioWarehousing or
+            TenantModuleFeatureKeys.InventarioStockBalances or
+            TenantModuleFeatureKeys.InventarioMovements or
+            TenantModuleFeatureKeys.InventarioReservations or
             TenantModuleFeatureKeys.MessagingChat or
             TenantModuleFeatureKeys.Community or
             TenantModuleFeatureKeys.Notifications => "active",
+            TenantModuleFeatureKeys.InventarioFulfillment or
+            TenantModuleFeatureKeys.InventarioPurchasing or
+            TenantModuleFeatureKeys.InventarioTraceability or
+            TenantModuleFeatureKeys.InventarioPlanning or
+            TenantModuleFeatureKeys.InventarioReporting or
+            TenantModuleFeatureKeys.InventarioNegativeStock or
             TenantModuleFeatureKeys.MessagingAudioVideo => "pending",
             TenantModuleFeatureKeys.Payments => "inactive",
             _ => "inactive"
         };
+
+    private static bool IsInventarioRootFeature(ModuleFeatureRow row) =>
+        string.Equals(row.ModuleKey, TenantModuleFeatureKeys.Inventario, StringComparison.OrdinalIgnoreCase) &&
+        string.IsNullOrWhiteSpace(row.SubFeatureKey);
+
+    private static bool IsInventarioSubFeature(ModuleFeatureRow row) =>
+        string.Equals(row.ModuleKey, TenantModuleFeatureKeys.Inventario, StringComparison.OrdinalIgnoreCase) &&
+        !string.IsNullOrWhiteSpace(row.SubFeatureKey);
+
+    private static string GetModuleFeatureCardClass(ModuleFeatureRow row) =>
+        IsInventarioRootFeature(row)
+            ? "rounded-lg border bg-card p-4 shadow-sm md:col-span-2 xl:col-span-3"
+            : "rounded-lg border bg-card p-4 shadow-sm";
 
     private static string NormalizeSection(string? section)
     {

--- a/src/Tests/XFramework.TestInfrastructure/TestSeedData.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestSeedData.cs
@@ -90,7 +90,7 @@ public static class TestSeedData
                 DisplayName = definition.DisplayName,
                 Description = definition.Description,
                 CreatedAt = DateTime.UtcNow,
-                IsEnabled = true
+                IsEnabled = definition.DefaultEnabled
             });
         }
     }


### PR DESCRIPTION
Adds Inventario sub-feature definitions and defaults under the tenant module registry. Catalog, variations, transactions, and low-stock alerts default on when Inventario is enabled; advanced warehouse, movement, reservation, fulfillment, purchasing, traceability, planning, reporting, and negative-stock flags stay off until enabled. Updates ControlPanel tenant module UI to group Inventario sub-features. Verification: dotnet test src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj --filter TenantModuleFeatureServiceTests -m:1 /nr:false; dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false.