### PR TITLE
Add Inventario product defaults

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260619030500_AddInventarioProductDefaults.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619030500_AddInventarioProductDefaults.cs
@@ -1,0 +1,62 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260619030500_AddInventarioProductDefaults")]
+    public partial class AddInventarioProductDefaults : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "StockQuantity",
+                schema: "Inventario",
+                table: "Product",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsAvailable",
+                schema: "Inventario",
+                table: "Product",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "StockQuantity",
+                schema: "Inventario",
+                table: "Product",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldDefaultValue: 0);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsAvailable",
+                schema: "Inventario",
+                table: "Product",
+                type: "boolean",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a migration for restored Product table defaults expected by current EF configuration
- set Product.StockQuantity default to 0
- set Product.IsAvailable default to true

## Browser evidence
- Category creation now succeeds after #244
- Product creation reached the database and failed on missing Product.StockQuantity default

## Verification
- dotnet build src/Tools/XFramework.MigrationRunner/XFramework.MigrationRunner.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly