### PR TITLE
Fix wallet ControlPanel reconciliation query

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/OutboxWebhooks.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/OutboxWebhooks.razor
@@ -88,7 +88,7 @@
             var query = DataContext.Query<WalletOutboxMessage>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
                 .OrderByDescending(x => x.CreatedAt);
 
             _items = await query.Take(200).ToListAsync();

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/PolicyDecisions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/PolicyDecisions.razor
@@ -80,14 +80,28 @@
             }
 
             var tenantId = TenantFilter.SelectedTenantId!.Value;
-            var query = DataContext.Query<WalletOperation>()
+            var baseQuery = DataContext.Query<WalletOperation>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.TenantId == tenantId)
-                .Where(x => x.RiskDecision != null || x.PolicyDecision != null)
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted);
+
+            var riskDecisions = await baseQuery
+                .Where(x => x.RiskDecision != null)
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(200)
+                .ToListAsync();
+
+            var policyDecisions = baseQuery
+                .Where(x => x.PolicyDecision != null)
                 .OrderByDescending(x => x.CreatedAt);
 
-            _items = await query.Take(200).ToListAsync();
+            _items = riskDecisions
+                .Concat(await policyDecisions.Take(200).ToListAsync())
+                .GroupBy(x => x.Id)
+                .Select(x => x.First())
+                .OrderByDescending(x => x.CreatedAt)
+                .Take(200)
+                .ToList();
         }
         catch (Exception ex)
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Reconciliation.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Reconciliation.razor
@@ -90,8 +90,9 @@
             var query = DataContext.Query<WalletBalanceSnapshot>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.TenantId == tenantId)
-                .OrderByDescending(x => x.ModifiedAt ?? x.CreatedAt);
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.ModifiedAt)
+                .ThenByDescending(x => x.CreatedAt);
 
             _items = await query.Take(200).ToListAsync();
         }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletAudit.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletAudit.razor
@@ -88,7 +88,7 @@
             var query = DataContext.Query<WalletLedgerEntry>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
                 .OrderByDescending(x => x.CreatedAt);
 
             _items = await query.Take(200).ToListAsync();

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
@@ -218,7 +218,7 @@ else
                         <BbAlert Variant="AlertVariant.Warning" class="mb-4">
                             <BbAlertTitle>Warning</BbAlertTitle>
                             <BbAlertDescription>
-                                Balance adjustment directly overwrites the wallet balance without creating a standard transaction. Use with caution.
+                                Balance adjustment posts the difference through the wallet operation workflow and records a transaction.
                             </BbAlertDescription>
                         </BbAlert>
                         <div class="grid gap-4 py-4 md:grid-cols-2">
@@ -543,7 +543,7 @@ else
             .IgnoreQueryFilters()
             .NoCache()
             .Include(x => x.WalletType)
-            .Where(x => x.Id == Id)
+            .Where(x => x.Id == Id && !x.IsDeleted)
             .FirstOrDefaultAsync();
         _outsideTenantContext = _wallet is not null
             && TenantFilter.SelectedTenantId is Guid tenantId
@@ -552,10 +552,17 @@ else
 
     private async Task LoadTransactions()
     {
+        if (_wallet is null)
+        {
+            _transactions = [];
+            return;
+        }
+
+        var walletTenantId = _wallet.TenantId;
         _transactions = await DataContext.Query<WalletTransaction>()
             .IgnoreQueryFilters()
             .NoCache()
-            .Where(x => x.WalletId == Id)
+            .Where(x => x.WalletId == Id && x.TenantId == walletTenantId && !x.IsDeleted)
             .OrderByDescending(x => x.CreatedAt)
             .Take(100)
             .ToListAsync();
@@ -701,7 +708,7 @@ else
             var fresh = await DataContext.Query<Wallet>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.Id == Id)
+                .Where(x => x.Id == Id && !x.IsDeleted)
                 .FirstOrDefaultAsync();
 
             if (fresh is null)
@@ -765,7 +772,7 @@ else
             var fresh = await DataContext.Query<Wallet>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.Id == Id)
+                .Where(x => x.Id == Id && !x.IsDeleted)
                 .FirstOrDefaultAsync();
 
             if (fresh is null)
@@ -836,7 +843,7 @@ else
             var fresh = await DataContext.Query<Wallet>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.Id == Id)
+                .Where(x => x.Id == Id && !x.IsDeleted)
                 .FirstOrDefaultAsync();
 
             if (fresh is null)
@@ -929,7 +936,7 @@ else
             var fresh = await DataContext.Query<Wallet>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.Id == Id)
+                .Where(x => x.Id == Id && !x.IsDeleted)
                 .FirstOrDefaultAsync();
 
             if (fresh is null)
@@ -973,7 +980,7 @@ else
             var fresh = await DataContext.Query<Wallet>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.Id == Id)
+                .Where(x => x.Id == Id && !x.IsDeleted)
                 .FirstOrDefaultAsync();
 
             if (fresh is null)
@@ -1017,7 +1024,7 @@ else
             var fresh = await DataContext.Query<Wallet>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.Id == Id)
+                .Where(x => x.Id == Id && !x.IsDeleted)
                 .FirstOrDefaultAsync();
 
             if (fresh is null)

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletOperations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletOperations.razor
@@ -91,7 +91,7 @@
             var query = DataContext.Query<WalletOperation>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
                 .OrderByDescending(x => x.CreatedAt);
 
             _items = await query.Take(200).ToListAsync();

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Wallets.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Wallets.razor
@@ -319,7 +319,7 @@ else
             .IgnoreQueryFilters()
             .NoCache()
             .Include(x => x.WalletType)
-            .Where(x => x.TenantId == tenantId);
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         _items = await query.Take(100).ToListAsync();
 
@@ -469,7 +469,7 @@ else
             var fresh = await DataContext.Query<Wallet>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.Id == wallet.Id)
+                .Where(x => x.Id == wallet.Id && x.TenantId == wallet.TenantId && !x.IsDeleted)
                 .FirstOrDefaultAsync();
 
             if (fresh is null)


### PR DESCRIPTION
## Summary
- replace the wallet reconciliation sort expression with provider-safe property sorts
- keep ControlPanel wallet finance grids scoped to tenant and non-deleted records when bypassing query filters
- avoid a provider-sensitive OR filter on wallet policy decisions by merging two simple queries
- update the wallet detail adjustment warning to match ledger-backed behavior

## Verification
- dotnet build src\\Presentation\\ControlPanel.Server\\ControlPanel.Server.csproj /nr:false -v:minimal -clp:ErrorsOnly