### PR TITLE
Allow Inventario catalog remote mutations

### DIFF
--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Product.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Product.cs
@@ -3,6 +3,7 @@ using XFramework.Domain.Shared.Attributes;
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
 [MemoryPackable(GenerateType.CircularReference)]
+[AllowRemoteDataContextMutation]
 [GenerateEndpoints(
     Type = EndpointType.Rest,
     Actions = EndpointActions.None,

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductCategory.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductCategory.cs
@@ -3,6 +3,7 @@ using XFramework.Domain.Shared.Attributes;
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
 [MemoryPackable(GenerateType.CircularReference)]
+[AllowRemoteDataContextMutation]
 [GenerateEndpoints(
     Type = EndpointType.Rest,
     Actions = EndpointActions.None,

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductVariation.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductVariation.cs
@@ -3,6 +3,7 @@ using XFramework.Domain.Shared.Attributes;
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
 [MemoryPackable(GenerateType.CircularReference)]
+[AllowRemoteDataContextMutation]
 [GenerateEndpoints(
     Type = EndpointType.Rest,
     Actions = EndpointActions.None,

--- a/src/Shared/XFramework.Domain.Shared/Attributes/AllowRemoteDataContextMutationAttribute.cs
+++ b/src/Shared/XFramework.Domain.Shared/Attributes/AllowRemoteDataContextMutationAttribute.cs
@@ -1,0 +1,11 @@
+namespace XFramework.Domain.Shared.Attributes;
+
+/// <summary>
+/// Explicitly allows remote <c>IDataContext</c> mutation for an entity without exposing generated REST CRUD endpoints.
+/// </summary>
+/// <remarks>
+/// Use this only for entities that have an authenticated admin/client surface which intentionally writes through
+/// remote <c>IDataContext</c>. Server-side tenant metadata validation still applies.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class AllowRemoteDataContextMutationAttribute : Attribute;

--- a/src/SourceGenerators/XFramework.SourceGenerators/DataContextRegistrationGenerator.cs
+++ b/src/SourceGenerators/XFramework.SourceGenerators/DataContextRegistrationGenerator.cs
@@ -16,6 +16,9 @@ namespace XFramework.SourceGenerators;
 public class DataContextRegistrationGenerator : IIncrementalGenerator
 {
     private const int MutatingEndpointActions = 1 | 8 | 16; // Create | Update | Delete
+    private const string CoreGenerateEndpointsAttribute = "XFramework.Core.Attributes.GenerateEndpointsAttribute";
+    private const string SharedGenerateEndpointsAttribute = "XFramework.Domain.Shared.Attributes.GenerateEndpointsAttribute";
+    private const string SharedAllowRemoteMutationAttribute = "XFramework.Domain.Shared.Attributes.AllowRemoteDataContextMutationAttribute";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -54,7 +57,8 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
                 ClassName = classSymbol.Name,
                 FullyQualifiedName = classSymbol.ToDisplayString(),
                 AssemblyName = classSymbol.ContainingAssembly?.Name ?? "",
-                EndpointActionsValue = GetEndpointActionsValue(attributeData)
+                EndpointActionsValue = GetEndpointActionsValue(attributeData),
+                AllowRemoteMutation = HasAllowRemoteMutationAttribute(classSymbol)
             };
         }
 
@@ -74,8 +78,6 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
         }
 
         // Discover from referenced assemblies
-        var coreAttr = "XFramework.Core.Attributes.GenerateEndpointsAttribute";
-        var sharedAttr = "XFramework.Domain.Shared.Attributes.GenerateEndpointsAttribute";
         foreach (var reference in compilation.References)
         {
             var symbol = compilation.GetAssemblyOrModuleSymbol(reference);
@@ -91,8 +93,8 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
                     continue;
 
                 var generateEndpointsAttribute = type.GetAttributes().FirstOrDefault(a =>
-                    a.AttributeClass?.ToDisplayString() == coreAttr ||
-                    a.AttributeClass?.ToDisplayString() == sharedAttr);
+                    a.AttributeClass?.ToDisplayString() == CoreGenerateEndpointsAttribute ||
+                    a.AttributeClass?.ToDisplayString() == SharedGenerateEndpointsAttribute);
 
                 if (generateEndpointsAttribute is not null)
                 {
@@ -101,7 +103,8 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
                         ClassName = type.Name,
                         FullyQualifiedName = type.ToDisplayString(),
                         AssemblyName = assembly.Name,
-                        EndpointActionsValue = GetEndpointActionsValue(generateEndpointsAttribute)
+                        EndpointActionsValue = GetEndpointActionsValue(generateEndpointsAttribute),
+                        AllowRemoteMutation = HasAllowRemoteMutationAttribute(type)
                     });
                 }
             }
@@ -144,7 +147,7 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
 
         sb.AppendLine("    public static HashSet<string> GetDataContextMutableEntityTypes() => new(StringComparer.OrdinalIgnoreCase)");
         sb.AppendLine("    {");
-        foreach (var entity in validEntities.Where(static e => HasMutatingEndpointActions(e.EndpointActionsValue)))
+        foreach (var entity in validEntities.Where(static e => HasMutatingEndpointActions(e.EndpointActionsValue) || e.AllowRemoteMutation))
         {
             sb.AppendLine($"        \"{entity.ClassName}\",");
         }
@@ -212,6 +215,10 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
     private static bool HasMutatingEndpointActions(int endpointActionsValue) =>
         (endpointActionsValue & MutatingEndpointActions) != 0;
 
+    private static bool HasAllowRemoteMutationAttribute(INamedTypeSymbol type) =>
+        type.GetAttributes().Any(static a =>
+            a.AttributeClass?.ToDisplayString() == SharedAllowRemoteMutationAttribute);
+
     private static bool ShouldIncludeEntity(string assemblyName, string currentModuleName)
     {
         if (string.IsNullOrWhiteSpace(assemblyName) || string.IsNullOrWhiteSpace(currentModuleName))
@@ -253,5 +260,6 @@ public class DataContextRegistrationGenerator : IIncrementalGenerator
         public string FullyQualifiedName { get; set; } = "";
         public string AssemblyName { get; set; } = "";
         public int EndpointActionsValue { get; set; } = 31;
+        public bool AllowRemoteMutation { get; set; }
     }
 }

