### PR TITLE
Fix ControlPanel tenant module reload loop

### DIFF
--- a/src/Presentation/ControlPanel.Server/Services/TenantModuleNavigationService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/TenantModuleNavigationService.cs
@@ -49,8 +49,12 @@ public sealed class TenantModuleNavigationService(
 
     private async Task LoadAsync(CancellationToken ct = default)
     {
+        if (_loading)
+        {
+            return;
+        }
+
         _loading = true;
-        OnChanged?.Invoke();
 
         try
         {


### PR DESCRIPTION
## Summary
- Prevent TenantModuleNavigationService from broadcasting module changes while it is already loading
- Avoid recursive Inventario page reloads when switching active tenants

## Test Plan
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly