### PR TITLE
Use DataContext for Inventario warehouse reads

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
@@ -184,9 +184,29 @@ else
                 .Take(250)
                 .ToListAsync();
 
-            _warehouses = (await Inventario.GetWarehouses(new GetWarehousesRequest { Metadata = BuildMetadata() })).Response ?? [];
-            _locations = (await Inventario.GetInventoryLocations(new GetInventoryLocationsRequest { Metadata = BuildMetadata() })).Response ?? [];
-            _reservations = (await Inventario.GetReservations(new GetReservationsRequest { Metadata = BuildMetadata() })).Response ?? [];
+            _warehouses = await DataContext.Query<Warehouse>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Code)
+                .Take(200)
+                .ToListAsync();
+
+            _locations = await DataContext.Query<InventoryLocation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Code)
+                .Take(500)
+                .ToListAsync();
+
+            _reservations = await DataContext.Query<Reservation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(500)
+                .ToListAsync();
 
             ApplyDefaultSelections();
         }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -203,14 +203,39 @@ else
                 .Take(250)
                 .ToListAsync();
 
-            _warehouses = (await Inventario.GetWarehouses(new GetWarehousesRequest { Metadata = BuildMetadata() })).Response ?? [];
-            _locations = (await Inventario.GetInventoryLocations(new GetInventoryLocationsRequest { Metadata = BuildMetadata() })).Response ?? [];
+            _warehouses = await DataContext.Query<Warehouse>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Code)
+                .Take(200)
+                .ToListAsync();
+
+            _locations = await DataContext.Query<InventoryLocation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Code)
+                .Take(500)
+                .ToListAsync();
 
             if (_stockEnabled)
-                _balances = (await Inventario.GetStockBalances(new GetStockBalancesRequest { Metadata = BuildMetadata() })).Response ?? [];
+                _balances = await DataContext.Query<StockBalance>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                    .OrderBy(x => x.ProductId)
+                    .Take(500)
+                    .ToListAsync();
 
             if (_movementsEnabled)
-                _movements = (await Inventario.GetInventoryMovements(new GetInventoryMovementsRequest { Metadata = BuildMetadata() })).Response ?? [];
+                _movements = await DataContext.Query<InventoryMovement>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                    .OrderByDescending(x => x.CreatedAt)
+                    .Take(500)
+                    .ToListAsync();
 
             ApplyDefaultMovementSelections();
         }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
@@ -1,4 +1,5 @@
 @page "/inventario/warehouses"
+@using XFramework.Domain.Shared.DataContext
 @using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations
 @using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses
 @using XFramework.Inventario.Domain.Shared.Enums
@@ -155,6 +156,7 @@ else
 }
 
 @code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
@@ -194,12 +196,23 @@ else
 
             if (!_hasTenant || !_warehousingEnabled) return;
 
-            var warehouseResult = await Inventario.GetWarehouses(new GetWarehousesRequest { Metadata = BuildMetadata() });
-            _warehouses = warehouseResult.Response ?? [];
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _warehouses = await DataContext.Query<Warehouse>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Code)
+                .Take(200)
+                .ToListAsync();
             _locationForm.WarehouseId = _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
 
-            var locationResult = await Inventario.GetInventoryLocations(new GetInventoryLocationsRequest { Metadata = BuildMetadata() });
-            _locations = locationResult.Response ?? [];
+            _locations = await DataContext.Query<InventoryLocation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Code)
+                .Take(500)
+                .ToListAsync();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- load Inventario warehouses and locations in ControlPanel via IDataContext, matching catalog pages
- load stock balances, movements, and reservations via IDataContext for consistent tenant-scoped lists
- keep create/post/reservation actions on Inventario business RPCs

## Browser evidence
- Warehouse create returned success and persisted in Postgres, but the page kept showing 0 warehouses
- Direct DB check showed the saved warehouse under the selected smoke tenant

## Verification
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly