### PR TITLE
Polish Inventario list and detail pages

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/InventoryMovementDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/InventoryMovementDetail.razor
@@ -1,0 +1,277 @@
+@page "/inventario/stock/movements/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Movement - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_movementsEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Movements" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/stock"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Stock
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Movement Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this movement's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_movement is null)
+{
+    <BbTypographyMuted>Inventory movement not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/stock"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <BbTypographyH3>@_movement.MovementType Movement</BbTypographyH3>
+                        <StatusBadge Text="@FormatDelta(_movement.QuantityDelta)" Status="@(_movement.QuantityDelta >= 0 ? "active" : "inactive")" />
+                    </div>
+                    <BbTypographyMuted>@GetProductLabel() - @FormatDate(_movement.MovementDate)</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Quantity Before</BbTypographyMuted>
+                            <BbTypographyH3>@_movement.QuantityBefore.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Delta</BbTypographyMuted>
+                            <BbTypographyH3>@FormatDelta(_movement.QuantityDelta)</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Quantity After</BbTypographyMuted>
+                            <BbTypographyH3>@_movement.QuantityAfter.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Movement Details</BbCardTitle>
+                    <BbCardDescription>Read-only append ledger entry.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Product</BbTypographyMuted>
+                            <div>@GetProductLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Warehouse</BbTypographyMuted>
+                            <div>@GetWarehouseLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Location</BbTypographyMuted>
+                            <div>@GetLocationLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Balance</BbTypographyMuted>
+                            <div>@GetBalanceLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Unit</BbTypographyMuted>
+                            <div>@(_movement.UnitOfMeasure ?? "N/A")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Reference</BbTypographyMuted>
+                            <div>@FormatReference()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Movement Date</BbTypographyMuted>
+                            <div>@FormatDate(_movement.MovementDate)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@_movement.CreatedAt.ToLocalTime().ToString("g")</div>
+                        </div>
+                        <div class="md:col-span-2">
+                            <BbTypographyMuted>Reason</BbTypographyMuted>
+                            <div>@(_movement.Reason ?? "N/A")</div>
+                        </div>
+                        <div class="md:col-span-2">
+                            <BbTypographyMuted>ID</BbTypographyMuted>
+                            <div class="font-mono text-xs">@_movement.Id</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private InventoryMovement? _movement;
+    private Product? _product;
+    private Warehouse? _warehouse;
+    private InventoryLocation? _location;
+    private StockBalance? _balance;
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _movementsEnabled;
+    private bool _outsideTenantContext;
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _movementsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "movements");
+            _outsideTenantContext = false;
+            _movement = null;
+            _product = null;
+            _warehouse = null;
+            _location = null;
+            _balance = null;
+
+            if (!_hasTenant || !_movementsEnabled) return;
+
+            _movement = await DataContext.Query<InventoryMovement>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _movement is not null && _movement.TenantId != TenantFilter.SelectedTenantId;
+            if (_movement is null || _outsideTenantContext) return;
+
+            var tenantId = _movement.TenantId;
+            _product = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.Id == _movement.ProductId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            if (_movement.WarehouseId is { } warehouseId)
+            {
+                _warehouse = await DataContext.Query<Warehouse>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.Id == warehouseId && !x.IsDeleted)
+                    .FirstOrDefaultAsync();
+            }
+
+            if (_movement.LocationId is { } locationId)
+            {
+                _location = await DataContext.Query<InventoryLocation>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.Id == locationId && !x.IsDeleted)
+                    .FirstOrDefaultAsync();
+            }
+
+            if (_movement.StockBalanceId is { } balanceId)
+            {
+                _balance = await DataContext.Query<StockBalance>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.Id == balanceId && !x.IsDeleted)
+                    .FirstOrDefaultAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load movement: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private string GetProductLabel() =>
+        _product is null
+            ? _movement?.ProductId.ToString()[..8] ?? "N/A"
+            : string.IsNullOrWhiteSpace(_product.SKU) ? _product.Name ?? _product.Id.ToString()[..8] : $"{_product.Name} ({_product.SKU})";
+
+    private string GetWarehouseLabel() =>
+        _warehouse is null ? ShortId(_movement?.WarehouseId) : $"{_warehouse.Code} - {_warehouse.Name}";
+
+    private string GetLocationLabel() =>
+        _location is null ? ShortId(_movement?.LocationId) : $"{_location.Code} - {_location.Name}";
+
+    private string GetBalanceLabel() =>
+        _balance is null ? ShortId(_movement?.StockBalanceId) : $"{_balance.OnHandQuantity:N2} on hand";
+
+    private string FormatReference() =>
+        string.IsNullOrWhiteSpace(_movement?.ReferenceType)
+            ? "N/A"
+            : _movement.ReferenceId is { } referenceId ? $"{_movement.ReferenceType} / {referenceId}" : _movement.ReferenceType;
+
+    private static string FormatDelta(decimal value) =>
+        value >= 0 ? $"+{value:N2}" : value.ToString("N2");
+
+    private static string FormatDate(DateTime value) => value.ToLocalTime().ToString("g");
+
+    private static string ShortId(Guid? id) =>
+        id is null ? "N/A" : id.Value.ToString()[..8];
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LocationDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LocationDetail.razor
@@ -1,0 +1,343 @@
+@page "/inventario/locations/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Location - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_warehousingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Warehousing" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/warehouses"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Warehouses
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Location Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this location's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_location is null)
+{
+    <BbTypographyMuted>Location not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/warehouses"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <BbTypographyH3>@_location.Name</BbTypographyH3>
+                        <StatusBadge Text="@(_location.IsPickable ? "Pickable" : "Storage")"
+                                     Status="@(_location.IsPickable ? "active" : "inactive")" />
+                    </div>
+                    <BbTypographyMuted>@_location.Code - Warehouse: @GetWarehouseLabel()</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Location Summary</BbCardTitle>
+                    <BbCardDescription>Internal storage position details.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Code</BbTypographyMuted>
+                            <div class="font-mono">@_location.Code</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Name</BbTypographyMuted>
+                            <div>@_location.Name</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Warehouse</BbTypographyMuted>
+                            <div>@GetWarehouseLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Type</BbTypographyMuted>
+                            <div>@_location.LocationType</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Parent Location</BbTypographyMuted>
+                            <div>@GetParentLocationName()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@_location.CreatedAt.ToLocalTime().ToString("g")</div>
+                        </div>
+                        <div class="md:col-span-2">
+                            <BbTypographyMuted>Description</BbTypographyMuted>
+                            <div>@(_location.Description ?? "No description")</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Stock Balances</BbTypographyMuted>
+                            <BbTypographyH3>@_balances.Count</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Movements</BbTypographyMuted>
+                            <BbTypographyH3>@_movements.Count</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Reservations</BbTypographyMuted>
+                            <BbTypographyH3>@_reservations.Count</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Stock Balances</BbCardTitle>
+                    <BbCardDescription>Current balances stored at this location.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Recent Movements</BbCardTitle>
+                    <BbCardDescription>Latest movement ledger entries at this location.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Reservations</BbCardTitle>
+                    <BbCardDescription>Reservation records associated with this location.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_reservations" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((Reservation item) => Navigation.NavigateTo($"/inventario/reservations/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@item.Status.ToString()" Status="@(item.Status == ReservationStatus.Active ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private InventoryLocation? _location;
+    private Warehouse? _warehouse;
+    private InventoryLocation? _parentLocation;
+    private List<StockBalance> _balances = [];
+    private List<InventoryMovement> _movements = [];
+    private List<Reservation> _reservations = [];
+    private Dictionary<Guid, string> _productNames = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _warehousingEnabled;
+    private bool _outsideTenantContext;
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _warehousingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "warehousing");
+            _outsideTenantContext = false;
+            _location = null;
+            _warehouse = null;
+            _parentLocation = null;
+            _balances = [];
+            _movements = [];
+            _reservations = [];
+            _productNames = [];
+
+            if (!_hasTenant || !_warehousingEnabled) return;
+
+            _location = await DataContext.Query<InventoryLocation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _location is not null && _location.TenantId != TenantFilter.SelectedTenantId;
+            if (_location is null || _outsideTenantContext) return;
+
+            var tenantId = _location.TenantId;
+            _warehouse = await DataContext.Query<Warehouse>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.Id == _location.WarehouseId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            if (_location.ParentLocationId is { } parentId)
+            {
+                _parentLocation = await DataContext.Query<InventoryLocation>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.Id == parentId && !x.IsDeleted)
+                    .FirstOrDefaultAsync();
+            }
+
+            _balances = await DataContext.Query<StockBalance>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.LocationId == Id && !x.IsDeleted)
+                .OrderBy(x => x.ProductId)
+                .Take(200)
+                .ToListAsync();
+
+            _movements = await DataContext.Query<InventoryMovement>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.LocationId == Id && !x.IsDeleted)
+                .OrderByDescending(x => x.MovementDate)
+                .Take(100)
+                .ToListAsync();
+
+            _reservations = await DataContext.Query<Reservation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.LocationId == Id && !x.IsDeleted)
+                .OrderByDescending(x => x.ReservedAt)
+                .Take(100)
+                .ToListAsync();
+
+            var productIds = _balances.Select(x => x.ProductId)
+                .Concat(_movements.Select(x => x.ProductId))
+                .Concat(_reservations.Select(x => x.ProductId))
+                .Distinct()
+                .ToList();
+            if (productIds.Count > 0)
+            {
+                var products = await DataContext.Query<Product>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && productIds.Contains(x.Id) && !x.IsDeleted)
+                    .Take(500)
+                    .ToListAsync();
+                _productNames = products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]);
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load location: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private string GetProductName(Guid productId) =>
+        _productNames.TryGetValue(productId, out var name) ? name : productId.ToString()[..8];
+
+    private string GetWarehouseLabel() =>
+        _warehouse is null ? _location?.WarehouseId.ToString()[..8] ?? "N/A" : $"{_warehouse.Code} - {_warehouse.Name}";
+
+    private string GetParentLocationName() =>
+        _parentLocation is null ? "None" : $"{_parentLocation.Code} - {_parentLocation.Name}";
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductTransactionDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductTransactionDetail.razor
@@ -1,0 +1,196 @@
+@page "/inventario/transactions/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Transaction - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/transactions"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Transactions
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Transaction Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this transaction's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_transaction is null)
+{
+    <BbTypographyMuted>Inventory transaction not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/transactions"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <BbTypographyH3>Inventory Transaction</BbTypographyH3>
+                    <BbTypographyMuted>@GetProductLabel() - @FormatDate(_transaction.TransactionDate)</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Quantity</BbTypographyMuted>
+                            <BbTypographyH3>@_transaction.Quantity</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Total</BbTypographyMuted>
+                            <BbTypographyH3>@_transaction.TotalPrice.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Date</BbTypographyMuted>
+                            <BbTypographyH3>@FormatDate(_transaction.TransactionDate)</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Transaction Details</BbCardTitle>
+                    <BbCardDescription>Read-only product transaction record.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Product</BbTypographyMuted>
+                            <div>@GetProductLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Transaction Date</BbTypographyMuted>
+                            <div>@FormatDate(_transaction.TransactionDate)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@_transaction.CreatedAt.ToLocalTime().ToString("g")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>ID</BbTypographyMuted>
+                            <div class="font-mono text-xs">@_transaction.Id</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private ProductTransaction? _transaction;
+    private Product? _product;
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private bool _outsideTenantContext;
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _outsideTenantContext = false;
+            _transaction = null;
+            _product = null;
+
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            _transaction = await DataContext.Query<ProductTransaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _transaction is not null && _transaction.TenantId != TenantFilter.SelectedTenantId;
+            if (_transaction is null || _outsideTenantContext) return;
+
+            _product = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == _transaction.TenantId && x.Id == _transaction.ProductId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load transaction: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private string GetProductLabel() =>
+        _product is null
+            ? _transaction?.ProductId.ToString()[..8] ?? "N/A"
+            : string.IsNullOrWhiteSpace(_product.SKU) ? _product.Name ?? _product.Id.ToString()[..8] : $"{_product.Name} ({_product.SKU})";
+
+    private static string FormatDate(DateTime value) => value.ToLocalTime().ToString("g");
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReservationDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReservationDetail.razor
@@ -1,0 +1,345 @@
+@page "/inventario/reservations/{Id:guid}"
+@using XFramework.Domain.Shared.BusinessObjects
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Reservation - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_reservationsEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Reservations" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/reservations"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Reservations
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Reservation Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this reservation's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_reservation is null)
+{
+    <BbTypographyMuted>Reservation not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/reservations"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <BbTypographyH3>Reservation</BbTypographyH3>
+                        <StatusBadge Text="@_reservation.Status.ToString()" Status="@GetStatusBadge(_reservation.Status)" />
+                    </div>
+                    <BbTypographyMuted>@GetProductLabel() - Qty @_reservation.Quantity.ToString("N2")</BbTypographyMuted>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    @if (_reservation.Status == ReservationStatus.Active)
+                    {
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@ReleaseReservation" Disabled="@_runningAction">
+                            Release
+                        </BbButton>
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@FulfillReservation" Disabled="@_runningAction">
+                            Fulfill
+                        </BbButton>
+                        <BbButton Variant="ButtonVariant.Destructive" OnClick="@CancelReservation" Disabled="@_runningAction">
+                            Cancel
+                        </BbButton>
+                    }
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Quantity</BbTypographyMuted>
+                            <BbTypographyH3>@_reservation.Quantity.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Reserved</BbTypographyMuted>
+                            <BbTypographyH3>@FormatDate(_reservation.ReservedAt)</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Expires</BbTypographyMuted>
+                            <BbTypographyH3>@FormatDate(_reservation.ExpiresAt)</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Reservation Details</BbCardTitle>
+                    <BbCardDescription>Allocation context and lifecycle timestamps.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Product</BbTypographyMuted>
+                            <div>@GetProductLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Warehouse</BbTypographyMuted>
+                            <div>@GetWarehouseLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Location</BbTypographyMuted>
+                            <div>@GetLocationLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Stock Balance</BbTypographyMuted>
+                            <div>@GetBalanceLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Reference</BbTypographyMuted>
+                            <div>@FormatReference()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@_reservation.CreatedAt.ToLocalTime().ToString("g")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Released</BbTypographyMuted>
+                            <div>@FormatDate(_reservation.ReleasedAt)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Fulfilled</BbTypographyMuted>
+                            <div>@FormatDate(_reservation.FulfilledAt)</div>
+                        </div>
+                        <div class="md:col-span-2">
+                            <BbTypographyMuted>ID</BbTypographyMuted>
+                            <div class="font-mono text-xs">@_reservation.Id</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private Reservation? _reservation;
+    private Product? _product;
+    private Warehouse? _warehouse;
+    private InventoryLocation? _location;
+    private StockBalance? _balance;
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _reservationsEnabled;
+    private bool _outsideTenantContext;
+    private bool _runningAction;
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _reservationsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "reservations");
+            _outsideTenantContext = false;
+            _reservation = null;
+            _product = null;
+            _warehouse = null;
+            _location = null;
+            _balance = null;
+
+            if (!_hasTenant || !_reservationsEnabled) return;
+
+            _reservation = await DataContext.Query<Reservation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _reservation is not null && _reservation.TenantId != TenantFilter.SelectedTenantId;
+            if (_reservation is null || _outsideTenantContext) return;
+
+            var tenantId = _reservation.TenantId;
+            _product = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.Id == _reservation.ProductId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            if (_reservation.WarehouseId is { } warehouseId)
+            {
+                _warehouse = await DataContext.Query<Warehouse>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.Id == warehouseId && !x.IsDeleted)
+                    .FirstOrDefaultAsync();
+            }
+
+            if (_reservation.LocationId is { } locationId)
+            {
+                _location = await DataContext.Query<InventoryLocation>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.Id == locationId && !x.IsDeleted)
+                    .FirstOrDefaultAsync();
+            }
+
+            if (_reservation.StockBalanceId is { } balanceId)
+            {
+                _balance = await DataContext.Query<StockBalance>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.Id == balanceId && !x.IsDeleted)
+                    .FirstOrDefaultAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load reservation: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ReleaseReservation() =>
+        await RunReservationAction(
+            () => Inventario.ReleaseReservation(new ReleaseReservationRequest
+            {
+                Metadata = BuildMetadata(),
+                ReservationId = Id
+            }),
+            "Reservation released.");
+
+    private async Task FulfillReservation() =>
+        await RunReservationAction(
+            () => Inventario.FulfillReservation(new FulfillReservationRequest
+            {
+                Metadata = BuildMetadata(),
+                ReservationId = Id
+            }),
+            "Reservation fulfilled.");
+
+    private async Task CancelReservation() =>
+        await RunReservationAction(
+            () => Inventario.CancelReservation(new CancelReservationRequest
+            {
+                Metadata = BuildMetadata(),
+                ReservationId = Id
+            }),
+            "Reservation cancelled.");
+
+    private async Task RunReservationAction(Func<Task<CmdResponse>> action, string successMessage)
+    {
+        _runningAction = true;
+        try
+        {
+            var result = await action();
+            ToastService.Show(result.IsSuccess ? successMessage : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+                await Reload();
+        }
+        finally
+        {
+            _runningAction = false;
+        }
+    }
+
+    private RequestMetadata BuildMetadata() => new()
+    {
+        TenantId = TenantFilter.SelectedTenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "ControlPanel"
+    };
+
+    private string GetProductLabel() =>
+        _product is null
+            ? _reservation?.ProductId.ToString()[..8] ?? "N/A"
+            : string.IsNullOrWhiteSpace(_product.SKU) ? _product.Name ?? _product.Id.ToString()[..8] : $"{_product.Name} ({_product.SKU})";
+
+    private string GetWarehouseLabel() =>
+        _warehouse is null ? ShortId(_reservation?.WarehouseId) : $"{_warehouse.Code} - {_warehouse.Name}";
+
+    private string GetLocationLabel() =>
+        _location is null ? ShortId(_reservation?.LocationId) : $"{_location.Code} - {_location.Name}";
+
+    private string GetBalanceLabel() =>
+        _balance is null ? ShortId(_reservation?.StockBalanceId) : $"{_balance.OnHandQuantity:N2} on hand";
+
+    private string FormatReference() =>
+        string.IsNullOrWhiteSpace(_reservation?.ReferenceType)
+            ? "N/A"
+            : _reservation.ReferenceId is { } referenceId ? $"{_reservation.ReferenceType} / {referenceId}" : _reservation.ReferenceType;
+
+    private static string GetStatusBadge(ReservationStatus status) =>
+        status == ReservationStatus.Active ? "active" : "inactive";
+
+    private static string FormatDate(DateTime value) => value.ToLocalTime().ToString("g");
+
+    private static string FormatDate(DateTime? value) =>
+        value is null ? "N/A" : value.Value.ToLocalTime().ToString("g");
+
+    private static string ShortId(Guid? id) =>
+        id is null ? "N/A" : id.Value.ToString()[..8];
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
@@ -31,6 +31,10 @@ else
                     <BbTypographyMuted>Reserve, release, fulfill, and expire allocated inventory.</BbTypographyMuted>
                 </div>
                 <div class="flex flex-wrap gap-2">
+                    <BbButton OnClick="@OpenReservationDialog">
+                        <LucideIcon Name="clipboard-plus" class="mr-2 h-4 w-4" />
+                        Reserve Inventory
+                    </BbButton>
                     <BbButton Variant="ButtonVariant.Outline" OnClick="@ExpireDueReservations" Disabled="@_expiring">
                         <LucideIcon Name="timer" class="mr-2 h-4 w-4" />
                         Expire Due
@@ -44,79 +48,13 @@ else
 
             <BbCard>
                 <BbCardHeader>
-                    <BbCardTitle>Reserve Inventory</BbCardTitle>
-                    <BbCardDescription>Reservations reduce available quantity without changing on-hand stock.</BbCardDescription>
-                </BbCardHeader>
-                <BbCardContent>
-                    <div class="grid gap-3">
-                        <div class="grid gap-3 xl:grid-cols-3">
-                            <div class="xf-form-field">
-                                <BbLabel>Product</BbLabel>
-                                <BbCombobox TValue="string"
-                                             @bind-Value="_form.ProductId"
-                                             Options="@ProductOptions"
-                                             Placeholder="Select product"
-                                             SearchPlaceholder="Search products..."
-                                             EmptyMessage="No products found."
-                                             Class="xf-entity-combobox"
-                                             MatchTriggerWidth="true" />
-                            </div>
-                            <div class="xf-form-field">
-                                <BbLabel>Warehouse</BbLabel>
-                                <BbCombobox TValue="string"
-                                             Value="@_form.WarehouseId"
-                                             ValueChanged="@OnReservationWarehouseChanged"
-                                             Options="@WarehouseOptions"
-                                             Placeholder="Select warehouse"
-                                             SearchPlaceholder="Search warehouses..."
-                                             EmptyMessage="No warehouses found."
-                                             Class="xf-entity-combobox"
-                                             MatchTriggerWidth="true" />
-                            </div>
-                            <div class="xf-form-field">
-                                <BbLabel>Location</BbLabel>
-                                <BbCombobox TValue="string"
-                                             @bind-Value="_form.LocationId"
-                                             Options="@ReservationLocationOptions"
-                                             Placeholder="Select location"
-                                             SearchPlaceholder="Search locations..."
-                                             EmptyMessage="No locations found."
-                                             Class="xf-entity-combobox"
-                                             MatchTriggerWidth="true" />
-                            </div>
-                        </div>
-                        <div class="grid gap-3 md:grid-cols-3">
-                            <BbFormFieldInput TValue="string" @bind-Value="_form.Quantity" Label="Quantity" />
-                            <div class="xf-form-field">
-                                <BbLabel>Expires At</BbLabel>
-                                <input type="datetime-local"
-                                       class="xf-datetime-input"
-                                       value="@_form.ExpiresAt"
-                                       @oninput="@((ChangeEventArgs e) => _form.ExpiresAt = e.Value?.ToString() ?? string.Empty)" />
-                            </div>
-                            <BbFormFieldInput TValue="string" @bind-Value="_form.ReferenceType" Label="Reference Type" />
-                        </div>
-                        <div class="grid gap-3 md:grid-cols-2">
-                            <BbFormFieldInput TValue="string" @bind-Value="_form.ReferenceId" Label="Reference ID" />
-                            <BbFormFieldInput TValue="string" @bind-Value="_form.Reason" Label="Reason" />
-                        </div>
-                        <div>
-                            <BbButton OnClick="@ReserveInventory" Disabled="@IsReserveDisabled">
-                                <LucideIcon Name="clipboard-plus" class="mr-2 h-4 w-4" />
-                                Reserve
-                            </BbButton>
-                        </div>
-                    </div>
-                </BbCardContent>
-            </BbCard>
-
-            <BbCard>
-                <BbCardHeader>
                     <BbCardTitle>Reservation List</BbCardTitle>
                     <BbCardDescription>@_reservations.Count reservation(s) loaded</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_reservations" ShowPagination="true" InitialPageSize="20">
+                    <BbDataGrid Items="@_reservations" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((Reservation item) => Navigation.NavigateTo($"/inventario/reservations/{item.Id}"))"
+                                Class="cursor-pointer">
                         <Columns>
                             <BbDataGridTemplateColumn Title="Product">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
@@ -137,10 +75,19 @@ else
                                 <ChildContent Context="item">
                                     @if (item.Status == ReservationStatus.Active)
                                     {
-                                        <div class="flex flex-wrap gap-1">
+                                        <div class="flex flex-wrap gap-1" @onclick:stopPropagation="true">
                                             <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => ReleaseReservation(item.Id))">Release</BbButton>
                                             <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => FulfillReservation(item.Id))">Fulfill</BbButton>
                                             <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Destructive" OnClick="@(() => CancelReservation(item.Id))">Cancel</BbButton>
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        <div @onclick:stopPropagation="true">
+                                            <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                      OnClick="@(() => Navigation.NavigateTo($"/inventario/reservations/{item.Id}"))">
+                                                <LucideIcon Name="eye" class="h-4 w-4" />
+                                            </BbButton>
                                         </div>
                                     }
                                 </ChildContent>
@@ -153,9 +100,78 @@ else
     </FadeInContent>
 }
 
+<BbDialog Open="@_reservationDialogOpen" OpenChanged="@(v => _reservationDialogOpen = v)">
+    <BbDialogContent TrapFocus="false">
+        <BbDialogHeader>
+            <BbDialogTitle>Reserve Inventory</BbDialogTitle>
+            <BbDialogDescription>Reservations reduce available quantity without changing on-hand stock.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 xl:grid-cols-3">
+                <div class="xf-form-field">
+                    <BbLabel>Product</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_form.ProductId"
+                                 Options="@ProductOptions"
+                                 Placeholder="Select product"
+                                 SearchPlaceholder="Search products..."
+                                 EmptyMessage="No products found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <div class="xf-form-field">
+                    <BbLabel>Warehouse</BbLabel>
+                    <BbCombobox TValue="string"
+                                 Value="@_form.WarehouseId"
+                                 ValueChanged="@OnReservationWarehouseChanged"
+                                 Options="@WarehouseOptions"
+                                 Placeholder="Select warehouse"
+                                 SearchPlaceholder="Search warehouses..."
+                                 EmptyMessage="No warehouses found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <div class="xf-form-field">
+                    <BbLabel>Location</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_form.LocationId"
+                                 Options="@ReservationLocationOptions"
+                                 Placeholder="Select location"
+                                 SearchPlaceholder="Search locations..."
+                                 EmptyMessage="No locations found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+            </div>
+            <div class="grid gap-3 md:grid-cols-3">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Quantity" Label="Quantity" />
+                <div class="xf-form-field">
+                    <BbLabel>Expires At</BbLabel>
+                    <input type="datetime-local"
+                           class="xf-datetime-input"
+                           value="@_form.ExpiresAt"
+                           @oninput="@((ChangeEventArgs e) => _form.ExpiresAt = e.Value?.ToString() ?? string.Empty)" />
+                </div>
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ReferenceType" Label="Reference Type" />
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ReferenceId" Label="Reference ID" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Reason" Label="Reason" />
+            </div>
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _reservationDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@ReserveInventory" Disabled="@IsReserveDisabled">
+                Reserve
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
@@ -170,6 +186,7 @@ else
     private bool _reservationsEnabled;
     private bool _reserving;
     private bool _expiring;
+    private bool _reservationDialogOpen;
     private bool IsReserveDisabled => _reserving || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
     private List<SelectOption<string>> ProductOptions =>
         _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
@@ -293,6 +310,7 @@ else
                 _form.Quantity = "0";
                 _form.ExpiresAt = "";
                 _form.Reason = "";
+                _reservationDialogOpen = false;
                 await Reload();
             }
         }
@@ -300,6 +318,12 @@ else
         {
             _reserving = false;
         }
+    }
+
+    private void OpenReservationDialog()
+    {
+        ApplyDefaultSelections();
+        _reservationDialogOpen = true;
     }
 
     private async Task ReleaseReservation(Guid reservationId) =>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -29,82 +29,20 @@ else
                     <BbTypographyH3>Stock Control</BbTypographyH3>
                     <BbTypographyMuted>Post stock movements and inspect balances for the selected tenant.</BbTypographyMuted>
                 </div>
-                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
-                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-                    Refresh
-                </BbButton>
+                <div class="flex flex-wrap gap-2">
+                    @if (_movementsEnabled)
+                    {
+                        <BbButton OnClick="@OpenMovementDialog">
+                            <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                            Post Movement
+                        </BbButton>
+                    }
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                </div>
             </div>
-
-            @if (_movementsEnabled)
-            {
-                <BbCard>
-                    <BbCardHeader>
-                        <BbCardTitle>Post Movement</BbCardTitle>
-                        <BbCardDescription>Movements are append-only and update stock balances through Inventario services.</BbCardDescription>
-                    </BbCardHeader>
-                    <BbCardContent>
-                        <div class="grid gap-3">
-                            <div class="grid gap-3 xl:grid-cols-4">
-                                <div class="xf-form-field">
-                                    <BbLabel>Product</BbLabel>
-                                    <BbCombobox TValue="string"
-                                                 @bind-Value="_movementForm.ProductId"
-                                                 Options="@ProductOptions"
-                                                 Placeholder="Select product"
-                                                 SearchPlaceholder="Search products..."
-                                                 EmptyMessage="No products found."
-                                                 Class="xf-entity-combobox"
-                                                 MatchTriggerWidth="true" />
-                                </div>
-                                <div class="xf-form-field">
-                                    <BbLabel>Warehouse</BbLabel>
-                                    <BbCombobox TValue="string"
-                                                 Value="@_movementForm.WarehouseId"
-                                                 ValueChanged="@OnMovementWarehouseChanged"
-                                                 Options="@WarehouseOptions"
-                                                 Placeholder="Select warehouse"
-                                                 SearchPlaceholder="Search warehouses..."
-                                                 EmptyMessage="No warehouses found."
-                                                 Class="xf-entity-combobox"
-                                                 MatchTriggerWidth="true" />
-                                </div>
-                                <div class="xf-form-field">
-                                    <BbLabel>Location</BbLabel>
-                                    <BbCombobox TValue="string"
-                                                 @bind-Value="_movementForm.LocationId"
-                                                 Options="@MovementLocationOptions"
-                                                 Placeholder="Select location"
-                                                 SearchPlaceholder="Search locations..."
-                                                 EmptyMessage="No locations found."
-                                                 Class="xf-entity-combobox"
-                                                 MatchTriggerWidth="true" />
-                                </div>
-                                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.MovementType" Label="Movement Type">
-                                    @foreach (var type in Enum.GetValues<InventoryMovementType>())
-                                    {
-                                        <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
-                                    }
-                                </BbFormFieldSelect>
-                            </div>
-                            <div class="grid gap-3 md:grid-cols-3">
-                                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Quantity" Label="Quantity" />
-                                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.UnitOfMeasure" Label="Unit" />
-                                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.ReferenceType" Label="Reference Type" />
-                            </div>
-                            <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Reason" Label="Reason" />
-                            <BbFormFieldSwitch Checked="@_movementForm.AllowNegativeStock"
-                                               CheckedChanged="@((bool value) => _movementForm.AllowNegativeStock = value)"
-                                               Label="Allow negative stock for this posting" />
-                            <div>
-                                <BbButton OnClick="@PostMovement" Disabled="@IsPostMovementDisabled">
-                                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
-                                    Post Movement
-                                </BbButton>
-                            </div>
-                        </div>
-                    </BbCardContent>
-                </BbCard>
-            }
 
             @if (_stockEnabled)
             {
@@ -114,7 +52,9 @@ else
                         <BbCardDescription>@_balances.Count balance row(s) loaded</BbCardDescription>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="20">
+                        <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="20"
+                                    OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
+                                    Class="cursor-pointer">
                             <Columns>
                                 <BbDataGridTemplateColumn Title="Product">
                                     <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
@@ -129,6 +69,14 @@ else
                                 <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
                                 <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
                                 <BbDataGridPropertyColumn Property="@(x => x.LastMovementAt)" Title="Last Movement" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="item">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))">
+                                            <LucideIcon Name="eye" class="h-4 w-4" />
+                                        </BbButton>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
                             </Columns>
                         </BbDataGrid>
                     </BbCardContent>
@@ -143,7 +91,9 @@ else
                         <BbCardDescription>@_movements.Count movement(s) loaded</BbCardDescription>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="20">
+                        <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="20"
+                                    OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
+                                    Class="cursor-pointer">
                             <Columns>
                                 <BbDataGridTemplateColumn Title="Product">
                                     <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
@@ -154,6 +104,14 @@ else
                                 <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
                                 <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" />
                                 <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="item">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))">
+                                            <LucideIcon Name="eye" class="h-4 w-4" />
+                                        </BbButton>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
                             </Columns>
                         </BbDataGrid>
                     </BbCardContent>
@@ -163,9 +121,78 @@ else
     </FadeInContent>
 }
 
+<BbDialog Open="@_movementDialogOpen" OpenChanged="@(v => _movementDialogOpen = v)">
+    <BbDialogContent TrapFocus="false">
+        <BbDialogHeader>
+            <BbDialogTitle>Post Movement</BbDialogTitle>
+            <BbDialogDescription>Movements are append-only and update stock balances through Inventario services.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 xl:grid-cols-2">
+                <div class="xf-form-field">
+                    <BbLabel>Product</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_movementForm.ProductId"
+                                 Options="@ProductOptions"
+                                 Placeholder="Select product"
+                                 SearchPlaceholder="Search products..."
+                                 EmptyMessage="No products found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <div class="xf-form-field">
+                    <BbLabel>Warehouse</BbLabel>
+                    <BbCombobox TValue="string"
+                                 Value="@_movementForm.WarehouseId"
+                                 ValueChanged="@OnMovementWarehouseChanged"
+                                 Options="@WarehouseOptions"
+                                 Placeholder="Select warehouse"
+                                 SearchPlaceholder="Search warehouses..."
+                                 EmptyMessage="No warehouses found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <div class="xf-form-field">
+                    <BbLabel>Location</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_movementForm.LocationId"
+                                 Options="@MovementLocationOptions"
+                                 Placeholder="Select location"
+                                 SearchPlaceholder="Search locations..."
+                                 EmptyMessage="No locations found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.MovementType" Label="Movement Type">
+                    @foreach (var type in Enum.GetValues<InventoryMovementType>())
+                    {
+                        <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
+                    }
+                </BbFormFieldSelect>
+            </div>
+            <div class="grid gap-3 md:grid-cols-3">
+                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Quantity" Label="Quantity" />
+                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.UnitOfMeasure" Label="Unit" />
+                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.ReferenceType" Label="Reference Type" />
+            </div>
+            <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Reason" Label="Reason" />
+            <BbFormFieldSwitch Checked="@_movementForm.AllowNegativeStock"
+                               CheckedChanged="@((bool value) => _movementForm.AllowNegativeStock = value)"
+                               Label="Allow negative stock for this posting" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _movementDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@PostMovement" Disabled="@IsPostMovementDisabled">
+                Post Movement
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
@@ -181,6 +208,7 @@ else
     private bool _stockEnabled;
     private bool _movementsEnabled;
     private bool _postingMovement;
+    private bool _movementDialogOpen;
     private bool IsPostMovementDisabled => _postingMovement || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
     private List<SelectOption<string>> ProductOptions =>
         _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
@@ -310,6 +338,7 @@ else
             {
                 _movementForm.Quantity = "0";
                 _movementForm.Reason = "";
+                _movementDialogOpen = false;
                 await Reload();
             }
         }
@@ -317,6 +346,12 @@ else
         {
             _postingMovement = false;
         }
+    }
+
+    private void OpenMovementDialog()
+    {
+        ApplyDefaultMovementSelections();
+        _movementDialogOpen = true;
     }
 
     private IEnumerable<InventoryLocation> LocationsForSelectedWarehouse()

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/StockBalanceDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/StockBalanceDetail.razor
@@ -1,0 +1,255 @@
+@page "/inventario/stock/balances/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Stock Balance - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_stockEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Stock" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/stock"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Stock
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Stock Balance Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this balance's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_balance is null)
+{
+    <BbTypographyMuted>Stock balance not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/stock"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <BbTypographyH3>Stock Balance</BbTypographyH3>
+                    <BbTypographyMuted>@GetProductLabel() - @GetWarehouseLabel() / @GetLocationLabel()</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>On Hand</BbTypographyMuted>
+                            <BbTypographyH3>@_balance.OnHandQuantity.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Reserved</BbTypographyMuted>
+                            <BbTypographyH3>@_balance.ReservedQuantity.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Available</BbTypographyMuted>
+                            <BbTypographyH3>@_balance.AvailableQuantity.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Balance Context</BbCardTitle>
+                    <BbCardDescription>Product and storage position for this balance row.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Product</BbTypographyMuted>
+                            <div>@GetProductLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Warehouse</BbTypographyMuted>
+                            <div>@GetWarehouseLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Location</BbTypographyMuted>
+                            <div>@GetLocationLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Last Movement</BbTypographyMuted>
+                            <div>@FormatDate(_balance.LastMovementAt)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@_balance.CreatedAt.ToLocalTime().ToString("g")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>ID</BbTypographyMuted>
+                            <div class="font-mono text-xs">@_balance.Id</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Movement Ledger</BbCardTitle>
+                    <BbCardDescription>Recent movement rows that affected this balance.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityBefore)" Title="Before" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private StockBalance? _balance;
+    private Product? _product;
+    private Warehouse? _warehouse;
+    private InventoryLocation? _location;
+    private List<InventoryMovement> _movements = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _stockEnabled;
+    private bool _outsideTenantContext;
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _stockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances");
+            _outsideTenantContext = false;
+            _balance = null;
+            _product = null;
+            _warehouse = null;
+            _location = null;
+            _movements = [];
+
+            if (!_hasTenant || !_stockEnabled) return;
+
+            _balance = await DataContext.Query<StockBalance>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _balance is not null && _balance.TenantId != TenantFilter.SelectedTenantId;
+            if (_balance is null || _outsideTenantContext) return;
+
+            var tenantId = _balance.TenantId;
+            _product = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.Id == _balance.ProductId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+            _warehouse = await DataContext.Query<Warehouse>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.Id == _balance.WarehouseId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+            _location = await DataContext.Query<InventoryLocation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.Id == _balance.LocationId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+            _movements = await DataContext.Query<InventoryMovement>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.StockBalanceId == Id && !x.IsDeleted)
+                .OrderByDescending(x => x.MovementDate)
+                .Take(100)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load stock balance: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private string GetProductLabel() =>
+        _product is null
+            ? _balance?.ProductId.ToString()[..8] ?? "N/A"
+            : string.IsNullOrWhiteSpace(_product.SKU) ? _product.Name ?? _product.Id.ToString()[..8] : $"{_product.Name} ({_product.SKU})";
+
+    private string GetWarehouseLabel() =>
+        _warehouse is null ? _balance?.WarehouseId.ToString()[..8] ?? "N/A" : $"{_warehouse.Code} - {_warehouse.Name}";
+
+    private string GetLocationLabel() =>
+        _location is null ? _balance?.LocationId.ToString()[..8] ?? "N/A" : $"{_location.Code} - {_location.Name}";
+
+    private static string FormatDate(DateTime? value) =>
+        value is null ? "N/A" : value.Value.ToLocalTime().ToString("g");
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
@@ -37,7 +37,9 @@ else
                     <BbCardDescription>@_transactions.Count transaction(s) loaded</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
+                    <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((ProductTransaction item) => Navigation.NavigateTo($"/inventario/transactions/{item.Id}"))"
+                                Class="cursor-pointer">
                         <Columns>
                             <BbDataGridTemplateColumn Title="Product">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
@@ -48,6 +50,14 @@ else
                             </BbDataGridTemplateColumn>
                             <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" />
                             <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              OnClick="@(() => Navigation.NavigateTo($"/inventario/transactions/{item.Id}"))">
+                                        <LucideIcon Name="eye" class="h-4 w-4" />
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -58,6 +68,7 @@ else
 
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/WarehouseDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/WarehouseDetail.razor
@@ -1,0 +1,317 @@
+@page "/inventario/warehouses/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Warehouse - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_warehousingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Warehousing" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/warehouses"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Warehouses
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Warehouse Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this warehouse's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_warehouse is null)
+{
+    <BbTypographyMuted>Warehouse not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/warehouses"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <BbTypographyH3>@_warehouse.Name</BbTypographyH3>
+                        <StatusBadge Text="@(_warehouse.IsDefault ? "Default" : "Standard")"
+                                     Status="@(_warehouse.IsDefault ? "active" : "inactive")" />
+                    </div>
+                    <BbTypographyMuted>@_warehouse.Code - ID: @_warehouse.Id</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Warehouse Summary</BbCardTitle>
+                    <BbCardDescription>Storage facility details for the selected tenant.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Code</BbTypographyMuted>
+                            <div class="font-mono">@_warehouse.Code</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Name</BbTypographyMuted>
+                            <div>@_warehouse.Name</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Address</BbTypographyMuted>
+                            <div>@FormatAddress(_warehouse)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@_warehouse.CreatedAt.ToLocalTime().ToString("g")</div>
+                        </div>
+                        <div class="md:col-span-2">
+                            <BbTypographyMuted>Description</BbTypographyMuted>
+                            <div>@(_warehouse.Description ?? "No description")</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Locations</BbTypographyMuted>
+                            <BbTypographyH3>@_locations.Count</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Stock Balances</BbTypographyMuted>
+                            <BbTypographyH3>@_balances.Count</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Recent Movements</BbTypographyMuted>
+                            <BbTypographyH3>@_movements.Count</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Locations</BbCardTitle>
+                    <BbCardDescription>Internal positions inside this warehouse.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_locations" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((InventoryLocation item) => Navigation.NavigateTo($"/inventario/locations/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LocationType)" Title="Type" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Pickable">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsPickable ? "Pickable" : "Storage")" Status="@(item.IsPickable ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Stock Balances</BbCardTitle>
+                    <BbCardDescription>Current balances held in this warehouse.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Location">
+                                <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Recent Movements</BbCardTitle>
+                    <BbCardDescription>Latest movement ledger entries for this warehouse.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private Warehouse? _warehouse;
+    private List<InventoryLocation> _locations = [];
+    private List<StockBalance> _balances = [];
+    private List<InventoryMovement> _movements = [];
+    private Dictionary<Guid, string> _productNames = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _warehousingEnabled;
+    private bool _outsideTenantContext;
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _warehousingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "warehousing");
+            _outsideTenantContext = false;
+            _warehouse = null;
+            _locations = [];
+            _balances = [];
+            _movements = [];
+            _productNames = [];
+
+            if (!_hasTenant || !_warehousingEnabled) return;
+
+            _warehouse = await DataContext.Query<Warehouse>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _warehouse is not null && _warehouse.TenantId != TenantFilter.SelectedTenantId;
+            if (_warehouse is null || _outsideTenantContext) return;
+
+            var tenantId = _warehouse.TenantId;
+            _locations = await DataContext.Query<InventoryLocation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.WarehouseId == Id && !x.IsDeleted)
+                .OrderBy(x => x.Code)
+                .Take(200)
+                .ToListAsync();
+
+            _balances = await DataContext.Query<StockBalance>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.WarehouseId == Id && !x.IsDeleted)
+                .OrderBy(x => x.ProductId)
+                .Take(200)
+                .ToListAsync();
+
+            _movements = await DataContext.Query<InventoryMovement>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.WarehouseId == Id && !x.IsDeleted)
+                .OrderByDescending(x => x.MovementDate)
+                .Take(100)
+                .ToListAsync();
+
+            var productIds = _balances.Select(x => x.ProductId).Concat(_movements.Select(x => x.ProductId)).Distinct().ToList();
+            if (productIds.Count > 0)
+            {
+                var products = await DataContext.Query<Product>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && productIds.Contains(x.Id) && !x.IsDeleted)
+                    .Take(500)
+                    .ToListAsync();
+                _productNames = products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]);
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load warehouse: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private string GetProductName(Guid productId) =>
+        _productNames.TryGetValue(productId, out var name) ? name : productId.ToString()[..8];
+
+    private string GetLocationName(Guid locationId) =>
+        _locations.FirstOrDefault(x => x.Id == locationId)?.Name ?? locationId.ToString()[..8];
+
+    private static string FormatAddress(Warehouse warehouse)
+    {
+        var parts = new[] { warehouse.AddressLine, warehouse.City, warehouse.Region, warehouse.PostalCode, warehouse.CountryCode }
+            .Where(x => !string.IsNullOrWhiteSpace(x));
+        var address = string.Join(", ", parts);
+        return string.IsNullOrWhiteSpace(address) ? "N/A" : address;
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
@@ -28,85 +28,20 @@ else
                     <BbTypographyH3>Warehouses</BbTypographyH3>
                     <BbTypographyMuted>Set up stock storage warehouses and internal locations.</BbTypographyMuted>
                 </div>
-                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
-                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-                    Refresh
-                </BbButton>
-            </div>
-
-            <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-                <BbCard>
-                    <BbCardHeader>
-                        <BbCardTitle>Create Warehouse</BbCardTitle>
-                        <BbCardDescription>Warehouse codes are unique inside a tenant.</BbCardDescription>
-                    </BbCardHeader>
-                    <BbCardContent>
-                        <div class="grid gap-3">
-                            <div class="grid gap-3 md:grid-cols-2">
-                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Code" Label="Code" Required="true" />
-                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Name" Label="Name" Required="true" />
-                            </div>
-                            <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Description" Label="Description" />
-                            <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.AddressLine" Label="Address" />
-                            <div class="grid gap-3 md:grid-cols-3">
-                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.City" Label="City" />
-                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Region" Label="Region" />
-                                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.CountryCode" Label="Country Code" />
-                            </div>
-                            <BbFormFieldSwitch Checked="@_warehouseForm.IsDefault"
-                                               CheckedChanged="@((bool value) => _warehouseForm.IsDefault = value)"
-                                               Label="Default warehouse" />
-                            <div>
-                                <BbButton OnClick="@CreateWarehouse" Disabled="@_savingWarehouse">
-                                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
-                                    Create Warehouse
-                                </BbButton>
-                            </div>
-                        </div>
-                    </BbCardContent>
-                </BbCard>
-
-                <BbCard>
-                    <BbCardHeader>
-                        <BbCardTitle>Create Location</BbCardTitle>
-                        <BbCardDescription>Locations belong to a warehouse and can represent bins, shelves, or zones.</BbCardDescription>
-                    </BbCardHeader>
-                    <BbCardContent>
-                        <div class="grid gap-3">
-                            <div class="xf-form-field">
-                                <BbLabel>Warehouse</BbLabel>
-                                <BbCombobox TValue="string"
-                                             @bind-Value="_locationForm.WarehouseId"
-                                             Options="@WarehouseOptions"
-                                             Placeholder="Select warehouse"
-                                             SearchPlaceholder="Search warehouses..."
-                                             EmptyMessage="No warehouses found."
-                                             Class="xf-entity-combobox"
-                                             MatchTriggerWidth="true" />
-                            </div>
-                            <div class="grid gap-3 md:grid-cols-2">
-                                <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Code" Label="Code" Required="true" />
-                                <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Name" Label="Name" Required="true" />
-                            </div>
-                            <BbFormFieldSelect TValue="string" @bind-Value="_locationForm.LocationType" Label="Location Type">
-                                @foreach (var type in Enum.GetValues<InventoryLocationType>())
-                                {
-                                    <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
-                                }
-                            </BbFormFieldSelect>
-                            <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Description" Label="Description" />
-                            <BbFormFieldSwitch Checked="@_locationForm.IsPickable"
-                                               CheckedChanged="@((bool value) => _locationForm.IsPickable = value)"
-                                               Label="Pickable location" />
-                            <div>
-                                <BbButton OnClick="@CreateLocation" Disabled="@IsCreateLocationDisabled">
-                                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
-                                    Create Location
-                                </BbButton>
-                            </div>
-                        </div>
-                    </BbCardContent>
-                </BbCard>
+                <div class="flex flex-wrap gap-2">
+                    <BbButton OnClick="@OpenWarehouseDialog">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Create Warehouse
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@OpenLocationDialog" Disabled="@(_warehouses.Count == 0)">
+                        <LucideIcon Name="map-pin" class="mr-2 h-4 w-4" />
+                        Create Location
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                </div>
             </div>
 
             <BbCard>
@@ -115,7 +50,9 @@ else
                     <BbCardDescription>@_warehouses.Count warehouse(s), @_locations.Count location(s)</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_warehouses" ShowPagination="true" InitialPageSize="20">
+                    <BbDataGrid Items="@_warehouses" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((Warehouse item) => Navigation.NavigateTo($"/inventario/warehouses/{item.Id}"))"
+                                Class="cursor-pointer">
                         <Columns>
                             <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
                             <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
@@ -128,6 +65,14 @@ else
                             <BbDataGridTemplateColumn Title="Locations">
                                 <ChildContent Context="item">@_locations.Count(x => x.WarehouseId == item.Id)</ChildContent>
                             </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              OnClick="@(() => Navigation.NavigateTo($"/inventario/warehouses/{item.Id}"))">
+                                        <LucideIcon Name="eye" class="h-4 w-4" />
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -139,7 +84,9 @@ else
                     <BbCardDescription>Internal stock positions by warehouse.</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_locations" ShowPagination="true" InitialPageSize="20">
+                    <BbDataGrid Items="@_locations" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((InventoryLocation item) => Navigation.NavigateTo($"/inventario/locations/{item.Id}"))"
+                                Class="cursor-pointer">
                         <Columns>
                             <BbDataGridTemplateColumn Title="Warehouse">
                                 <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
@@ -152,6 +99,14 @@ else
                                     <StatusBadge Text="@(item.IsPickable ? "Pickable" : "Storage")" Status="@(item.IsPickable ? "active" : "inactive")" />
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              OnClick="@(() => Navigation.NavigateTo($"/inventario/locations/{item.Id}"))">
+                                        <LucideIcon Name="eye" class="h-4 w-4" />
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -160,9 +115,83 @@ else
     </FadeInContent>
 }
 
+<BbDialog Open="@_warehouseDialogOpen" OpenChanged="@(v => _warehouseDialogOpen = v)">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>Create Warehouse</BbDialogTitle>
+            <BbDialogDescription>Warehouse codes are unique inside the selected tenant.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Code" Label="Code" Required="true" />
+                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Name" Label="Name" Required="true" />
+            </div>
+            <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Description" Label="Description" />
+            <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.AddressLine" Label="Address" />
+            <div class="grid gap-3 md:grid-cols-3">
+                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.City" Label="City" />
+                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Region" Label="Region" />
+                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.CountryCode" Label="Country Code" />
+            </div>
+            <BbFormFieldSwitch Checked="@_warehouseForm.IsDefault"
+                               CheckedChanged="@((bool value) => _warehouseForm.IsDefault = value)"
+                               Label="Default warehouse" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _warehouseDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@CreateWarehouse" Disabled="@_savingWarehouse">
+                Create
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+<BbDialog Open="@_locationDialogOpen" OpenChanged="@(v => _locationDialogOpen = v)">
+    <BbDialogContent TrapFocus="false">
+        <BbDialogHeader>
+            <BbDialogTitle>Create Location</BbDialogTitle>
+            <BbDialogDescription>Locations belong to a warehouse and represent bins, shelves, or zones.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="xf-form-field">
+                <BbLabel>Warehouse</BbLabel>
+                <BbCombobox TValue="string"
+                             @bind-Value="_locationForm.WarehouseId"
+                             Options="@WarehouseOptions"
+                             Placeholder="Select warehouse"
+                             SearchPlaceholder="Search warehouses..."
+                             EmptyMessage="No warehouses found."
+                             Class="xf-entity-combobox"
+                             MatchTriggerWidth="true" />
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Code" Label="Code" Required="true" />
+                <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Name" Label="Name" Required="true" />
+            </div>
+            <BbFormFieldSelect TValue="string" @bind-Value="_locationForm.LocationType" Label="Location Type">
+                @foreach (var type in Enum.GetValues<InventoryLocationType>())
+                {
+                    <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
+                }
+            </BbFormFieldSelect>
+            <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Description" Label="Description" />
+            <BbFormFieldSwitch Checked="@_locationForm.IsPickable"
+                               CheckedChanged="@((bool value) => _locationForm.IsPickable = value)"
+                               Label="Pickable location" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _locationDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@CreateLocation" Disabled="@IsCreateLocationDisabled">
+                Create
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
@@ -176,6 +205,8 @@ else
     private bool _warehousingEnabled;
     private bool _savingWarehouse;
     private bool _savingLocation;
+    private bool _warehouseDialogOpen;
+    private bool _locationDialogOpen;
     private bool IsCreateLocationDisabled => _savingLocation || _warehouses.Count == 0;
     private List<SelectOption<string>> WarehouseOptions =>
         _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
@@ -232,6 +263,19 @@ else
         }
     }
 
+    private void OpenWarehouseDialog()
+    {
+        _warehouseForm.Reset();
+        _warehouseDialogOpen = true;
+    }
+
+    private void OpenLocationDialog()
+    {
+        _locationForm.Reset();
+        _locationForm.WarehouseId = _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
+        _locationDialogOpen = true;
+    }
+
     private async Task CreateWarehouse()
     {
         if (TenantFilter.SelectedTenantId is not Guid)
@@ -265,6 +309,7 @@ else
             if (result.IsSuccess)
             {
                 _warehouseForm.Reset();
+                _warehouseDialogOpen = false;
                 await Reload();
             }
         }
@@ -306,6 +351,7 @@ else
             {
                 _locationForm.Reset();
                 _locationForm.WarehouseId = _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
+                _locationDialogOpen = false;
                 await Reload();
             }
         }


### PR DESCRIPTION
## Summary
- Make Inventario operational pages list-first by moving Warehouse, Location, Stock Movement, and Reservation action forms into dialogs.
- Add detail pages for warehouses, locations, stock balances, inventory movements, reservations, and product transactions.
- Wire list row clicks/actions to the appropriate details while keeping compact create/post/reserve actions as modal workflows.

## Verification
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- dotnet build src/Modules/XFramework.Blazor/XFramework.Blazor.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- Browser smoke on http://localhost:5012 against xeon-dev backend:
  - Warehouses page is list-first and no longer shows embedded create sections.
  - Warehouse and location rows navigate to detail pages.
  - Stock page is list-first; stock balance and movement rows navigate to detail pages.
  - Reservations page is list-first; reservation rows navigate to detail pages.
  - Create Warehouse, Create Location, Post Movement, and Reserve Inventory dialogs open correctly.
  - Browser console reported no errors.