### PR TITLE
fix: restore ControlPanel login after DataContext tenant hardening

### DIFF
--- a/src/Infrastructure/XFramework.Integration/DataContext/RemoteQuery.cs
+++ b/src/Infrastructure/XFramework.Integration/DataContext/RemoteQuery.cs
@@ -330,10 +330,35 @@ public class RemoteQuery<T> : IRemoteQuery<T> where T : class
         {
             return MemoryPackSerializer.Deserialize<TQueryResult>(resultBytes);
         }
-        catch (MemoryPackSerializationException ex)
+        catch (Exception ex) when (ex is MemoryPackSerializationException or OverflowException or InvalidOperationException)
         {
+            if (TryDeserializeFailure(resultBytes, out var failure))
+            {
+                throw new InvalidOperationException(
+                    $"Remote data context query '{mode}' failed: {failure.Message}", ex);
+            }
+
             throw new InvalidOperationException(
                 $"Remote data context query '{mode}' returned an invalid response: {ex.Message}", ex);
+        }
+    }
+
+    private static bool TryDeserializeFailure(byte[] resultBytes, out DataContextResult failure)
+    {
+        failure = null!;
+
+        try
+        {
+            var result = MemoryPackSerializer.Deserialize<DataContextResult>(resultBytes);
+            if (result is not { IsSuccess: false } || string.IsNullOrWhiteSpace(result.Message))
+                return false;
+
+            failure = result;
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/Presentation/ControlPanel.Server/Services/ControlPanelAuthService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/ControlPanelAuthService.cs
@@ -14,6 +14,7 @@ public sealed class ControlPanelAuthService(
     IDataContext dataContext,
     IIdentityServerServiceWrapper identityServer,
     IConfiguration configuration,
+    RequestMetadata requestMetadata,
     ILogger<ControlPanelAuthService> logger)
 {
     public async Task<ControlPanelLoginResult> AuthenticateAsync(
@@ -42,6 +43,8 @@ public sealed class ControlPanelAuthService(
         {
             return ControlPanelLoginResult.Failed("ControlPanel admin tenant is not seeded yet.");
         }
+
+        requestMetadata.TenantId = tenant.Id;
 
         var roleType = await dataContext.Query<IdentityRoleType>()
             .IgnoreQueryFilters()

--- a/src/Tests/XFramework.Core.Tests/DataContext/QueryExecutionServiceTests.cs
+++ b/src/Tests/XFramework.Core.Tests/DataContext/QueryExecutionServiceTests.cs
@@ -154,6 +154,48 @@ public partial class QueryExecutionServiceTests
     }
 
     [Test]
+    public async Task ExecuteAsync_TenantOwnedEntityWithMetadata_ReturnsSerializedRows()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var services = new ServiceCollection()
+            .AddDbContext<TestTenantEntityDbContext>(options => options.UseSqlite(connection))
+            .AddScoped<DbContext>(provider => provider.GetRequiredService<TestTenantEntityDbContext>())
+            .BuildServiceProvider();
+
+        var tenantId = Guid.NewGuid();
+        await using (var setupScope = services.CreateAsyncScope())
+        {
+            var setupDbContext = setupScope.ServiceProvider.GetRequiredService<TestTenantEntityDbContext>();
+            await setupDbContext.Database.EnsureCreatedAsync();
+            setupDbContext.TestTenantEntities.Add(new TestTenantEntity
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                Name = "Tenant scoped"
+            });
+            await setupDbContext.SaveChangesAsync();
+        }
+
+        var service = new QueryExecutionService(services, NullLogger<QueryExecutionService>.Instance);
+        service.RegisterEntity<TestTenantEntity>("TestTenantEntity");
+
+        var descriptor = new QueryDescriptor
+        {
+            EntityTypeName = "TestTenantEntity",
+            Mode = QueryExecutionMode.ToList,
+            Metadata = new RequestMetadata { TenantId = tenantId }
+        };
+
+        var resultBytes = await service.ExecuteAsync(MemoryPackSerializer.Serialize(descriptor));
+        var rows = MemoryPackSerializer.Deserialize<List<TestTenantEntity>>(resultBytes);
+
+        rows.Should().NotBeNull();
+        rows!.Should().ContainSingle(x => x.Name == "Tenant scoped");
+    }
+
+    [Test]
     public async Task ExecuteChangesAsync_TenantOwnedEntityWithMismatchedMetadata_ReturnsFailureAndDoesNotSave()
     {
         await using var connection = new SqliteConnection("DataSource=:memory:");


### PR DESCRIPTION
Fixes xeon-dev ControlPanel login 500s after DataContext tenant hardening. The login flow now sets the scoped RequestMetadata tenant after locating the bootstrap admin tenant and before querying tenant-owned IdentityRoleType rows. RemoteQuery also converts DataContext failure payloads into readable InvalidOperationException messages instead of MemoryPack overflow crashes. Verification: dotnet test src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj --filter QueryExecutionServiceTests -m:1 /nr:false; dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false.