### PR TITLE
Add Inventario catalog base defaults

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260618182000_AddInventarioCatalogDefaults.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260618182000_AddInventarioCatalogDefaults.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260618182000_AddInventarioCatalogDefaults")]
+    public partial class AddInventarioCatalogDefaults : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            AddConcurrencyStampDefault(migrationBuilder, "Product");
+            AddConcurrencyStampDefault(migrationBuilder, "ProductCategory");
+            AddConcurrencyStampDefault(migrationBuilder, "ProductTransaction");
+            AddConcurrencyStampDefault(migrationBuilder, "ProductVariation");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            RemoveConcurrencyStampDefault(migrationBuilder, "Product");
+            RemoveConcurrencyStampDefault(migrationBuilder, "ProductCategory");
+            RemoveConcurrencyStampDefault(migrationBuilder, "ProductTransaction");
+            RemoveConcurrencyStampDefault(migrationBuilder, "ProductVariation");
+        }
+
+        private static void AddConcurrencyStampDefault(MigrationBuilder migrationBuilder, string table)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ConcurrencyStamp",
+                schema: "Inventario",
+                table: table,
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "(uuid_generate_v4())",
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        private static void RemoveConcurrencyStampDefault(MigrationBuilder migrationBuilder, string table)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ConcurrencyStamp",
+                schema: "Inventario",
+                table: table,
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "(uuid_generate_v4())");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a migration to backfill uuid defaults for Inventario catalog ConcurrencyStamp columns
- aligns restored catalog tables with the current BaseModel EF configuration
- fixes ControlPanel catalog creates failing with Postgres 23502 on ConcurrencyStamp

## Verification
- dotnet build src/Tools/XFramework.MigrationRunner/XFramework.MigrationRunner.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly