### PR TITLE
Fix Inventario stock balance concurrency updates

### DIFF
--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
@@ -62,10 +62,10 @@ public sealed class StockPostingService(
         if (!request.AllowNegativeStock && (afterOnHand < 0 || afterReserved < 0 || afterOnHand - afterReserved < 0))
             return Result<StockPostingResponse>.Failure("Stock movement would create a negative stock position.", 409);
 
-        ApplyBalance(balance, afterOnHand, afterReserved);
         if (!balanceState.IsNew)
             dataContext.Update(balance);
 
+        ApplyBalance(balance, afterOnHand, afterReserved);
         AddMovement(tenantId, request, balance.Id, delta == 0 ? reservedDelta : delta, before, afterOnHand);
         await UpdateProductSnapshot(tenantId, product, request.ProductId, delta, ct);
 
@@ -169,12 +169,13 @@ public sealed class StockPostingService(
         var now = DateTime.UtcNow;
         var sourceBefore = source.OnHandQuantity;
         var destinationBefore = destination.OnHandQuantity;
-        ApplyBalance(source, sourceAfter, source.ReservedQuantity, now);
-        ApplyBalance(destination, destination.OnHandQuantity + request.Quantity, destination.ReservedQuantity, now);
         if (!sourceState.IsNew)
             dataContext.Update(source);
         if (!destinationState.IsNew)
             dataContext.Update(destination);
+
+        ApplyBalance(source, sourceAfter, source.ReservedQuantity, now);
+        ApplyBalance(destination, destination.OnHandQuantity + request.Quantity, destination.ReservedQuantity, now);
 
         AddMovement(tenantId, request, source.Id, -request.Quantity, sourceBefore, source.OnHandQuantity);
         AddMovement(tenantId, request with


### PR DESCRIPTION
## Summary
- fix detached StockBalance concurrency updates by attaching existing balances before rotating the concurrency stamp
- keeps optimistic concurrency token semantics while persisting reservation/release/transfer balance changes

## Verification
- dotnet build src\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- browser smoke before fix hit EF optimistic concurrency exception when reserving against an existing balance