### PR TITLE
Fix Inventario ControlPanel UI gaps

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/App.razor
+++ b/src/Presentation/ControlPanel.Server/Components/App.razor
@@ -13,7 +13,7 @@
     <link href="_content/BlazorBlueprint.Components/blazorblueprint.css" rel="stylesheet" />
     <!-- App styles (Tailwind utilities) -->
     <link href="css/app.css" rel="stylesheet" />
-    <HeadOutlet />
+    <HeadOutlet @rendermode="InteractiveServer" />
 </head>
 <body class="font-sans antialiased">
     <Routes @rendermode="InteractiveServer" />

--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -140,10 +140,12 @@
     [Inject] private NavigationManager Nav { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private NavigationHistoryService NavigationHistory { get; set; } = default!;
+    [Inject] private IJSRuntime Js { get; set; } = default!;
     [CascadingParameter] private Task<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>? AuthenticationStateTask { get; set; }
 
     private List<IdentityServer.Domain.Shared.Contracts.Tenant> _tenants = [];
     private const string AllTenantsValue = "__all_tenants__";
+    private const string ActiveTenantStorageKey = "xframework.controlpanel.activeTenantId";
     private string _selectedTenantId = AllTenantsValue;
     private int _contentRenderKey;
     private string _displayName = "Administrator";
@@ -221,21 +223,85 @@
                 .Take(100)
                 .ToListAsync();
 
-            if (TenantFilter.SelectedTenantId is Guid selectedTenantId)
-            {
-                _selectedTenantId = selectedTenantId.ToString();
-            }
-            else
-            {
-                _selectedTenantId = AllTenantsValue;
-            }
+            await RestoreTenantSelection();
 
             StateHasChanged();
         }
         catch { /* Tenant loading is non-critical */ }
     }
 
-    private void OnTenantSelectionChanged(string? value)
+    private async Task RestoreTenantSelection()
+    {
+        var selectedTenantId = TenantFilter.SelectedTenantId;
+        var storedTenantId = await ReadStoredTenantId();
+
+        if (selectedTenantId is null && Guid.TryParse(storedTenantId, out var persistedTenantId))
+        {
+            selectedTenantId = persistedTenantId;
+        }
+
+        if (selectedTenantId is Guid tenantId
+            && _tenants.FirstOrDefault(t => t.Id == tenantId) is { } tenant)
+        {
+            _selectedTenantId = tenantId.ToString();
+
+            if (TenantFilter.SelectedTenantId != tenantId || TenantFilter.SelectedTenantName != tenant.Name)
+            {
+                TenantFilter.SetTenant(tenantId, tenant.Name);
+            }
+
+            return;
+        }
+
+        _selectedTenantId = AllTenantsValue;
+        if (TenantFilter.SelectedTenantId is not null)
+        {
+            TenantFilter.Clear();
+        }
+
+        if (!string.IsNullOrWhiteSpace(storedTenantId))
+        {
+            await ClearStoredTenantId();
+        }
+    }
+
+    private async Task<string?> ReadStoredTenantId()
+    {
+        try
+        {
+            return await Js.InvokeAsync<string?>("localStorage.getItem", ActiveTenantStorageKey);
+        }
+        catch (JSException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private async Task StoreTenantId(string tenantId)
+    {
+        try
+        {
+            await Js.InvokeVoidAsync("localStorage.setItem", ActiveTenantStorageKey, tenantId);
+        }
+        catch (JSException) { }
+        catch (InvalidOperationException) { }
+    }
+
+    private async Task ClearStoredTenantId()
+    {
+        try
+        {
+            await Js.InvokeVoidAsync("localStorage.removeItem", ActiveTenantStorageKey);
+        }
+        catch (JSException) { }
+        catch (InvalidOperationException) { }
+    }
+
+    private async Task OnTenantSelectionChanged(string? value)
     {
         _selectedTenantId = string.IsNullOrWhiteSpace(value) ? AllTenantsValue : value;
 
@@ -243,10 +309,12 @@
         {
             var name = _tenants.FirstOrDefault(t => t.Id == tenantId)?.Name ?? "";
             TenantFilter.SetTenant(tenantId, name);
+            await StoreTenantId(_selectedTenantId);
         }
         else
         {
             TenantFilter.Clear();
+            await ClearStoredTenantId();
         }
 
         _profileMenuOpen = false;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
@@ -50,28 +50,50 @@ else
                 <BbCardContent>
                     <div class="grid gap-3">
                         <div class="grid gap-3 xl:grid-cols-3">
-                            <BbFormFieldSelect TValue="string" @bind-Value="_form.ProductId" Label="Product" Placeholder="Select product">
-                                @foreach (var product in _products)
-                                {
-                                    <BbSelectItem Value="@product.Id.ToString()">@GetProductLabel(product)</BbSelectItem>
-                                }
-                            </BbFormFieldSelect>
-                            <BbFormFieldSelect TValue="string" @bind-Value="_form.WarehouseId" Label="Warehouse" Placeholder="Select warehouse">
-                                @foreach (var warehouse in _warehouses)
-                                {
-                                    <BbSelectItem Value="@warehouse.Id.ToString()">@warehouse.Code - @warehouse.Name</BbSelectItem>
-                                }
-                            </BbFormFieldSelect>
-                            <BbFormFieldSelect TValue="string" @bind-Value="_form.LocationId" Label="Location" Placeholder="Select location">
-                                @foreach (var location in LocationsForSelectedWarehouse())
-                                {
-                                    <BbSelectItem Value="@location.Id.ToString()">@location.Code - @location.Name</BbSelectItem>
-                                }
-                            </BbFormFieldSelect>
+                            <div class="xf-form-field">
+                                <BbLabel>Product</BbLabel>
+                                <BbCombobox TValue="string"
+                                             @bind-Value="_form.ProductId"
+                                             Options="@ProductOptions"
+                                             Placeholder="Select product"
+                                             SearchPlaceholder="Search products..."
+                                             EmptyMessage="No products found."
+                                             Class="xf-entity-combobox"
+                                             MatchTriggerWidth="true" />
+                            </div>
+                            <div class="xf-form-field">
+                                <BbLabel>Warehouse</BbLabel>
+                                <BbCombobox TValue="string"
+                                             Value="@_form.WarehouseId"
+                                             ValueChanged="@OnReservationWarehouseChanged"
+                                             Options="@WarehouseOptions"
+                                             Placeholder="Select warehouse"
+                                             SearchPlaceholder="Search warehouses..."
+                                             EmptyMessage="No warehouses found."
+                                             Class="xf-entity-combobox"
+                                             MatchTriggerWidth="true" />
+                            </div>
+                            <div class="xf-form-field">
+                                <BbLabel>Location</BbLabel>
+                                <BbCombobox TValue="string"
+                                             @bind-Value="_form.LocationId"
+                                             Options="@ReservationLocationOptions"
+                                             Placeholder="Select location"
+                                             SearchPlaceholder="Search locations..."
+                                             EmptyMessage="No locations found."
+                                             Class="xf-entity-combobox"
+                                             MatchTriggerWidth="true" />
+                            </div>
                         </div>
                         <div class="grid gap-3 md:grid-cols-3">
                             <BbFormFieldInput TValue="string" @bind-Value="_form.Quantity" Label="Quantity" />
-                            <BbFormFieldInput TValue="string" @bind-Value="_form.ExpiresAt" Label="Expires At" Placeholder="YYYY-MM-DD HH:mm" />
+                            <div class="xf-form-field">
+                                <BbLabel>Expires At</BbLabel>
+                                <input type="datetime-local"
+                                       class="xf-datetime-input"
+                                       value="@_form.ExpiresAt"
+                                       @oninput="@((ChangeEventArgs e) => _form.ExpiresAt = e.Value?.ToString() ?? string.Empty)" />
+                            </div>
                             <BbFormFieldInput TValue="string" @bind-Value="_form.ReferenceType" Label="Reference Type" />
                         </div>
                         <div class="grid gap-3 md:grid-cols-2">
@@ -149,6 +171,12 @@ else
     private bool _reserving;
     private bool _expiring;
     private bool IsReserveDisabled => _reserving || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
+    private List<SelectOption<string>> ProductOptions =>
+        _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
+    private List<SelectOption<string>> WarehouseOptions =>
+        _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
+    private List<SelectOption<string>> ReservationLocationOptions =>
+        LocationsForSelectedWarehouse().Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
 
     protected override void OnInitialized()
     {
@@ -263,6 +291,7 @@ else
             if (result.IsSuccess)
             {
                 _form.Quantity = "0";
+                _form.ExpiresAt = "";
                 _form.Reason = "";
                 await Reload();
             }
@@ -335,6 +364,13 @@ else
         return _locations.Where(x => x.WarehouseId == warehouseId);
     }
 
+    private void OnReservationWarehouseChanged(string? value)
+    {
+        _form.WarehouseId = value ?? "";
+        var location = LocationsForSelectedWarehouse().FirstOrDefault();
+        _form.LocationId = location?.Id.ToString() ?? "";
+    }
+
     private void ApplyDefaultSelections()
     {
         _form.ProductId = _form.ProductId.Length > 0 ? _form.ProductId : _products.FirstOrDefault()?.Id.ToString() ?? "";
@@ -363,6 +399,10 @@ else
 
         return _locations.FirstOrDefault(x => x.Id == id)?.Name ?? id.ToString()[..8];
     }
+
+    private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+
+    private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
 
     private static string GetStatusBadge(ReservationStatus status) =>
         status == ReservationStatus.Active ? "active" : "inactive";

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -45,24 +45,40 @@ else
                     <BbCardContent>
                         <div class="grid gap-3">
                             <div class="grid gap-3 xl:grid-cols-4">
-                                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.ProductId" Label="Product" Placeholder="Select product">
-                                    @foreach (var product in _products)
-                                    {
-                                        <BbSelectItem Value="@product.Id.ToString()">@GetProductLabel(product)</BbSelectItem>
-                                    }
-                                </BbFormFieldSelect>
-                                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.WarehouseId" Label="Warehouse" Placeholder="Select warehouse">
-                                    @foreach (var warehouse in _warehouses)
-                                    {
-                                        <BbSelectItem Value="@warehouse.Id.ToString()">@warehouse.Code - @warehouse.Name</BbSelectItem>
-                                    }
-                                </BbFormFieldSelect>
-                                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.LocationId" Label="Location" Placeholder="Select location">
-                                    @foreach (var location in LocationsForSelectedWarehouse())
-                                    {
-                                        <BbSelectItem Value="@location.Id.ToString()">@location.Code - @location.Name</BbSelectItem>
-                                    }
-                                </BbFormFieldSelect>
+                                <div class="xf-form-field">
+                                    <BbLabel>Product</BbLabel>
+                                    <BbCombobox TValue="string"
+                                                 @bind-Value="_movementForm.ProductId"
+                                                 Options="@ProductOptions"
+                                                 Placeholder="Select product"
+                                                 SearchPlaceholder="Search products..."
+                                                 EmptyMessage="No products found."
+                                                 Class="xf-entity-combobox"
+                                                 MatchTriggerWidth="true" />
+                                </div>
+                                <div class="xf-form-field">
+                                    <BbLabel>Warehouse</BbLabel>
+                                    <BbCombobox TValue="string"
+                                                 Value="@_movementForm.WarehouseId"
+                                                 ValueChanged="@OnMovementWarehouseChanged"
+                                                 Options="@WarehouseOptions"
+                                                 Placeholder="Select warehouse"
+                                                 SearchPlaceholder="Search warehouses..."
+                                                 EmptyMessage="No warehouses found."
+                                                 Class="xf-entity-combobox"
+                                                 MatchTriggerWidth="true" />
+                                </div>
+                                <div class="xf-form-field">
+                                    <BbLabel>Location</BbLabel>
+                                    <BbCombobox TValue="string"
+                                                 @bind-Value="_movementForm.LocationId"
+                                                 Options="@MovementLocationOptions"
+                                                 Placeholder="Select location"
+                                                 SearchPlaceholder="Search locations..."
+                                                 EmptyMessage="No locations found."
+                                                 Class="xf-entity-combobox"
+                                                 MatchTriggerWidth="true" />
+                                </div>
                                 <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.MovementType" Label="Movement Type">
                                     @foreach (var type in Enum.GetValues<InventoryMovementType>())
                                     {
@@ -166,6 +182,12 @@ else
     private bool _movementsEnabled;
     private bool _postingMovement;
     private bool IsPostMovementDisabled => _postingMovement || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
+    private List<SelectOption<string>> ProductOptions =>
+        _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
+    private List<SelectOption<string>> WarehouseOptions =>
+        _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
+    private List<SelectOption<string>> MovementLocationOptions =>
+        LocationsForSelectedWarehouse().Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
 
     protected override void OnInitialized()
     {
@@ -305,6 +327,13 @@ else
         return _locations.Where(x => x.WarehouseId == warehouseId);
     }
 
+    private void OnMovementWarehouseChanged(string? value)
+    {
+        _movementForm.WarehouseId = value ?? "";
+        var location = LocationsForSelectedWarehouse().FirstOrDefault();
+        _movementForm.LocationId = location?.Id.ToString() ?? "";
+    }
+
     private void ApplyDefaultMovementSelections()
     {
         _movementForm.ProductId = _movementForm.ProductId.Length > 0 ? _movementForm.ProductId : _products.FirstOrDefault()?.Id.ToString() ?? "";
@@ -326,11 +355,15 @@ else
     private string GetProductName(Guid productId) =>
         _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
 
+    private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+
     private string GetWarehouseName(Guid warehouseId) =>
         _warehouses.FirstOrDefault(x => x.Id == warehouseId)?.Name ?? warehouseId.ToString()[..8];
 
     private string GetLocationName(Guid locationId) =>
         _locations.FirstOrDefault(x => x.Id == locationId)?.Name ?? locationId.ToString()[..8];
+
+    private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
@@ -73,12 +73,17 @@ else
                     </BbCardHeader>
                     <BbCardContent>
                         <div class="grid gap-3">
-                            <BbFormFieldSelect TValue="string" @bind-Value="_locationForm.WarehouseId" Label="Warehouse" Placeholder="Select warehouse">
-                                @foreach (var warehouse in _warehouses)
-                                {
-                                    <BbSelectItem Value="@warehouse.Id.ToString()">@warehouse.Code - @warehouse.Name</BbSelectItem>
-                                }
-                            </BbFormFieldSelect>
+                            <div class="xf-form-field">
+                                <BbLabel>Warehouse</BbLabel>
+                                <BbCombobox TValue="string"
+                                             @bind-Value="_locationForm.WarehouseId"
+                                             Options="@WarehouseOptions"
+                                             Placeholder="Select warehouse"
+                                             SearchPlaceholder="Search warehouses..."
+                                             EmptyMessage="No warehouses found."
+                                             Class="xf-entity-combobox"
+                                             MatchTriggerWidth="true" />
+                            </div>
                             <div class="grid gap-3 md:grid-cols-2">
                                 <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Code" Label="Code" Required="true" />
                                 <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Name" Label="Name" Required="true" />
@@ -137,7 +142,7 @@ else
                     <BbDataGrid Items="@_locations" ShowPagination="true" InitialPageSize="20">
                         <Columns>
                             <BbDataGridTemplateColumn Title="Warehouse">
-                                <ChildContent Context="item">@GetWarehouseLabel(item.WarehouseId)</ChildContent>
+                                <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
                             </BbDataGridTemplateColumn>
                             <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
                             <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
@@ -172,6 +177,8 @@ else
     private bool _savingWarehouse;
     private bool _savingLocation;
     private bool IsCreateLocationDisabled => _savingLocation || _warehouses.Count == 0;
+    private List<SelectOption<string>> WarehouseOptions =>
+        _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
 
     protected override void OnInitialized()
     {
@@ -315,10 +322,12 @@ else
         Name = "ControlPanel"
     };
 
-    private string GetWarehouseLabel(Guid warehouseId) =>
+    private string GetWarehouseName(Guid warehouseId) =>
         _warehouses.FirstOrDefault(x => x.Id == warehouseId) is { } warehouse
-            ? $"{warehouse.Code} - {warehouse.Name}"
+            ? GetWarehouseLabel(warehouse)
             : warehouseId.ToString()[..8];
+
+    private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -113,6 +113,28 @@
     white-space: nowrap;
 }
 
+.xf-entity-combobox,
+.xf-entity-combobox * {
+    min-width: 0;
+}
+
+.xf-entity-combobox[role="combobox"],
+.xf-entity-combobox [role="combobox"] {
+    width: 100%;
+    min-height: 2.5rem;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.xf-entity-combobox[role="combobox"] span,
+.xf-entity-combobox [role="combobox"] span {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .xf-form-field {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Persist the active tenant selection in browser localStorage so hard reloads/direct Inventario navigation keep the selected tenant.
- Make the HeadOutlet interactive so PageTitle updates follow client-side navigation.
- Replace Inventario entity select fields with BlazorBlueprint combobox options so selected Product/Warehouse/Location values show friendly names instead of GUIDs.
- Use the existing styled optional datetime-local input for reservation expiration.

## Verification
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- dotnet build src/Modules/XFramework.Blazor/XFramework.Blazor.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- Local browser smoke on http://localhost:5010 against xeon-dev backend: login, select tenant, hard reload Stock, navigate Categories/Products/Warehouses/Stock/Reservations, verify titles, friendly selector labels, and optional datetime-local field.