### PR TITLE
Fix wallet operation target resolution

### DIFF
--- a/src/Modules/XFramework.Wallets/Wallets.Api/Services/WalletOperationsService.cs
+++ b/src/Modules/XFramework.Wallets/Wallets.Api/Services/WalletOperationsService.cs
@@ -262,21 +262,17 @@ public sealed class WalletOperationsService : IWalletOperationsService
                 return Result.Failure("Total fee cannot exceed increment amount", 400);
             }
 
-            // Fetch wallet
-            var wallet = request.WalletTypeId != Guid.Empty
-                ? await _dataContext.Query<Wallet>()
-                    .IgnoreQueryFilters()
-                    .Where(w => w.TenantId == tenant.Id && !w.IsDeleted && w.WalletTypeId == request.WalletTypeId && w.CredentialId == request.CredentialId)
-                    .FirstOrDefaultAsync(cancellationToken)
-                : await _dataContext.Query<Wallet>()
-                    .IgnoreQueryFilters()
-                    .Where(w => w.TenantId == tenant.Id && !w.IsDeleted && w.Id == request.WalletId)
-                    .FirstOrDefaultAsync(cancellationToken);
+            var wallet = await FindWalletForTransactionAsync(
+                tenant.Id,
+                request.WalletId,
+                request.CredentialId,
+                request.WalletTypeId,
+                cancellationToken);
 
             if (wallet is null)
             {
                 // Auto-create wallet if WalletTypeId provided
-                if (request.WalletTypeId != Guid.Empty)
+                if (request.WalletId == Guid.Empty && request.WalletTypeId != Guid.Empty)
                 {
                     var createResult = await CreateWalletAsync(
                         request.CredentialId,
@@ -304,6 +300,9 @@ public sealed class WalletOperationsService : IWalletOperationsService
                     return Result.NotFound("Wallet not found");
                 }
             }
+
+            var targetCheck = CheckWalletRequestTarget(wallet, request.CredentialId, request.WalletTypeId);
+            if (targetCheck is not null) return targetCheck;
 
             var statusCheck = CheckWalletStatus(wallet, "IncrementWallet");
             if (statusCheck is not null) return statusCheck;
@@ -482,22 +481,21 @@ public sealed class WalletOperationsService : IWalletOperationsService
                 return Result.Failure("Invalid decrement amount", 400);
             }
 
-            // Fetch wallet
-            var wallet = request.WalletTypeId != Guid.Empty
-                ? await _dataContext.Query<Wallet>()
-                    .IgnoreQueryFilters()
-                    .Where(w => w.TenantId == tenant.Id && !w.IsDeleted && w.WalletTypeId == request.WalletTypeId && w.CredentialId == request.CredentialId)
-                    .FirstOrDefaultAsync(cancellationToken)
-                : await _dataContext.Query<Wallet>()
-                    .IgnoreQueryFilters()
-                    .Where(w => w.TenantId == tenant.Id && !w.IsDeleted && w.Id == request.WalletId)
-                    .FirstOrDefaultAsync(cancellationToken);
+            var wallet = await FindWalletForTransactionAsync(
+                tenant.Id,
+                request.WalletId,
+                request.CredentialId,
+                request.WalletTypeId,
+                cancellationToken);
 
             if (wallet == null)
             {
                 _logger.EntityNotFound("Wallet", request.WalletId);
                 return Result.NotFound("Wallet not found");
             }
+
+            var targetCheck = CheckWalletRequestTarget(wallet, request.CredentialId, request.WalletTypeId);
+            if (targetCheck is not null) return targetCheck;
 
             var statusCheck = CheckWalletStatus(wallet, "DecrementWallet");
             if (statusCheck is not null) return statusCheck;
@@ -1546,6 +1544,49 @@ public sealed class WalletOperationsService : IWalletOperationsService
             WalletStatus.Closed => Result.Failure("Wallet is closed. No operations allowed.", 403),
             _ => null
         };
+    }
+
+    private async Task<Wallet?> FindWalletForTransactionAsync(
+        Guid tenantId,
+        Guid walletId,
+        Guid credentialId,
+        Guid walletTypeId,
+        CancellationToken cancellationToken)
+    {
+        var query = _dataContext.Query<Wallet>()
+            .IgnoreQueryFilters()
+            .Where(w => w.TenantId == tenantId && !w.IsDeleted);
+
+        if (walletId != Guid.Empty)
+        {
+            return await query
+                .Where(w => w.Id == walletId)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        if (credentialId == Guid.Empty || walletTypeId == Guid.Empty)
+        {
+            return null;
+        }
+
+        return await query
+            .Where(w => w.CredentialId == credentialId && w.WalletTypeId == walletTypeId)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static Result? CheckWalletRequestTarget(Wallet wallet, Guid credentialId, Guid walletTypeId)
+    {
+        if (credentialId != Guid.Empty && wallet.CredentialId != credentialId)
+        {
+            return Result.Failure("Wallet does not belong to the requested credential", 400);
+        }
+
+        if (walletTypeId != Guid.Empty && wallet.WalletTypeId != walletTypeId)
+        {
+            return Result.Failure("Wallet does not match requested wallet type", 400);
+        }
+
+        return null;
     }
 
     private async Task<bool> HasProcessedIdempotencyKey(

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
@@ -178,7 +178,7 @@ else
                                               Label="Remarks"
                                               Placeholder="Admin credit" />
                         </div>
-                        <BbButton OnClick="@AddFunds" Disabled="@_isProcessing">
+                        <BbButton OnClick="@AddFunds" Disabled="@MoneyOperationsDisabled">
                             @if (_isProcessing)
                             {
                                 <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
@@ -204,7 +204,7 @@ else
                                               Label="Remarks"
                                               Placeholder="Admin debit" />
                         </div>
-                        <BbButton Variant="ButtonVariant.Destructive" OnClick="@WithdrawFunds" Disabled="@_isProcessing">
+                        <BbButton Variant="ButtonVariant.Destructive" OnClick="@WithdrawFunds" Disabled="@MoneyOperationsDisabled">
                             @if (_isProcessing)
                             {
                                 <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
@@ -232,7 +232,7 @@ else
                                               Label="Remarks"
                                               Placeholder="Admin balance adjustment" />
                         </div>
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@AdjustBalance" Disabled="@_isProcessing">
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@AdjustBalance" Disabled="@MoneyOperationsDisabled">
                             @if (_isProcessing)
                             {
                                 <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
@@ -467,6 +467,7 @@ else
     private bool _isProcessing;
     private bool _showCloseDialog;
     private bool _outsideTenantContext;
+    private bool MoneyOperationsDisabled => _isProcessing || _wallet?.Status == WalletStatus.Closed;
 
     // Add Funds form
     private string _addFundsAmount = "";
@@ -717,7 +718,7 @@ else
                 return;
             }
 
-            if (!TryGetWalletTypeId(fresh, out var walletTypeId))
+            if (!HasWalletType(fresh))
             {
                 return;
             }
@@ -727,7 +728,6 @@ else
                 WalletId = Id,
                 CredentialId = fresh.CredentialId,
                 Amount = amount,
-                WalletTypeId = walletTypeId,
                 ReferenceNumber = string.IsNullOrWhiteSpace(_addFundsRef) ? null : _addFundsRef.Trim(),
                 Remarks = string.IsNullOrWhiteSpace(_addFundsRemarks) ? "Admin credit" : _addFundsRemarks.Trim(),
                 IdempotencyKey = $"controlpanel-add-{Guid.NewGuid():N}",
@@ -781,7 +781,7 @@ else
                 return;
             }
 
-            if (!TryGetWalletTypeId(fresh, out var walletTypeId))
+            if (!HasWalletType(fresh))
             {
                 return;
             }
@@ -797,7 +797,6 @@ else
                 WalletId = Id,
                 CredentialId = fresh.CredentialId,
                 Amount = amount,
-                WalletTypeId = walletTypeId,
                 ReferenceNumber = string.IsNullOrWhiteSpace(_withdrawRef) ? null : _withdrawRef.Trim(),
                 Remarks = string.IsNullOrWhiteSpace(_withdrawRemarks) ? "Admin debit" : _withdrawRemarks.Trim(),
                 IdempotencyKey = $"controlpanel-withdraw-{Guid.NewGuid():N}",
@@ -852,7 +851,7 @@ else
                 return;
             }
 
-            if (!TryGetWalletTypeId(fresh, out var walletTypeId))
+            if (!HasWalletType(fresh))
             {
                 return;
             }
@@ -874,7 +873,6 @@ else
                 {
                     WalletId = Id,
                     CredentialId = fresh.CredentialId,
-                    WalletTypeId = walletTypeId,
                     Amount = difference,
                     ReferenceNumber = referenceNumber,
                     Remarks = remarks,
@@ -885,7 +883,6 @@ else
                 {
                     WalletId = Id,
                     CredentialId = fresh.CredentialId,
-                    WalletTypeId = walletTypeId,
                     Amount = Math.Abs(difference),
                     ReferenceNumber = referenceNumber,
                     Remarks = remarks,
@@ -916,15 +913,13 @@ else
         }
     }
 
-    private bool TryGetWalletTypeId(Wallet wallet, out Guid walletTypeId)
+    private bool HasWalletType(Wallet wallet)
     {
         if (wallet.WalletTypeId is Guid value && value != Guid.Empty)
         {
-            walletTypeId = value;
             return true;
         }
 
-        walletTypeId = Guid.Empty;
         ToastService.Show("This wallet has no wallet type. Assign a wallet type before submitting money operations.");
         return false;
     }

--- a/src/Tests/Wallets.IntegrationTests/Infrastructure/WalletsTestBase.cs
+++ b/src/Tests/Wallets.IntegrationTests/Infrastructure/WalletsTestBase.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using XFramework.Domain.Contexts;
 using IdentityServer.Domain.Shared.Contracts;
 using Wallets.Domain.Shared.Contracts;
+using Wallets.Domain.Shared.Enums;
 
 namespace Wallets.IntegrationTests;
 
@@ -61,7 +62,10 @@ public abstract class WalletsTestBase
         return credential;
     }
 
-    protected async Task<Wallet> SeedWallet(Guid credentialId, decimal balance = 1000m)
+    protected async Task<Wallet> SeedWallet(
+        Guid credentialId,
+        decimal balance = 1000m,
+        WalletStatus status = WalletStatus.Active)
     {
         await using var db = CreateDbContext();
 
@@ -72,6 +76,7 @@ public abstract class WalletsTestBase
             WalletTypeId = WalletsTestFixture.TestWalletTypeId,
             Balance = balance,
             TransferableBalance = balance,
+            Status = status,
             TenantId = WalletsTestFixture.TestTenantId
         };
         db.Set<Wallet>().Add(wallet);

--- a/src/Tests/Wallets.IntegrationTests/Tests/WalletTransactionTests.cs
+++ b/src/Tests/Wallets.IntegrationTests/Tests/WalletTransactionTests.cs
@@ -204,6 +204,37 @@ public class WalletTransactionTests : WalletsTestBase
         operationCount.Should().Be(1);
     }
 
+    [Test]
+    public async Task Http_AddFunds_WithWalletIdAndDuplicateCredentialType_TargetsExplicitWallet()
+    {
+        var credential = await SeedCredential();
+        var otherWallet = await SeedWallet(credential.Id, 100m, WalletStatus.Frozen);
+        var targetWallet = await SeedWallet(credential.Id, 0m);
+
+        var request = new IncrementWalletRequest
+        {
+            CredentialId = credential.Id,
+            WalletId = targetWallet.Id,
+            WalletTypeId = WalletsTestFixture.TestWalletTypeId,
+            Amount = 25m,
+            ReferenceNumber = $"walletid-add-{Guid.NewGuid():N}",
+            Metadata = CreateMetadata()
+        };
+
+        var response = await HttpClient.PostAsJsonAsync("/api/wallets/add-funds", request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.IsSuccessStatusCode.Should().BeTrue($"Response: {body}");
+
+        await using var db = CreateDbContext();
+        var unchangedOther = await db.Set<Wallet>().SingleAsync(w => w.Id == otherWallet.Id);
+        var updatedTarget = await db.Set<Wallet>().SingleAsync(w => w.Id == targetWallet.Id);
+
+        unchangedOther.Balance.Should().Be(100m);
+        unchangedOther.Status.Should().Be(WalletStatus.Frozen);
+        updatedTarget.Balance.Should().Be(25m);
+    }
+
     #endregion
 
     #region HTTP — WithdrawFunds (Decrement)
@@ -230,6 +261,37 @@ public class WalletTransactionTests : WalletsTestBase
         await using var db = CreateDbContext();
         var updated = await db.Set<Wallet>().FirstAsync(w => w.Id == wallet.Id);
         updated.Balance.Should().Be(700m);
+    }
+
+    [Test]
+    public async Task Http_WithdrawFunds_WithWalletIdAndDuplicateCredentialType_TargetsExplicitWallet()
+    {
+        var credential = await SeedCredential();
+        var otherWallet = await SeedWallet(credential.Id, 1000m, WalletStatus.Frozen);
+        var targetWallet = await SeedWallet(credential.Id, 100m);
+
+        var request = new DecrementWalletRequest
+        {
+            CredentialId = credential.Id,
+            WalletId = targetWallet.Id,
+            WalletTypeId = WalletsTestFixture.TestWalletTypeId,
+            Amount = 25m,
+            ReferenceNumber = $"walletid-withdraw-{Guid.NewGuid():N}",
+            Metadata = CreateMetadata()
+        };
+
+        var response = await HttpClient.PostAsJsonAsync("/api/wallets/withdraw-funds", request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.IsSuccessStatusCode.Should().BeTrue($"Response: {body}");
+
+        await using var db = CreateDbContext();
+        var unchangedOther = await db.Set<Wallet>().SingleAsync(w => w.Id == otherWallet.Id);
+        var updatedTarget = await db.Set<Wallet>().SingleAsync(w => w.Id == targetWallet.Id);
+
+        unchangedOther.Balance.Should().Be(1000m);
+        unchangedOther.Status.Should().Be(WalletStatus.Frozen);
+        updatedTarget.Balance.Should().Be(75m);
     }
 
     [Test]
@@ -785,6 +847,66 @@ public class WalletTransactionTests : WalletsTestBase
         updated.Balance.Should().Be(1500m);
     }
 
+    [Test]
+    public async Task Bolt_AddFunds_WithWalletIdAndDuplicateCredentialType_TargetsExplicitWallet()
+    {
+        var credential = await SeedCredential();
+        var otherWallet = await SeedWallet(credential.Id, 100m, WalletStatus.Frozen);
+        var targetWallet = await SeedWallet(credential.Id, 0m);
+
+        var result = await WalletsTestFixture.ServiceWrapper.IncrementWallet(
+            new IncrementWalletRequest
+            {
+                CredentialId = credential.Id,
+                WalletId = targetWallet.Id,
+                WalletTypeId = WalletsTestFixture.TestWalletTypeId,
+                Amount = 25m,
+                ReferenceNumber = $"bolt-walletid-add-{Guid.NewGuid():N}",
+                Metadata = CreateMetadata()
+            });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDbContext();
+        var unchangedOther = await db.Set<Wallet>().SingleAsync(w => w.Id == otherWallet.Id);
+        var updatedTarget = await db.Set<Wallet>().SingleAsync(w => w.Id == targetWallet.Id);
+
+        unchangedOther.Balance.Should().Be(100m);
+        unchangedOther.Status.Should().Be(WalletStatus.Frozen);
+        updatedTarget.Balance.Should().Be(25m);
+    }
+
+    [Test]
+    public async Task Bolt_AddFunds_WithClosedWalletAndDuplicateCredentialType_ReturnsClosedWalletFailure()
+    {
+        var credential = await SeedCredential();
+        var otherWallet = await SeedWallet(credential.Id, 100m, WalletStatus.Frozen);
+        var targetWallet = await SeedWallet(credential.Id, 0m, WalletStatus.Closed);
+
+        var result = await WalletsTestFixture.ServiceWrapper.IncrementWallet(
+            new IncrementWalletRequest
+            {
+                CredentialId = credential.Id,
+                WalletId = targetWallet.Id,
+                WalletTypeId = WalletsTestFixture.TestWalletTypeId,
+                Amount = 25m,
+                ReferenceNumber = $"bolt-walletid-closed-{Guid.NewGuid():N}",
+                Metadata = CreateMetadata()
+            });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.Forbidden);
+        result.Message.Should().Be("Wallet is closed. No operations allowed.");
+
+        await using var db = CreateDbContext();
+        var unchangedOther = await db.Set<Wallet>().SingleAsync(w => w.Id == otherWallet.Id);
+        var unchangedTarget = await db.Set<Wallet>().SingleAsync(w => w.Id == targetWallet.Id);
+
+        unchangedOther.Balance.Should().Be(100m);
+        unchangedOther.Status.Should().Be(WalletStatus.Frozen);
+        unchangedTarget.Balance.Should().Be(0m);
+        unchangedTarget.Status.Should().Be(WalletStatus.Closed);
+    }
+
     #endregion
 
     #region Bolt — WithdrawFunds
@@ -809,6 +931,35 @@ public class WalletTransactionTests : WalletsTestBase
         await using var db = CreateDbContext();
         var updated = await db.Set<Wallet>().FirstAsync(w => w.Id == wallet.Id);
         updated.Balance.Should().Be(700m);
+    }
+
+    [Test]
+    public async Task Bolt_WithdrawFunds_WithWalletIdAndDuplicateCredentialType_TargetsExplicitWallet()
+    {
+        var credential = await SeedCredential();
+        var otherWallet = await SeedWallet(credential.Id, 1000m, WalletStatus.Frozen);
+        var targetWallet = await SeedWallet(credential.Id, 100m);
+
+        var result = await WalletsTestFixture.ServiceWrapper.DecrementWallet(
+            new DecrementWalletRequest
+            {
+                CredentialId = credential.Id,
+                WalletId = targetWallet.Id,
+                WalletTypeId = WalletsTestFixture.TestWalletTypeId,
+                Amount = 25m,
+                ReferenceNumber = $"bolt-walletid-withdraw-{Guid.NewGuid():N}",
+                Metadata = CreateMetadata()
+            });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDbContext();
+        var unchangedOther = await db.Set<Wallet>().SingleAsync(w => w.Id == otherWallet.Id);
+        var updatedTarget = await db.Set<Wallet>().SingleAsync(w => w.Id == targetWallet.Id);
+
+        unchangedOther.Balance.Should().Be(1000m);
+        unchangedOther.Status.Should().Be(WalletStatus.Frozen);
+        updatedTarget.Balance.Should().Be(75m);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Resolve increment/decrement wallet targets by explicit WalletId before falling back to credential + wallet type lookup.
- Only auto-create wallets on the no-WalletId credential/type path.
- Validate supplied credential and wallet type against the resolved wallet.
- Stop ControlPanel wallet detail add/withdraw/adjust calls from sending WalletTypeId with explicit WalletId requests.
- Disable money operation buttons on closed wallets.

## Verification
- dotnet build src\\Modules\\XFramework.Wallets\\Wallets.Api\\Wallets.Api.csproj /nr:false -v:minimal -clp:ErrorsOnly
- dotnet build src\\Presentation\\ControlPanel.Server\\ControlPanel.Server.csproj /nr:false -v:minimal -clp:ErrorsOnly
- DOCKER_HOST=tcp://127.0.0.1:23750 TESTCONTAINERS_HOST_OVERRIDE=100.75.11.49 dotnet test .\\src\\Tests\\Wallets.IntegrationTests\\Wallets.IntegrationTests.csproj -m:1 /nr:false --logger 'console;verbosity=minimal'