### PR TITLE
Add Bolt service discovery registry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,19 +38,19 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
 
     <!-- Microsoft Extensions -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Memory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
 
     <!-- OpenTelemetry Suite -->
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />

--- a/src/Infrastructure/XFramework.Integration/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/XFramework.Integration/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Bolt.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using XFramework.Domain.Shared.BusinessObjects;
@@ -11,6 +12,7 @@ using XFramework.Integration.Abstractions;
 using XFramework.Integration.Abstractions.Wrappers;
 using XFramework.Integration.DataContext;
 using XFramework.Integration.Drivers;
+using XFramework.Integration.ServiceDiscovery;
 
 namespace XFramework.Integration.Extensions;
 
@@ -30,6 +32,8 @@ public static class ServiceCollectionExtensions
         bool autoConnect = true)
     {
         services.Configure<BoltConfiguration>(configuration.GetSection("BoltConfiguration"));
+        services.Configure<BoltServiceDiscoveryOptions>(
+            configuration.GetSection(BoltServiceDiscoveryOptions.SectionName));
 
         var boltConfig = configuration.GetSection("BoltConfiguration").Get<BoltConfiguration>()
             ?? throw new InvalidOperationException("BoltConfiguration section is missing or empty in configuration.");
@@ -60,8 +64,17 @@ public static class ServiceCollectionExtensions
                 builder.DisableAutoConnect();
         });
 
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBoltServiceManifestProvider, ConfigurationBoltServiceManifestProvider>());
+        services.AddHostedService<BoltServiceManifestAdvertisementHostedService>();
         services.AddSingleton<IMessageBusWrapper, BoltDriver>();
 
+        return services;
+    }
+
+    public static IServiceCollection AddBoltServiceManifestProvider<TProvider>(this IServiceCollection services)
+        where TProvider : class, IBoltServiceManifestProvider
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBoltServiceManifestProvider, TProvider>());
         return services;
     }
 

--- a/src/Infrastructure/XFramework.Integration/ServiceDiscovery/BoltServiceDiscoveryOptions.cs
+++ b/src/Infrastructure/XFramework.Integration/ServiceDiscovery/BoltServiceDiscoveryOptions.cs
@@ -1,0 +1,8 @@
+namespace XFramework.Integration.ServiceDiscovery;
+
+public sealed class BoltServiceDiscoveryOptions
+{
+    public const string SectionName = "BoltServiceDiscovery";
+
+    public int ManifestRefreshSeconds { get; set; } = 30;
+}

--- a/src/Infrastructure/XFramework.Integration/ServiceDiscovery/BoltServiceManifestAdvertisementHostedService.cs
+++ b/src/Infrastructure/XFramework.Integration/ServiceDiscovery/BoltServiceManifestAdvertisementHostedService.cs
@@ -1,0 +1,104 @@
+using Bolt.Client;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace XFramework.Integration.ServiceDiscovery;
+
+public sealed class BoltServiceManifestAdvertisementHostedService(
+    BoltClient client,
+    IEnumerable<IBoltServiceManifestProvider> manifestProviders,
+    IOptions<BoltServiceDiscoveryOptions> options,
+    ILogger<BoltServiceManifestAdvertisementHostedService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var refreshSeconds = Math.Max(5, options.Value.ManifestRefreshSeconds);
+        var refreshInterval = TimeSpan.FromSeconds(refreshSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await WaitForConnectionAsync(stoppingToken);
+
+            if (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await AdvertiseAsync(stoppingToken);
+            await Task.Delay(refreshInterval, stoppingToken);
+        }
+    }
+
+    private async Task WaitForConnectionAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested && !client.IsConnected)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(500), ct);
+        }
+    }
+
+    private async Task AdvertiseAsync(CancellationToken ct)
+    {
+        try
+        {
+            var manifest = await BuildManifestAsync(ct);
+            if (manifest is null)
+            {
+                return;
+            }
+
+            var response = await client.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+                string.Empty,
+                BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+                manifest,
+                ct);
+
+            if (response is { Accepted: false })
+            {
+                logger.LogWarning("Bolt service manifest rejected: {Message}", response.Message);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Not connected", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug("Skipping Bolt service manifest advertisement while disconnected");
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to advertise Bolt service manifest");
+        }
+    }
+
+    private async ValueTask<BoltServiceManifest?> BuildManifestAsync(CancellationToken ct)
+    {
+        BoltServiceManifest? merged = null;
+
+        foreach (var provider in manifestProviders)
+        {
+            var manifest = await provider.GetManifestAsync(ct);
+            if (manifest is null)
+            {
+                continue;
+            }
+
+            if (merged is null)
+            {
+                merged = manifest;
+                continue;
+            }
+
+            merged.Modules.AddRange(manifest.Modules);
+            merged.Dependencies.AddRange(manifest.Dependencies);
+            foreach (var (key, value) in manifest.Metadata)
+            {
+                merged.Metadata.TryAdd(key, value);
+            }
+        }
+
+        return merged;
+    }
+}

--- a/src/Infrastructure/XFramework.Integration/ServiceDiscovery/ConfigurationBoltServiceManifestProvider.cs
+++ b/src/Infrastructure/XFramework.Integration/ServiceDiscovery/ConfigurationBoltServiceManifestProvider.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using XFramework.Domain.Shared.Configurations;
+
+namespace XFramework.Integration.ServiceDiscovery;
+
+public sealed class ConfigurationBoltServiceManifestProvider(
+    IConfiguration configuration,
+    IOptions<BoltConfiguration> boltConfiguration) : IBoltServiceManifestProvider
+{
+    public const string SectionName = "XFrameworkServiceManifest";
+
+    public ValueTask<BoltServiceManifest?> GetManifestAsync(CancellationToken ct = default)
+    {
+        var manifest = configuration.GetSection(SectionName).Get<BoltServiceManifest>()
+            ?? new BoltServiceManifest();
+
+        var clientName = boltConfiguration.Value.ClientName ?? "unknown";
+        if (string.IsNullOrWhiteSpace(manifest.ServiceName))
+        {
+            manifest.ServiceName = clientName;
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.DisplayName))
+        {
+            manifest.DisplayName = manifest.ServiceName;
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Version))
+        {
+            manifest.Version = Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+        }
+
+        manifest.Modules ??= [];
+        manifest.Dependencies ??= [];
+        manifest.Metadata ??= [];
+
+        return ValueTask.FromResult<BoltServiceManifest?>(manifest);
+    }
+}

--- a/src/Infrastructure/XFramework.Integration/ServiceDiscovery/IBoltServiceManifestProvider.cs
+++ b/src/Infrastructure/XFramework.Integration/ServiceDiscovery/IBoltServiceManifestProvider.cs
@@ -1,0 +1,8 @@
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+namespace XFramework.Integration.ServiceDiscovery;
+
+public interface IBoltServiceManifestProvider
+{
+    ValueTask<BoltServiceManifest?> GetManifestAsync(CancellationToken ct = default);
+}

--- a/src/Kernel/XFramework.Core/Extensions/TenantModuleFeatureExtensions.cs
+++ b/src/Kernel/XFramework.Core/Extensions/TenantModuleFeatureExtensions.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using XFramework.Core.Middlewares;
 using XFramework.Core.Services.FeatureGates;
@@ -11,6 +12,19 @@ public static class TenantModuleFeatureExtensions
     public static IServiceCollection AddTenantModuleFeatures(this IServiceCollection services)
     {
         RuntimeHelpers.RunClassConstructor(typeof(TenantModuleFeature).TypeHandle);
+        services.AddTenantModuleFeatureDefinitions();
+        services.AddMemoryCache();
+        services.TryAddScoped<ITenantModuleFeatureService, TenantModuleFeatureService>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddTenantModuleFeatures(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        RuntimeHelpers.RunClassConstructor(typeof(TenantModuleFeature).TypeHandle);
+        services.AddTenantModuleFeatureDefinitions(configuration);
         services.AddMemoryCache();
         services.TryAddScoped<ITenantModuleFeatureService, TenantModuleFeatureService>();
 

--- a/src/Kernel/XFramework.Domain/Migrations/20260619090000_AddBoltServiceDiscoveryManifests.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619090000_AddBoltServiceDiscoveryManifests.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260619090000_AddBoltServiceDiscoveryManifests")]
+    public partial class AddBoltServiceDiscoveryManifests : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(name: "Bolt");
+
+            migrationBuilder.CreateTable(
+                name: "ServiceManifest",
+                schema: "Bolt",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ClientId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    ClientName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    ServiceName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Version = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    IsConnected = table.Column<bool>(type: "boolean", nullable: false),
+                    ConnectionCount = table.Column<int>(type: "integer", nullable: false),
+                    LastSeenAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastConnectedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastDisconnectedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ManifestHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ManifestJson = table.Column<string>(type: "jsonb", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("boltservicemanifest_pk", x => x.ID);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceManifest_ClientId",
+                schema: "Bolt",
+                table: "ServiceManifest",
+                column: "ClientId",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ServiceManifest",
+                schema: "Bolt");
+        }
+    }
+}

