### PR TITLE
Add ControlPanel randomUUID fallback

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/App.razor
+++ b/src/Presentation/ControlPanel.Server/Components/App.razor
@@ -23,6 +23,48 @@
         <a href="" class="underline">Reload</a>
     </div>
 
+    <script>
+        (() => {
+            if (window.crypto?.randomUUID) {
+                return;
+            }
+
+            const bytesToHex = [];
+            for (let i = 0; i < 256; i += 1) {
+                bytesToHex.push((i + 0x100).toString(16).slice(1));
+            }
+
+            const createUuid = () => {
+                const bytes = new Uint8Array(16);
+                if (window.crypto?.getRandomValues) {
+                    window.crypto.getRandomValues(bytes);
+                } else {
+                    for (let i = 0; i < bytes.length; i += 1) {
+                        bytes[i] = Math.floor(Math.random() * 256);
+                    }
+                }
+
+                bytes[6] = (bytes[6] & 0x0f) | 0x40;
+                bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+                return `${bytesToHex[bytes[0]]}${bytesToHex[bytes[1]]}${bytesToHex[bytes[2]]}${bytesToHex[bytes[3]]}-${bytesToHex[bytes[4]]}${bytesToHex[bytes[5]]}-${bytesToHex[bytes[6]]}${bytesToHex[bytes[7]]}-${bytesToHex[bytes[8]]}${bytesToHex[bytes[9]]}-${bytesToHex[bytes[10]]}${bytesToHex[bytes[11]]}${bytesToHex[bytes[12]]}${bytesToHex[bytes[13]]}${bytesToHex[bytes[14]]}${bytesToHex[bytes[15]]}`;
+            };
+
+            if (!window.crypto) {
+                window.crypto = {};
+            }
+
+            try {
+                Object.defineProperty(window.crypto, "randomUUID", {
+                    value: createUuid,
+                    configurable: true
+                });
+            } catch {
+                window.crypto.randomUUID = createUuid;
+            }
+        })();
+    </script>
+
     <!-- Preload Floating UI for positioning (Select, Popover, etc.) -->
     <script type="module">
         import * as FloatingUI from 'https://cdn.jsdelivr.net/npm/@@floating-ui/dom@@1.5.3/+esm';


### PR DESCRIPTION
## Summary
- add a browser-side crypto.randomUUID fallback before Blazor starts
- keeps BlazorBlueprint overlays working on the HTTP xeon-dev deployment where randomUUID is unavailable

## Test Plan
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly