### PR TITLE
inventario: add warehouse stock movement core

### DIFF
--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Locations/Create/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Locations/Create/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
+
+namespace Inventario.Api.Features.Locations.Create;
+
+public static class CreateInventoryLocationEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/locations", Tags = ["Inventario Warehousing"],
+        Summary = "Create inventory location",
+        Description = "Creates an inventory location for a warehouse.")]
+    public static async Task<Result<InventoryLocation>> Handle(
+        CreateInventoryLocationRequest request,
+        WarehouseService warehouseService,
+        CancellationToken ct)
+    {
+        return await warehouseService.CreateLocationAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Locations/GetList/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Locations/GetList/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
+
+namespace Inventario.Api.Features.Locations.GetList;
+
+public static class GetInventoryLocationsEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/locations", Tags = ["Inventario Warehousing"],
+        Summary = "Get inventory locations",
+        Description = "Gets inventory locations for the authenticated tenant.")]
+    public static async Task<Result<List<InventoryLocation>>> Handle(
+        GetInventoryLocationsRequest request,
+        WarehouseService warehouseService,
+        CancellationToken ct)
+    {
+        return await warehouseService.GetLocationsAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/GetBalances/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/GetBalances/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+
+namespace Inventario.Api.Features.Stock.GetBalances;
+
+public static class GetStockBalancesEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/stock/balances", Tags = ["Inventario Stock"],
+        Summary = "Get stock balances",
+        Description = "Gets stock balances for the authenticated tenant.")]
+    public static async Task<Result<List<StockBalance>>> Handle(
+        GetStockBalancesRequest request,
+        StockPostingService stockPostingService,
+        CancellationToken ct)
+    {
+        return await stockPostingService.GetBalancesAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/GetMovements/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/GetMovements/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+
+namespace Inventario.Api.Features.Stock.GetMovements;
+
+public static class GetInventoryMovementsEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/stock/movements", Tags = ["Inventario Stock"],
+        Summary = "Get inventory movement ledger",
+        Description = "Gets append-only inventory movements for the authenticated tenant.")]
+    public static async Task<Result<List<InventoryMovement>>> Handle(
+        GetInventoryMovementsRequest request,
+        StockPostingService stockPostingService,
+        CancellationToken ct)
+    {
+        return await stockPostingService.GetMovementsAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/Post/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/Post/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses;
+
+namespace Inventario.Api.Features.Stock.Post;
+
+public static class PostStockMovementEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/stock/post", Tags = ["Inventario Stock"],
+        Summary = "Post an inventory stock movement",
+        Description = "Creates an append-only stock movement and updates the matching stock balance.")]
+    public static async Task<Result<StockPostingResponse>> Handle(
+        PostStockMovementRequest request,
+        StockPostingService stockPostingService,
+        CancellationToken ct)
+    {
+        return await stockPostingService.PostAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Warehouses/Create/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Warehouses/Create/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+
+namespace Inventario.Api.Features.Warehouses.Create;
+
+public static class CreateWarehouseEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/warehouses", Tags = ["Inventario Warehousing"],
+        Summary = "Create warehouse",
+        Description = "Creates a warehouse for the authenticated tenant.")]
+    public static async Task<Result<Warehouse>> Handle(
+        CreateWarehouseRequest request,
+        WarehouseService warehouseService,
+        CancellationToken ct)
+    {
+        return await warehouseService.CreateWarehouseAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Warehouses/GetList/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Warehouses/GetList/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+
+namespace Inventario.Api.Features.Warehouses.GetList;
+
+public static class GetWarehousesEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/warehouses", Tags = ["Inventario Warehousing"],
+        Summary = "Get warehouses",
+        Description = "Gets warehouses for the authenticated tenant.")]
+    public static async Task<Result<List<Warehouse>>> Handle(
+        GetWarehousesRequest request,
+        WarehouseService warehouseService,
+        CancellationToken ct)
+    {
+        return await warehouseService.GetWarehousesAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Installers/ServicesInstaller.cs
@@ -16,6 +16,8 @@ public class ServicesInstaller : IInstaller
 
         // Register ProductService
         services.AddScoped<ProductService>();
+        services.AddScoped<StockPostingService>();
+        services.AddScoped<WarehouseService>();
 
         // Register FluentValidation validators
         services.AddValidatorsFromAssemblyContaining<Program>();

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
@@ -38,7 +38,14 @@ var app = (WebApplication)builder.Build();
 // Add correlation ID middleware early in the pipeline for request tracing
 app.UseCorrelationId();
 app.UseTenantModuleFeatureGate(options =>
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api"));
+{
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/warehouses", "warehousing");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/locations", "warehousing");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/balances", "stock_balances");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/movements", "movements");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/post", "movements");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api");
+});
 
 app.EnsureDatabase<DbContext>();
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
@@ -1,0 +1,316 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Api.Services;
+
+public sealed class StockPostingService(
+    IDataContext dataContext,
+    IHttpContextAccessor httpContextAccessor)
+{
+    public async Task<Result<StockPostingResponse>> PostAsync(
+        PostStockMovementRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<StockPostingResponse>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        if (request.Quantity == 0)
+            return Result<StockPostingResponse>.Failure("Quantity must not be zero.", 400);
+
+        if (request.MovementType != InventoryMovementType.Adjustment && request.Quantity < 0)
+            return Result<StockPostingResponse>.Failure("Quantity must be positive for this movement type.", 400);
+
+        if (request.MovementType == InventoryMovementType.Transfer)
+            return await PostTransferAsync(tenantId, request, ct);
+
+        var product = await GetProduct(tenantId, request.ProductId, ct);
+        if (product is null)
+            return Result<StockPostingResponse>.NotFound("Product not found.");
+
+        var balanceResult = await GetOrCreateBalance(tenantId, request.ProductId, request.WarehouseId, request.LocationId, ct);
+        if (!balanceResult.IsSuccess)
+            return Result<StockPostingResponse>.Failure(balanceResult.Message!, balanceResult.StatusCode);
+
+        var balance = balanceResult.Data!;
+        var before = balance.OnHandQuantity;
+        var delta = GetOnHandDelta(request.MovementType, request.Quantity);
+        var reservedDelta = GetReservedDelta(request.MovementType, request.Quantity);
+        var afterOnHand = before + delta;
+        var afterReserved = balance.ReservedQuantity + reservedDelta;
+
+        if (!request.AllowNegativeStock && (afterOnHand < 0 || afterReserved < 0 || afterOnHand - afterReserved < 0))
+            return Result<StockPostingResponse>.Failure("Stock movement would create a negative stock position.", 409);
+
+        ApplyBalance(balance, afterOnHand, afterReserved);
+        AddMovement(tenantId, request, balance.Id, delta == 0 ? reservedDelta : delta, before, afterOnHand);
+        await UpdateProductSnapshot(tenantId, product, request.ProductId, delta, ct);
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<StockPostingResponse>.Failure(saveResult.Message ?? "Stock posting failed.", saveResult.StatusCode);
+
+        return Result<StockPostingResponse>.Success(new StockPostingResponse(
+            balance.Id,
+            request.ProductId,
+            balance.WarehouseId,
+            balance.LocationId,
+            balance.OnHandQuantity,
+            balance.ReservedQuantity,
+            balance.AvailableQuantity));
+    }
+
+    public async Task<Result<List<StockBalance>>> GetBalancesAsync(
+        GetStockBalancesRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<StockBalance>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var query = dataContext.Query<StockBalance>()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted);
+
+        if (request.ProductId is { } id)
+            query = query.Where(x => x.ProductId == id);
+
+        var balances = await query
+            .OrderBy(x => x.ProductId)
+            .Take(500)
+            .ToListAsync(ct);
+
+        return Result<List<StockBalance>>.Success(balances);
+    }
+
+    public async Task<Result<List<InventoryMovement>>> GetMovementsAsync(
+        GetInventoryMovementsRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<InventoryMovement>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var query = dataContext.Query<InventoryMovement>()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted);
+
+        if (request.ProductId is { } id)
+            query = query.Where(x => x.ProductId == id);
+
+        var movements = await query
+            .OrderByDescending(x => x.MovementDate)
+            .Take(500)
+            .ToListAsync(ct);
+
+        return Result<List<InventoryMovement>>.Success(movements);
+    }
+
+    private async Task<Result<StockPostingResponse>> PostTransferAsync(
+        Guid tenantId,
+        PostStockMovementRequest request,
+        CancellationToken ct)
+    {
+        if (request.DestinationWarehouseId is not { } destinationWarehouseId ||
+            request.DestinationLocationId is not { } destinationLocationId)
+        {
+            return Result<StockPostingResponse>.Failure("Transfers require destination warehouse and location.", 400);
+        }
+
+        var product = await GetProduct(tenantId, request.ProductId, ct);
+        if (product is null)
+            return Result<StockPostingResponse>.NotFound("Product not found.");
+
+        var sourceResult = await GetOrCreateBalance(tenantId, request.ProductId, request.WarehouseId, request.LocationId, ct);
+        if (!sourceResult.IsSuccess)
+            return Result<StockPostingResponse>.Failure(sourceResult.Message!, sourceResult.StatusCode);
+
+        var destinationResult = await GetOrCreateBalance(tenantId, request.ProductId, destinationWarehouseId, destinationLocationId, ct);
+        if (!destinationResult.IsSuccess)
+            return Result<StockPostingResponse>.Failure(destinationResult.Message!, destinationResult.StatusCode);
+
+        var source = sourceResult.Data!;
+        var destination = destinationResult.Data!;
+        var sourceAfter = source.OnHandQuantity - request.Quantity;
+        if (!request.AllowNegativeStock && sourceAfter < source.ReservedQuantity)
+            return Result<StockPostingResponse>.Failure("Transfer would create a negative source stock position.", 409);
+
+        var now = DateTime.UtcNow;
+        var sourceBefore = source.OnHandQuantity;
+        var destinationBefore = destination.OnHandQuantity;
+        ApplyBalance(source, sourceAfter, source.ReservedQuantity, now);
+        ApplyBalance(destination, destination.OnHandQuantity + request.Quantity, destination.ReservedQuantity, now);
+
+        AddMovement(tenantId, request, source.Id, -request.Quantity, sourceBefore, source.OnHandQuantity);
+        AddMovement(tenantId, request with
+        {
+            WarehouseId = destinationWarehouseId,
+            LocationId = destinationLocationId
+        }, destination.Id, request.Quantity, destinationBefore, destination.OnHandQuantity);
+
+        await UpdateProductSnapshot(tenantId, product, request.ProductId, 0, ct);
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<StockPostingResponse>.Failure(saveResult.Message ?? "Stock transfer failed.", saveResult.StatusCode);
+
+        return Result<StockPostingResponse>.Success(new StockPostingResponse(
+            destination.Id,
+            request.ProductId,
+            destination.WarehouseId,
+            destination.LocationId,
+            destination.OnHandQuantity,
+            destination.ReservedQuantity,
+            destination.AvailableQuantity));
+    }
+
+    private async Task<Product?> GetProduct(Guid tenantId, Guid productId, CancellationToken ct) =>
+        await dataContext.Query<Product>()
+            .Where(x => x.TenantId == tenantId && x.Id == productId && !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+
+    private async Task<Result<StockBalance>> GetOrCreateBalance(
+        Guid tenantId,
+        Guid productId,
+        Guid warehouseId,
+        Guid locationId,
+        CancellationToken ct)
+    {
+        var warehouseExists = await dataContext.Query<Warehouse>()
+            .AnyAsync(x => x.TenantId == tenantId && x.Id == warehouseId && !x.IsDeleted, ct);
+        if (!warehouseExists)
+            return Result<StockBalance>.NotFound("Warehouse not found.");
+
+        var locationExists = await dataContext.Query<InventoryLocation>()
+            .AnyAsync(x => x.TenantId == tenantId && x.Id == locationId && x.WarehouseId == warehouseId && !x.IsDeleted, ct);
+        if (!locationExists)
+            return Result<StockBalance>.NotFound("Location not found.");
+
+        var balance = await dataContext.Query<StockBalance>()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                x.ProductId == productId &&
+                x.WarehouseId == warehouseId &&
+                x.LocationId == locationId &&
+                !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+
+        if (balance is not null)
+            return Result<StockBalance>.Success(balance);
+
+        balance = new StockBalance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+        dataContext.Add(balance);
+        return Result<StockBalance>.Success(balance);
+    }
+
+    private static decimal GetOnHandDelta(InventoryMovementType movementType, decimal quantity) =>
+        movementType switch
+        {
+            InventoryMovementType.OpeningBalance or InventoryMovementType.Receipt or InventoryMovementType.Return => quantity,
+            InventoryMovementType.Adjustment => quantity,
+            InventoryMovementType.Shipment => -quantity,
+            _ => 0
+        };
+
+    private static decimal GetReservedDelta(InventoryMovementType movementType, decimal quantity) =>
+        movementType switch
+        {
+            InventoryMovementType.Reservation => quantity,
+            InventoryMovementType.Release => -quantity,
+            _ => 0
+        };
+
+    private static void ApplyBalance(
+        StockBalance balance,
+        decimal onHandQuantity,
+        decimal reservedQuantity,
+        DateTime? movementDate = null)
+    {
+        balance.OnHandQuantity = onHandQuantity;
+        balance.ReservedQuantity = reservedQuantity;
+        balance.AvailableQuantity = onHandQuantity - reservedQuantity;
+        balance.LastMovementAt = movementDate ?? DateTime.UtcNow;
+        balance.ModifiedAt = DateTime.UtcNow;
+        balance.ConcurrencyStamp = Guid.NewGuid();
+    }
+
+    private void AddMovement(
+        Guid tenantId,
+        PostStockMovementRequest request,
+        Guid stockBalanceId,
+        decimal quantityDelta,
+        decimal quantityBefore,
+        decimal quantityAfter)
+    {
+        dataContext.Add(new InventoryMovement
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = request.ProductId,
+            WarehouseId = request.WarehouseId,
+            LocationId = request.LocationId,
+            StockBalanceId = stockBalanceId,
+            MovementType = request.MovementType,
+            QuantityDelta = quantityDelta,
+            QuantityBefore = quantityBefore,
+            QuantityAfter = quantityAfter,
+            MovementDate = DateTime.UtcNow,
+            UnitOfMeasure = request.UnitOfMeasure,
+            ReferenceType = request.ReferenceType,
+            ReferenceId = request.ReferenceId,
+            Reason = request.Reason,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+    }
+
+    private async Task UpdateProductSnapshot(
+        Guid tenantId,
+        Product product,
+        Guid productId,
+        decimal currentDelta,
+        CancellationToken ct)
+    {
+        await Task.CompletedTask;
+        product.StockQuantity += (int)Math.Round(currentDelta, MidpointRounding.AwayFromZero);
+        product.ModifiedAt = DateTime.UtcNow;
+        dataContext.Update(product);
+    }
+
+    private Result<Guid> GetCurrentTenantId(RequestBase? request)
+    {
+        if (request?.Metadata?.TenantId is { } metadataTenantId && metadataTenantId != Guid.Empty)
+            return Result<Guid>.Success(metadataTenantId);
+
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return Result<Guid>.Unauthorized("Authentication is required for stock operations.");
+
+        var tenantIdClaim = user.FindFirst("tenantId")?.Value
+            ?? user.FindFirst("TenantId")?.Value
+            ?? user.FindFirst("tid")?.Value;
+
+        if (Guid.TryParse(tenantIdClaim, out var tenantId) && tenantId != Guid.Empty)
+            return Result<Guid>.Success(tenantId);
+
+        return Result<Guid>.Forbidden("Authenticated user does not have a valid tenant context.");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/WarehouseService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/WarehouseService.cs
@@ -1,0 +1,173 @@
+using Microsoft.AspNetCore.Http;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Api.Services;
+
+public sealed class WarehouseService(
+    IDataContext dataContext,
+    IHttpContextAccessor httpContextAccessor)
+{
+    public async Task<Result<List<Warehouse>>> GetWarehousesAsync(
+        GetWarehousesRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<Warehouse>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var warehouses = await dataContext.Query<Warehouse>()
+            .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted)
+            .OrderBy(x => x.Code)
+            .Take(200)
+            .ToListAsync(ct);
+
+        return Result<List<Warehouse>>.Success(warehouses);
+    }
+
+    public async Task<Result<Warehouse>> CreateWarehouseAsync(CreateWarehouseRequest request, CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<Warehouse>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var code = NormalizeRequired(request.Code);
+        var name = NormalizeRequired(request.Name);
+        if (code is null || name is null)
+            return Result<Warehouse>.Failure("Warehouse code and name are required.", 400);
+
+        var duplicate = await dataContext.Query<Warehouse>()
+            .AnyAsync(x => x.TenantId == tenantId && x.Code == code && !x.IsDeleted, ct);
+        if (duplicate)
+            return Result<Warehouse>.Failure("A warehouse with the same code already exists.", 409);
+
+        var warehouse = new Warehouse
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Code = code,
+            Name = name,
+            Description = NormalizeOptional(request.Description),
+            AddressLine = NormalizeOptional(request.AddressLine),
+            City = NormalizeOptional(request.City),
+            Region = NormalizeOptional(request.Region),
+            PostalCode = NormalizeOptional(request.PostalCode),
+            CountryCode = NormalizeOptional(request.CountryCode),
+            IsDefault = request.IsDefault,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        dataContext.Add(warehouse);
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<Warehouse>.Failure(saveResult.Message ?? "Warehouse save failed.", saveResult.StatusCode);
+
+        return Result<Warehouse>.Success(warehouse, 201, "Warehouse created.");
+    }
+
+    public async Task<Result<List<InventoryLocation>>> GetLocationsAsync(
+        GetInventoryLocationsRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<InventoryLocation>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var query = dataContext.Query<InventoryLocation>()
+            .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
+
+        if (request.WarehouseId is { } id)
+            query = query.Where(x => x.WarehouseId == id);
+
+        var locations = await query
+            .OrderBy(x => x.Code)
+            .Take(500)
+            .ToListAsync(ct);
+
+        return Result<List<InventoryLocation>>.Success(locations);
+    }
+
+    public async Task<Result<InventoryLocation>> CreateLocationAsync(CreateInventoryLocationRequest request, CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<InventoryLocation>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var code = NormalizeRequired(request.Code);
+        var name = NormalizeRequired(request.Name);
+        if (code is null || name is null)
+            return Result<InventoryLocation>.Failure("Location code and name are required.", 400);
+
+        var warehouseExists = await dataContext.Query<Warehouse>()
+            .AnyAsync(x => x.TenantId == tenantId && x.Id == request.WarehouseId && !x.IsDeleted, ct);
+        if (!warehouseExists)
+            return Result<InventoryLocation>.NotFound("Warehouse not found.");
+
+        var duplicate = await dataContext.Query<InventoryLocation>()
+            .AnyAsync(x =>
+                x.TenantId == tenantId &&
+                x.WarehouseId == request.WarehouseId &&
+                x.Code == code &&
+                !x.IsDeleted,
+                ct);
+        if (duplicate)
+            return Result<InventoryLocation>.Failure("A location with the same code already exists in this warehouse.", 409);
+
+        var location = new InventoryLocation
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            WarehouseId = request.WarehouseId,
+            ParentLocationId = request.ParentLocationId,
+            Code = code,
+            Name = name,
+            Description = NormalizeOptional(request.Description),
+            LocationType = request.LocationType,
+            IsPickable = request.IsPickable,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        dataContext.Add(location);
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<InventoryLocation>.Failure(saveResult.Message ?? "Location save failed.", saveResult.StatusCode);
+
+        return Result<InventoryLocation>.Success(location, 201, "Location created.");
+    }
+
+    private Result<Guid> GetCurrentTenantId(RequestBase? request)
+    {
+        if (request?.Metadata?.TenantId is { } metadataTenantId && metadataTenantId != Guid.Empty)
+            return Result<Guid>.Success(metadataTenantId);
+
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return Result<Guid>.Unauthorized("Authentication is required for warehouse operations.");
+
+        var tenantIdClaim = user.FindFirst("tenantId")?.Value
+            ?? user.FindFirst("TenantId")?.Value
+            ?? user.FindFirst("tid")?.Value;
+
+        if (Guid.TryParse(tenantIdClaim, out var tenantId) && tenantId != Guid.Empty)
+            return Result<Guid>.Success(tenantId);
+
+        return Result<Guid>.Forbidden("Authenticated user does not have a valid tenant context.");
+    }
+
+    private static string? NormalizeRequired(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryLocation.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryLocation.cs
@@ -1,18 +1,38 @@
 using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Domain.Shared.Attributes;
 using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-public class InventoryLocation : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/locations",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-locations"
+)]
+public partial class InventoryLocation : BaseModel
 {
+    [MemoryPackOrder(0)]
     public Guid WarehouseId { get; set; }
+    [MemoryPackIgnore]
     public Warehouse? Warehouse { get; set; }
+    [MemoryPackOrder(1)]
     public Guid? ParentLocationId { get; set; }
+    [MemoryPackIgnore]
     public InventoryLocation? ParentLocation { get; set; }
+    [MemoryPackIgnore]
     public List<InventoryLocation> ChildLocations { get; set; } = new();
+    [MemoryPackOrder(2)]
     public string Code { get; set; } = string.Empty;
+    [MemoryPackOrder(3)]
     public string Name { get; set; } = string.Empty;
+    [MemoryPackOrder(4)]
     public string? Description { get; set; }
+    [MemoryPackOrder(5)]
     public InventoryLocationType LocationType { get; set; } = InventoryLocationType.Bin;
+    [MemoryPackOrder(6)]
     public bool IsPickable { get; set; } = true;
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryMovement.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryMovement.cs
@@ -1,25 +1,52 @@
 using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Domain.Shared.Attributes;
 using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-public class InventoryMovement : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/stock/movements",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-stock-movements"
+)]
+public partial class InventoryMovement : BaseModel
 {
+    [MemoryPackOrder(0)]
     public Guid ProductId { get; set; }
+    [MemoryPackIgnore]
     public Product? Product { get; set; }
+    [MemoryPackOrder(1)]
     public Guid? WarehouseId { get; set; }
+    [MemoryPackIgnore]
     public Warehouse? Warehouse { get; set; }
+    [MemoryPackOrder(2)]
     public Guid? LocationId { get; set; }
+    [MemoryPackIgnore]
     public InventoryLocation? Location { get; set; }
+    [MemoryPackOrder(3)]
     public Guid? StockBalanceId { get; set; }
+    [MemoryPackIgnore]
     public StockBalance? StockBalance { get; set; }
+    [MemoryPackOrder(4)]
     public InventoryMovementType MovementType { get; set; }
+    [MemoryPackOrder(5)]
     public decimal QuantityDelta { get; set; }
+    [MemoryPackOrder(6)]
     public decimal QuantityBefore { get; set; }
+    [MemoryPackOrder(7)]
     public decimal QuantityAfter { get; set; }
+    [MemoryPackOrder(8)]
     public DateTime MovementDate { get; set; }
+    [MemoryPackOrder(9)]
     public string? UnitOfMeasure { get; set; }
+    [MemoryPackOrder(10)]
     public string? ReferenceType { get; set; }
+    [MemoryPackOrder(11)]
     public Guid? ReferenceId { get; set; }
+    [MemoryPackOrder(12)]
     public string? Reason { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Locations/CreateInventoryLocationRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Locations/CreateInventoryLocationRequest.cs
@@ -1,0 +1,23 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
+
+using TRequest = CreateInventoryLocationRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreateInventoryLocationRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid WarehouseId { get; init; }
+    public Guid? ParentLocationId { get; init; }
+    public string? Code { get; init; }
+    public string? Name { get; init; }
+    public string? Description { get; init; }
+    public InventoryLocationType LocationType { get; init; } = InventoryLocationType.Bin;
+    public bool IsPickable { get; init; } = true;
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Locations/GetInventoryLocationsRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Locations/GetInventoryLocationsRequest.cs
@@ -1,0 +1,17 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
+
+using TRequest = GetInventoryLocationsRequest;
+using TResponse = QueryResponse<List<InventoryLocation>>;
+
+[MemoryPackable]
+public partial record GetInventoryLocationsRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? WarehouseId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/GetInventoryMovementsRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/GetInventoryMovementsRequest.cs
@@ -1,0 +1,17 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+
+using TRequest = GetInventoryMovementsRequest;
+using TResponse = QueryResponse<List<InventoryMovement>>;
+
+[MemoryPackable]
+public partial record GetInventoryMovementsRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/GetStockBalancesRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/GetStockBalancesRequest.cs
@@ -1,0 +1,17 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+
+using TRequest = GetStockBalancesRequest;
+using TResponse = QueryResponse<List<StockBalance>>;
+
+[MemoryPackable]
+public partial record GetStockBalancesRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/PostStockMovementRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/PostStockMovementRequest.cs
@@ -1,0 +1,28 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+
+using TRequest = PostStockMovementRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record PostStockMovementRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid ProductId { get; init; }
+    public Guid WarehouseId { get; init; }
+    public Guid LocationId { get; init; }
+    public Guid? DestinationWarehouseId { get; init; }
+    public Guid? DestinationLocationId { get; init; }
+    public InventoryMovementType MovementType { get; init; }
+    public decimal Quantity { get; init; }
+    public string? UnitOfMeasure { get; init; }
+    public string? ReferenceType { get; init; }
+    public Guid? ReferenceId { get; init; }
+    public string? Reason { get; init; }
+    public bool AllowNegativeStock { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Warehouses/CreateWarehouseRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Warehouses/CreateWarehouseRequest.cs
@@ -1,0 +1,24 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+
+using TRequest = CreateWarehouseRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreateWarehouseRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public string? Code { get; init; }
+    public string? Name { get; init; }
+    public string? Description { get; init; }
+    public string? AddressLine { get; init; }
+    public string? City { get; init; }
+    public string? Region { get; init; }
+    public string? PostalCode { get; init; }
+    public string? CountryCode { get; init; }
+    public bool IsDefault { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Warehouses/GetWarehousesRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Warehouses/GetWarehousesRequest.cs
@@ -1,0 +1,14 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+
+using TRequest = GetWarehousesRequest;
+using TResponse = QueryResponse<List<Warehouse>>;
+
+[MemoryPackable]
+public partial record GetWarehousesRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>;

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Responses/StockPostingResponse.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Responses/StockPostingResponse.cs
@@ -1,0 +1,11 @@
+namespace XFramework.Inventario.Domain.Shared.Contracts.Responses;
+
+[MemoryPackable]
+public partial record StockPostingResponse(
+    Guid StockBalanceId,
+    Guid ProductId,
+    Guid WarehouseId,
+    Guid LocationId,
+    decimal OnHandQuantity,
+    decimal ReservedQuantity,
+    decimal AvailableQuantity);

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/StockBalance.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/StockBalance.cs
@@ -1,17 +1,37 @@
 using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Domain.Shared.Attributes;
 
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-public class StockBalance : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/stock/balances",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-stock-balances"
+)]
+public partial class StockBalance : BaseModel
 {
+    [MemoryPackOrder(0)]
     public Guid ProductId { get; set; }
+    [MemoryPackIgnore]
     public Product? Product { get; set; }
+    [MemoryPackOrder(1)]
     public Guid WarehouseId { get; set; }
+    [MemoryPackIgnore]
     public Warehouse? Warehouse { get; set; }
+    [MemoryPackOrder(2)]
     public Guid LocationId { get; set; }
+    [MemoryPackIgnore]
     public InventoryLocation? Location { get; set; }
+    [MemoryPackOrder(3)]
     public decimal OnHandQuantity { get; set; }
+    [MemoryPackOrder(4)]
     public decimal ReservedQuantity { get; set; }
+    [MemoryPackOrder(5)]
     public decimal AvailableQuantity { get; set; }
+    [MemoryPackOrder(6)]
     public DateTime? LastMovementAt { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Warehouse.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Warehouse.cs
@@ -1,17 +1,37 @@
 using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Domain.Shared.Attributes;
 
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
-public class Warehouse : BaseModel
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/warehouses",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 300,
+    CacheKeyPrefix = "inventario-warehouses"
+)]
+public partial class Warehouse : BaseModel
 {
+    [MemoryPackOrder(0)]
     public string Code { get; set; } = string.Empty;
+    [MemoryPackOrder(1)]
     public string Name { get; set; } = string.Empty;
+    [MemoryPackOrder(2)]
     public string? Description { get; set; }
+    [MemoryPackOrder(3)]
     public string? AddressLine { get; set; }
+    [MemoryPackOrder(4)]
     public string? City { get; set; }
+    [MemoryPackOrder(5)]
     public string? Region { get; set; }
+    [MemoryPackOrder(6)]
     public string? PostalCode { get; set; }
+    [MemoryPackOrder(7)]
     public string? CountryCode { get; set; }
+    [MemoryPackOrder(8)]
     public bool IsDefault { get; set; }
+    [MemoryPackIgnore]
     public List<InventoryLocation> Locations { get; set; } = new();
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Inventario.Domain.Shared.csproj
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Inventario.Domain.Shared.csproj
@@ -23,6 +23,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\Shared\XFramework.Domain.Shared\XFramework.Domain.Shared.csproj" />
+        <ProjectReference Include="..\..\XFramework.Bolt\Bolt.Domain.Shared\Bolt.Domain.Shared.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -39,9 +39,25 @@
             <NavLink href="/inventario/categories" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
                 <LucideIcon Name="folders" class="h-4 w-4" /> Categories
             </NavLink>
-            <NavLink href="/inventario/transactions" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
-                <LucideIcon Name="arrow-left-right" class="h-4 w-4" /> Transactions
-            </NavLink>
+            @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "warehousing"))
+            {
+                <NavLink href="/inventario/warehouses" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="warehouse" class="h-4 w-4" /> Warehouses
+                </NavLink>
+            }
+            @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances")
+                 || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "movements"))
+            {
+                <NavLink href="/inventario/stock" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="boxes" class="h-4 w-4" /> Stock
+                </NavLink>
+            }
+            @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "transactions"))
+            {
+                <NavLink href="/inventario/transactions" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="arrow-left-right" class="h-4 w-4" /> Transactions
+                </NavLink>
+            }
             <NavLink href="/inventario/settings" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
                 <LucideIcon Name="settings" class="h-4 w-4" /> Settings
             </NavLink>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -1,0 +1,331 @@
+@page "/inventario/stock"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Stock - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_stockEnabled && !_movementsEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Stock" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Stock Control</BbTypographyH3>
+                    <BbTypographyMuted>Post stock movements and inspect balances for the selected tenant.</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            @if (_movementsEnabled)
+            {
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Post Movement</BbCardTitle>
+                        <BbCardDescription>Movements are append-only and update stock balances through Inventario services.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <div class="grid gap-3">
+                            <div class="grid gap-3 xl:grid-cols-4">
+                                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.ProductId" Label="Product" Placeholder="Select product">
+                                    @foreach (var product in _products)
+                                    {
+                                        <BbSelectItem Value="@product.Id.ToString()">@GetProductLabel(product)</BbSelectItem>
+                                    }
+                                </BbFormFieldSelect>
+                                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.WarehouseId" Label="Warehouse" Placeholder="Select warehouse">
+                                    @foreach (var warehouse in _warehouses)
+                                    {
+                                        <BbSelectItem Value="@warehouse.Id.ToString()">@warehouse.Code - @warehouse.Name</BbSelectItem>
+                                    }
+                                </BbFormFieldSelect>
+                                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.LocationId" Label="Location" Placeholder="Select location">
+                                    @foreach (var location in LocationsForSelectedWarehouse())
+                                    {
+                                        <BbSelectItem Value="@location.Id.ToString()">@location.Code - @location.Name</BbSelectItem>
+                                    }
+                                </BbFormFieldSelect>
+                                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.MovementType" Label="Movement Type">
+                                    @foreach (var type in Enum.GetValues<InventoryMovementType>())
+                                    {
+                                        <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
+                                    }
+                                </BbFormFieldSelect>
+                            </div>
+                            <div class="grid gap-3 md:grid-cols-3">
+                                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Quantity" Label="Quantity" />
+                                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.UnitOfMeasure" Label="Unit" />
+                                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.ReferenceType" Label="Reference Type" />
+                            </div>
+                            <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Reason" Label="Reason" />
+                            <BbFormFieldSwitch Checked="@_movementForm.AllowNegativeStock"
+                                               CheckedChanged="@((bool value) => _movementForm.AllowNegativeStock = value)"
+                                               Label="Allow negative stock for this posting" />
+                            <div>
+                                <BbButton OnClick="@PostMovement" Disabled="@IsPostMovementDisabled">
+                                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                                    Post Movement
+                                </BbButton>
+                            </div>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            }
+
+            @if (_stockEnabled)
+            {
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Stock Balances</BbCardTitle>
+                        <BbCardDescription>@_balances.Count balance row(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridTemplateColumn Title="Product">
+                                    <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Warehouse">
+                                    <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Location">
+                                    <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.LastMovementAt)" Title="Last Movement" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            }
+
+            @if (_movementsEnabled)
+            {
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Movement Ledger</BbCardTitle>
+                        <BbCardDescription>@_movements.Count movement(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridTemplateColumn Title="Product">
+                                    <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.QuantityBefore)" Title="Before" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            }
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private readonly MovementForm _movementForm = new();
+    private List<Product> _products = [];
+    private List<Warehouse> _warehouses = [];
+    private List<InventoryLocation> _locations = [];
+    private List<StockBalance> _balances = [];
+    private List<InventoryMovement> _movements = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _stockEnabled;
+    private bool _movementsEnabled;
+    private bool _postingMovement;
+    private bool IsPostMovementDisabled => _postingMovement || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _stockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances");
+            _movementsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "movements");
+            _products = [];
+            _warehouses = [];
+            _locations = [];
+            _balances = [];
+            _movements = [];
+
+            if (!_hasTenant || (!_stockEnabled && !_movementsEnabled)) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(250)
+                .ToListAsync();
+
+            _warehouses = (await Inventario.GetWarehouses(new GetWarehousesRequest { Metadata = BuildMetadata() })).Response ?? [];
+            _locations = (await Inventario.GetInventoryLocations(new GetInventoryLocationsRequest { Metadata = BuildMetadata() })).Response ?? [];
+
+            if (_stockEnabled)
+                _balances = (await Inventario.GetStockBalances(new GetStockBalancesRequest { Metadata = BuildMetadata() })).Response ?? [];
+
+            if (_movementsEnabled)
+                _movements = (await Inventario.GetInventoryMovements(new GetInventoryMovementsRequest { Metadata = BuildMetadata() })).Response ?? [];
+
+            ApplyDefaultMovementSelections();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load stock control: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task PostMovement()
+    {
+        if (!Guid.TryParse(_movementForm.ProductId, out var productId) ||
+            !Guid.TryParse(_movementForm.WarehouseId, out var warehouseId) ||
+            !Guid.TryParse(_movementForm.LocationId, out var locationId))
+        {
+            ToastService.Show("Select product, warehouse, and location.");
+            return;
+        }
+
+        if (!decimal.TryParse(_movementForm.Quantity, out var quantity) || quantity == 0)
+        {
+            ToastService.Show("Quantity must not be zero.");
+            return;
+        }
+
+        _postingMovement = true;
+        try
+        {
+            var result = await Inventario.PostStockMovement(new PostStockMovementRequest
+            {
+                Metadata = BuildMetadata(),
+                ProductId = productId,
+                WarehouseId = warehouseId,
+                LocationId = locationId,
+                MovementType = Enum.TryParse<InventoryMovementType>(_movementForm.MovementType, out var type) ? type : InventoryMovementType.Adjustment,
+                Quantity = quantity,
+                UnitOfMeasure = NullIfEmpty(_movementForm.UnitOfMeasure),
+                ReferenceType = NullIfEmpty(_movementForm.ReferenceType),
+                Reason = NullIfEmpty(_movementForm.Reason),
+                AllowNegativeStock = _movementForm.AllowNegativeStock
+            });
+
+            ToastService.Show(result.IsSuccess ? "Stock movement posted." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _movementForm.Quantity = "0";
+                _movementForm.Reason = "";
+                await Reload();
+            }
+        }
+        finally
+        {
+            _postingMovement = false;
+        }
+    }
+
+    private IEnumerable<InventoryLocation> LocationsForSelectedWarehouse()
+    {
+        if (!Guid.TryParse(_movementForm.WarehouseId, out var warehouseId))
+            return _locations;
+
+        return _locations.Where(x => x.WarehouseId == warehouseId);
+    }
+
+    private void ApplyDefaultMovementSelections()
+    {
+        _movementForm.ProductId = _movementForm.ProductId.Length > 0 ? _movementForm.ProductId : _products.FirstOrDefault()?.Id.ToString() ?? "";
+        _movementForm.WarehouseId = _movementForm.WarehouseId.Length > 0 ? _movementForm.WarehouseId : _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
+        var location = LocationsForSelectedWarehouse().FirstOrDefault() ?? _locations.FirstOrDefault();
+        _movementForm.LocationId = _movementForm.LocationId.Length > 0 ? _movementForm.LocationId : location?.Id.ToString() ?? "";
+    }
+
+    private RequestMetadata BuildMetadata() => new()
+    {
+        TenantId = TenantFilter.SelectedTenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "ControlPanel"
+    };
+
+    private string GetProductLabel(Product product) =>
+        string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
+
+    private string GetProductName(Guid productId) =>
+        _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
+
+    private string GetWarehouseName(Guid warehouseId) =>
+        _warehouses.FirstOrDefault(x => x.Id == warehouseId)?.Name ?? warehouseId.ToString()[..8];
+
+    private string GetLocationName(Guid locationId) =>
+        _locations.FirstOrDefault(x => x.Id == locationId)?.Name ?? locationId.ToString()[..8];
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class MovementForm
+    {
+        public string ProductId { get; set; } = "";
+        public string WarehouseId { get; set; } = "";
+        public string LocationId { get; set; } = "";
+        public string MovementType { get; set; } = InventoryMovementType.Adjustment.ToString();
+        public string Quantity { get; set; } = "0";
+        public string UnitOfMeasure { get; set; } = "each";
+        public string ReferenceType { get; set; } = "";
+        public string Reason { get; set; } = "";
+        public bool AllowNegativeStock { get; set; }
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
@@ -1,0 +1,361 @@
+@page "/inventario/warehouses"
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Warehouses - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_warehousingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Warehousing" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Warehouses</BbTypographyH3>
+                    <BbTypographyMuted>Set up stock storage warehouses and internal locations.</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Create Warehouse</BbCardTitle>
+                        <BbCardDescription>Warehouse codes are unique inside a tenant.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <div class="grid gap-3">
+                            <div class="grid gap-3 md:grid-cols-2">
+                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Code" Label="Code" Required="true" />
+                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Name" Label="Name" Required="true" />
+                            </div>
+                            <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Description" Label="Description" />
+                            <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.AddressLine" Label="Address" />
+                            <div class="grid gap-3 md:grid-cols-3">
+                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.City" Label="City" />
+                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Region" Label="Region" />
+                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.CountryCode" Label="Country Code" />
+                            </div>
+                            <BbFormFieldSwitch Checked="@_warehouseForm.IsDefault"
+                                               CheckedChanged="@((bool value) => _warehouseForm.IsDefault = value)"
+                                               Label="Default warehouse" />
+                            <div>
+                                <BbButton OnClick="@CreateWarehouse" Disabled="@_savingWarehouse">
+                                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                                    Create Warehouse
+                                </BbButton>
+                            </div>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Create Location</BbCardTitle>
+                        <BbCardDescription>Locations belong to a warehouse and can represent bins, shelves, or zones.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <div class="grid gap-3">
+                            <BbFormFieldSelect TValue="string" @bind-Value="_locationForm.WarehouseId" Label="Warehouse" Placeholder="Select warehouse">
+                                @foreach (var warehouse in _warehouses)
+                                {
+                                    <BbSelectItem Value="@warehouse.Id.ToString()">@warehouse.Code - @warehouse.Name</BbSelectItem>
+                                }
+                            </BbFormFieldSelect>
+                            <div class="grid gap-3 md:grid-cols-2">
+                                <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Code" Label="Code" Required="true" />
+                                <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Name" Label="Name" Required="true" />
+                            </div>
+                            <BbFormFieldSelect TValue="string" @bind-Value="_locationForm.LocationType" Label="Location Type">
+                                @foreach (var type in Enum.GetValues<InventoryLocationType>())
+                                {
+                                    <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
+                                }
+                            </BbFormFieldSelect>
+                            <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Description" Label="Description" />
+                            <BbFormFieldSwitch Checked="@_locationForm.IsPickable"
+                                               CheckedChanged="@((bool value) => _locationForm.IsPickable = value)"
+                                               Label="Pickable location" />
+                            <div>
+                                <BbButton OnClick="@CreateLocation" Disabled="@IsCreateLocationDisabled">
+                                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                                    Create Location
+                                </BbButton>
+                            </div>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Warehouse List</BbCardTitle>
+                    <BbCardDescription>@_warehouses.Count warehouse(s), @_locations.Count location(s)</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_warehouses" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.City)" Title="City" />
+                            <BbDataGridTemplateColumn Title="Default">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsDefault ? "Default" : "Standard")" Status="@(item.IsDefault ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Locations">
+                                <ChildContent Context="item">@_locations.Count(x => x.WarehouseId == item.Id)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Locations</BbCardTitle>
+                    <BbCardDescription>Internal stock positions by warehouse.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_locations" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Warehouse">
+                                <ChildContent Context="item">@GetWarehouseLabel(item.WarehouseId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LocationType)" Title="Type" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Pickable">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsPickable ? "Pickable" : "Storage")" Status="@(item.IsPickable ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private readonly WarehouseForm _warehouseForm = new();
+    private readonly LocationForm _locationForm = new();
+    private List<Warehouse> _warehouses = [];
+    private List<InventoryLocation> _locations = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _warehousingEnabled;
+    private bool _savingWarehouse;
+    private bool _savingLocation;
+    private bool IsCreateLocationDisabled => _savingLocation || _warehouses.Count == 0;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _warehousingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "warehousing");
+            _warehouses = [];
+            _locations = [];
+
+            if (!_hasTenant || !_warehousingEnabled) return;
+
+            var warehouseResult = await Inventario.GetWarehouses(new GetWarehousesRequest { Metadata = BuildMetadata() });
+            _warehouses = warehouseResult.Response ?? [];
+            _locationForm.WarehouseId = _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
+
+            var locationResult = await Inventario.GetInventoryLocations(new GetInventoryLocationsRequest { Metadata = BuildMetadata() });
+            _locations = locationResult.Response ?? [];
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load warehouses: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task CreateWarehouse()
+    {
+        if (TenantFilter.SelectedTenantId is not Guid)
+        {
+            ToastService.Show("Select a tenant before creating a warehouse.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_warehouseForm.Code) || string.IsNullOrWhiteSpace(_warehouseForm.Name))
+        {
+            ToastService.Show("Warehouse code and name are required.");
+            return;
+        }
+
+        _savingWarehouse = true;
+        try
+        {
+            var result = await Inventario.CreateWarehouse(new CreateWarehouseRequest
+            {
+                Metadata = BuildMetadata(),
+                Code = _warehouseForm.Code,
+                Name = _warehouseForm.Name,
+                Description = NullIfEmpty(_warehouseForm.Description),
+                AddressLine = NullIfEmpty(_warehouseForm.AddressLine),
+                City = NullIfEmpty(_warehouseForm.City),
+                Region = NullIfEmpty(_warehouseForm.Region),
+                CountryCode = NullIfEmpty(_warehouseForm.CountryCode),
+                IsDefault = _warehouseForm.IsDefault
+            });
+            ToastService.Show(result.IsSuccess ? "Warehouse created." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _warehouseForm.Reset();
+                await Reload();
+            }
+        }
+        finally
+        {
+            _savingWarehouse = false;
+        }
+    }
+
+    private async Task CreateLocation()
+    {
+        if (!Guid.TryParse(_locationForm.WarehouseId, out var warehouseId))
+        {
+            ToastService.Show("Select a warehouse.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_locationForm.Code) || string.IsNullOrWhiteSpace(_locationForm.Name))
+        {
+            ToastService.Show("Location code and name are required.");
+            return;
+        }
+
+        _savingLocation = true;
+        try
+        {
+            var result = await Inventario.CreateInventoryLocation(new CreateInventoryLocationRequest
+            {
+                Metadata = BuildMetadata(),
+                WarehouseId = warehouseId,
+                Code = _locationForm.Code,
+                Name = _locationForm.Name,
+                Description = NullIfEmpty(_locationForm.Description),
+                LocationType = Enum.TryParse<InventoryLocationType>(_locationForm.LocationType, out var type) ? type : InventoryLocationType.Bin,
+                IsPickable = _locationForm.IsPickable
+            });
+            ToastService.Show(result.IsSuccess ? "Location created." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _locationForm.Reset();
+                _locationForm.WarehouseId = _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
+                await Reload();
+            }
+        }
+        finally
+        {
+            _savingLocation = false;
+        }
+    }
+
+    private RequestMetadata BuildMetadata() => new()
+    {
+        TenantId = TenantFilter.SelectedTenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "ControlPanel"
+    };
+
+    private string GetWarehouseLabel(Guid warehouseId) =>
+        _warehouses.FirstOrDefault(x => x.Id == warehouseId) is { } warehouse
+            ? $"{warehouse.Code} - {warehouse.Name}"
+            : warehouseId.ToString()[..8];
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class WarehouseForm
+    {
+        public string Code { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string Description { get; set; } = "";
+        public string AddressLine { get; set; } = "";
+        public string City { get; set; } = "";
+        public string Region { get; set; } = "";
+        public string CountryCode { get; set; } = "";
+        public bool IsDefault { get; set; }
+
+        public void Reset()
+        {
+            Code = "";
+            Name = "";
+            Description = "";
+            AddressLine = "";
+            City = "";
+            Region = "";
+            CountryCode = "";
+            IsDefault = false;
+        }
+    }
+
+    private sealed class LocationForm
+    {
+        public string WarehouseId { get; set; } = "";
+        public string Code { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string Description { get; set; } = "";
+        public string LocationType { get; set; } = InventoryLocationType.Bin.ToString();
+        public bool IsPickable { get; set; } = true;
+
+        public void Reset()
+        {
+            Code = "";
+            Name = "";
+            Description = "";
+            LocationType = InventoryLocationType.Bin.ToString();
+            IsPickable = true;
+        }
+    }
+}

--- a/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
@@ -1,0 +1,228 @@
+using System.Collections;
+using System.Linq.Expressions;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace Inventario.Api.Tests;
+
+[TestFixture]
+public sealed class StockPostingServiceTests
+{
+    [Test]
+    public async Task PostAsync_OpeningBalance_CreatesBalanceMovementAndUpdatesProductSnapshot()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 25,
+            Reason = "Initial count"
+        });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.Data!.OnHandQuantity.Should().Be(25);
+        result.Data.ReservedQuantity.Should().Be(0);
+        result.Data.AvailableQuantity.Should().Be(25);
+
+        dataContext.Set<StockBalance>().Should().ContainSingle(x =>
+            x.ProductId == productId &&
+            x.OnHandQuantity == 25 &&
+            x.AvailableQuantity == 25);
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x =>
+            x.ProductId == productId &&
+            x.MovementType == InventoryMovementType.OpeningBalance &&
+            x.QuantityDelta == 25);
+        dataContext.Set<Product>().Single().StockQuantity.Should().Be(25);
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task PostAsync_ShipmentBeyondAvailableStock_ReturnsConflictWithoutSaving()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        dataContext.Set<StockBalance>().Add(new StockBalance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            OnHandQuantity = 3,
+            ReservedQuantity = 0,
+            AvailableQuantity = 3
+        });
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            MovementType = InventoryMovementType.Shipment,
+            Quantity = 5
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        dataContext.Added.OfType<InventoryMovement>().Should().BeEmpty();
+        dataContext.SaveCount.Should().Be(0);
+    }
+
+    private static FakeDataContext SeedStockData(Guid tenantId, Guid productId, Guid warehouseId, Guid locationId)
+    {
+        var dataContext = new FakeDataContext();
+        dataContext.Set<Product>().Add(new Product
+        {
+            Id = productId,
+            TenantId = tenantId,
+            Name = "Widget",
+            CategoryId = Guid.NewGuid(),
+            IsEnabled = true
+        });
+        dataContext.Set<Warehouse>().Add(new Warehouse
+        {
+            Id = warehouseId,
+            TenantId = tenantId,
+            Code = "MAIN",
+            Name = "Main Warehouse",
+            IsEnabled = true
+        });
+        dataContext.Set<InventoryLocation>().Add(new InventoryLocation
+        {
+            Id = locationId,
+            TenantId = tenantId,
+            WarehouseId = warehouseId,
+            Code = "BIN-01",
+            Name = "Bin 01",
+            IsEnabled = true
+        });
+
+        return dataContext;
+    }
+
+    private static StockPostingService CreateService(FakeDataContext dataContext, Guid tenantId)
+    {
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim("tenantId", tenantId.ToString())],
+                    authenticationType: "Test"))
+            }
+        };
+
+        return new StockPostingService(dataContext, httpContextAccessor);
+    }
+
+    private sealed class FakeDataContext : IDataContext
+    {
+        private readonly Dictionary<Type, IList> sets = [];
+
+        public List<object> Added { get; } = [];
+        public List<object> Updated { get; } = [];
+        public int SaveCount { get; private set; }
+
+        public List<T> Set<T>() where T : class
+        {
+            if (!sets.TryGetValue(typeof(T), out var set))
+            {
+                set = new List<T>();
+                sets[typeof(T)] = set;
+            }
+
+            return (List<T>)set;
+        }
+
+        public IRemoteQuery<T> Query<T>() where T : class =>
+            new InMemoryRemoteQuery<T>(Set<T>().AsQueryable());
+
+        public void Add<T>(T entity) where T : class
+        {
+            Added.Add(entity);
+            Set<T>().Add(entity);
+        }
+
+        public void Update<T>(T entity) where T : class =>
+            Updated.Add(entity);
+
+        public void Remove<T>(T entity) where T : class =>
+            Set<T>().Remove(entity);
+
+        public Task<DataContextResult> SaveChangesAsync(CancellationToken ct = default)
+        {
+            SaveCount++;
+            return Task.FromResult(DataContextResult.Success());
+        }
+    }
+
+    private sealed class InMemoryRemoteQuery<T>(IQueryable<T> queryable) : IRemoteQuery<T>
+        where T : class
+    {
+        private IQueryable<T> query = queryable;
+
+        public IRemoteQuery<T> Where(Expression<Func<T, bool>> predicate) { query = query.Where(predicate); return this; }
+        public IRemoteQuery<T> OrderBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.OrderBy(keySelector); return this; }
+        public IRemoteQuery<T> OrderByDescending<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.OrderByDescending(keySelector); return this; }
+        public IRemoteQuery<T> ThenBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = ((IOrderedQueryable<T>)query).ThenBy(keySelector); return this; }
+        public IRemoteQuery<T> ThenByDescending<TKey>(Expression<Func<T, TKey>> keySelector) { query = ((IOrderedQueryable<T>)query).ThenByDescending(keySelector); return this; }
+        public IRemoteQuery<T> Skip(int count) { query = query.Skip(count); return this; }
+        public IRemoteQuery<T> Take(int count) { query = query.Take(count); return this; }
+        public IRemoteQuery<T> Include<TProperty>(Expression<Func<T, TProperty>> navigationSelector) => this;
+        public IRemoteQuery<T> Distinct() { query = query.Distinct(); return this; }
+        public IRemoteQuery<T> DistinctBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.AsEnumerable().DistinctBy(keySelector.Compile()).AsQueryable(); return this; }
+        public IRemoteQuery<T> NoCache() => this;
+        public IRemoteQuery<T> IgnoreQueryFilters() => this;
+        public Task<List<T>> ToListAsync(CancellationToken ct = default) => Task.FromResult(query.ToList());
+        public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) => Task.FromResult(query.FirstOrDefault());
+        public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default) => Task.FromResult(query.SingleOrDefault());
+        public async IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in query)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+        public Task<int> CountAsync(CancellationToken ct = default) => Task.FromResult(query.Count());
+        public Task<bool> AnyAsync(CancellationToken ct = default) => Task.FromResult(query.Any());
+        public Task<bool> AnyAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) => Task.FromResult(query.Any(predicate));
+        public Task<bool> AllAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) => Task.FromResult(query.All(predicate));
+        public Task<TResult?> MinAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) => Task.FromResult(query.Select(selector).Min());
+        public Task<TResult?> MaxAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) => Task.FromResult(query.Select(selector).Max());
+        public Task<T?> MinByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) => Task.FromResult(query.AsEnumerable().MinBy(keySelector.Compile()));
+        public Task<T?> MaxByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) => Task.FromResult(query.AsEnumerable().MaxBy(keySelector.Compile()));
+        public Task<decimal> SumAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) => Task.FromResult(query.Sum(selector));
+        public Task<double> AverageAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) => Task.FromResult((double)query.Average(selector));
+        public Task<List<GroupResult<TKey, T>>> GroupByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default)
+        {
+            var compiled = keySelector.Compile();
+            return Task.FromResult(query.AsEnumerable()
+                .GroupBy(compiled)
+                .Select(g => new GroupResult<TKey, T> { Key = g.Key, Items = g.ToList() })
+                .ToList());
+        }
+    }
+}


### PR DESCRIPTION
Adds the first advanced stock core behind feature gates: warehouse and location services/endpoints, stock balance and append-only movement contracts, stock posting service, movement/balance APIs, ControlPanel warehouse and stock pages, and focused stock posting tests. Verification: dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false; dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false.