--- a/src/Kernel/XFramework.Domain/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/AppDbContextModelSnapshot.cs
@@ -23,6 +23,82 @@ namespace XFramework.Domain.Migrations
             NpgsqlModelBuilderExtensions.HasPostgresExtension(modelBuilder, "uuid-ossp");
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
+            modelBuilder.Entity("Bolt.Domain.Shared.Contracts.ServiceDiscovery.BoltServiceManifestRecord", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("ID")
+                        .HasDefaultValueSql("(uuid_generate_v4())");
+
+                    b.Property<string>("ClientId")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("ClientName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying");
+
+                    b.Property<int>("ConnectionCount")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<string>("DisplayName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying");
+
+                    b.Property<bool>("IsConnected")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime?>("LastConnectedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime?>("LastDisconnectedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime>("LastSeenAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("ManifestHash")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("ManifestJson")
+                        .IsRequired()
+                        .HasColumnType("jsonb");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<string>("ServiceName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("Version")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying");
+
+                    b.HasKey("Id")
+                        .HasName("boltservicemanifest_pk");
+
+                    b.HasIndex("ClientId")
+                        .IsUnique()
+                        .HasDatabaseName("IX_ServiceManifest_ClientId");
+
+                    b.ToTable("ServiceManifest", "Bolt");
+                });
+
             modelBuilder.Entity("Community.Domain.Shared.Contracts.CommunityConnection", b =>
                 {
                     b.Property<Guid>("Id")

--- a/src/Libraries/Bolt/Bolt.Server/BoltServer.cs
+++ b/src/Libraries/Bolt/Bolt.Server/BoltServer.cs
@@ -37,6 +37,7 @@ public sealed class BoltServer : IDisposable
 
     // Direct handlers — when registered, server handles requests locally instead of routing
     private readonly ConcurrentDictionary<int, Func<ReadOnlyMemory<byte>, Guid, Task<(HttpStatusCode, ReadOnlyMemory<byte>)>>> _localHandlers = new();
+    private readonly ConcurrentDictionary<int, Func<BoltRequestContext, ReadOnlyMemory<byte>, Guid, Task<(HttpStatusCode, ReadOnlyMemory<byte>)>>> _contextLocalHandlers = new();
 
     // Media processor tap: registered processors receive copies of media frames on a background thread
     private readonly List<IMediaProcessor> _mediaProcessors = new();
@@ -113,6 +114,22 @@ public sealed class BoltServer : IDisposable
         _localHandlers[hash] = handler;
     }
 
+    /// <summary>
+    /// Register a local handler that receives sender connection context.
+    /// This is for hub-local infrastructure commands such as service discovery.
+    /// </summary>
+    public void RegisterHandler(
+        string commandName,
+        Func<BoltRequestContext, ReadOnlyMemory<byte>, Guid, Task<(HttpStatusCode, ReadOnlyMemory<byte>)>> handler)
+    {
+        var hash = BoltCodec.Fnv1aHash(commandName);
+        _contextLocalHandlers[hash] = handler;
+    }
+
+    public event Func<BoltClientConnectionEvent, CancellationToken, Task>? ClientRegistered;
+
+    public event Func<BoltClientConnectionEvent, CancellationToken, Task>? ClientDisconnected;
+
     public async Task HandleConnectionAsync(IBoltConnection transport, CancellationToken ct)
     {
         var connection = new BoltHubConnection(transport);
@@ -179,7 +196,7 @@ public sealed class BoltServer : IDisposable
             connection.CompleteSendChannel();
             ArrayPool<byte>.Shared.Return(receiveBuffer);
             if (largeBuffer != null) ArrayPool<byte>.Shared.Return(largeBuffer);
-            RemoveConnection(connection);
+            await RemoveConnectionAsync(connection);
 
             try { await transport.CloseAsync(); }
             catch { }
@@ -276,6 +293,8 @@ public sealed class BoltServer : IDisposable
         var writer = new ArrayBufferWriter<byte>(2);
         BoltCodec.WriteRegisterAck(writer, true);
         await connection.SendAsync(writer.WrittenMemory, ct);
+
+        await NotifyClientRegisteredAsync(connection, ct);
     }
 
     private async Task HandleRequestAsync(BoltHubConnection caller, byte[] buffer, int length, CancellationToken ct)
@@ -283,8 +302,31 @@ public sealed class BoltServer : IDisposable
         var span = buffer.AsSpan(0, length);
 
         // Check for local handler first (direct mode — server handles request itself)
-        if (_localHandlers.Count > 0 && BoltCodec.TryReadRequest(span, out var frame, out var consumed))
+        if ((_contextLocalHandlers.Count > 0 || _localHandlers.Count > 0)
+            && BoltCodec.TryReadRequest(span, out var frame, out var consumed))
         {
+            if (_contextLocalHandlers.TryGetValue(frame.CommandHash, out var contextHandler))
+            {
+                try
+                {
+                    var payload = frame.GetPayload(buffer.AsMemory(0, length));
+                    var context = BoltRequestContext.FromConnection(caller);
+                    var (statusCode, responsePayload) = await contextHandler(context, payload, frame.RequestId);
+
+                    var writer = RentedBufferWriter.GetThreadLocal();
+                    BoltCodec.WriteResponse(writer, frame.RequestId, statusCode, responsePayload.Span);
+                    await caller.SendAsync(writer.WrittenMemory, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Context local handler error for command hash {Hash}", frame.CommandHash);
+                    var errWriter = RentedBufferWriter.GetThreadLocal();
+                    BoltCodec.WriteResponse(errWriter, frame.RequestId, HttpStatusCode.InternalServerError, ReadOnlySpan<byte>.Empty);
+                    await caller.SendAsync(errWriter.WrittenMemory, ct);
+                }
+                return;
+            }
+
             if (_localHandlers.TryGetValue(frame.CommandHash, out var handler))
             {
                 try
@@ -1179,7 +1221,7 @@ public sealed class BoltServer : IDisposable
         return firstAlive;
     }
 
-    private void RemoveConnection(BoltHubConnection connection)
+    private async Task RemoveConnectionAsync(BoltHubConnection connection)
     {
         if (connection.ClientId is not null)
         {
@@ -1195,6 +1237,7 @@ public sealed class BoltServer : IDisposable
             }
 
             _logger.LogInformation("Client disconnected: {ClientId} ({ClientName})", connection.ClientId, connection.ClientName);
+            await NotifyClientDisconnectedAsync(connection, CancellationToken.None);
         }
 
         foreach (var (requestId, pending) in _pendingInvocations)
@@ -1260,6 +1303,46 @@ public sealed class BoltServer : IDisposable
         var keysToRemove = _liveDurableConnections.Where(kvp => kvp.Value == connection).Select(kvp => kvp.Key).ToList();
         foreach (var key in keysToRemove)
             _liveDurableConnections.TryRemove(key, out _);
+    }
+
+    private async Task NotifyClientRegisteredAsync(BoltHubConnection connection, CancellationToken ct)
+    {
+        var handler = ClientRegistered;
+        if (handler is null || connection.ClientId is null)
+            return;
+
+        var connectionEvent = BoltClientConnectionEvent.FromConnection(connection);
+        foreach (Func<BoltClientConnectionEvent, CancellationToken, Task> subscriber in handler.GetInvocationList())
+        {
+            try
+            {
+                await subscriber(connectionEvent, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Client registered subscriber failed for {ClientId}", connection.ClientId);
+            }
+        }
+    }
+
+    private async Task NotifyClientDisconnectedAsync(BoltHubConnection connection, CancellationToken ct)
+    {
+        var handler = ClientDisconnected;
+        if (handler is null || connection.ClientId is null)
+            return;
+
+        var connectionEvent = BoltClientConnectionEvent.FromConnection(connection);
+        foreach (Func<BoltClientConnectionEvent, CancellationToken, Task> subscriber in handler.GetInvocationList())
+        {
+            try
+            {
+                await subscriber(connectionEvent, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Client disconnected subscriber failed for {ClientId}", connection.ClientId);
+            }
+        }
     }
 
     private void CleanupStaleInvocations(object? state)
@@ -1331,6 +1414,40 @@ public sealed class BoltServer : IDisposable
         _cleanupTimer.Dispose();
         _mediaTapCts.Dispose();
     }
+}
+
+public sealed record BoltRequestContext(
+    string ConnectionId,
+    string? ClientId,
+    string? ClientName,
+    int ServiceHash,
+    BoltTransport TransportType)
+{
+    internal static BoltRequestContext FromConnection(BoltHubConnection connection) =>
+        new(
+            connection.StreamId,
+            connection.ClientId,
+            connection.ClientName,
+            connection.ServiceHash,
+            connection.TransportType);
+}
+
+public sealed record BoltClientConnectionEvent(
+    string ConnectionId,
+    string ClientId,
+    string? ClientName,
+    int ServiceHash,
+    BoltTransport TransportType,
+    DateTime OccurredAt)
+{
+    internal static BoltClientConnectionEvent FromConnection(BoltHubConnection connection) =>
+        new(
+            connection.StreamId,
+            connection.ClientId ?? string.Empty,
+            connection.ClientName,
+            connection.ServiceHash,
+            connection.TransportType,
+            DateTime.UtcNow);
 }
 
 /// <summary>

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Bolt.Domain.Shared.csproj
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Bolt.Domain.Shared.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <LangVersion>14</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
         <PackageId>XFramework.Bolt.Domain.Shared</PackageId>
         <Version>$(XFrameworkVersion)</Version>
         <Description>XFramework Bolt domain types - IBoltRequest and RPC contracts.</Description>
@@ -16,5 +17,7 @@
     <ItemGroup>
       <PackageReference Include="MessagePack" />
       <PackageReference Include="MessagePack.Annotations" />
+      <PackageReference Include="MemoryPack" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     </ItemGroup>
 </Project>

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Configurations/BoltServiceManifestRecordConfiguration.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Configurations/BoltServiceManifestRecordConfiguration.cs
@@ -1,0 +1,59 @@
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Bolt.Domain.Shared.Configurations;
+
+public sealed class BoltServiceManifestRecordConfiguration : IEntityTypeConfiguration<BoltServiceManifestRecord>
+{
+    public void Configure(EntityTypeBuilder<BoltServiceManifestRecord> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("boltservicemanifest_pk");
+
+        entity.ToTable("ServiceManifest", "Bolt");
+
+        entity.HasIndex(e => e.ClientId)
+            .IsUnique()
+            .HasDatabaseName("IX_ServiceManifest_ClientId");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+
+        entity.Property(e => e.ClientId)
+            .IsRequired()
+            .HasMaxLength(128)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.ClientName)
+            .IsRequired()
+            .HasMaxLength(200)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.ServiceName)
+            .IsRequired()
+            .HasMaxLength(200)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.DisplayName)
+            .IsRequired()
+            .HasMaxLength(200)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.Version)
+            .HasMaxLength(64)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.ManifestHash)
+            .IsRequired()
+            .HasMaxLength(64)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.ManifestJson)
+            .IsRequired()
+            .HasColumnType("jsonb");
+
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+    }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyKind.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyKind.cs
@@ -1,0 +1,8 @@
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+public enum BoltDependencyKind
+{
+    Service = 0,
+    Module = 1,
+    TenantFeature = 2
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyRequirement.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyRequirement.cs
@@ -1,0 +1,22 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltDependencyRequirement
+{
+    [MemoryPackOrder(0)]
+    public BoltDependencyKind Kind { get; set; }
+
+    [MemoryPackOrder(1)]
+    public string Key { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string? DisplayName { get; set; }
+
+    [MemoryPackOrder(3)]
+    public string? MinVersion { get; set; }
+
+    [MemoryPackOrder(4)]
+    public bool Required { get; set; } = true;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyStatus.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyStatus.cs
@@ -1,0 +1,19 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltDependencyStatus
+{
+    [MemoryPackOrder(0)]
+    public BoltDependencyRequirement Requirement { get; set; } = new();
+
+    [MemoryPackOrder(1)]
+    public bool IsSatisfied { get; set; }
+
+    [MemoryPackOrder(2)]
+    public string? MatchedKey { get; set; }
+
+    [MemoryPackOrder(3)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleManifest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleManifest.cs
@@ -1,0 +1,28 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltModuleManifest
+{
+    [MemoryPackOrder(0)]
+    public string ModuleKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string? Version { get; set; }
+
+    [MemoryPackOrder(4)]
+    public string IconName { get; set; } = "box";
+
+    [MemoryPackOrder(5)]
+    public List<BoltTenantModuleFeatureManifest> Features { get; set; } = [];
+
+    [MemoryPackOrder(6)]
+    public List<BoltDependencyRequirement> Dependencies { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryItem.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryItem.cs
@@ -1,0 +1,40 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltModuleRegistryItem
+{
+    [MemoryPackOrder(0)]
+    public string ModuleKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string? Version { get; set; }
+
+    [MemoryPackOrder(4)]
+    public string IconName { get; set; } = "box";
+
+    [MemoryPackOrder(5)]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(6)]
+    public string ClientId { get; set; } = string.Empty;
+
+    [MemoryPackOrder(7)]
+    public string ClientName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(8)]
+    public BoltRegistryStatus Status { get; set; }
+
+    [MemoryPackOrder(9)]
+    public List<BoltTenantModuleFeatureRegistryItem> Features { get; set; } = [];
+
+    [MemoryPackOrder(10)]
+    public List<BoltDependencyStatus> DependencyStatuses { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryRequest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryRequest.cs
@@ -1,0 +1,10 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltModuleRegistryRequest
+{
+    [MemoryPackOrder(0)]
+    public bool IncludeOffline { get; set; } = true;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryResponse.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryResponse.cs
@@ -1,0 +1,10 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltModuleRegistryResponse
+{
+    [MemoryPackOrder(0)]
+    public List<BoltModuleRegistryItem> Modules { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltRegistryStatus.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltRegistryStatus.cs
@@ -1,0 +1,8 @@
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+public enum BoltRegistryStatus
+{
+    Offline = 0,
+    Online = 1,
+    Degraded = 2
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceDiscoveryCommands.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceDiscoveryCommands.cs
@@ -1,0 +1,8 @@
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+public static class BoltServiceDiscoveryCommands
+{
+    public const string AdvertiseServiceManifest = "__xframework.service_manifest.advertise";
+    public const string GetServiceRegistry = "__xframework.service_registry.get";
+    public const string GetModuleRegistry = "__xframework.module_registry.get";
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifest.cs
@@ -1,0 +1,31 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceManifest
+{
+    [MemoryPackOrder(0)]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string? Version { get; set; }
+
+    [MemoryPackOrder(4)]
+    public string? HealthUrl { get; set; }
+
+    [MemoryPackOrder(5)]
+    public List<BoltModuleManifest> Modules { get; set; } = [];
+
+    [MemoryPackOrder(6)]
+    public List<BoltDependencyRequirement> Dependencies { get; set; } = [];
+
+    [MemoryPackOrder(7)]
+    public Dictionary<string, string> Metadata { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifestAdvertisementResponse.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifestAdvertisementResponse.cs
@@ -1,0 +1,13 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceManifestAdvertisementResponse
+{
+    [MemoryPackOrder(0)]
+    public bool Accepted { get; set; }
+
+    [MemoryPackOrder(1)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifestRecord.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifestRecord.cs
@@ -1,0 +1,22 @@
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+public sealed class BoltServiceManifestRecord : IAuditable
+{
+    public Guid Id { get; set; }
+    public string ClientId { get; set; } = string.Empty;
+    public string ClientName { get; set; } = string.Empty;
+    public string ServiceName { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string? Version { get; set; }
+    public bool IsConnected { get; set; }
+    public int ConnectionCount { get; set; }
+    public DateTime LastSeenAt { get; set; }
+    public DateTime? LastConnectedAt { get; set; }
+    public DateTime? LastDisconnectedAt { get; set; }
+    public string ManifestHash { get; set; } = string.Empty;
+    public string ManifestJson { get; set; } = "{}";
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ModifiedAt { get; set; }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryItem.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryItem.cs
@@ -1,0 +1,43 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceRegistryItem
+{
+    [MemoryPackOrder(0)]
+    public string ClientId { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string ClientName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(4)]
+    public string? Version { get; set; }
+
+    [MemoryPackOrder(5)]
+    public BoltRegistryStatus Status { get; set; }
+
+    [MemoryPackOrder(6)]
+    public int ConnectionCount { get; set; }
+
+    [MemoryPackOrder(7)]
+    public DateTime LastSeenAt { get; set; }
+
+    [MemoryPackOrder(8)]
+    public DateTime? LastConnectedAt { get; set; }
+
+    [MemoryPackOrder(9)]
+    public DateTime? LastDisconnectedAt { get; set; }
+
+    [MemoryPackOrder(10)]
+    public BoltServiceManifest Manifest { get; set; } = new();
+
+    [MemoryPackOrder(11)]
+    public List<BoltDependencyStatus> DependencyStatuses { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryRequest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryRequest.cs
@@ -1,0 +1,10 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceRegistryRequest
+{
+    [MemoryPackOrder(0)]
+    public bool IncludeOffline { get; set; } = true;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryResponse.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryResponse.cs
@@ -1,0 +1,10 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceRegistryResponse
+{
+    [MemoryPackOrder(0)]
+    public List<BoltServiceRegistryItem> Services { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltTenantModuleFeatureManifest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltTenantModuleFeatureManifest.cs
@@ -1,0 +1,31 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltTenantModuleFeatureManifest
+{
+    [MemoryPackOrder(0)]
+    public string? Key { get; set; }
+
+    [MemoryPackOrder(1)]
+    public string ModuleKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string SubFeatureKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(4)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(5)]
+    public string IconName { get; set; } = "box";
+
+    [MemoryPackOrder(6)]
+    public bool DefaultEnabled { get; set; } = true;
+
+    [MemoryPackOrder(7)]
+    public List<BoltDependencyRequirement> Dependencies { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltTenantModuleFeatureRegistryItem.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltTenantModuleFeatureRegistryItem.cs
@@ -1,0 +1,37 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltTenantModuleFeatureRegistryItem
+{
+    [MemoryPackOrder(0)]
+    public string Key { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string ModuleKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string SubFeatureKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(4)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(5)]
+    public string IconName { get; set; } = "box";
+
+    [MemoryPackOrder(6)]
+    public bool DefaultEnabled { get; set; } = true;
+
+    [MemoryPackOrder(7)]
+    public BoltRegistryStatus Status { get; set; }
+
+    [MemoryPackOrder(8)]
+    public List<BoltDependencyRequirement> Dependencies { get; set; } = [];
+
+    [MemoryPackOrder(9)]
+    public List<BoltDependencyStatus> DependencyStatuses { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Extensions/ApplicationBuilderExtension.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Extensions/ApplicationBuilderExtension.cs
@@ -1,4 +1,6 @@
-﻿using Bolt.Server;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Hub.Services;
+using Bolt.Server;
 
 namespace Bolt.Hub.Extensions;
 
@@ -6,12 +8,26 @@ public static class ApplicationBuilderExtension
 {
     public static IApplicationBuilder UseAppServices(this IApplicationBuilder appBuilder)
     {
-        var app = appBuilder as WebApplication;
+        var app = appBuilder as WebApplication
+            ?? throw new InvalidOperationException("Bolt Hub service mapping requires WebApplication.");
 
         // Bolt thin-protocol WebSocket endpoint
         app.UseWebSockets();
         app.MapBolt("/bolt/ws");
 
-        return app as IApplicationBuilder;
+        if (app.Configuration.GetValue<bool>("BoltServiceDiscovery:ExposeHttpEndpoints"))
+        {
+            app.MapGet("/api/bolt/services", async (
+                    IBoltServiceDiscoveryRegistry registry,
+                    CancellationToken ct) =>
+                Results.Ok(await registry.GetServicesAsync(new BoltServiceRegistryRequest(), ct)));
+
+            app.MapGet("/api/bolt/modules", async (
+                    IBoltServiceDiscoveryRegistry registry,
+                    CancellationToken ct) =>
+                Results.Ok(await registry.GetModulesAsync(new BoltModuleRegistryRequest(), ct)));
+        }
+
+        return app;
     }
 }

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/BoltInstaller.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/BoltInstaller.cs
@@ -1,3 +1,4 @@
+using Bolt.Hub.Services;
 using Bolt.Server;
 using Microsoft.AspNetCore.ResponseCompression;
 using XFramework.Domain.Shared.Configurations;
@@ -19,6 +20,9 @@ public sealed class BoltInstaller : IInstaller
 
         // Bolt thin protocol server
         services.AddBoltServer();
+        services.AddSingleton<IBoltServicePresenceTracker, BoltServicePresenceTracker>();
+        services.AddScoped<IBoltServiceDiscoveryRegistry, BoltServiceDiscoveryRegistry>();
+        services.AddHostedService<BoltServiceDiscoveryHostedService>();
 
         // Durable queue store (Redis if configured, in-memory fallback)
         services.Configure<Bolt.Server.Durable.DurableQueueOptions>(configuration.GetSection("BoltConfiguration:Durable"));

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServiceDiscoveryHostedService.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServiceDiscoveryHostedService.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Server;
+using MemoryPack;
+
+namespace Bolt.Hub.Services;
+
+public sealed class BoltServiceDiscoveryHostedService(
+    BoltServer server,
+    IServiceScopeFactory scopeFactory,
+    ILogger<BoltServiceDiscoveryHostedService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+            await registry.ResetPresenceAsync(cancellationToken);
+        }
+
+        server.RegisterHandler(
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            HandleAdvertiseServiceManifestAsync);
+        server.RegisterHandler(
+            BoltServiceDiscoveryCommands.GetServiceRegistry,
+            HandleGetServiceRegistryAsync);
+        server.RegisterHandler(
+            BoltServiceDiscoveryCommands.GetModuleRegistry,
+            HandleGetModuleRegistryAsync);
+
+        server.ClientRegistered += HandleClientRegisteredAsync;
+        server.ClientDisconnected += HandleClientDisconnectedAsync;
+
+        logger.LogInformation("Bolt service discovery registry handlers registered");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        server.ClientRegistered -= HandleClientRegisteredAsync;
+        server.ClientDisconnected -= HandleClientDisconnectedAsync;
+        return Task.CompletedTask;
+    }
+
+    private async Task<(HttpStatusCode, ReadOnlyMemory<byte>)> HandleAdvertiseServiceManifestAsync(
+        BoltRequestContext context,
+        ReadOnlyMemory<byte> payload,
+        Guid requestId)
+    {
+        var manifest = MemoryPackSerializer.Deserialize<BoltServiceManifest>(payload.Span);
+        if (manifest is null)
+        {
+            return Serialize(HttpStatusCode.BadRequest, new BoltServiceManifestAdvertisementResponse
+            {
+                Accepted = false,
+                Message = "Manifest payload is required."
+            });
+        }
+
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        var response = await registry.AdvertiseAsync(context, manifest, CancellationToken.None);
+
+        return Serialize(response.Accepted ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response);
+    }
+
+    private async Task<(HttpStatusCode, ReadOnlyMemory<byte>)> HandleGetServiceRegistryAsync(
+        BoltRequestContext context,
+        ReadOnlyMemory<byte> payload,
+        Guid requestId)
+    {
+        var request = payload.IsEmpty
+            ? new BoltServiceRegistryRequest()
+            : MemoryPackSerializer.Deserialize<BoltServiceRegistryRequest>(payload.Span) ?? new BoltServiceRegistryRequest();
+
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        var response = await registry.GetServicesAsync(request, CancellationToken.None);
+
+        return Serialize(HttpStatusCode.OK, response);
+    }
+
+    private async Task<(HttpStatusCode, ReadOnlyMemory<byte>)> HandleGetModuleRegistryAsync(
+        BoltRequestContext context,
+        ReadOnlyMemory<byte> payload,
+        Guid requestId)
+    {
+        var request = payload.IsEmpty
+            ? new BoltModuleRegistryRequest()
+            : MemoryPackSerializer.Deserialize<BoltModuleRegistryRequest>(payload.Span) ?? new BoltModuleRegistryRequest();
+
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        var response = await registry.GetModulesAsync(request, CancellationToken.None);
+
+        return Serialize(HttpStatusCode.OK, response);
+    }
+
+    private async Task HandleClientRegisteredAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        await registry.MarkConnectedAsync(connectionEvent, ct);
+    }
+
+    private async Task HandleClientDisconnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        await registry.MarkDisconnectedAsync(connectionEvent, ct);
+    }
+
+    private static (HttpStatusCode, ReadOnlyMemory<byte>) Serialize<T>(HttpStatusCode statusCode, T response) =>
+        (statusCode, MemoryPackSerializer.Serialize(response));
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServiceDiscoveryRegistry.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServiceDiscoveryRegistry.cs
@@ -1,0 +1,526 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Server;
+using Microsoft.EntityFrameworkCore;
+
+namespace Bolt.Hub.Services;
+
+public sealed class BoltServiceDiscoveryRegistry(
+    DbContext db,
+    IBoltServicePresenceTracker presenceTracker) : IBoltServiceDiscoveryRegistry
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task ResetPresenceAsync(CancellationToken ct)
+    {
+        presenceTracker.Clear();
+
+        var now = DateTime.UtcNow;
+        var records = await db.Set<BoltServiceManifestRecord>()
+            .AsTracking()
+            .Where(record => record.IsConnected || record.ConnectionCount > 0)
+            .ToListAsync(ct);
+
+        foreach (var record in records)
+        {
+            record.IsConnected = false;
+            record.ConnectionCount = 0;
+            record.LastSeenAt = now;
+            record.LastDisconnectedAt = now;
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<BoltServiceManifestAdvertisementResponse> AdvertiseAsync(
+        BoltRequestContext context,
+        BoltServiceManifest manifest,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(context.ClientId))
+        {
+            return new BoltServiceManifestAdvertisementResponse
+            {
+                Accepted = false,
+                Message = "Registered Bolt client id is required before advertising a manifest."
+            };
+        }
+
+        return await presenceTracker.UpdateAsync(
+            context.ClientId,
+            async connectionIds =>
+            {
+                if (!string.IsNullOrWhiteSpace(context.ConnectionId))
+                {
+                    connectionIds.Add(context.ConnectionId);
+                }
+
+                return await UpsertAdvertisedManifestAsync(
+                    context.ClientId,
+                    context,
+                    manifest,
+                    Math.Max(1, connectionIds.Count),
+                    ct);
+            },
+            ct);
+    }
+
+    private async Task<BoltServiceManifestAdvertisementResponse> UpsertAdvertisedManifestAsync(
+        string clientId,
+        BoltRequestContext context,
+        BoltServiceManifest manifest,
+        int connectionCount,
+        CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var normalized = NormalizeManifest(context, manifest);
+        var manifestJson = JsonSerializer.Serialize(normalized, JsonOptions);
+        var manifestHash = ComputeSha256(manifestJson);
+        var record = await db.Set<BoltServiceManifestRecord>()
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ClientId == clientId, ct);
+
+        if (record is null)
+        {
+            record = new BoltServiceManifestRecord
+            {
+                Id = Guid.NewGuid(),
+                ClientId = clientId,
+                CreatedAt = now
+            };
+            db.Add(record);
+        }
+
+        record.ClientName = context.ClientName ?? clientId;
+        record.ServiceName = normalized.ServiceName;
+        record.DisplayName = normalized.DisplayName;
+        record.Version = normalized.Version;
+        record.IsConnected = true;
+        record.ConnectionCount = connectionCount;
+        record.LastSeenAt = now;
+        record.LastConnectedAt ??= now;
+
+        if (!string.Equals(record.ManifestHash, manifestHash, StringComparison.Ordinal))
+        {
+            record.ManifestHash = manifestHash;
+            record.ManifestJson = manifestJson;
+        }
+
+        await db.SaveChangesAsync(ct);
+        return new BoltServiceManifestAdvertisementResponse { Accepted = true, Message = "Accepted" };
+    }
+
+    public async Task MarkConnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(connectionEvent.ClientId))
+        {
+            return;
+        }
+
+        await presenceTracker.UpdateAsync(
+            connectionEvent.ClientId,
+            async connectionIds =>
+            {
+                connectionIds.Add(connectionEvent.ConnectionId);
+                await UpsertConnectedRecordAsync(connectionEvent, connectionIds.Count, ct);
+                return true;
+            },
+            ct);
+    }
+
+    public async Task MarkDisconnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(connectionEvent.ClientId))
+        {
+            return;
+        }
+
+        await presenceTracker.UpdateAsync(
+            connectionEvent.ClientId,
+            async connectionIds =>
+            {
+                connectionIds.Remove(connectionEvent.ConnectionId);
+                await MarkDisconnectedRecordAsync(connectionEvent, connectionIds.Count, ct);
+                return true;
+            },
+            ct);
+    }
+
+    private async Task UpsertConnectedRecordAsync(
+        BoltClientConnectionEvent connectionEvent,
+        int connectionCount,
+        CancellationToken ct)
+    {
+        var now = connectionEvent.OccurredAt == default ? DateTime.UtcNow : connectionEvent.OccurredAt;
+        var record = await db.Set<BoltServiceManifestRecord>()
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ClientId == connectionEvent.ClientId, ct);
+
+        if (record is null)
+        {
+            var manifest = NormalizeManifest(
+                new BoltRequestContext(
+                    connectionEvent.ConnectionId,
+                    connectionEvent.ClientId,
+                    connectionEvent.ClientName,
+                    connectionEvent.ServiceHash,
+                    connectionEvent.TransportType),
+                new BoltServiceManifest());
+            var manifestJson = JsonSerializer.Serialize(manifest, JsonOptions);
+
+            record = new BoltServiceManifestRecord
+            {
+                Id = Guid.NewGuid(),
+                ClientId = connectionEvent.ClientId,
+                ClientName = connectionEvent.ClientName ?? connectionEvent.ClientId,
+                ServiceName = manifest.ServiceName,
+                DisplayName = manifest.DisplayName,
+                Version = manifest.Version,
+                ManifestJson = manifestJson,
+                ManifestHash = ComputeSha256(manifestJson),
+                CreatedAt = now
+            };
+            db.Add(record);
+        }
+
+        record.ClientName = connectionEvent.ClientName ?? connectionEvent.ClientId;
+        record.IsConnected = true;
+        record.ConnectionCount = Math.Max(1, connectionCount);
+        record.LastSeenAt = now;
+        record.LastConnectedAt = now;
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    private async Task MarkDisconnectedRecordAsync(
+        BoltClientConnectionEvent connectionEvent,
+        int connectionCount,
+        CancellationToken ct)
+    {
+        var record = await db.Set<BoltServiceManifestRecord>()
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ClientId == connectionEvent.ClientId, ct);
+
+        if (record is null)
+        {
+            return;
+        }
+
+        var count = Math.Max(0, connectionCount);
+        record.ConnectionCount = count;
+        record.IsConnected = count > 0;
+        record.LastSeenAt = DateTime.UtcNow;
+        if (count == 0)
+        {
+            record.LastDisconnectedAt = connectionEvent.OccurredAt == default
+                ? DateTime.UtcNow
+                : connectionEvent.OccurredAt;
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<BoltServiceRegistryResponse> GetServicesAsync(
+        BoltServiceRegistryRequest request,
+        CancellationToken ct)
+    {
+        var records = await LoadRecordsAsync(request.IncludeOffline, ct);
+        var items = records
+            .Select(record =>
+            {
+                var manifest = DeserializeManifest(record);
+                var dependencyStatuses = EvaluateDependencies(manifest.Dependencies, records);
+                var status = GetStatus(record, dependencyStatuses);
+
+                return new BoltServiceRegistryItem
+                {
+                    ClientId = record.ClientId,
+                    ClientName = record.ClientName,
+                    ServiceName = record.ServiceName,
+                    DisplayName = record.DisplayName,
+                    Version = record.Version,
+                    Status = status,
+                    ConnectionCount = record.ConnectionCount,
+                    LastSeenAt = record.LastSeenAt,
+                    LastConnectedAt = record.LastConnectedAt,
+                    LastDisconnectedAt = record.LastDisconnectedAt,
+                    Manifest = manifest,
+                    DependencyStatuses = dependencyStatuses
+                };
+            })
+            .OrderBy(item => item.DisplayName)
+            .ThenBy(item => item.ClientId)
+            .ToList();
+
+        return new BoltServiceRegistryResponse { Services = items };
+    }
+
+    public async Task<BoltModuleRegistryResponse> GetModulesAsync(
+        BoltModuleRegistryRequest request,
+        CancellationToken ct)
+    {
+        var records = await LoadRecordsAsync(request.IncludeOffline, ct);
+        var modules = new List<BoltModuleRegistryItem>();
+
+        foreach (var record in records)
+        {
+            var manifest = DeserializeManifest(record);
+            var serviceDependencies = EvaluateDependencies(manifest.Dependencies, records);
+            var serviceStatus = GetStatus(record, serviceDependencies);
+
+            foreach (var module in manifest.Modules)
+            {
+                var moduleDependencies = serviceDependencies
+                    .Concat(EvaluateDependencies(module.Dependencies, records))
+                    .ToList();
+                var moduleStatus = GetStatus(record, moduleDependencies);
+
+                modules.Add(new BoltModuleRegistryItem
+                {
+                    ModuleKey = module.ModuleKey,
+                    DisplayName = module.DisplayName,
+                    Description = module.Description,
+                    Version = module.Version ?? manifest.Version,
+                    IconName = module.IconName,
+                    ServiceName = manifest.ServiceName,
+                    ClientId = record.ClientId,
+                    ClientName = record.ClientName,
+                    Status = serviceStatus == BoltRegistryStatus.Offline ? serviceStatus : moduleStatus,
+                    DependencyStatuses = moduleDependencies,
+                    Features = module.Features
+                        .Select(feature => CreateFeatureItem(feature, record, records, moduleDependencies))
+                        .ToList()
+                });
+            }
+        }
+
+        return new BoltModuleRegistryResponse
+        {
+            Modules = modules
+                .OrderBy(module => module.DisplayName)
+                .ThenBy(module => module.ModuleKey)
+                .ToList()
+        };
+    }
+
+    private async Task<List<BoltServiceManifestRecord>> LoadRecordsAsync(bool includeOffline, CancellationToken ct) =>
+        await db.Set<BoltServiceManifestRecord>()
+            .AsNoTracking()
+            .Where(record => includeOffline || record.IsConnected)
+            .OrderBy(record => record.ServiceName)
+            .ToListAsync(ct);
+
+    private static BoltTenantModuleFeatureRegistryItem CreateFeatureItem(
+        BoltTenantModuleFeatureManifest feature,
+        BoltServiceManifestRecord owner,
+        IReadOnlyList<BoltServiceManifestRecord> allRecords,
+        IReadOnlyList<BoltDependencyStatus> inheritedDependencies)
+    {
+        var dependencyStatuses = inheritedDependencies
+            .Concat(EvaluateDependencies(feature.Dependencies, allRecords))
+            .ToList();
+
+        return new BoltTenantModuleFeatureRegistryItem
+        {
+            Key = feature.Key ?? CombineKey(feature.ModuleKey, feature.SubFeatureKey),
+            ModuleKey = feature.ModuleKey,
+            SubFeatureKey = feature.SubFeatureKey,
+            DisplayName = feature.DisplayName,
+            Description = feature.Description,
+            IconName = feature.IconName,
+            DefaultEnabled = feature.DefaultEnabled,
+            Dependencies = feature.Dependencies,
+            DependencyStatuses = dependencyStatuses,
+            Status = GetStatus(owner, dependencyStatuses)
+        };
+    }
+
+    private static BoltRegistryStatus GetStatus(
+        BoltServiceManifestRecord record,
+        IReadOnlyCollection<BoltDependencyStatus> dependencyStatuses)
+    {
+        if (!record.IsConnected || record.ConnectionCount <= 0)
+        {
+            return BoltRegistryStatus.Offline;
+        }
+
+        return dependencyStatuses.Any(status => status.Requirement.Required && !status.IsSatisfied)
+            ? BoltRegistryStatus.Degraded
+            : BoltRegistryStatus.Online;
+    }
+
+    private static List<BoltDependencyStatus> EvaluateDependencies(
+        IEnumerable<BoltDependencyRequirement> requirements,
+        IReadOnlyList<BoltServiceManifestRecord> records)
+    {
+        var onlineRecords = records
+            .Where(record => record.IsConnected && record.ConnectionCount > 0)
+            .ToList();
+
+        var serviceKeys = onlineRecords
+            .SelectMany(record => new[] { record.ClientId, record.ClientName, record.ServiceName })
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .Select(NormalizeLookupKey)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var moduleKeys = onlineRecords
+            .SelectMany(record => DeserializeManifest(record).Modules)
+            .Select(module => NormalizeLookupKey(module.ModuleKey))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var featureKeys = onlineRecords
+            .SelectMany(record => DeserializeManifest(record).Modules)
+            .SelectMany(module => module.Features)
+            .Select(feature => NormalizeLookupKey(feature.Key ?? CombineKey(feature.ModuleKey, feature.SubFeatureKey)))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return requirements
+            .Select(requirement => EvaluateDependency(requirement, serviceKeys, moduleKeys, featureKeys))
+            .ToList();
+    }
+
+    private static BoltDependencyStatus EvaluateDependency(
+        BoltDependencyRequirement requirement,
+        IReadOnlySet<string> serviceKeys,
+        IReadOnlySet<string> moduleKeys,
+        IReadOnlySet<string> featureKeys)
+    {
+        var key = NormalizeLookupKey(requirement.Key);
+        var satisfied = requirement.Kind switch
+        {
+            BoltDependencyKind.Service => serviceKeys.Contains(key),
+            BoltDependencyKind.Module => moduleKeys.Contains(key),
+            BoltDependencyKind.TenantFeature => featureKeys.Contains(key),
+            _ => false
+        };
+
+        var displayName = string.IsNullOrWhiteSpace(requirement.DisplayName)
+            ? requirement.Key
+            : requirement.DisplayName;
+
+        return new BoltDependencyStatus
+        {
+            Requirement = requirement,
+            IsSatisfied = satisfied,
+            MatchedKey = satisfied ? requirement.Key : null,
+            Message = satisfied
+                ? $"{displayName} is available."
+                : $"{displayName} is not available."
+        };
+    }
+
+    private static BoltServiceManifest NormalizeManifest(BoltRequestContext context, BoltServiceManifest manifest)
+    {
+        manifest.ServiceName = FirstNonEmpty(manifest.ServiceName, context.ClientName, context.ClientId, "unknown");
+        manifest.DisplayName = FirstNonEmpty(manifest.DisplayName, manifest.ServiceName);
+        manifest.Description ??= string.Empty;
+        manifest.Modules ??= [];
+        manifest.Dependencies ??= [];
+        manifest.Metadata ??= [];
+
+        foreach (var module in manifest.Modules)
+        {
+            module.ModuleKey = NormalizeLookupKey(module.ModuleKey);
+            module.DisplayName = FirstNonEmpty(module.DisplayName, module.ModuleKey);
+            module.Description ??= string.Empty;
+            module.IconName = FirstNonEmpty(module.IconName, "box");
+            module.Features ??= [];
+            module.Dependencies ??= [];
+
+            foreach (var feature in module.Features)
+            {
+                NormalizeFeature(module, feature);
+            }
+        }
+
+        return manifest;
+    }
+
+    private static void NormalizeFeature(BoltModuleManifest module, BoltTenantModuleFeatureManifest feature)
+    {
+        if (string.IsNullOrWhiteSpace(feature.ModuleKey))
+        {
+            feature.ModuleKey = module.ModuleKey;
+        }
+
+        if (!string.IsNullOrWhiteSpace(feature.Key))
+        {
+            var split = SplitCombinedKey(feature.Key);
+            if (string.IsNullOrWhiteSpace(feature.ModuleKey))
+            {
+                feature.ModuleKey = split.ModuleKey;
+            }
+
+            if (string.IsNullOrWhiteSpace(feature.SubFeatureKey))
+            {
+                feature.SubFeatureKey = split.SubFeatureKey;
+            }
+        }
+
+        feature.ModuleKey = NormalizeLookupKey(feature.ModuleKey);
+        feature.SubFeatureKey = NormalizeLookupKey(feature.SubFeatureKey);
+        feature.Key = CombineKey(feature.ModuleKey, feature.SubFeatureKey);
+        feature.DisplayName = FirstNonEmpty(feature.DisplayName, feature.Key);
+        feature.Description ??= string.Empty;
+        feature.IconName = FirstNonEmpty(feature.IconName, module.IconName, "box");
+        feature.Dependencies ??= [];
+    }
+
+    private static BoltServiceManifest DeserializeManifest(BoltServiceManifestRecord record)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<BoltServiceManifest>(record.ManifestJson, JsonOptions)
+                ?? new BoltServiceManifest
+                {
+                    ServiceName = record.ServiceName,
+                    DisplayName = record.DisplayName,
+                    Version = record.Version
+                };
+        }
+        catch (JsonException ex)
+        {
+            return new BoltServiceManifest
+            {
+                ServiceName = record.ServiceName,
+                DisplayName = record.DisplayName,
+                Version = record.Version,
+                Metadata = { ["manifestError"] = ex.Message }
+            };
+        }
+    }
+
+    private static string ComputeSha256(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    private static string FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
+
+    private static string NormalizeLookupKey(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : value.Trim().ToLowerInvariant();
+
+    private static (string ModuleKey, string SubFeatureKey) SplitCombinedKey(string key)
+    {
+        var normalized = NormalizeLookupKey(key);
+        var separatorIndex = normalized.IndexOf('.', StringComparison.Ordinal);
+        return separatorIndex > 0 && separatorIndex < normalized.Length - 1
+            ? (normalized[..separatorIndex], normalized[(separatorIndex + 1)..])
+            : (normalized, string.Empty);
+    }
+
+    private static string CombineKey(string moduleKey, string? subFeatureKey = null)
+    {
+        var normalizedModule = NormalizeLookupKey(moduleKey);
+        var normalizedSubFeature = NormalizeLookupKey(subFeatureKey);
+        return string.IsNullOrWhiteSpace(normalizedSubFeature)
+            ? normalizedModule
+            : $"{normalizedModule}.{normalizedSubFeature}";
+    }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServicePresenceTracker.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServicePresenceTracker.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+
+namespace Bolt.Hub.Services;
+
+public sealed class BoltServicePresenceTracker : IBoltServicePresenceTracker
+{
+    private readonly ConcurrentDictionary<string, ClientPresenceState> _states =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public async Task<TResult> UpdateAsync<TResult>(
+        string clientId,
+        Func<ISet<string>, Task<TResult>> update,
+        CancellationToken ct = default)
+    {
+        var state = _states.GetOrAdd(clientId, _ => new ClientPresenceState());
+        await state.Gate.WaitAsync(ct);
+        try
+        {
+            return await update(state.ConnectionIds);
+        }
+        finally
+        {
+            state.Gate.Release();
+        }
+    }
+
+    public void Clear() => _states.Clear();
+
+    private sealed class ClientPresenceState
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public HashSet<string> ConnectionIds { get; } = new(StringComparer.Ordinal);
+    }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/IBoltServiceDiscoveryRegistry.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/IBoltServiceDiscoveryRegistry.cs
@@ -1,0 +1,22 @@
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Server;
+
+namespace Bolt.Hub.Services;
+
+public interface IBoltServiceDiscoveryRegistry
+{
+    Task ResetPresenceAsync(CancellationToken ct);
+
+    Task<BoltServiceManifestAdvertisementResponse> AdvertiseAsync(
+        BoltRequestContext context,
+        BoltServiceManifest manifest,
+        CancellationToken ct);
+
+    Task MarkConnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct);
+
+    Task MarkDisconnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct);
+
+    Task<BoltServiceRegistryResponse> GetServicesAsync(BoltServiceRegistryRequest request, CancellationToken ct);
+
+    Task<BoltModuleRegistryResponse> GetModulesAsync(BoltModuleRegistryRequest request, CancellationToken ct);
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/IBoltServicePresenceTracker.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/IBoltServicePresenceTracker.cs
@@ -1,0 +1,11 @@
+namespace Bolt.Hub.Services;
+
+public interface IBoltServicePresenceTracker
+{
+    Task<TResult> UpdateAsync<TResult>(
+        string clientId,
+        Func<ISet<string>, Task<TResult>> update,
+        CancellationToken ct = default);
+
+    void Clear();
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/BuiltInTenantModuleFeatureDefinitionProvider.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/BuiltInTenantModuleFeatureDefinitionProvider.cs
@@ -1,0 +1,6 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public sealed class BuiltInTenantModuleFeatureDefinitionProvider : ITenantModuleFeatureDefinitionProvider
+{
+    public IReadOnlyList<TenantModuleFeatureDefinition> Definitions => TenantModuleFeatureKeys.All;
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ConfigurationTenantModuleFeatureDefinitionProvider.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ConfigurationTenantModuleFeatureDefinitionProvider.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Configuration;
+
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public sealed class ConfigurationTenantModuleFeatureDefinitionProvider : ITenantModuleFeatureDefinitionProvider
+{
+    public const string SectionName = "TenantModuleFeatures:Definitions";
+
+    public ConfigurationTenantModuleFeatureDefinitionProvider(IConfiguration configuration)
+    {
+        Definitions = BuildDefinitions(configuration.GetSection(SectionName));
+    }
+
+    public IReadOnlyList<TenantModuleFeatureDefinition> Definitions { get; }
+
+    private static IReadOnlyList<TenantModuleFeatureDefinition> BuildDefinitions(IConfigurationSection section)
+    {
+        var definitions = new List<TenantModuleFeatureDefinition>();
+
+        foreach (var child in section.GetChildren())
+        {
+            var moduleKey = child["ModuleKey"] ?? string.Empty;
+            var subFeatureKey = child["SubFeatureKey"] ?? string.Empty;
+            var combinedKey = child["Key"];
+
+            if (string.IsNullOrWhiteSpace(moduleKey) && !string.IsNullOrWhiteSpace(combinedKey))
+            {
+                (moduleKey, subFeatureKey) = TenantModuleFeatureKeys.Normalize(combinedKey);
+            }
+
+            var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+            definitions.Add(new TenantModuleFeatureDefinition(
+                moduleKey,
+                subFeatureKey,
+                string.IsNullOrWhiteSpace(child["DisplayName"]) ? key : child["DisplayName"]!,
+                child["Description"] ?? string.Empty,
+                string.IsNullOrWhiteSpace(child["IconName"]) ? "box" : child["IconName"]!,
+                !bool.TryParse(child["DefaultEnabled"], out var defaultEnabled) || defaultEnabled));
+        }
+
+        return definitions;
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ITenantModuleFeatureCatalog.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ITenantModuleFeatureCatalog.cs
@@ -1,0 +1,8 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public interface ITenantModuleFeatureCatalog
+{
+    IReadOnlyList<TenantModuleFeatureDefinition> All { get; }
+
+    TenantModuleFeatureDefinition? Find(string moduleKey, string? subFeatureKey = null);
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ITenantModuleFeatureDefinitionProvider.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ITenantModuleFeatureDefinitionProvider.cs
@@ -1,0 +1,6 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public interface ITenantModuleFeatureDefinitionProvider
+{
+    IReadOnlyList<TenantModuleFeatureDefinition> Definitions { get; }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureCatalog.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureCatalog.cs
@@ -1,0 +1,61 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public sealed class TenantModuleFeatureCatalog : ITenantModuleFeatureCatalog
+{
+    private readonly IReadOnlyList<TenantModuleFeatureDefinition> _definitions;
+
+    public TenantModuleFeatureCatalog(IEnumerable<ITenantModuleFeatureDefinitionProvider> providers)
+    {
+        _definitions = BuildDefinitions(providers);
+    }
+
+    public IReadOnlyList<TenantModuleFeatureDefinition> All => _definitions;
+
+    public TenantModuleFeatureDefinition? Find(string moduleKey, string? subFeatureKey = null)
+    {
+        var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+        return _definitions.FirstOrDefault(definition =>
+            string.Equals(definition.Key, key, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IReadOnlyList<TenantModuleFeatureDefinition> BuildDefinitions(
+        IEnumerable<ITenantModuleFeatureDefinitionProvider> providers)
+    {
+        var definitions = new List<TenantModuleFeatureDefinition>();
+        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var provider in providers)
+        {
+            foreach (var definition in provider.Definitions)
+            {
+                var normalizedDefinition = NormalizeDefinition(provider, definition);
+                if (keys.Add(normalizedDefinition.Key))
+                {
+                    definitions.Add(normalizedDefinition);
+                }
+            }
+        }
+
+        return definitions;
+    }
+
+    private static TenantModuleFeatureDefinition NormalizeDefinition(
+        ITenantModuleFeatureDefinitionProvider provider,
+        TenantModuleFeatureDefinition definition)
+    {
+        var (moduleKey, subFeatureKey) =
+            TenantModuleFeatureKeys.Normalize(definition.ModuleKey, definition.SubFeatureKey);
+
+        if (string.IsNullOrWhiteSpace(moduleKey))
+        {
+            throw new InvalidOperationException(
+                $"{provider.GetType().FullName} returned a tenant module feature definition with an empty module key.");
+        }
+
+        return definition with
+        {
+            ModuleKey = moduleKey,
+            SubFeatureKey = subFeatureKey
+        };
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureDefinitionServiceCollectionExtensions.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureDefinitionServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public static class TenantModuleFeatureDefinitionServiceCollectionExtensions
+{
+    public static IServiceCollection AddTenantModuleFeatureDefinitions(this IServiceCollection services)
+    {
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ITenantModuleFeatureDefinitionProvider, BuiltInTenantModuleFeatureDefinitionProvider>());
+        services.TryAddSingleton<ITenantModuleFeatureCatalog, TenantModuleFeatureCatalog>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddTenantModuleFeatureDefinitions(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddTenantModuleFeatureDefinitions();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ITenantModuleFeatureDefinitionProvider>(
+            new ConfigurationTenantModuleFeatureDefinitionProvider(configuration)));
+
+        return services;
+    }
+
+    public static IServiceCollection AddTenantModuleFeatureDefinitions(
+        this IServiceCollection services,
+        ITenantModuleFeatureDefinitionProvider provider)
+    {
+        services.AddTenantModuleFeatureDefinitions();
+        services.AddSingleton(provider);
+
+        return services;
+    }
+
+    public static IServiceCollection AddTenantModuleFeatureDefinitionProvider<TProvider>(
+        this IServiceCollection services)
+        where TProvider : class, ITenantModuleFeatureDefinitionProvider
+    {
+        services.AddTenantModuleFeatureDefinitions();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ITenantModuleFeatureDefinitionProvider, TProvider>());
+
+        return services;
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/IdentityServer.Domain.Shared.csproj
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/IdentityServer.Domain.Shared.csproj
@@ -11,6 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     </ItemGroup>
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -141,6 +141,10 @@ else
                                                     </div>
                                                     <div class="mt-1 text-sm text-muted-foreground">@row.Description</div>
                                                     <div class="mt-2 font-mono text-xs text-muted-foreground">@row.Key</div>
+                                                    @if (!string.IsNullOrWhiteSpace(row.DependencySummary))
+                                                    {
+                                                        <div class="mt-2 text-xs text-amber-600 dark:text-amber-400">@row.DependencySummary</div>
+                                                    }
                                                 </div>
                                             </div>
                                             <StatusBadge Text="@(row.IsEnabled ? "Enabled" : "Disabled")"
@@ -149,7 +153,7 @@ else
                                         <div class="mt-4 border-t pt-3">
                                             <BbFormFieldSwitch Checked="@row.IsEnabled"
                                                                CheckedChanged="@((bool enabled) => ToggleModuleFeature(row, enabled))"
-                                                               Disabled="@(_savingModuleFeatureIds.Contains(row.Id))"
+                                                               Disabled="@(_savingModuleFeatureIds.Contains(row.Id) || (!row.IsEnabled && row.IsBlocked))"
                                                                Label="Module enabled" />
                                         </div>
                                         @if (IsInventarioRootFeature(row) && _inventarioSubFeatureRows.Count > 0)
@@ -178,6 +182,10 @@ else
                                                                         </div>
                                                                         <div class="mt-1 text-sm text-muted-foreground">@childRow.Description</div>
                                                                         <div class="mt-2 font-mono text-xs text-muted-foreground">@childRow.Key</div>
+                                                                        @if (!string.IsNullOrWhiteSpace(childRow.DependencySummary))
+                                                                        {
+                                                                            <div class="mt-2 text-xs text-amber-600 dark:text-amber-400">@childRow.DependencySummary</div>
+                                                                        }
                                                                     </div>
                                                                 </div>
                                                                 <StatusBadge Text="@(childRow.IsEnabled ? "Enabled" : "Disabled")"
@@ -186,7 +194,7 @@ else
                                                             <div class="mt-3 border-t pt-3">
                                                                 <BbFormFieldSwitch Checked="@childRow.IsEnabled"
                                                                                    CheckedChanged="@((bool enabled) => ToggleModuleFeature(childRow, enabled))"
-                                                                                   Disabled="@(_savingModuleFeatureIds.Contains(childRow.Id))"
+                                                                                   Disabled="@(_savingModuleFeatureIds.Contains(childRow.Id) || (!childRow.IsEnabled && childRow.IsBlocked))"
                                                                                    Label="Feature enabled" />
                                                             </div>
                                                         </div>
@@ -378,6 +386,7 @@ else
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleFeatureDefinitionResolver ModuleFeatureDefinitionResolver { get; set; } = default!;
 
     private Tenant? _tenant;
     private bool _loading;
@@ -570,15 +579,17 @@ else
                     .ToListAsync())
                 .ToList();
 
-            var missingDefinitions = TenantModuleFeatureKeys.All
-                .Where(definition => _detailModuleFeatures.All(feature =>
-                    !string.Equals(feature.Key, definition.Key, StringComparison.OrdinalIgnoreCase)))
+            var resolvedDefinitions = await ModuleFeatureDefinitionResolver.ResolveAsync(_detailModuleFeatures);
+            var missingDefinitions = resolvedDefinitions
+                .Where(resolved => _detailModuleFeatures.All(feature =>
+                    !string.Equals(feature.Key, resolved.Definition.Key, StringComparison.OrdinalIgnoreCase)))
                 .ToList();
 
             if (missingDefinitions.Count > 0)
             {
-                foreach (var definition in missingDefinitions)
+                foreach (var resolved in missingDefinitions)
                 {
+                    var definition = resolved.Definition;
                     DataContext.Add(new TenantModuleFeature
                     {
                         Id = Guid.NewGuid(),
@@ -587,7 +598,7 @@ else
                         SubFeatureKey = definition.SubFeatureKey,
                         DisplayName = definition.DisplayName,
                         Description = definition.Description,
-                        IsEnabled = definition.DefaultEnabled,
+                        IsEnabled = definition.DefaultEnabled && !resolved.IsBlocked,
                         CreatedAt = DateTime.UtcNow
                     });
                 }
@@ -606,11 +617,14 @@ else
                         .ThenBy(x => x.SubFeatureKey)
                         .ToListAsync())
                     .ToList();
+
+                resolvedDefinitions = await ModuleFeatureDefinitionResolver.ResolveAsync(_detailModuleFeatures);
             }
 
-            _moduleFeatureRows = TenantModuleFeatureKeys.All
-                .Select(definition =>
+            _moduleFeatureRows = resolvedDefinitions
+                .Select(resolved =>
                 {
+                    var definition = resolved.Definition;
                     var feature = _detailModuleFeatures.FirstOrDefault(item =>
                         string.Equals(item.Key, definition.Key, StringComparison.OrdinalIgnoreCase));
 
@@ -622,7 +636,10 @@ else
                         feature?.DisplayName ?? definition.DisplayName,
                         feature?.Description ?? definition.Description,
                         definition.IconName,
-                        feature?.IsEnabled ?? false);
+                        feature?.IsEnabled ?? false,
+                        resolved.IsBlocked,
+                        resolved.MissingRequiredDependencies,
+                        resolved.MissingOptionalDependencies);
                 })
                 .ToList();
             ApplyModuleFeatureGrouping();
@@ -650,6 +667,12 @@ else
 
     private async Task ToggleModuleFeature(ModuleFeatureRow row, bool enabled)
     {
+        if (enabled && row.IsBlocked)
+        {
+            ToastService.Show($"Cannot enable {row.DisplayName}: {row.DependencySummary}");
+            return;
+        }
+
         if (row.Id == Guid.Empty)
         {
             ToastService.Show("Module toggle is still initializing. Refresh the page and try again.");
@@ -921,7 +944,10 @@ else
         string displayName,
         string description,
         string icon,
-        bool isEnabled)
+        bool isEnabled,
+        bool isBlocked,
+        IReadOnlyList<string> missingRequiredDependencies,
+        IReadOnlyList<string> missingOptionalDependencies)
     {
         public Guid Id { get; } = id;
         public string Key { get; } = key;
@@ -931,6 +957,13 @@ else
         public string Description { get; } = description;
         public string Icon { get; } = icon;
         public bool IsEnabled { get; set; } = isEnabled;
+        public bool IsBlocked { get; } = isBlocked;
+        public IReadOnlyList<string> MissingRequiredDependencies { get; } = missingRequiredDependencies;
+        public IReadOnlyList<string> MissingOptionalDependencies { get; } = missingOptionalDependencies;
+        public string DependencySummary =>
+            MissingRequiredDependencies.Count > 0
+                ? string.Join(" ", MissingRequiredDependencies)
+                : string.Join(" ", MissingOptionalDependencies);
     }
 
     public void Dispose()

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -5,6 +5,7 @@ using Community.Integration.Drivers;
 using ControlPanel.Server.Extensions;
 using ControlPanel.Server.Health;
 using ControlPanel.Server.Services;
+using IdentityServer.Domain.Shared.Contracts;
 using XFramework.Integration.Extensions;
 using IdentityServer.Integration.Drivers;
 using Inventario.Integration.Drivers;
@@ -70,6 +71,7 @@ builder.Services.AddIdentityServerWrapperServices();
 builder.Services.AddInventarioWrapperServices();
 builder.Services.AddMessagingWrapperServices();
 builder.Services.AddWalletsWrapperServices();
+builder.Services.AddTenantModuleFeatureDefinitions(builder.Configuration);
 
 // IDataContext — universal query layer routed through service wrappers
 builder.Services.AddScoped(sp =>
@@ -103,6 +105,7 @@ builder.Services.AddRemoteDataContext();
 // Tenant filter state (sidebar selection)
 builder.Services.AddScoped<TenantFilterService>();
 builder.Services.AddScoped<TenantModuleNavigationService>();
+builder.Services.AddScoped<TenantModuleFeatureDefinitionResolver>();
 builder.Services.AddScoped<MessagingControlPanelGuard>();
 builder.Services.AddScoped<NavigationHistoryService>();
 builder.Services.AddScoped<CommunityControlPanelAccessService>();

--- a/src/Presentation/ControlPanel.Server/Services/ResolvedTenantModuleFeatureDefinition.cs
+++ b/src/Presentation/ControlPanel.Server/Services/ResolvedTenantModuleFeatureDefinition.cs
@@ -1,0 +1,11 @@
+using IdentityServer.Domain.Shared.Contracts;
+
+namespace ControlPanel.Server.Services;
+
+public sealed record ResolvedTenantModuleFeatureDefinition(
+    TenantModuleFeatureDefinition Definition,
+    IReadOnlyList<string> MissingRequiredDependencies,
+    IReadOnlyList<string> MissingOptionalDependencies)
+{
+    public bool IsBlocked => MissingRequiredDependencies.Count > 0;
+}

--- a/src/Presentation/ControlPanel.Server/Services/TenantModuleFeatureDefinitionResolver.cs
+++ b/src/Presentation/ControlPanel.Server/Services/TenantModuleFeatureDefinitionResolver.cs
@@ -1,0 +1,203 @@
+using Bolt.Client;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using IdentityServer.Domain.Shared.Contracts;
+
+namespace ControlPanel.Server.Services;
+
+public sealed class TenantModuleFeatureDefinitionResolver(
+    ITenantModuleFeatureCatalog localCatalog,
+    BoltClient boltClient,
+    ILogger<TenantModuleFeatureDefinitionResolver> logger)
+{
+    public async Task<IReadOnlyList<ResolvedTenantModuleFeatureDefinition>> ResolveAsync(
+        IReadOnlyCollection<TenantModuleFeature> tenantFeatures,
+        CancellationToken ct = default)
+    {
+        var definitions = new List<ResolvedTenantModuleFeatureDefinition>();
+        var indexes = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var definition in localCatalog.All)
+        {
+            AddDefinition(
+                definitions,
+                indexes,
+                new ResolvedTenantModuleFeatureDefinition(definition, [], []));
+        }
+
+        var discoveredModules = await GetDiscoveredModulesAsync(ct);
+        if (discoveredModules is null)
+        {
+            return definitions;
+        }
+
+        var enabledTenantFeatureKeys = tenantFeatures
+            .Where(feature => feature.IsEnabled && !feature.IsDeleted)
+            .Select(feature => feature.Key)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var module in discoveredModules.Modules)
+        {
+            foreach (var feature in module.Features)
+            {
+                var resolved = CreateResolvedDefinition(module, feature, enabledTenantFeatureKeys);
+                AddDefinition(definitions, indexes, resolved);
+            }
+        }
+
+        return definitions;
+    }
+
+    private async Task<BoltModuleRegistryResponse?> GetDiscoveredModulesAsync(CancellationToken ct)
+    {
+        if (!boltClient.IsConnected)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await boltClient.SendAsync<BoltModuleRegistryRequest, BoltModuleRegistryResponse>(
+                string.Empty,
+                BoltServiceDiscoveryCommands.GetModuleRegistry,
+                new BoltModuleRegistryRequest { IncludeOffline = true },
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to query Bolt module registry");
+            return null;
+        }
+    }
+
+    public static ResolvedTenantModuleFeatureDefinition CreateResolvedDefinition(
+        BoltModuleRegistryItem module,
+        BoltTenantModuleFeatureRegistryItem feature,
+        ISet<string> enabledTenantFeatureKeys)
+    {
+        var (moduleKey, subFeatureKey) = NormalizeFeatureKey(feature.Key, feature.ModuleKey, feature.SubFeatureKey);
+        var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+        var missingRequired = new List<string>();
+        var missingOptional = new List<string>();
+
+        if (feature.Status == BoltRegistryStatus.Offline)
+        {
+            missingRequired.Add($"Service {module.ServiceName} is offline.");
+        }
+
+        foreach (var status in feature.DependencyStatuses)
+        {
+            if (status.Requirement.Kind == BoltDependencyKind.TenantFeature)
+            {
+                continue;
+            }
+
+            if (!status.IsSatisfied)
+            {
+                AddDependencyMessage(status, missingRequired, missingOptional);
+            }
+        }
+
+        foreach (var dependency in feature.Dependencies.Where(x => x.Kind == BoltDependencyKind.TenantFeature))
+        {
+            var dependencyKey = TenantModuleFeatureKeys.Combine(dependency.Key);
+            var isSatisfied = enabledTenantFeatureKeys.Contains(dependencyKey);
+            if (isSatisfied)
+            {
+                continue;
+            }
+
+            var message = $"{GetDependencyDisplayName(dependency)} is not enabled for this tenant.";
+            if (dependency.Required)
+            {
+                missingRequired.Add(message);
+            }
+            else
+            {
+                missingOptional.Add(message);
+            }
+        }
+
+        var isBlocked = missingRequired.Count > 0;
+        var definition = new TenantModuleFeatureDefinition(
+            moduleKey,
+            subFeatureKey,
+            string.IsNullOrWhiteSpace(feature.DisplayName) ? key : feature.DisplayName,
+            feature.Description,
+            string.IsNullOrWhiteSpace(feature.IconName) ? module.IconName : feature.IconName,
+            feature.DefaultEnabled && !isBlocked);
+
+        return new ResolvedTenantModuleFeatureDefinition(definition, missingRequired, missingOptional);
+    }
+
+    private static void AddDependencyMessage(
+        BoltDependencyStatus status,
+        ICollection<string> missingRequired,
+        ICollection<string> missingOptional)
+    {
+        var message = string.IsNullOrWhiteSpace(status.Message)
+            ? $"{GetDependencyDisplayName(status.Requirement)} is not available."
+            : status.Message;
+
+        if (status.Requirement.Required)
+        {
+            missingRequired.Add(message);
+        }
+        else
+        {
+            missingOptional.Add(message);
+        }
+    }
+
+    private static string GetDependencyDisplayName(BoltDependencyRequirement dependency) =>
+        string.IsNullOrWhiteSpace(dependency.DisplayName)
+            ? dependency.Key
+            : dependency.DisplayName;
+
+    private static void AddDefinition(
+        IList<ResolvedTenantModuleFeatureDefinition> definitions,
+        IDictionary<string, int> indexes,
+        ResolvedTenantModuleFeatureDefinition resolved)
+    {
+        if (!indexes.TryGetValue(resolved.Definition.Key, out var index))
+        {
+            indexes[resolved.Definition.Key] = definitions.Count;
+            definitions.Add(resolved);
+            return;
+        }
+
+        definitions[index] = MergeResolvedDefinition(definitions[index], resolved);
+    }
+
+    public static ResolvedTenantModuleFeatureDefinition MergeResolvedDefinition(
+        ResolvedTenantModuleFeatureDefinition existing,
+        ResolvedTenantModuleFeatureDefinition discovered)
+    {
+        var missingRequired = existing.MissingRequiredDependencies
+            .Concat(discovered.MissingRequiredDependencies)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var missingOptional = existing.MissingOptionalDependencies
+            .Concat(discovered.MissingOptionalDependencies)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return existing with
+        {
+            MissingRequiredDependencies = missingRequired,
+            MissingOptionalDependencies = missingOptional
+        };
+    }
+
+    private static (string ModuleKey, string SubFeatureKey) NormalizeFeatureKey(
+        string? key,
+        string moduleKey,
+        string subFeatureKey)
+    {
+        if (!string.IsNullOrWhiteSpace(moduleKey))
+        {
+            return TenantModuleFeatureKeys.Normalize(moduleKey, subFeatureKey);
+        }
+
+        return TenantModuleFeatureKeys.Normalize(key ?? string.Empty);
+    }
+}

--- a/src/Tests/Bolt.Tests/Bolt.Tests.csproj
+++ b/src/Tests/Bolt.Tests/Bolt.Tests.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Tests/Bolt.Tests/BoltServiceDiscoveryIntegrationTests.cs
+++ b/src/Tests/Bolt.Tests/BoltServiceDiscoveryIntegrationTests.cs
@@ -1,0 +1,352 @@
+using Bolt.Client;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Hub.Services;
+using Bolt.Server;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System.Text.Json;
+using XFramework.Domain.Contexts;
+
+namespace Bolt.Tests;
+
+[TestFixture]
+[CancelAfter(30000)]
+public sealed class BoltServiceDiscoveryIntegrationTests
+{
+    private static int _portCounter = 20200;
+    private WebApplication _hubApp = null!;
+    private ILoggerFactory _loggerFactory = null!;
+    private string _databaseName = string.Empty;
+    private int _port;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _port = Interlocked.Increment(ref _portCounter);
+        _databaseName = $"bolt-discovery-{Guid.NewGuid():N}";
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls($"http://localhost:{_port}");
+        builder.Services.AddDbContext<DbContext, AppDbContext>(options =>
+            options.UseInMemoryDatabase(_databaseName));
+        builder.Services.AddBoltServer();
+        builder.Services.AddSingleton<IBoltServicePresenceTracker, BoltServicePresenceTracker>();
+        builder.Services.AddScoped<IBoltServiceDiscoveryRegistry, BoltServiceDiscoveryRegistry>();
+        builder.Services.AddHostedService<BoltServiceDiscoveryHostedService>();
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+        _hubApp = builder.Build();
+        _hubApp.UseWebSockets();
+        _hubApp.MapBolt("/bolt");
+        _hubApp.MapGet("/health", () => "ok");
+        _ = Task.Run(() => _hubApp.RunAsync());
+        await WaitForHealth($"http://localhost:{_port}/health");
+        _loggerFactory = _hubApp.Services.GetRequiredService<ILoggerFactory>();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        try { await _hubApp.StopAsync(); } catch { }
+        try { await _hubApp.DisposeAsync(); } catch { }
+    }
+
+    [Test]
+    public async Task AdvertiseServiceManifest_ThroughHubLocalHandler_PersistsSenderClientAndReturnsRegistry()
+    {
+        var client = CreateClient("discovery_client", "DiscoveryService");
+        await client.ConnectAsync();
+
+        var response = await client.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            CreateJuanBarangayManifest());
+
+        response.Should().NotBeNull();
+        response!.Accepted.Should().BeTrue();
+
+        var modules = await client.SendAsync<BoltModuleRegistryRequest, BoltModuleRegistryResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.GetModuleRegistry,
+            new BoltModuleRegistryRequest { IncludeOffline = true });
+
+        modules!.Modules.Should().ContainSingle(module => module.ModuleKey == "juan_barangay");
+        modules.Modules.Single(module => module.ModuleKey == "juan_barangay")
+            .Features.Should().Contain(feature => feature.Key == "juan_barangay.residents");
+
+        using var scope = _hubApp.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+        var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "discovery_client");
+        record.ClientName.Should().Be("DiscoveryService");
+        record.ServiceName.Should().Be("Juan_Barangay_Service");
+        record.IsConnected.Should().BeTrue();
+
+        await client.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Disconnect_AfterManifestAdvertisement_KeepsManifestAndMarksServiceOffline()
+    {
+        var client = CreateClient("disconnect_client", "DisconnectService");
+        await client.ConnectAsync();
+        await client.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            CreateJuanBarangayManifest());
+
+        await client.DisposeAsync();
+
+        await WaitUntilAsync(async () =>
+        {
+            using var scope = _hubApp.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "disconnect_client");
+            return !record.IsConnected && record.ConnectionCount == 0 && record.ManifestJson.Contains("juan_barangay");
+        });
+    }
+
+    [Test]
+    public async Task ResetPresenceAsync_KeepsManifestAndMarksPersistedOnlineServicesOffline()
+    {
+        var manifestJson = JsonSerializer.Serialize(
+            CreateJuanBarangayManifest(),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        using (var scope = _hubApp.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            db.Add(new BoltServiceManifestRecord
+            {
+                Id = Guid.NewGuid(),
+                ClientId = "stale_client",
+                ClientName = "StaleService",
+                ServiceName = "Juan_Barangay_Service",
+                DisplayName = "Juan Barangay",
+                Version = "1.0.0",
+                IsConnected = true,
+                ConnectionCount = 2,
+                LastSeenAt = DateTime.UtcNow.AddMinutes(-5),
+                LastConnectedAt = DateTime.UtcNow.AddMinutes(-5),
+                ManifestHash = "stale-hash",
+                ManifestJson = manifestJson,
+                CreatedAt = DateTime.UtcNow.AddMinutes(-5)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        using (var scope = _hubApp.Services.CreateScope())
+        {
+            var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+            await registry.ResetPresenceAsync(CancellationToken.None);
+        }
+
+        using (var scope = _hubApp.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "stale_client");
+            record.IsConnected.Should().BeFalse();
+            record.ConnectionCount.Should().Be(0);
+            record.ManifestJson.Should().Be(manifestJson);
+            record.LastDisconnectedAt.Should().NotBeNull();
+        }
+    }
+
+    [Test]
+    public async Task MultipleConnectionsForSameClient_DisconnectingOneKeepsServiceOnlineUntilFinalConnectionCloses()
+    {
+        var firstClient = CreateClient("pooled_client", "PooledService");
+        var secondClient = CreateClient("pooled_client", "PooledService");
+
+        try
+        {
+            await Task.WhenAll(firstClient.ConnectAsync(), secondClient.ConnectAsync());
+
+            await WaitUntilAsync(async () =>
+            {
+                using var scope = _hubApp.Services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+                var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "pooled_client");
+                return record.IsConnected && record.ConnectionCount == 2;
+            });
+
+            await firstClient.DisposeAsync();
+
+            await WaitUntilAsync(async () =>
+            {
+                using var scope = _hubApp.Services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+                var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "pooled_client");
+                return record.IsConnected && record.ConnectionCount == 1;
+            });
+
+            await secondClient.DisposeAsync();
+
+            await WaitUntilAsync(async () =>
+            {
+                using var scope = _hubApp.Services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+                var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "pooled_client");
+                return !record.IsConnected && record.ConnectionCount == 0;
+            });
+        }
+        finally
+        {
+            await firstClient.DisposeAsync();
+            await secondClient.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Reconnect_AfterDisconnect_MarksServiceOnlineAndUpdatesLastSeen()
+    {
+        var firstClient = CreateClient("reconnect_client", "ReconnectService");
+        await firstClient.ConnectAsync();
+        await firstClient.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            CreateJuanBarangayManifest());
+        await firstClient.DisposeAsync();
+
+        await WaitUntilAsync(async () =>
+        {
+            using var scope = _hubApp.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "reconnect_client");
+            return !record.IsConnected;
+        });
+
+        DateTime offlineSeenAt;
+        using (var scope = _hubApp.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            offlineSeenAt = (await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "reconnect_client")).LastSeenAt;
+        }
+
+        var secondClient = CreateClient("reconnect_client", "ReconnectService");
+        await secondClient.ConnectAsync();
+
+        await WaitUntilAsync(async () =>
+        {
+            using var scope = _hubApp.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "reconnect_client");
+            return record.IsConnected && record.ConnectionCount == 1 && record.LastSeenAt >= offlineSeenAt;
+        });
+
+        await secondClient.DisposeAsync();
+    }
+
+    [Test]
+    public async Task GetModuleRegistry_RequiredMissingServiceDependency_ReturnsDegradedModuleAndFeature()
+    {
+        var client = CreateClient("dependency_client", "DependencyService");
+        await client.ConnectAsync();
+        var manifest = CreateJuanBarangayManifest();
+        manifest.Modules[0].Dependencies.Add(new BoltDependencyRequirement
+        {
+            Kind = BoltDependencyKind.Service,
+            Key = "missing_service",
+            DisplayName = "Missing Service",
+            Required = true
+        });
+
+        await client.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            manifest);
+
+        var modules = await client.SendAsync<BoltModuleRegistryRequest, BoltModuleRegistryResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.GetModuleRegistry,
+            new BoltModuleRegistryRequest { IncludeOffline = true });
+
+        var module = modules!.Modules.Single(x => x.ModuleKey == "juan_barangay");
+        module.Status.Should().Be(BoltRegistryStatus.Degraded);
+        module.DependencyStatuses.Should().Contain(status =>
+            status.Requirement.Key == "missing_service" && !status.IsSatisfied && status.Requirement.Required);
+        module.Features.Should().Contain(feature =>
+            feature.Key == "juan_barangay.residents" && feature.Status == BoltRegistryStatus.Degraded);
+
+        await client.DisposeAsync();
+    }
+
+    private BoltClient CreateClient(string id, string name) =>
+        new(
+            new Uri($"ws://localhost:{_port}/bolt"),
+            id,
+            name,
+            new BoltClientOptions { RpcTimeoutSeconds = 5 },
+            _loggerFactory.CreateLogger<BoltClient>());
+
+    private static BoltServiceManifest CreateJuanBarangayManifest() =>
+        new()
+        {
+            ServiceName = "Juan_Barangay_Service",
+            DisplayName = "Juan Barangay",
+            Version = "1.0.0",
+            Modules =
+            [
+                new BoltModuleManifest
+                {
+                    ModuleKey = "Juan_Barangay",
+                    DisplayName = "Juan Barangay",
+                    Description = "Barangay resident operations.",
+                    IconName = "users",
+                    Features =
+                    [
+                        new BoltTenantModuleFeatureManifest
+                        {
+                            Key = "Juan_Barangay.Residents",
+                            DisplayName = "Residents",
+                            Description = "Resident registry.",
+                            IconName = "users"
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static async Task WaitForHealth(string url, int timeoutSeconds = 15)
+    {
+        using var client = new HttpClient();
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                if ((await client.GetAsync(url)).IsSuccessStatusCode)
+                {
+                    return;
+                }
+            }
+            catch
+            {
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Service at {url} not healthy within {timeoutSeconds}s");
+    }
+
+    private static async Task WaitUntilAsync(Func<Task<bool>> condition, int timeoutSeconds = 10)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException("Condition was not met before timeout.");
+    }
+}

--- a/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantModuleFeatureCatalogTests.cs
+++ b/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantModuleFeatureCatalogTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace XFramework.Core.Tests.Services.FeatureGates;
+
+[TestFixture]
+public sealed class TenantModuleFeatureCatalogTests
+{
+    [Test]
+    public void Definitions_BuiltInProvider_ReturnsTenantModuleFeatureKeysAll()
+    {
+        var provider = new BuiltInTenantModuleFeatureDefinitionProvider();
+
+        provider.Definitions.Should().Equal(TenantModuleFeatureKeys.All);
+    }
+
+    [Test]
+    public void All_ExternalProviderRegistered_IncludesExternalDefinitions()
+    {
+        var catalog = new TenantModuleFeatureCatalog(
+        [
+            new BuiltInTenantModuleFeatureDefinitionProvider(),
+            new TestTenantModuleFeatureDefinitionProvider(
+                new TenantModuleFeatureDefinition(
+                    "juan_barangay",
+                    "residents",
+                    "Residents",
+                    "Resident registry and household records.",
+                    "users"))
+        ]);
+
+        catalog.All.Should().Contain(definition =>
+            definition.Key == "juan_barangay.residents" &&
+            definition.DisplayName == "Residents");
+    }
+
+    [Test]
+    public void Find_CombinedAndSplitKeys_ReturnsMatchingDefinition()
+    {
+        var catalog = new TenantModuleFeatureCatalog(
+        [
+            new TestTenantModuleFeatureDefinitionProvider(
+                new TenantModuleFeatureDefinition(
+                    "juan_barangay",
+                    "health_services",
+                    "Health Services",
+                    "Health service case management.",
+                    "heart-pulse"))
+        ]);
+
+        var combinedResult = catalog.Find("Juan_Barangay.Health_Services");
+        var splitResult = catalog.Find("juan_barangay", "health_services");
+
+        combinedResult.Should().NotBeNull();
+        splitResult.Should().BeSameAs(combinedResult);
+    }
+
+    [Test]
+    public void All_DuplicateNormalizedKeys_KeepsFirstDefinition()
+    {
+        var catalog = new TenantModuleFeatureCatalog(
+        [
+            new TestTenantModuleFeatureDefinitionProvider(
+                new TenantModuleFeatureDefinition(
+                    "Juan_Barangay",
+                    "Residents",
+                    "First Residents",
+                    "First definition wins.",
+                    "users")),
+            new TestTenantModuleFeatureDefinitionProvider(
+                new TenantModuleFeatureDefinition(
+                    "juan_barangay.residents",
+                    string.Empty,
+                    "Second Residents",
+                    "Duplicate definition should be ignored.",
+                    "user-x"))
+        ]);
+
+        var matchingDefinitions = catalog.All
+            .Where(definition => definition.Key == "juan_barangay.residents")
+            .ToList();
+
+        matchingDefinitions.Should().ContainSingle();
+        matchingDefinitions[0].DisplayName.Should().Be("First Residents");
+        matchingDefinitions[0].ModuleKey.Should().Be("juan_barangay");
+        matchingDefinitions[0].SubFeatureKey.Should().Be("residents");
+    }
+
+    [Test]
+    public void AddTenantModuleFeatureDefinitions_ConfigurationContainsDefinitions_RegistersConfigDefinitions()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TenantModuleFeatures:Definitions:0:Key"] = "juan_barangay.residents",
+                ["TenantModuleFeatures:Definitions:0:DisplayName"] = "Residents",
+                ["TenantModuleFeatures:Definitions:0:Description"] = "Resident registry and household records.",
+                ["TenantModuleFeatures:Definitions:0:IconName"] = "users",
+                ["TenantModuleFeatures:Definitions:1:ModuleKey"] = "juan_barangay",
+                ["TenantModuleFeatures:Definitions:1:SubFeatureKey"] = "health_services",
+                ["TenantModuleFeatures:Definitions:1:DisplayName"] = "Health Services",
+                ["TenantModuleFeatures:Definitions:1:DefaultEnabled"] = "false"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddTenantModuleFeatureDefinitions(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var catalog = provider.GetRequiredService<ITenantModuleFeatureCatalog>();
+
+        catalog.All.Should().Contain(definition =>
+            definition.Key == "juan_barangay.residents" &&
+            definition.DisplayName == "Residents" &&
+            definition.DefaultEnabled);
+        catalog.All.Should().Contain(definition =>
+            definition.Key == "juan_barangay.health_services" &&
+            definition.DisplayName == "Health Services" &&
+            !definition.DefaultEnabled);
+    }
+
+    private sealed class TestTenantModuleFeatureDefinitionProvider(
+        params TenantModuleFeatureDefinition[] definitions) : ITenantModuleFeatureDefinitionProvider
+    {
+        public IReadOnlyList<TenantModuleFeatureDefinition> Definitions { get; } = definitions;
+    }
+}

--- a/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantModuleFeatureDefinitionResolverTests.cs
+++ b/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantModuleFeatureDefinitionResolverTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using ControlPanel.Server.Services;
+using FluentAssertions;
+using IdentityServer.Domain.Shared.Contracts;
+using NUnit.Framework;
+
+namespace XFramework.Core.Tests.Services.FeatureGates;
+
+[TestFixture]
+public sealed class TenantModuleFeatureDefinitionResolverTests
+{
+    [Test]
+    public void CreateResolvedDefinition_RequiredTenantFeatureDependencyMissing_BlocksDefinitionAndDisablesDefault()
+    {
+        var module = new BoltModuleRegistryItem
+        {
+            ModuleKey = "juan_barangay",
+            DisplayName = "Juan Barangay",
+            ServiceName = "JuanBarangay",
+            Status = BoltRegistryStatus.Online
+        };
+        var feature = new BoltTenantModuleFeatureRegistryItem
+        {
+            Key = "juan_barangay.health_services",
+            ModuleKey = "juan_barangay",
+            SubFeatureKey = "health_services",
+            DisplayName = "Health Services",
+            Description = "Health service case management.",
+            IconName = "heart-pulse",
+            DefaultEnabled = true,
+            Status = BoltRegistryStatus.Online,
+            Dependencies =
+            [
+                new BoltDependencyRequirement
+                {
+                    Kind = BoltDependencyKind.TenantFeature,
+                    Key = "juan_barangay.residents",
+                    DisplayName = "Residents",
+                    Required = true
+                }
+            ]
+        };
+
+        var resolved = TenantModuleFeatureDefinitionResolver.CreateResolvedDefinition(
+            module,
+            feature,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        resolved.IsBlocked.Should().BeTrue();
+        resolved.Definition.DefaultEnabled.Should().BeFalse();
+        resolved.MissingRequiredDependencies.Should().ContainSingle()
+            .Which.Should().Contain("Residents");
+    }
+
+    [Test]
+    public void CreateResolvedDefinition_RequiredTenantFeatureDependencyEnabled_AllowsDefinitionDefault()
+    {
+        var module = new BoltModuleRegistryItem
+        {
+            ModuleKey = "juan_barangay",
+            DisplayName = "Juan Barangay",
+            ServiceName = "JuanBarangay",
+            Status = BoltRegistryStatus.Online
+        };
+        var feature = new BoltTenantModuleFeatureRegistryItem
+        {
+            Key = "juan_barangay.health_services",
+            ModuleKey = "juan_barangay",
+            SubFeatureKey = "health_services",
+            DisplayName = "Health Services",
+            Description = "Health service case management.",
+            IconName = "heart-pulse",
+            DefaultEnabled = true,
+            Status = BoltRegistryStatus.Online,
+            Dependencies =
+            [
+                new BoltDependencyRequirement
+                {
+                    Kind = BoltDependencyKind.TenantFeature,
+                    Key = "juan_barangay.residents",
+                    DisplayName = "Residents",
+                    Required = true
+                }
+            ]
+        };
+
+        var resolved = TenantModuleFeatureDefinitionResolver.CreateResolvedDefinition(
+            module,
+            feature,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "juan_barangay.residents" });
+
+        resolved.IsBlocked.Should().BeFalse();
+        resolved.Definition.DefaultEnabled.Should().BeTrue();
+        resolved.MissingRequiredDependencies.Should().BeEmpty();
+    }
+
+    [Test]
+    public void MergeResolvedDefinition_DuplicateDiscoveredKey_PreservesFirstDefinitionAndMergesDependencyState()
+    {
+        var builtIn = new ResolvedTenantModuleFeatureDefinition(
+            new TenantModuleFeatureDefinition(
+                "wallets",
+                string.Empty,
+                "Wallets",
+                "Built-in wallet module.",
+                "wallet"),
+            [],
+            ["Optional accounting service is not available."]);
+        var discovered = new ResolvedTenantModuleFeatureDefinition(
+            new TenantModuleFeatureDefinition(
+                "wallets",
+                string.Empty,
+                "Discovered Wallets",
+                "Discovered wallet module.",
+                "credit-card"),
+            ["Service Wallets is offline."],
+            ["Optional accounting service is not available."]);
+
+        var merged = TenantModuleFeatureDefinitionResolver.MergeResolvedDefinition(builtIn, discovered);
+
+        merged.Definition.DisplayName.Should().Be("Wallets");
+        merged.Definition.Description.Should().Be("Built-in wallet module.");
+        merged.MissingRequiredDependencies.Should().ContainSingle()
+            .Which.Should().Be("Service Wallets is offline.");
+        merged.MissingOptionalDependencies.Should().ContainSingle()
+            .Which.Should().Be("Optional accounting service is not available.");
+        merged.IsBlocked.Should().BeTrue();
+    }
+}

--- a/src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj
+++ b/src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj
@@ -26,6 +26,7 @@
         <ProjectReference Include="..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Integration\IdentityServer.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Integration\Wallets.Integration.csproj" />
+        <ProjectReference Include="..\..\Presentation\ControlPanel.Server\ControlPanel.Server.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Add Bolt service/module discovery contracts, post-connect manifest advertisement, and hub-local registry RPC handlers.
- Persist last-known service manifests in Bolt Hub with online/offline/degraded dependency status and startup presence reset.
- Add tenant module feature catalog providers plus ControlPanel resolver that merges built-in/config/Bolt-discovered definitions and blocks required missing dependencies.
- Add focused Bolt discovery and tenant catalog/resolver tests.
- Align Microsoft.Extensions central package versions to 10.0.9 so the rebased develop dependency graph restores without downgrade errors.

## Verification
- dotnet test src\\Tests\\Bolt.Tests\\Bolt.Tests.csproj
- dotnet test src\\Tests\\XFramework.Core.Tests\\XFramework.Core.Tests.csproj
- dotnet build src\\Presentation\\ControlPanel.Server\\ControlPanel.Server.csproj
- dotnet build src\\Modules\\XFramework.Bolt\\Bolt.Hub\\Bolt.Hub.csproj

## Notes
- No DLL loading or plugin probing is introduced.
- Existing Bolt register frame format is unchanged.
- External services still need to be deployed and connected to Bolt Hub; this registry handles discovery/presence and tenant toggle display/seeding.