### PR TITLE
Prefer wallet reference numbers over idempotency keys

### DIFF
--- a/src/Modules/XFramework.Wallets/Wallets.Api/Services/WalletOperationsService.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/Services/WalletOperationsService.cs
@@ -1556,14 +1556,14 @@ public sealed class WalletOperationsService : IWalletOperationsService
 
     private static string CreateReferenceNumber(TransactionRequestBase request)
     {
-        if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
+        if (!string.IsNullOrWhiteSpace(request.ReferenceNumber))
         {
-            return request.IdempotencyKey;
+            return request.ReferenceNumber;
         }
 
-        return string.IsNullOrWhiteSpace(request.ReferenceNumber)
+        return string.IsNullOrWhiteSpace(request.IdempotencyKey)
             ? Guid.NewGuid().ToString()
-            : request.ReferenceNumber;
+            : request.IdempotencyKey;
     }
 
     private static decimal GetHeldReleaseAmount(WalletTransaction transaction)

--- a/src/Tests/Wallets.IntegrationTests/Tests/WalletTransactionTests.cs
+++ b/src/Tests/Wallets.IntegrationTests/Tests/WalletTransactionTests.cs
@@ -87,6 +87,42 @@ public class WalletTransactionTests : WalletsTestBase
     }
 
     [Test]
+    public async Task Http_AddFunds_WithReferenceAndIdempotencyKey_UsesReferenceAndDeduplicatesByIdempotency()
+    {
+        var credential = await SeedCredential();
+        var wallet = await SeedWallet(credential.Id, 1000m);
+        var idempotencyKey = $"add-{Guid.NewGuid():N}";
+        var referenceNumber = $"ref-{Guid.NewGuid():N}";
+
+        var request = new IncrementWalletRequest
+        {
+            CredentialId = credential.Id,
+            WalletId = wallet.Id,
+            Amount = 500m,
+            ReferenceNumber = referenceNumber,
+            IdempotencyKey = idempotencyKey,
+            Metadata = CreateMetadata()
+        };
+
+        var firstResponse = await HttpClient.PostAsJsonAsync("/api/wallets/add-funds", request);
+        var secondResponse = await HttpClient.PostAsJsonAsync("/api/wallets/add-funds", request);
+
+        firstResponse.IsSuccessStatusCode.Should().BeTrue();
+        secondResponse.IsSuccessStatusCode.Should().BeTrue();
+
+        await using var db = CreateDbContext();
+        var updated = await db.Set<Wallet>().FirstAsync(w => w.Id == wallet.Id);
+        var transaction = await db.Set<WalletTransaction>()
+            .SingleAsync(t => t.WalletId == wallet.Id && t.ReferenceNumber == referenceNumber);
+        var operation = await db.Set<WalletOperation>()
+            .SingleAsync(o => o.IdempotencyKey == idempotencyKey);
+
+        updated.Balance.Should().Be(1500m);
+        transaction.ReferenceNumber.Should().Be(referenceNumber);
+        operation.ReferenceNumber.Should().Be(referenceNumber);
+    }
+
+    [Test]
     public async Task Http_AddFunds_WithFee_CreatesBalancedLedgerSnapshotAndOutbox()
     {
         var credential = await SeedCredential();


### PR DESCRIPTION
## Summary
- keep supplied wallet ReferenceNumber as the user-facing transaction/operation reference
- retain IdempotencyKey as the durable replay key and fallback reference when no reference is supplied
- add an integration regression test covering reference + idempotency replay

## Verification
- dotnet build src\\Modules\\XFramework.Wallets\\Wallets.Api\\Wallets.Api.csproj /nr:false -v:minimal -clp:ErrorsOnly
- DOCKER_HOST=tcp://127.0.0.1:23750 TESTCONTAINERS_HOST_OVERRIDE=100.75.11.49 dotnet test .\\src\\Tests\\Wallets.IntegrationTests\\Wallets.IntegrationTests.csproj -m:1 /nr:false --logger 'console;verbosity=minimal'