### PR TITLE
Fix Inventario Bolt client routing

### DIFF
--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Development.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Development.json
@@ -44,7 +44,7 @@
       "SmsGatewayService": "24ebae0e-9705-4386-a9ba-66c1c710144d"
     },
     "ClientGuid": "3902761a-822d-4c6b-8e2d-323fd501bcd6",
-    "ClientName": "XFramework.Inventario",
+    "ClientName": "Inventario",
     "ClientDescription": "Inventario",
     "ReconnectDelay": 1500,
     "MaxRetry": 3,

--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Staging.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.Staging.json
@@ -39,7 +39,7 @@
       "SmsGatewayService": "24ebae0e-9705-4386-a9ba-66c1c710144d"
     },
     "ClientGuid": "3902761a-822d-4c6b-8e2d-323fd501bcd6",
-    "ClientName": "XFramework.Inventario",
+    "ClientName": "Inventario",
     "ClientDescription": "Inventario",
     "ReconnectDelay": 1500,
     "MaxRetry": 3,

--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.json
@@ -53,7 +53,7 @@
       "SmsGatewayService": "24ebae0e-9705-4386-a9ba-66c1c710144d"
     },
     "ClientGuid": "3902761a-822d-4c6b-8e2d-323fd501bcd6",
-    "ClientName": "XFramework.Inventario",
+    "ClientName": "Inventario",
     "ClientDescription": "Inventario",
     "ReconnectDelay": 1500,
     "MaxRetry": 3,


### PR DESCRIPTION
## Summary
- align Inventario Bolt client name with source-generated wrapper target
- update base/development/staging config so the service registers as SHA256(Inventario)

## Test Plan
- dotnet build src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly