### PR TITLE
Register Inventario foundation migration

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260617222322_InventarioFoundationCore.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260617222322_InventarioFoundationCore.cs
@@ -1,11 +1,15 @@
 using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
 
 #nullable disable
 
 namespace XFramework.Domain.Migrations
 {
     /// <inheritdoc />
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260617222322_InventarioFoundationCore")]
     public partial class InventarioFoundationCore : Migration
     {
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- add EF migration metadata to InventarioFoundationCore
- allows the migration runner to discover and apply the advanced Inventario tables

## Test Plan
- dotnet build src/Tools/XFramework.MigrationRunner/XFramework.MigrationRunner.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly

## Verification notes
- xeon-dev currently has only the earlier Inventario product tables; after this merges, rerun the migration runner and verify Warehouse, InventoryLocation, StockBalance, InventoryMovement, and Reservation tables exist.