--- a/src/Tests/XFramework.SourceGenerators.Tests/DataContextRegistrationGeneratorTests.cs
+++ b/src/Tests/XFramework.SourceGenerators.Tests/DataContextRegistrationGeneratorTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+using XFramework.SourceGenerators;
+
+namespace XFramework.SourceGenerators.Tests;
+
+[TestFixture]
+public sealed class DataContextRegistrationGeneratorTests
+{
+    [Test]
+    public void GenerateRegistration_ActionsNoneWithoutOptIn_IsQueryOnly()
+    {
+        const string source = """
+namespace Sample;
+
+using XFramework.Domain.Shared.Attributes;
+
+[GenerateEndpoints(Actions = EndpointActions.None)]
+public sealed class QueryOnlyEntity;
+
+[AllowRemoteDataContextMutation]
+[GenerateEndpoints(Actions = EndpointActions.None)]
+public sealed class AdminMutableEntity;
+
+[GenerateEndpoints(Actions = EndpointActions.Create)]
+public sealed class GeneratedCreateEntity;
+""";
+
+        var generatedSource = RunGenerator(source);
+
+        generatedSource.Should().Contain("[\"QueryOnlyEntity\"] = typeof(global::Sample.QueryOnlyEntity),");
+        generatedSource.Should().Contain("[\"AdminMutableEntity\"] = typeof(global::Sample.AdminMutableEntity),");
+        generatedSource.Should().Contain("[\"GeneratedCreateEntity\"] = typeof(global::Sample.GeneratedCreateEntity),");
+
+        generatedSource.Should().Contain("\"AdminMutableEntity\",");
+        generatedSource.Should().Contain("\"GeneratedCreateEntity\",");
+        generatedSource.Should().NotContain("\"QueryOnlyEntity\",");
+    }
+
+    private static string RunGenerator(string source)
+    {
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        var compilation = CSharpCompilation.Create(
+            "SampleModule.Api",
+            [
+                CSharpSyntaxTree.ParseText(CommonStubs, parseOptions),
+                CSharpSyntaxTree.ParseText(source, parseOptions)
+            ],
+            GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var inputDiagnostics = compilation.GetDiagnostics()
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        inputDiagnostics.Should().BeEmpty();
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [new DataContextRegistrationGenerator().AsSourceGenerator()],
+            parseOptions: parseOptions);
+        driver = driver.RunGeneratorsAndUpdateCompilation(
+            compilation,
+            out var outputCompilation,
+            out var generatorDiagnostics);
+
+        generatorDiagnostics
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .Should()
+            .BeEmpty();
+
+        outputCompilation.GetDiagnostics()
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .Should()
+            .BeEmpty();
+
+        var generatedSource = driver.GetRunResult()
+            .GeneratedTrees
+            .Single(tree => tree.FilePath.EndsWith("DataContextEntityRegistrations.g.cs", StringComparison.Ordinal))
+            .GetText()
+            .ToString();
+
+        generatedSource.Should().NotBeNullOrWhiteSpace();
+        return generatedSource;
+    }
+
+    private static IEnumerable<MetadataReference> GetMetadataReferences()
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(static assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
+            .Select(static assembly => MetadataReference.CreateFromFile(assembly.Location))
+            .DistinctBy(static reference => reference.Display);
+    }
+
+    private const string CommonStubs = """
+using System;
+
+namespace XFramework.Domain.Shared.Attributes
+{
+    [Flags]
+    public enum EndpointActions
+    {
+        None = 0,
+        Create = 1,
+        Get = 2,
+        GetList = 4,
+        Update = 8,
+        Delete = 16,
+        All = Create | Get | GetList | Update | Delete
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class GenerateEndpointsAttribute : Attribute
+    {
+        public EndpointActions Actions { get; set; } = EndpointActions.All;
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class AllowRemoteDataContextMutationAttribute : Attribute;
+}
+""";
+}


### PR DESCRIPTION
## Summary
- add an explicit `[AllowRemoteDataContextMutation]` opt-in for entities that need remote `IDataContext` writes without generated REST CRUD
- keep `EndpointActions.None` query-only by default in the DataContext registration generator
- opt in only Inventario catalog entities written by ControlPanel: `Product`, `ProductCategory`, and `ProductVariation`
- add a source-generator regression test for the query-only/default and explicit opt-in behavior

## Browser finding
ControlPanel Inventario category creation failed with:

`Entity type 'ProductCategory' is not registered for remote mutation.`

## Verification
- `dotnet test src\Tests\XFramework.SourceGenerators.Tests\XFramework.SourceGenerators.Tests.csproj -m:1 /nr:false --nologo -v:minimal`
- `dotnet build src\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly`
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly`