### PR TITLE
Add wallet close workflow

### DIFF
--- a/src/Modules/XFramework.Wallets/Wallets.Api/Events/WalletClosedEvent.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/Events/WalletClosedEvent.cs
@@ -1,0 +1,9 @@
+namespace Wallets.Api.Events;
+
+/// <summary>
+/// Published when an empty wallet is closed.
+/// </summary>
+public record WalletClosedEvent : WalletEvent
+{
+    public string? Reason { get; init; }
+}

--- a/src/Modules/XFramework.Wallets/Wallets.Api/Features/Wallets/Close/Endpoint.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/Features/Wallets/Close/Endpoint.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using Wallets.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+namespace Wallets.Api.Features.Wallets.Close;
+
+public static class CloseWalletEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/wallets/close", Tags = ["Wallets"],
+        Summary = "Close a wallet",
+        Description = "Closes an empty wallet, preventing future financial operations.",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static async Task<Result> Handle(
+        CloseWalletRequest request,
+        IWalletOperationsService walletService,
+        CancellationToken ct)
+    {
+        return await walletService.CloseWalletAsync(request, ct);
+    }
+}
+
+public class CloseWalletValidator : AbstractValidator<CloseWalletRequest>
+{
+    public CloseWalletValidator()
+    {
+        RuleFor(x => x.WalletId)
+            .NotEmpty().WithMessage("Wallet ID is required");
+
+        RuleFor(x => x.Reason)
+            .MaximumLength(500).WithMessage("Reason must be 500 characters or fewer");
+    }
+}

--- a/src/Modules/XFramework.Wallets/Wallets.Api/Services/IWalletOperationsService.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/Services/IWalletOperationsService.cs
@@ -171,4 +171,11 @@ public interface IWalletOperationsService
     Task<Result> UnfreezeWalletAsync(
         UnfreezeWalletRequest request,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Closes an empty wallet, preventing future financial operations.
+    /// </summary>
+    Task<Result> CloseWalletAsync(
+        CloseWalletRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Modules/XFramework.Wallets/Wallets.Api/Services/WalletOperationsService.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/Services/WalletOperationsService.cs
@@ -2173,4 +2173,58 @@ public sealed class WalletOperationsService : IWalletOperationsService
             return Result.Failure("An error occurred while unfreezing the wallet", 500);
         }
     }
+
+    /// <inheritdoc />
+    public async Task<Result> CloseWalletAsync(
+        CloseWalletRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var tenant = await _tenantService.GetTenant(request.Metadata.TenantId);
+
+            var wallet = await _dataContext.Query<Wallet>()
+                .IgnoreQueryFilters()
+                .Where(w => w.Id == request.WalletId && w.TenantId == tenant.Id && !w.IsDeleted)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (wallet is null)
+            {
+                _logger.EntityNotFound("Wallet", request.WalletId);
+                return Result.NotFound("Wallet not found");
+            }
+
+            if (wallet.Status == WalletStatus.Closed)
+                return Result.Failure("Wallet is already closed", 400);
+
+            if (wallet.Balance != 0)
+                return Result.Failure("Cannot close wallet with a remaining balance", 400);
+
+            if (wallet.DebitOnHoldBalance != 0 || wallet.CreditOnHoldBalance != 0)
+                return Result.Failure("Cannot close wallet with held funds", 400);
+
+            wallet.Status = WalletStatus.Closed;
+            wallet.ModifiedAt = DateTime.UtcNow;
+            _dataContext.Update(wallet);
+            await _dataContext.SaveChangesAsync(cancellationToken);
+
+            _logger.EntityUpdated("Wallet", wallet.Id);
+
+            await _eventPublisher.PublishAsync(new WalletClosedEvent
+            {
+                EventType = nameof(WalletClosedEvent),
+                WalletId = wallet.Id,
+                CredentialId = wallet.CredentialId,
+                TenantId = tenant.Id,
+                Reason = request.Reason
+            });
+
+            return Result.Success("Wallet closed successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.OperationFailed("CloseWallet", "Wallet", request.WalletId, ex.Message, ex);
+            return Result.Failure("An error occurred while closing the wallet", 500);
+        }
+    }
 }

--- a/src/Modules/XFramework.Wallets/Wallets.Domain.Shared/Contracts/Requests/CloseWalletRequest.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Domain.Shared/Contracts/Requests/CloseWalletRequest.cs
@@ -1,0 +1,13 @@
+namespace Wallets.Domain.Shared.Contracts.Requests;
+
+using TRequest = CloseWalletRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CloseWalletRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid WalletId { get; set; }
+    public string? Reason { get; set; }
+}

--- a/src/Modules/XFramework.Wallets/Wallets.Integration/Drivers/WalletsServiceWrapper.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Integration/Drivers/WalletsServiceWrapper.cs
@@ -1,5 +1,6 @@
 // Custom Bolt wrapper methods are now source-generated from IBoltRequest types
 // in the Wallets.Domain.Shared assembly. See ServiceWrapperGenerator.
 //
-// Generated methods: IncrementWallet, DecrementWallet, TransferWallet, ConvertWallet, ReleaseTransaction
+// Generated methods: IncrementWallet, DecrementWallet, TransferWallet, ConvertWallet, ReleaseTransaction,
+// FreezeWallet, UnfreezeWallet, CloseWallet
 // These are part of the generated partial interface/record in WalletsServiceWrapperGenerator.g.cs

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletAudit.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletAudit.razor
@@ -30,6 +30,7 @@
         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
             <Columns>
                 <BbDataGridPropertyColumn Property="@(x => x.OperationId)" Title="Operation" />
+                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
                 <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
                 <BbDataGridTemplateColumn Title="Direction">
                     <ChildContent Context="item">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
@@ -432,18 +432,18 @@ else
         <BbDialogHeader>
             <BbDialogTitle>Close Wallet</BbDialogTitle>
             <BbDialogDescription>
-                Are you sure you want to close this wallet? This action cannot be easily undone.
-                @if (_wallet?.Balance > 0)
+                Are you sure you want to close this wallet? Closed wallets cannot be used for future financial operations.
+                @if (_wallet?.Balance != 0 || _wallet?.DebitOnHoldBalance != 0 || _wallet?.CreditOnHoldBalance != 0)
                 {
                     <span class="mt-2 block font-semibold text-red-500">
-                        Warning: This wallet still has a balance of @_wallet.Balance.ToString("N2").
+                        Wallets can only be closed after balance and held funds are zero.
                     </span>
                 }
             </BbDialogDescription>
         </BbDialogHeader>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _showCloseDialog = false)">Cancel</BbButton>
-            <BbButton Variant="ButtonVariant.Destructive" OnClick="@CloseWallet">
+            <BbButton Variant="ButtonVariant.Destructive" OnClick="@CloseWallet" Disabled="@_isProcessing">
                 Confirm Close
             </BbButton>
         </BbDialogFooter>
@@ -1040,13 +1040,32 @@ else
                 return;
             }
 
-            ToastService.Show("Closing wallets requires the backend close-wallet workflow and was not applied.");
-            _showCloseDialog = false;
-            await Task.CompletedTask;
+            _isProcessing = true;
+            var response = await WalletsService.CloseWallet(new CloseWalletRequest
+            {
+                WalletId = fresh.Id,
+                Reason = "Closed from ControlPanel",
+                Metadata = BuildCommandMetadata(fresh.TenantId)
+            });
+
+            if (response.IsSuccess)
+            {
+                ToastService.Show("Wallet closed successfully.");
+                _showCloseDialog = false;
+                await LoadWallet();
+            }
+            else
+            {
+                ToastService.Show($"Failed to close wallet: {response.Message}");
+            }
         }
         catch (Exception ex)
         {
             ToastService.Show($"Error closing wallet: {ex.Message}");
+        }
+        finally
+        {
+            _isProcessing = false;
         }
     }
 

--- a/src/Tests/Wallets.IntegrationTests/Tests/WalletTransactionTests.cs
+++ b/src/Tests/Wallets.IntegrationTests/Tests/WalletTransactionTests.cs
@@ -626,6 +626,91 @@ public class WalletTransactionTests : WalletsTestBase
 
     #endregion
 
+    #region HTTP - Close
+
+    [Test]
+    public async Task Http_CloseWallet_WhenEmpty_SetsClosedStatusAndBlocksOperations()
+    {
+        var credential = await SeedCredential();
+        var wallet = await SeedWallet(credential.Id, 0m);
+
+        var closeResponse = await HttpClient.PostAsJsonAsync("/api/wallets/close",
+            new CloseWalletRequest
+            {
+                WalletId = wallet.Id,
+                Reason = "test close empty wallet",
+                Metadata = CreateMetadata()
+            });
+        var closeBody = await closeResponse.Content.ReadAsStringAsync();
+
+        closeResponse.IsSuccessStatusCode.Should().BeTrue($"Response: {closeBody}");
+
+        await using (var db = CreateDbContext())
+        {
+            var updated = await db.Set<Wallet>().SingleAsync(w => w.Id == wallet.Id);
+            updated.Status.Should().Be(WalletStatus.Closed);
+        }
+
+        var addResponse = await HttpClient.PostAsJsonAsync("/api/wallets/add-funds",
+            new IncrementWalletRequest
+            {
+                CredentialId = credential.Id,
+                WalletId = wallet.Id,
+                Amount = 10m,
+                Metadata = CreateMetadata()
+            });
+
+        addResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Http_CloseWallet_WithRemainingBalance_Returns400()
+    {
+        var credential = await SeedCredential();
+        var wallet = await SeedWallet(credential.Id, 10m);
+
+        var response = await HttpClient.PostAsJsonAsync("/api/wallets/close",
+            new CloseWalletRequest
+            {
+                WalletId = wallet.Id,
+                Reason = "test close non-empty wallet",
+                Metadata = CreateMetadata()
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        await using var db = CreateDbContext();
+        var updated = await db.Set<Wallet>().SingleAsync(w => w.Id == wallet.Id);
+        updated.Status.Should().Be(WalletStatus.Active);
+    }
+
+    [Test]
+    public async Task Http_CloseWallet_WithHeldFunds_Returns400()
+    {
+        var credential = await SeedCredential();
+        var wallet = await SeedWallet(credential.Id, 0m);
+
+        await using (var db = CreateDbContext())
+        {
+            var heldWallet = await db.Set<Wallet>().SingleAsync(w => w.Id == wallet.Id);
+            heldWallet.DebitOnHoldBalance = 5m;
+            db.Update(heldWallet);
+            await db.SaveChangesAsync();
+        }
+
+        var response = await HttpClient.PostAsJsonAsync("/api/wallets/close",
+            new CloseWalletRequest
+            {
+                WalletId = wallet.Id,
+                Reason = "test close held wallet",
+                Metadata = CreateMetadata()
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    #endregion
+
     #region HTTP - Batch
 
     [Test]
@@ -819,6 +904,31 @@ public class WalletTransactionTests : WalletsTestBase
 
         // Convert may succeed or fail depending on exchange rate config — just verify it doesn't crash
         result.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region Bolt - Close
+
+    [Test]
+    public async Task Bolt_CloseWallet_WhenEmpty_SetsClosedStatus()
+    {
+        var credential = await SeedCredential();
+        var wallet = await SeedWallet(credential.Id, 0m);
+
+        var result = await WalletsTestFixture.ServiceWrapper.CloseWallet(
+            new CloseWalletRequest
+            {
+                WalletId = wallet.Id,
+                Reason = "test bolt close empty wallet",
+                Metadata = CreateMetadata()
+            });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDbContext();
+        var updated = await db.Set<Wallet>().SingleAsync(w => w.Id == wallet.Id);
+        updated.Status.Should().Be(WalletStatus.Closed);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- add a Bolt/REST close-wallet workflow for empty wallets
- block close when a wallet has balance or held funds
- wire ControlPanel close confirmation to the backend workflow
- show ledger reference numbers on Wallet Audit
- add Wallets integration coverage for close success, balance/hold failures, and Bolt wrapper generation

## Verification
- dotnet build src\\Modules\\XFramework.Wallets\\Wallets.Api\\Wallets.Api.csproj /nr:false -v:minimal -clp:ErrorsOnly
- dotnet build src\\Presentation\\ControlPanel.Server\\ControlPanel.Server.csproj /nr:false -v:minimal -clp:ErrorsOnly
- DOCKER_HOST=tcp://127.0.0.1:23750 TESTCONTAINERS_HOST_OVERRIDE=100.75.11.49 dotnet test .\\src\\Tests\\Wallets.IntegrationTests\\Wallets.IntegrationTests.csproj -m:1 /nr:false --logger 'console;verbosity=minimal'