### PR TITLE
inventario: harden catalog correctness

### DIFF
--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Create/CreateProductValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Create/CreateProductValidator.cs
@@ -38,5 +38,9 @@ public class CreateProductValidator : AbstractValidator<CreateProductRequest>
         RuleFor(x => x.Description)
             .MaximumLength(1000).WithMessage("Description cannot exceed 1000 characters")
             .When(x => !string.IsNullOrEmpty(x.Description));
+
+        RuleFor(x => x.Image)
+            .MaximumLength(2048).WithMessage("Image cannot exceed 2048 characters")
+            .When(x => !string.IsNullOrEmpty(x.Image));
     }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/UpdateProductValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/UpdateProductValidator.cs
@@ -35,5 +35,9 @@ public class UpdateProductValidator : AbstractValidator<UpdateProductRequest>
         RuleFor(x => x.Description)
             .MaximumLength(1000).WithMessage("Description cannot exceed 1000 characters")
             .When(x => !string.IsNullOrEmpty(x.Description));
+
+        RuleFor(x => x.Image)
+            .MaximumLength(2048).WithMessage("Image cannot exceed 2048 characters")
+            .When(x => !string.IsNullOrEmpty(x.Image));
     }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
@@ -61,6 +61,17 @@ public class ProductService
                 return Result<Product>.NotFound("Product category not found");
             }
 
+            var normalizedSku = NormalizeSku(request.SKU);
+            if (normalizedSku is not null)
+            {
+                var skuExists = await _dataContext.Query<Product>()
+                    .AnyAsync(p => p.TenantId == tenantId && !p.IsDeleted && p.SKU == normalizedSku, ct);
+                if (skuExists)
+                {
+                    return Result<Product>.Failure("A product with the same SKU already exists for this tenant.", 409);
+                }
+            }
+
             var productId = Guid.NewGuid();
             activity?.SetTag("product.id", productId);
 
@@ -76,7 +87,7 @@ public class ProductService
                 Price = request.Price,
                 StockQuantity = request.StockQuantity,
                 CategoryId = request.CategoryId,
-                SKU = request.SKU,
+                SKU = normalizedSku,
                 Brand = request.Brand,
                 Weight = request.Weight,
                 Image = request.Image,
@@ -303,12 +314,28 @@ public class ProductService
                 return Result<Product>.NotFound("Product category not found");
             }
 
+            var normalizedSku = NormalizeSku(request.SKU);
+            if (normalizedSku is not null)
+            {
+                var skuExists = await _dataContext.Query<Product>()
+                    .AnyAsync(p =>
+                        p.TenantId == tenantId &&
+                        !p.IsDeleted &&
+                        p.Id != id &&
+                        p.SKU == normalizedSku,
+                        ct);
+                if (skuExists)
+                {
+                    return Result<Product>.Failure("A product with the same SKU already exists for this tenant.", 409);
+                }
+            }
+
             // Update properties
             product.Name = request.Name;
             product.Description = request.Description;
             product.Price = request.Price;
             product.CategoryId = request.CategoryId;
-            product.SKU = request.SKU;
+            product.SKU = normalizedSku;
             product.Brand = request.Brand;
             product.Weight = request.Weight;
             product.Image = request.Image;
@@ -406,6 +433,9 @@ public class ProductService
 
     private static string BuildProductListCachePrefix(Guid tenantId) =>
         $"products:list:{tenantId}:";
+
+    private static string? NormalizeSku(string? sku) =>
+        string.IsNullOrWhiteSpace(sku) ? null : sku.Trim();
 }
 
 /// <summary>

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductCategoryConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductCategoryConfiguration.cs
@@ -14,6 +14,8 @@ public class ProductCategoryConfiguration : IEntityTypeConfiguration<ProductCate
         entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
         entity.Property(e => e.Description).HasMaxLength(1000);
 
-        entity.HasIndex(e => new { e.TenantId, e.Name });
+        entity.HasIndex(e => new { e.TenantId, e.Name })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
     }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductConfiguration.cs
@@ -28,7 +28,9 @@ public class ProductConfiguration : IEntityTypeConfiguration<Product>
         entity.Ignore(e => e.Reviews);
 
         entity.HasIndex(e => new { e.TenantId, e.CategoryId });
-        entity.HasIndex(e => new { e.TenantId, e.SKU });
+        entity.HasIndex(e => new { e.TenantId, e.SKU })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false AND \"SKU\" IS NOT NULL AND \"SKU\" <> ''");
 
         entity.HasOne(e => e.Category)
             .WithMany(e => e.Products)

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
@@ -23,7 +23,7 @@ else
             <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div>
                     <BbTypographyH3>Products</BbTypographyH3>
-                    <BbTypographyMuted>Manage the selected tenant's product catalog and stock snapshot.</BbTypographyMuted>
+                    <BbTypographyMuted>Manage the selected tenant's product catalog.</BbTypographyMuted>
                 </div>
                 <BbButton OnClick="@OpenCreateDialog">
                     <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
@@ -134,9 +134,8 @@ else
                     <BbSelectItem Value="@category.Id.ToString()">@(category.Name ?? category.Id.ToString()[..8])</BbSelectItem>
                 }
             </BbFormFieldSelect>
-            <div class="grid gap-4 md:grid-cols-3">
+            <div class="grid gap-4 md:grid-cols-2">
                 <BbFormFieldInput TValue="string" @bind-Value="_form.Price" Label="Price" />
-                <BbFormFieldInput TValue="string" @bind-Value="_form.StockQuantity" Label="Stock Quantity" />
                 <BbFormFieldInput TValue="string" @bind-Value="_form.Brand" Label="Brand" />
             </div>
             <BbFormFieldInput TValue="string" @bind-Value="_form.Description" Label="Description" />
@@ -290,7 +289,6 @@ else
         _form.Sku = product.SKU ?? "";
         _form.CategoryId = product.CategoryId.ToString();
         _form.Price = product.Price.ToString("0.##");
-        _form.StockQuantity = product.StockQuantity.ToString();
         _form.Brand = product.Brand ?? "";
         _form.Description = product.Description ?? "";
         _form.IsAvailable = product.IsAvailable;
@@ -323,12 +321,6 @@ else
             return;
         }
 
-        if (!int.TryParse(_form.StockQuantity, out var quantity) || quantity < 0)
-        {
-            ToastService.Show("Stock quantity must be a non-negative whole number.");
-            return;
-        }
-
         _saving = true;
         try
         {
@@ -342,7 +334,7 @@ else
                     SKU = NullIfEmpty(_form.Sku),
                     CategoryId = categoryId,
                     Price = price,
-                    StockQuantity = quantity,
+                    StockQuantity = 0,
                     Brand = NullIfEmpty(_form.Brand),
                     Description = NullIfEmpty(_form.Description),
                     IsAvailable = _form.IsAvailable,
@@ -367,7 +359,6 @@ else
                 fresh.SKU = NullIfEmpty(_form.Sku);
                 fresh.CategoryId = categoryId;
                 fresh.Price = price;
-                fresh.StockQuantity = quantity;
                 fresh.Brand = NullIfEmpty(_form.Brand);
                 fresh.Description = NullIfEmpty(_form.Description);
                 fresh.IsAvailable = _form.IsAvailable;
@@ -412,7 +403,6 @@ else
         public string Sku { get; set; } = "";
         public string CategoryId { get; set; } = "";
         public string Price { get; set; } = "0";
-        public string StockQuantity { get; set; } = "0";
         public string Brand { get; set; } = "";
         public string Description { get; set; } = "";
         public bool IsAvailable { get; set; } = true;
@@ -423,7 +413,6 @@ else
             Sku = "";
             CategoryId = "";
             Price = "0";
-            StockQuantity = "0";
             Brand = "";
             Description = "";
             IsAvailable = true;

--- a/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
@@ -130,6 +130,88 @@ public sealed class ProductServiceTests
     }
 
     [Test]
+    public async Task CreateAsync_DuplicateSkuInTenant_ReturnsConflict()
+    {
+        var tenantId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var dataContext = new FakeDataContext();
+        dataContext.Set<ProductCategory>().Add(new ProductCategory
+        {
+            Id = categoryId,
+            TenantId = tenantId,
+            Name = "Parts"
+        });
+        dataContext.Set<Product>().Add(new Product
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            CategoryId = categoryId,
+            Name = "Existing",
+            SKU = "SKU-001"
+        });
+
+        var service = CreateService(dataContext, new FakeCacheService(), tenantId);
+
+        var result = await service.CreateAsync(new CreateProductRequest
+        {
+            Name = "Duplicate",
+            Price = 10m,
+            CategoryId = categoryId,
+            SKU = "SKU-001"
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        dataContext.Added.OfType<Product>().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task UpdateAsync_DuplicateSkuInTenant_ReturnsConflict()
+    {
+        var tenantId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var product = new Product
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            CategoryId = categoryId,
+            Name = "Editable",
+            SKU = "SKU-002"
+        };
+
+        var dataContext = new FakeDataContext();
+        dataContext.Set<ProductCategory>().Add(new ProductCategory
+        {
+            Id = categoryId,
+            TenantId = tenantId,
+            Name = "Parts"
+        });
+        dataContext.Set<Product>().Add(product);
+        dataContext.Set<Product>().Add(new Product
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            CategoryId = categoryId,
+            Name = "Existing",
+            SKU = "SKU-001"
+        });
+
+        var service = CreateService(dataContext, new FakeCacheService(), tenantId);
+
+        var result = await service.UpdateAsync(product.Id, new UpdateProductRequest
+        {
+            Name = "Editable",
+            Price = 10m,
+            CategoryId = categoryId,
+            SKU = "SKU-001"
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        dataContext.Updated.Should().BeEmpty();
+    }
+
+    [Test]
     public void ModelConfiguration_StockBalanceAndReservation_DefinesConcurrencyAndBalanceUniqueness()
     {
         using var db = CreateModelOnlyDbContext(Guid.NewGuid());
@@ -156,6 +238,28 @@ public sealed class ProductServiceTests
         reservation.Should().NotBeNull();
         reservation!.FindProperty(nameof(Reservation.ConcurrencyStamp))!
             .IsConcurrencyToken.Should().BeTrue();
+
+        var product = db.Model.FindEntityType(typeof(Product));
+        product.Should().NotBeNull();
+        var uniqueSkuIndex = product!.GetIndexes()
+            .SingleOrDefault(index => index.IsUnique &&
+                index.Properties.Select(p => p.Name).SequenceEqual([
+                    nameof(Product.TenantId),
+                    nameof(Product.SKU)
+                ]));
+        uniqueSkuIndex.Should().NotBeNull();
+        uniqueSkuIndex!.GetFilter().Should().Be("\"IsDeleted\" = false AND \"SKU\" IS NOT NULL AND \"SKU\" <> ''");
+
+        var category = db.Model.FindEntityType(typeof(ProductCategory));
+        category.Should().NotBeNull();
+        var uniqueCategoryNameIndex = category!.GetIndexes()
+            .SingleOrDefault(index => index.IsUnique &&
+                index.Properties.Select(p => p.Name).SequenceEqual([
+                    nameof(ProductCategory.TenantId),
+                    nameof(ProductCategory.Name)
+                ]));
+        uniqueCategoryNameIndex.Should().NotBeNull();
+        uniqueCategoryNameIndex!.GetFilter().Should().Be("\"IsDeleted\" = false");
     }
 
     private static ProductService CreateService(


### PR DESCRIPTION
Hardens the catalog baseline before deeper stock workflows. Adds tenant-level SKU and category uniqueness, aligns image validation with EF limits, normalizes SKU conflict checks, and stops the ControlPanel product form from directly changing stock snapshots. Verification: dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false; dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false.