### PR TITLE
Fix package publish caching dependency version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
 
     <!-- Microsoft Extensions -->
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />


### PR DESCRIPTION
## Summary
- Align Microsoft.Extensions.Caching.Memory with EF Core Sqlite 10.0.9 so Release solution restore no longer fails with NU1605 during Publish NuGet Packages.

## Verification
- dotnet build XFramework.slnx -c Release -p:XFrameworkVersion=1.0.1-dev.98 -p:BoltVersion=1.0.0-dev.98 /nr:false