### PR TITLE
Fix Inventario metadata-scoped service queries

### DIFF
--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
@@ -25,6 +25,7 @@ public sealed class ReservationService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<Reservation>()
+            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ProductId is { } productId)
@@ -197,6 +198,7 @@ public sealed class ReservationService(
         var cutoff = request.ExpiresBefore ?? DateTime.UtcNow;
         var maxCount = Math.Clamp(request.MaxCount, 1, 500);
         var reservations = await dataContext.Query<Reservation>()
+            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantResult.Data &&
                 x.Status == ReservationStatus.Active &&
@@ -236,6 +238,7 @@ public sealed class ReservationService(
             return Result<Reservation>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
         var reservation = await dataContext.Query<Reservation>()
+            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantResult.Data &&
                 x.Id == reservationId &&

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
@@ -92,6 +92,7 @@ public sealed class StockPostingService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<StockBalance>()
+            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ProductId is { } id)
@@ -115,6 +116,7 @@ public sealed class StockPostingService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<InventoryMovement>()
+            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ProductId is { } id)
@@ -192,6 +194,7 @@ public sealed class StockPostingService(
 
     private async Task<Product?> GetProduct(Guid tenantId, Guid productId, CancellationToken ct) =>
         await dataContext.Query<Product>()
+            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.Id == productId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
 
@@ -203,16 +206,19 @@ public sealed class StockPostingService(
         CancellationToken ct)
     {
         var warehouseExists = await dataContext.Query<Warehouse>()
+            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == warehouseId && !x.IsDeleted, ct);
         if (!warehouseExists)
             return Result<StockBalance>.NotFound("Warehouse not found.");
 
         var locationExists = await dataContext.Query<InventoryLocation>()
+            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == locationId && x.WarehouseId == warehouseId && !x.IsDeleted, ct);
         if (!locationExists)
             return Result<StockBalance>.NotFound("Location not found.");
 
         var balance = await dataContext.Query<StockBalance>()
+            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == productId &&

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/WarehouseService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/WarehouseService.cs
@@ -22,6 +22,7 @@ public sealed class WarehouseService(
             return Result<List<Warehouse>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
         var warehouses = await dataContext.Query<Warehouse>()
+            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted)
             .OrderBy(x => x.Code)
             .Take(200)
@@ -43,6 +44,7 @@ public sealed class WarehouseService(
             return Result<Warehouse>.Failure("Warehouse code and name are required.", 400);
 
         var duplicate = await dataContext.Query<Warehouse>()
+            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Code == code && !x.IsDeleted, ct);
         if (duplicate)
             return Result<Warehouse>.Failure("A warehouse with the same code already exists.", 409);
@@ -82,6 +84,7 @@ public sealed class WarehouseService(
             return Result<List<InventoryLocation>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
         var query = dataContext.Query<InventoryLocation>()
+            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
 
         if (request.WarehouseId is { } id)
@@ -108,11 +111,13 @@ public sealed class WarehouseService(
             return Result<InventoryLocation>.Failure("Location code and name are required.", 400);
 
         var warehouseExists = await dataContext.Query<Warehouse>()
+            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == request.WarehouseId && !x.IsDeleted, ct);
         if (!warehouseExists)
             return Result<InventoryLocation>.NotFound("Warehouse not found.");
 
         var duplicate = await dataContext.Query<InventoryLocation>()
+            .IgnoreQueryFilters()
             .AnyAsync(x =>
                 x.TenantId == tenantId &&
                 x.WarehouseId == request.WarehouseId &&


### PR DESCRIPTION
## Summary
- fix Inventario metadata-scoped business queries that conflicted with the DbContext global tenant filter during Bolt calls
- keep explicit TenantId and IsDeleted predicates while ignoring the implicit filter in warehouse, stock, and reservation services

## Verification
- dotnet build src\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly