### PR TITLE
Add XFramework operations dashboard

### DIFF
--- a/.github/workflows/deploy-xeon-dev-operations-dashboard.yml
+++ b/.github/workflows/deploy-xeon-dev-operations-dashboard.yml
@@ -1,0 +1,22 @@
+name: Deploy Xeon Dev - Operations Dashboard
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - src/Presentation/XFramework.Operations.Dashboard/**
+      - src/Infrastructure/XFramework.Integration/**
+      - src/Kernel/XFramework.Core/**
+      - src/Modules/XFramework.Bolt/Bolt.Domain.Shared/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-xeon-dev-service.yml
+    with:
+      service: operations-dashboard
+      health_url: http://localhost:5050/health/ready
+      diagnostics_services: bolt-hub seq jaeger operations-dashboard

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -86,6 +86,7 @@ jobs:
             "wallets=http://localhost:9696/health/ready"
             "inventario=http://localhost:8105/health/ready"
             "controlpanel=http://localhost:5000/health/ready"
+            "operations-dashboard=http://localhost:5050/health/ready"
           )
 
           for check in "${checks[@]}"; do
@@ -118,4 +119,4 @@ jobs:
         shell: bash
         run: |
           docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps || true
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 migrate bolt-hub identityserver messaging notifications smsgateway wallets inventario controlpanel || true
+          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 migrate bolt-hub identityserver messaging notifications smsgateway wallets inventario controlpanel operations-dashboard seq jaeger || true

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,19 +38,19 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
 
     <!-- Microsoft Extensions -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Memory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
 
     <!-- OpenTelemetry Suite -->
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />

--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -66,6 +66,7 @@
     <Project Path="src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj" />
     <Project Path="src\Presentation\Fluid\Fluid.csproj" />
     <Project Path="src\Presentation\Gateway\Gateway.csproj" />
+    <Project Path="src\Presentation\XFramework.Operations.Dashboard\XFramework.Operations.Dashboard.csproj" />
   </Folder>
   <Folder Name="/Libraries/Bolt/">
     <Project Path="src\Libraries\Bolt\Bolt.Protocol\Bolt.Protocol.csproj" />
@@ -78,6 +79,7 @@
   <Folder Name="/Tests/">
     <Project Path="src\Tests\ControlPanel.E2ETests\ControlPanel.E2ETests.csproj" />
     <Project Path="src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj" />
+    <Project Path="src\Tests\OperationsDashboard.Tests\OperationsDashboard.Tests.csproj" />
     <Project Path="src\Tests\XFramework.Core.Tests\XFramework.Core.Tests.csproj" />
     <Project Path="src\Tests\XFramework.SourceGenerators.Tests\XFramework.SourceGenerators.Tests.csproj" />
     <Project Path="src\Tests\XFramework.TestInfrastructure\XFramework.TestInfrastructure.csproj" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ x-common-env: &common-env
   ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Docker}
   DefaultDatabaseConnection: Host=${DB_HOST:-postgres};Port=${DB_PORT:-5432};Database=${DB_NAME:-XFramework};Username=${DB_USER:-dbAdmin};Password=${DB_PASSWORD:?Set DB_PASSWORD in .env}
   JwtOptions__Secret: ${JWT_SECRET:?Set JWT_SECRET in .env}
+  OpenTelemetry__Sampling__Probability: ${OTEL_SAMPLING_PROBABILITY:-1.0}
+  OpenTelemetry__Exporters__OTLP__Enabled: ${OTEL_OTLP_ENABLED:-true}
+  OpenTelemetry__Exporters__OTLP__Endpoint: ${OTEL_OTLP_ENDPOINT:-http://jaeger:4317}
 
 services:
 
@@ -228,6 +231,40 @@ services:
       start_period: 15s
 
   # ── Seq (structured log aggregator) ──────────────────────────
+  # Operations Dashboard
+  operations-dashboard:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT_PATH: src/Presentation/XFramework.Operations.Dashboard/XFramework.Operations.Dashboard.csproj
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      ASPNETCORE_ENVIRONMENT: ${OPERATIONS_DASHBOARD_ASPNETCORE_ENVIRONMENT:-Docker}
+      BoltConfiguration__ClientName: OperationsDashboard
+      BoltConfiguration__ServerUrls__0: ws://bolt-hub:8080/bolt/ws
+      BoltConfiguration__RpcTimeoutSeconds: 30
+      Seq__Url: http://seq:80
+      Jaeger__QueryUrl: http://jaeger:16686
+      OpenTelemetry__Sampling__Probability: ${OTEL_SAMPLING_PROBABILITY:-1.0}
+      OpenTelemetry__Exporters__OTLP__Enabled: ${OTEL_OTLP_ENABLED:-true}
+      OpenTelemetry__Exporters__OTLP__Endpoint: ${OTEL_OTLP_ENDPOINT:-http://jaeger:4317}
+    ports:
+      - "${OPERATIONS_DASHBOARD_EXPOSE_PORT:-5050}:8080"
+    depends_on:
+      bolt-hub:
+        condition: service_healthy
+      seq:
+        condition: service_started
+      jaeger:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 15s
+
   seq:
     image: datalust/seq:2025
     environment:
@@ -236,6 +273,16 @@ services:
       - "${SEQ_EXPOSE_PORT:-5341}:80"
     volumes:
       - seqdata:/data
+
+  # Jaeger (OpenTelemetry trace backend for dev)
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "${JAEGER_EXPOSE_PORT:-16686}:16686"
+      - "${JAEGER_OTLP_GRPC_EXPOSE_PORT:-4317}:4317"
+      - "${JAEGER_OTLP_HTTP_EXPOSE_PORT:-4318}:4318"
 
 volumes:
   pgdata:

--- a/src/Infrastructure/XFramework.Integration/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/XFramework.Integration/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Bolt.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using XFramework.Domain.Shared.BusinessObjects;
@@ -11,6 +12,7 @@ using XFramework.Integration.Abstractions;
 using XFramework.Integration.Abstractions.Wrappers;
 using XFramework.Integration.DataContext;
 using XFramework.Integration.Drivers;
+using XFramework.Integration.ServiceDiscovery;
 
 namespace XFramework.Integration.Extensions;
 
@@ -30,6 +32,8 @@ public static class ServiceCollectionExtensions
         bool autoConnect = true)
     {
         services.Configure<BoltConfiguration>(configuration.GetSection("BoltConfiguration"));
+        services.Configure<BoltServiceDiscoveryOptions>(
+            configuration.GetSection(BoltServiceDiscoveryOptions.SectionName));
 
         var boltConfig = configuration.GetSection("BoltConfiguration").Get<BoltConfiguration>()
             ?? throw new InvalidOperationException("BoltConfiguration section is missing or empty in configuration.");
@@ -60,8 +64,17 @@ public static class ServiceCollectionExtensions
                 builder.DisableAutoConnect();
         });
 
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBoltServiceManifestProvider, ConfigurationBoltServiceManifestProvider>());
+        services.AddHostedService<BoltServiceManifestAdvertisementHostedService>();
         services.AddSingleton<IMessageBusWrapper, BoltDriver>();
 
+        return services;
+    }
+
+    public static IServiceCollection AddBoltServiceManifestProvider<TProvider>(this IServiceCollection services)
+        where TProvider : class, IBoltServiceManifestProvider
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBoltServiceManifestProvider, TProvider>());
         return services;
     }
 

--- a/src/Infrastructure/XFramework.Integration/ServiceDiscovery/BoltServiceDiscoveryOptions.cs
+++ b/src/Infrastructure/XFramework.Integration/ServiceDiscovery/BoltServiceDiscoveryOptions.cs
@@ -1,0 +1,8 @@
+namespace XFramework.Integration.ServiceDiscovery;
+
+public sealed class BoltServiceDiscoveryOptions
+{
+    public const string SectionName = "BoltServiceDiscovery";
+
+    public int ManifestRefreshSeconds { get; set; } = 30;
+}

--- a/src/Infrastructure/XFramework.Integration/ServiceDiscovery/BoltServiceManifestAdvertisementHostedService.cs
+++ b/src/Infrastructure/XFramework.Integration/ServiceDiscovery/BoltServiceManifestAdvertisementHostedService.cs
@@ -1,0 +1,104 @@
+using Bolt.Client;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace XFramework.Integration.ServiceDiscovery;
+
+public sealed class BoltServiceManifestAdvertisementHostedService(
+    BoltClient client,
+    IEnumerable<IBoltServiceManifestProvider> manifestProviders,
+    IOptions<BoltServiceDiscoveryOptions> options,
+    ILogger<BoltServiceManifestAdvertisementHostedService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var refreshSeconds = Math.Max(5, options.Value.ManifestRefreshSeconds);
+        var refreshInterval = TimeSpan.FromSeconds(refreshSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await WaitForConnectionAsync(stoppingToken);
+
+            if (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await AdvertiseAsync(stoppingToken);
+            await Task.Delay(refreshInterval, stoppingToken);
+        }
+    }
+
+    private async Task WaitForConnectionAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested && !client.IsConnected)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(500), ct);
+        }
+    }
+
+    private async Task AdvertiseAsync(CancellationToken ct)
+    {
+        try
+        {
+            var manifest = await BuildManifestAsync(ct);
+            if (manifest is null)
+            {
+                return;
+            }
+
+            var response = await client.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+                string.Empty,
+                BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+                manifest,
+                ct);
+
+            if (response is { Accepted: false })
+            {
+                logger.LogWarning("Bolt service manifest rejected: {Message}", response.Message);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Not connected", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug("Skipping Bolt service manifest advertisement while disconnected");
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to advertise Bolt service manifest");
+        }
+    }
+
+    private async ValueTask<BoltServiceManifest?> BuildManifestAsync(CancellationToken ct)
+    {
+        BoltServiceManifest? merged = null;
+
+        foreach (var provider in manifestProviders)
+        {
+            var manifest = await provider.GetManifestAsync(ct);
+            if (manifest is null)
+            {
+                continue;
+            }
+
+            if (merged is null)
+            {
+                merged = manifest;
+                continue;
+            }
+
+            merged.Modules.AddRange(manifest.Modules);
+            merged.Dependencies.AddRange(manifest.Dependencies);
+            foreach (var (key, value) in manifest.Metadata)
+            {
+                merged.Metadata.TryAdd(key, value);
+            }
+        }
+
+        return merged;
+    }
+}

--- a/src/Infrastructure/XFramework.Integration/ServiceDiscovery/ConfigurationBoltServiceManifestProvider.cs
+++ b/src/Infrastructure/XFramework.Integration/ServiceDiscovery/ConfigurationBoltServiceManifestProvider.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using XFramework.Domain.Shared.Configurations;
+
+namespace XFramework.Integration.ServiceDiscovery;
+
+public sealed class ConfigurationBoltServiceManifestProvider(
+    IConfiguration configuration,
+    IOptions<BoltConfiguration> boltConfiguration) : IBoltServiceManifestProvider
+{
+    public const string SectionName = "XFrameworkServiceManifest";
+
+    public ValueTask<BoltServiceManifest?> GetManifestAsync(CancellationToken ct = default)
+    {
+        var manifest = configuration.GetSection(SectionName).Get<BoltServiceManifest>()
+            ?? new BoltServiceManifest();
+
+        var clientName = boltConfiguration.Value.ClientName ?? "unknown";
+        if (string.IsNullOrWhiteSpace(manifest.ServiceName))
+        {
+            manifest.ServiceName = clientName;
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.DisplayName))
+        {
+            manifest.DisplayName = manifest.ServiceName;
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Version))
+        {
+            manifest.Version = Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+        }
+
+        manifest.Modules ??= [];
+        manifest.Dependencies ??= [];
+        manifest.Metadata ??= [];
+
+        return ValueTask.FromResult<BoltServiceManifest?>(manifest);
+    }
+}

--- a/src/Infrastructure/XFramework.Integration/ServiceDiscovery/IBoltServiceManifestProvider.cs
+++ b/src/Infrastructure/XFramework.Integration/ServiceDiscovery/IBoltServiceManifestProvider.cs
@@ -1,0 +1,8 @@
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+namespace XFramework.Integration.ServiceDiscovery;
+
+public interface IBoltServiceManifestProvider
+{
+    ValueTask<BoltServiceManifest?> GetManifestAsync(CancellationToken ct = default);
+}

--- a/src/Kernel/XFramework.Core/Extensions/TenantModuleFeatureExtensions.cs
+++ b/src/Kernel/XFramework.Core/Extensions/TenantModuleFeatureExtensions.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using XFramework.Core.Middlewares;
 using XFramework.Core.Services.FeatureGates;
@@ -11,6 +12,19 @@ public static class TenantModuleFeatureExtensions
     public static IServiceCollection AddTenantModuleFeatures(this IServiceCollection services)
     {
         RuntimeHelpers.RunClassConstructor(typeof(TenantModuleFeature).TypeHandle);
+        services.AddTenantModuleFeatureDefinitions();
+        services.AddMemoryCache();
+        services.TryAddScoped<ITenantModuleFeatureService, TenantModuleFeatureService>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddTenantModuleFeatures(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        RuntimeHelpers.RunClassConstructor(typeof(TenantModuleFeature).TypeHandle);
+        services.AddTenantModuleFeatureDefinitions(configuration);
         services.AddMemoryCache();
         services.TryAddScoped<ITenantModuleFeatureService, TenantModuleFeatureService>();
 

--- a/src/Kernel/XFramework.Domain/Migrations/20260619090000_AddBoltServiceDiscoveryManifests.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619090000_AddBoltServiceDiscoveryManifests.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260619090000_AddBoltServiceDiscoveryManifests")]
+    public partial class AddBoltServiceDiscoveryManifests : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(name: "Bolt");
+
+            migrationBuilder.CreateTable(
+                name: "ServiceManifest",
+                schema: "Bolt",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ClientId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    ClientName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    ServiceName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Version = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    IsConnected = table.Column<bool>(type: "boolean", nullable: false),
+                    ConnectionCount = table.Column<int>(type: "integer", nullable: false),
+                    LastSeenAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastConnectedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastDisconnectedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ManifestHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ManifestJson = table.Column<string>(type: "jsonb", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("boltservicemanifest_pk", x => x.ID);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceManifest_ClientId",
+                schema: "Bolt",
+                table: "ServiceManifest",
+                column: "ClientId",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ServiceManifest",
+                schema: "Bolt");
+        }
+    }
+}

--- a/src/Kernel/XFramework.Domain/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/AppDbContextModelSnapshot.cs
@@ -23,6 +23,82 @@ namespace XFramework.Domain.Migrations
             NpgsqlModelBuilderExtensions.HasPostgresExtension(modelBuilder, "uuid-ossp");
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
+            modelBuilder.Entity("Bolt.Domain.Shared.Contracts.ServiceDiscovery.BoltServiceManifestRecord", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("ID")
+                        .HasDefaultValueSql("(uuid_generate_v4())");
+
+                    b.Property<string>("ClientId")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("ClientName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying");
+
+                    b.Property<int>("ConnectionCount")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<string>("DisplayName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying");
+
+                    b.Property<bool>("IsConnected")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime?>("LastConnectedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime?>("LastDisconnectedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime>("LastSeenAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("ManifestHash")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("ManifestJson")
+                        .IsRequired()
+                        .HasColumnType("jsonb");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<string>("ServiceName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("Version")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying");
+
+                    b.HasKey("Id")
+                        .HasName("boltservicemanifest_pk");
+
+                    b.HasIndex("ClientId")
+                        .IsUnique()
+                        .HasDatabaseName("IX_ServiceManifest_ClientId");
+
+                    b.ToTable("ServiceManifest", "Bolt");
+                });
+
             modelBuilder.Entity("Community.Domain.Shared.Contracts.CommunityConnection", b =>
                 {
                     b.Property<Guid>("Id")

--- a/src/Libraries/Bolt/Bolt.Server/BoltServer.cs
+++ b/src/Libraries/Bolt/Bolt.Server/BoltServer.cs
@@ -37,6 +37,7 @@ public sealed class BoltServer : IDisposable
 
     // Direct handlers — when registered, server handles requests locally instead of routing
     private readonly ConcurrentDictionary<int, Func<ReadOnlyMemory<byte>, Guid, Task<(HttpStatusCode, ReadOnlyMemory<byte>)>>> _localHandlers = new();
+    private readonly ConcurrentDictionary<int, Func<BoltRequestContext, ReadOnlyMemory<byte>, Guid, Task<(HttpStatusCode, ReadOnlyMemory<byte>)>>> _contextLocalHandlers = new();
 
     // Media processor tap: registered processors receive copies of media frames on a background thread
     private readonly List<IMediaProcessor> _mediaProcessors = new();
@@ -113,6 +114,22 @@ public sealed class BoltServer : IDisposable
         _localHandlers[hash] = handler;
     }
 
+    /// <summary>
+    /// Register a local handler that receives sender connection context.
+    /// This is for hub-local infrastructure commands such as service discovery.
+    /// </summary>
+    public void RegisterHandler(
+        string commandName,
+        Func<BoltRequestContext, ReadOnlyMemory<byte>, Guid, Task<(HttpStatusCode, ReadOnlyMemory<byte>)>> handler)
+    {
+        var hash = BoltCodec.Fnv1aHash(commandName);
+        _contextLocalHandlers[hash] = handler;
+    }
+
+    public event Func<BoltClientConnectionEvent, CancellationToken, Task>? ClientRegistered;
+
+    public event Func<BoltClientConnectionEvent, CancellationToken, Task>? ClientDisconnected;
+
     public async Task HandleConnectionAsync(IBoltConnection transport, CancellationToken ct)
     {
         var connection = new BoltHubConnection(transport);
@@ -179,7 +196,7 @@ public sealed class BoltServer : IDisposable
             connection.CompleteSendChannel();
             ArrayPool<byte>.Shared.Return(receiveBuffer);
             if (largeBuffer != null) ArrayPool<byte>.Shared.Return(largeBuffer);
-            RemoveConnection(connection);
+            await RemoveConnectionAsync(connection);
 
             try { await transport.CloseAsync(); }
             catch { }
@@ -276,6 +293,8 @@ public sealed class BoltServer : IDisposable
         var writer = new ArrayBufferWriter<byte>(2);
         BoltCodec.WriteRegisterAck(writer, true);
         await connection.SendAsync(writer.WrittenMemory, ct);
+
+        await NotifyClientRegisteredAsync(connection, ct);
     }
 
     private async Task HandleRequestAsync(BoltHubConnection caller, byte[] buffer, int length, CancellationToken ct)
@@ -283,8 +302,31 @@ public sealed class BoltServer : IDisposable
         var span = buffer.AsSpan(0, length);
 
         // Check for local handler first (direct mode — server handles request itself)
-        if (_localHandlers.Count > 0 && BoltCodec.TryReadRequest(span, out var frame, out var consumed))
+        if ((_contextLocalHandlers.Count > 0 || _localHandlers.Count > 0)
+            && BoltCodec.TryReadRequest(span, out var frame, out var consumed))
         {
+            if (_contextLocalHandlers.TryGetValue(frame.CommandHash, out var contextHandler))
+            {
+                try
+                {
+                    var payload = frame.GetPayload(buffer.AsMemory(0, length));
+                    var context = BoltRequestContext.FromConnection(caller);
+                    var (statusCode, responsePayload) = await contextHandler(context, payload, frame.RequestId);
+
+                    var writer = RentedBufferWriter.GetThreadLocal();
+                    BoltCodec.WriteResponse(writer, frame.RequestId, statusCode, responsePayload.Span);
+                    await caller.SendAsync(writer.WrittenMemory, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Context local handler error for command hash {Hash}", frame.CommandHash);
+                    var errWriter = RentedBufferWriter.GetThreadLocal();
+                    BoltCodec.WriteResponse(errWriter, frame.RequestId, HttpStatusCode.InternalServerError, ReadOnlySpan<byte>.Empty);
+                    await caller.SendAsync(errWriter.WrittenMemory, ct);
+                }
+                return;
+            }
+
             if (_localHandlers.TryGetValue(frame.CommandHash, out var handler))
             {
                 try
@@ -1179,7 +1221,7 @@ public sealed class BoltServer : IDisposable
         return firstAlive;
     }
 
-    private void RemoveConnection(BoltHubConnection connection)
+    private async Task RemoveConnectionAsync(BoltHubConnection connection)
     {
         if (connection.ClientId is not null)
         {
@@ -1195,6 +1237,7 @@ public sealed class BoltServer : IDisposable
             }
 
             _logger.LogInformation("Client disconnected: {ClientId} ({ClientName})", connection.ClientId, connection.ClientName);
+            await NotifyClientDisconnectedAsync(connection, CancellationToken.None);
         }
 
         foreach (var (requestId, pending) in _pendingInvocations)
@@ -1260,6 +1303,46 @@ public sealed class BoltServer : IDisposable
         var keysToRemove = _liveDurableConnections.Where(kvp => kvp.Value == connection).Select(kvp => kvp.Key).ToList();
         foreach (var key in keysToRemove)
             _liveDurableConnections.TryRemove(key, out _);
+    }
+
+    private async Task NotifyClientRegisteredAsync(BoltHubConnection connection, CancellationToken ct)
+    {
+        var handler = ClientRegistered;
+        if (handler is null || connection.ClientId is null)
+            return;
+
+        var connectionEvent = BoltClientConnectionEvent.FromConnection(connection);
+        foreach (Func<BoltClientConnectionEvent, CancellationToken, Task> subscriber in handler.GetInvocationList())
+        {
+            try
+            {
+                await subscriber(connectionEvent, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Client registered subscriber failed for {ClientId}", connection.ClientId);
+            }
+        }
+    }
+
+    private async Task NotifyClientDisconnectedAsync(BoltHubConnection connection, CancellationToken ct)
+    {
+        var handler = ClientDisconnected;
+        if (handler is null || connection.ClientId is null)
+            return;
+
+        var connectionEvent = BoltClientConnectionEvent.FromConnection(connection);
+        foreach (Func<BoltClientConnectionEvent, CancellationToken, Task> subscriber in handler.GetInvocationList())
+        {
+            try
+            {
+                await subscriber(connectionEvent, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Client disconnected subscriber failed for {ClientId}", connection.ClientId);
+            }
+        }
     }
 
     private void CleanupStaleInvocations(object? state)
@@ -1331,6 +1414,40 @@ public sealed class BoltServer : IDisposable
         _cleanupTimer.Dispose();
         _mediaTapCts.Dispose();
     }
+}
+
+public sealed record BoltRequestContext(
+    string ConnectionId,
+    string? ClientId,
+    string? ClientName,
+    int ServiceHash,
+    BoltTransport TransportType)
+{
+    internal static BoltRequestContext FromConnection(BoltHubConnection connection) =>
+        new(
+            connection.StreamId,
+            connection.ClientId,
+            connection.ClientName,
+            connection.ServiceHash,
+            connection.TransportType);
+}
+
+public sealed record BoltClientConnectionEvent(
+    string ConnectionId,
+    string ClientId,
+    string? ClientName,
+    int ServiceHash,
+    BoltTransport TransportType,
+    DateTime OccurredAt)
+{
+    internal static BoltClientConnectionEvent FromConnection(BoltHubConnection connection) =>
+        new(
+            connection.StreamId,
+            connection.ClientId ?? string.Empty,
+            connection.ClientName,
+            connection.ServiceHash,
+            connection.TransportType,
+            DateTime.UtcNow);
 }
 
 /// <summary>

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Bolt.Domain.Shared.csproj
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Bolt.Domain.Shared.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <LangVersion>14</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
         <PackageId>XFramework.Bolt.Domain.Shared</PackageId>
         <Version>$(XFrameworkVersion)</Version>
         <Description>XFramework Bolt domain types - IBoltRequest and RPC contracts.</Description>
@@ -16,5 +17,7 @@
     <ItemGroup>
       <PackageReference Include="MessagePack" />
       <PackageReference Include="MessagePack.Annotations" />
+      <PackageReference Include="MemoryPack" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     </ItemGroup>
 </Project>

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Configurations/BoltServiceManifestRecordConfiguration.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Configurations/BoltServiceManifestRecordConfiguration.cs
@@ -1,0 +1,59 @@
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Bolt.Domain.Shared.Configurations;
+
+public sealed class BoltServiceManifestRecordConfiguration : IEntityTypeConfiguration<BoltServiceManifestRecord>
+{
+    public void Configure(EntityTypeBuilder<BoltServiceManifestRecord> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("boltservicemanifest_pk");
+
+        entity.ToTable("ServiceManifest", "Bolt");
+
+        entity.HasIndex(e => e.ClientId)
+            .IsUnique()
+            .HasDatabaseName("IX_ServiceManifest_ClientId");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+
+        entity.Property(e => e.ClientId)
+            .IsRequired()
+            .HasMaxLength(128)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.ClientName)
+            .IsRequired()
+            .HasMaxLength(200)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.ServiceName)
+            .IsRequired()
+            .HasMaxLength(200)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.DisplayName)
+            .IsRequired()
+            .HasMaxLength(200)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.Version)
+            .HasMaxLength(64)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.ManifestHash)
+            .IsRequired()
+            .HasMaxLength(64)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.ManifestJson)
+            .IsRequired()
+            .HasColumnType("jsonb");
+
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+    }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyKind.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyKind.cs
@@ -1,0 +1,8 @@
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+public enum BoltDependencyKind
+{
+    Service = 0,
+    Module = 1,
+    TenantFeature = 2
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyRequirement.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyRequirement.cs
@@ -1,0 +1,22 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltDependencyRequirement
+{
+    [MemoryPackOrder(0)]
+    public BoltDependencyKind Kind { get; set; }
+
+    [MemoryPackOrder(1)]
+    public string Key { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string? DisplayName { get; set; }
+
+    [MemoryPackOrder(3)]
+    public string? MinVersion { get; set; }
+
+    [MemoryPackOrder(4)]
+    public bool Required { get; set; } = true;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyStatus.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltDependencyStatus.cs
@@ -1,0 +1,19 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltDependencyStatus
+{
+    [MemoryPackOrder(0)]
+    public BoltDependencyRequirement Requirement { get; set; } = new();
+
+    [MemoryPackOrder(1)]
+    public bool IsSatisfied { get; set; }
+
+    [MemoryPackOrder(2)]
+    public string? MatchedKey { get; set; }
+
+    [MemoryPackOrder(3)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleManifest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleManifest.cs
@@ -1,0 +1,28 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltModuleManifest
+{
+    [MemoryPackOrder(0)]
+    public string ModuleKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string? Version { get; set; }
+
+    [MemoryPackOrder(4)]
+    public string IconName { get; set; } = "box";
+
+    [MemoryPackOrder(5)]
+    public List<BoltTenantModuleFeatureManifest> Features { get; set; } = [];
+
+    [MemoryPackOrder(6)]
+    public List<BoltDependencyRequirement> Dependencies { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryItem.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryItem.cs
@@ -1,0 +1,40 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltModuleRegistryItem
+{
+    [MemoryPackOrder(0)]
+    public string ModuleKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string? Version { get; set; }
+
+    [MemoryPackOrder(4)]
+    public string IconName { get; set; } = "box";
+
+    [MemoryPackOrder(5)]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(6)]
+    public string ClientId { get; set; } = string.Empty;
+
+    [MemoryPackOrder(7)]
+    public string ClientName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(8)]
+    public BoltRegistryStatus Status { get; set; }
+
+    [MemoryPackOrder(9)]
+    public List<BoltTenantModuleFeatureRegistryItem> Features { get; set; } = [];
+
+    [MemoryPackOrder(10)]
+    public List<BoltDependencyStatus> DependencyStatuses { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryRequest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryRequest.cs
@@ -1,0 +1,10 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltModuleRegistryRequest
+{
+    [MemoryPackOrder(0)]
+    public bool IncludeOffline { get; set; } = true;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryResponse.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltModuleRegistryResponse.cs
@@ -1,0 +1,10 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltModuleRegistryResponse
+{
+    [MemoryPackOrder(0)]
+    public List<BoltModuleRegistryItem> Modules { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltRegistryStatus.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltRegistryStatus.cs
@@ -1,0 +1,8 @@
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+public enum BoltRegistryStatus
+{
+    Offline = 0,
+    Online = 1,
+    Degraded = 2
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceDiscoveryCommands.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceDiscoveryCommands.cs
@@ -1,0 +1,8 @@
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+public static class BoltServiceDiscoveryCommands
+{
+    public const string AdvertiseServiceManifest = "__xframework.service_manifest.advertise";
+    public const string GetServiceRegistry = "__xframework.service_registry.get";
+    public const string GetModuleRegistry = "__xframework.module_registry.get";
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifest.cs
@@ -1,0 +1,31 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceManifest
+{
+    [MemoryPackOrder(0)]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string? Version { get; set; }
+
+    [MemoryPackOrder(4)]
+    public string? HealthUrl { get; set; }
+
+    [MemoryPackOrder(5)]
+    public List<BoltModuleManifest> Modules { get; set; } = [];
+
+    [MemoryPackOrder(6)]
+    public List<BoltDependencyRequirement> Dependencies { get; set; } = [];
+
+    [MemoryPackOrder(7)]
+    public Dictionary<string, string> Metadata { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifestAdvertisementResponse.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifestAdvertisementResponse.cs
@@ -1,0 +1,13 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceManifestAdvertisementResponse
+{
+    [MemoryPackOrder(0)]
+    public bool Accepted { get; set; }
+
+    [MemoryPackOrder(1)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifestRecord.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceManifestRecord.cs
@@ -1,0 +1,22 @@
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+public sealed class BoltServiceManifestRecord : IAuditable
+{
+    public Guid Id { get; set; }
+    public string ClientId { get; set; } = string.Empty;
+    public string ClientName { get; set; } = string.Empty;
+    public string ServiceName { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string? Version { get; set; }
+    public bool IsConnected { get; set; }
+    public int ConnectionCount { get; set; }
+    public DateTime LastSeenAt { get; set; }
+    public DateTime? LastConnectedAt { get; set; }
+    public DateTime? LastDisconnectedAt { get; set; }
+    public string ManifestHash { get; set; } = string.Empty;
+    public string ManifestJson { get; set; } = "{}";
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ModifiedAt { get; set; }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryItem.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryItem.cs
@@ -1,0 +1,43 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceRegistryItem
+{
+    [MemoryPackOrder(0)]
+    public string ClientId { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string ClientName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(4)]
+    public string? Version { get; set; }
+
+    [MemoryPackOrder(5)]
+    public BoltRegistryStatus Status { get; set; }
+
+    [MemoryPackOrder(6)]
+    public int ConnectionCount { get; set; }
+
+    [MemoryPackOrder(7)]
+    public DateTime LastSeenAt { get; set; }
+
+    [MemoryPackOrder(8)]
+    public DateTime? LastConnectedAt { get; set; }
+
+    [MemoryPackOrder(9)]
+    public DateTime? LastDisconnectedAt { get; set; }
+
+    [MemoryPackOrder(10)]
+    public BoltServiceManifest Manifest { get; set; } = new();
+
+    [MemoryPackOrder(11)]
+    public List<BoltDependencyStatus> DependencyStatuses { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryRequest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryRequest.cs
@@ -1,0 +1,10 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceRegistryRequest
+{
+    [MemoryPackOrder(0)]
+    public bool IncludeOffline { get; set; } = true;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryResponse.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltServiceRegistryResponse.cs
@@ -1,0 +1,10 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltServiceRegistryResponse
+{
+    [MemoryPackOrder(0)]
+    public List<BoltServiceRegistryItem> Services { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltTenantModuleFeatureManifest.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltTenantModuleFeatureManifest.cs
@@ -1,0 +1,31 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltTenantModuleFeatureManifest
+{
+    [MemoryPackOrder(0)]
+    public string? Key { get; set; }
+
+    [MemoryPackOrder(1)]
+    public string ModuleKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string SubFeatureKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(4)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(5)]
+    public string IconName { get; set; } = "box";
+
+    [MemoryPackOrder(6)]
+    public bool DefaultEnabled { get; set; } = true;
+
+    [MemoryPackOrder(7)]
+    public List<BoltDependencyRequirement> Dependencies { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltTenantModuleFeatureRegistryItem.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceDiscovery/BoltTenantModuleFeatureRegistryItem.cs
@@ -1,0 +1,37 @@
+using MemoryPack;
+
+namespace Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+[MemoryPackable]
+public partial class BoltTenantModuleFeatureRegistryItem
+{
+    [MemoryPackOrder(0)]
+    public string Key { get; set; } = string.Empty;
+
+    [MemoryPackOrder(1)]
+    public string ModuleKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(2)]
+    public string SubFeatureKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MemoryPackOrder(4)]
+    public string Description { get; set; } = string.Empty;
+
+    [MemoryPackOrder(5)]
+    public string IconName { get; set; } = "box";
+
+    [MemoryPackOrder(6)]
+    public bool DefaultEnabled { get; set; } = true;
+
+    [MemoryPackOrder(7)]
+    public BoltRegistryStatus Status { get; set; }
+
+    [MemoryPackOrder(8)]
+    public List<BoltDependencyRequirement> Dependencies { get; set; } = [];
+
+    [MemoryPackOrder(9)]
+    public List<BoltDependencyStatus> DependencyStatuses { get; set; } = [];
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Extensions/ApplicationBuilderExtension.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Extensions/ApplicationBuilderExtension.cs
@@ -1,4 +1,6 @@
-﻿using Bolt.Server;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Hub.Services;
+using Bolt.Server;
 
 namespace Bolt.Hub.Extensions;
 
@@ -6,12 +8,26 @@ public static class ApplicationBuilderExtension
 {
     public static IApplicationBuilder UseAppServices(this IApplicationBuilder appBuilder)
     {
-        var app = appBuilder as WebApplication;
+        var app = appBuilder as WebApplication
+            ?? throw new InvalidOperationException("Bolt Hub service mapping requires WebApplication.");
 
         // Bolt thin-protocol WebSocket endpoint
         app.UseWebSockets();
         app.MapBolt("/bolt/ws");
 
-        return app as IApplicationBuilder;
+        if (app.Configuration.GetValue<bool>("BoltServiceDiscovery:ExposeHttpEndpoints"))
+        {
+            app.MapGet("/api/bolt/services", async (
+                    IBoltServiceDiscoveryRegistry registry,
+                    CancellationToken ct) =>
+                Results.Ok(await registry.GetServicesAsync(new BoltServiceRegistryRequest(), ct)));
+
+            app.MapGet("/api/bolt/modules", async (
+                    IBoltServiceDiscoveryRegistry registry,
+                    CancellationToken ct) =>
+                Results.Ok(await registry.GetModulesAsync(new BoltModuleRegistryRequest(), ct)));
+        }
+
+        return app;
     }
 }

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/BoltInstaller.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/BoltInstaller.cs
@@ -1,3 +1,4 @@
+using Bolt.Hub.Services;
 using Bolt.Server;
 using Microsoft.AspNetCore.ResponseCompression;
 using XFramework.Domain.Shared.Configurations;
@@ -19,6 +20,9 @@ public sealed class BoltInstaller : IInstaller
 
         // Bolt thin protocol server
         services.AddBoltServer();
+        services.AddSingleton<IBoltServicePresenceTracker, BoltServicePresenceTracker>();
+        services.AddScoped<IBoltServiceDiscoveryRegistry, BoltServiceDiscoveryRegistry>();
+        services.AddHostedService<BoltServiceDiscoveryHostedService>();
 
         // Durable queue store (Redis if configured, in-memory fallback)
         services.Configure<Bolt.Server.Durable.DurableQueueOptions>(configuration.GetSection("BoltConfiguration:Durable"));

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServiceDiscoveryHostedService.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServiceDiscoveryHostedService.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Server;
+using MemoryPack;
+
+namespace Bolt.Hub.Services;
+
+public sealed class BoltServiceDiscoveryHostedService(
+    BoltServer server,
+    IServiceScopeFactory scopeFactory,
+    ILogger<BoltServiceDiscoveryHostedService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+            await registry.ResetPresenceAsync(cancellationToken);
+        }
+
+        server.RegisterHandler(
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            HandleAdvertiseServiceManifestAsync);
+        server.RegisterHandler(
+            BoltServiceDiscoveryCommands.GetServiceRegistry,
+            HandleGetServiceRegistryAsync);
+        server.RegisterHandler(
+            BoltServiceDiscoveryCommands.GetModuleRegistry,
+            HandleGetModuleRegistryAsync);
+
+        server.ClientRegistered += HandleClientRegisteredAsync;
+        server.ClientDisconnected += HandleClientDisconnectedAsync;
+
+        logger.LogInformation("Bolt service discovery registry handlers registered");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        server.ClientRegistered -= HandleClientRegisteredAsync;
+        server.ClientDisconnected -= HandleClientDisconnectedAsync;
+        return Task.CompletedTask;
+    }
+
+    private async Task<(HttpStatusCode, ReadOnlyMemory<byte>)> HandleAdvertiseServiceManifestAsync(
+        BoltRequestContext context,
+        ReadOnlyMemory<byte> payload,
+        Guid requestId)
+    {
+        var manifest = MemoryPackSerializer.Deserialize<BoltServiceManifest>(payload.Span);
+        if (manifest is null)
+        {
+            return Serialize(HttpStatusCode.BadRequest, new BoltServiceManifestAdvertisementResponse
+            {
+                Accepted = false,
+                Message = "Manifest payload is required."
+            });
+        }
+
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        var response = await registry.AdvertiseAsync(context, manifest, CancellationToken.None);
+
+        return Serialize(response.Accepted ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response);
+    }
+
+    private async Task<(HttpStatusCode, ReadOnlyMemory<byte>)> HandleGetServiceRegistryAsync(
+        BoltRequestContext context,
+        ReadOnlyMemory<byte> payload,
+        Guid requestId)
+    {
+        var request = payload.IsEmpty
+            ? new BoltServiceRegistryRequest()
+            : MemoryPackSerializer.Deserialize<BoltServiceRegistryRequest>(payload.Span) ?? new BoltServiceRegistryRequest();
+
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        var response = await registry.GetServicesAsync(request, CancellationToken.None);
+
+        return Serialize(HttpStatusCode.OK, response);
+    }
+
+    private async Task<(HttpStatusCode, ReadOnlyMemory<byte>)> HandleGetModuleRegistryAsync(
+        BoltRequestContext context,
+        ReadOnlyMemory<byte> payload,
+        Guid requestId)
+    {
+        var request = payload.IsEmpty
+            ? new BoltModuleRegistryRequest()
+            : MemoryPackSerializer.Deserialize<BoltModuleRegistryRequest>(payload.Span) ?? new BoltModuleRegistryRequest();
+
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        var response = await registry.GetModulesAsync(request, CancellationToken.None);
+
+        return Serialize(HttpStatusCode.OK, response);
+    }
+
+    private async Task HandleClientRegisteredAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        await registry.MarkConnectedAsync(connectionEvent, ct);
+    }
+
+    private async Task HandleClientDisconnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+        await registry.MarkDisconnectedAsync(connectionEvent, ct);
+    }
+
+    private static (HttpStatusCode, ReadOnlyMemory<byte>) Serialize<T>(HttpStatusCode statusCode, T response) =>
+        (statusCode, MemoryPackSerializer.Serialize(response));
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServiceDiscoveryRegistry.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServiceDiscoveryRegistry.cs
@@ -1,0 +1,526 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Server;
+using Microsoft.EntityFrameworkCore;
+
+namespace Bolt.Hub.Services;
+
+public sealed class BoltServiceDiscoveryRegistry(
+    DbContext db,
+    IBoltServicePresenceTracker presenceTracker) : IBoltServiceDiscoveryRegistry
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task ResetPresenceAsync(CancellationToken ct)
+    {
+        presenceTracker.Clear();
+
+        var now = DateTime.UtcNow;
+        var records = await db.Set<BoltServiceManifestRecord>()
+            .AsTracking()
+            .Where(record => record.IsConnected || record.ConnectionCount > 0)
+            .ToListAsync(ct);
+
+        foreach (var record in records)
+        {
+            record.IsConnected = false;
+            record.ConnectionCount = 0;
+            record.LastSeenAt = now;
+            record.LastDisconnectedAt = now;
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<BoltServiceManifestAdvertisementResponse> AdvertiseAsync(
+        BoltRequestContext context,
+        BoltServiceManifest manifest,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(context.ClientId))
+        {
+            return new BoltServiceManifestAdvertisementResponse
+            {
+                Accepted = false,
+                Message = "Registered Bolt client id is required before advertising a manifest."
+            };
+        }
+
+        return await presenceTracker.UpdateAsync(
+            context.ClientId,
+            async connectionIds =>
+            {
+                if (!string.IsNullOrWhiteSpace(context.ConnectionId))
+                {
+                    connectionIds.Add(context.ConnectionId);
+                }
+
+                return await UpsertAdvertisedManifestAsync(
+                    context.ClientId,
+                    context,
+                    manifest,
+                    Math.Max(1, connectionIds.Count),
+                    ct);
+            },
+            ct);
+    }
+
+    private async Task<BoltServiceManifestAdvertisementResponse> UpsertAdvertisedManifestAsync(
+        string clientId,
+        BoltRequestContext context,
+        BoltServiceManifest manifest,
+        int connectionCount,
+        CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var normalized = NormalizeManifest(context, manifest);
+        var manifestJson = JsonSerializer.Serialize(normalized, JsonOptions);
+        var manifestHash = ComputeSha256(manifestJson);
+        var record = await db.Set<BoltServiceManifestRecord>()
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ClientId == clientId, ct);
+
+        if (record is null)
+        {
+            record = new BoltServiceManifestRecord
+            {
+                Id = Guid.NewGuid(),
+                ClientId = clientId,
+                CreatedAt = now
+            };
+            db.Add(record);
+        }
+
+        record.ClientName = context.ClientName ?? clientId;
+        record.ServiceName = normalized.ServiceName;
+        record.DisplayName = normalized.DisplayName;
+        record.Version = normalized.Version;
+        record.IsConnected = true;
+        record.ConnectionCount = connectionCount;
+        record.LastSeenAt = now;
+        record.LastConnectedAt ??= now;
+
+        if (!string.Equals(record.ManifestHash, manifestHash, StringComparison.Ordinal))
+        {
+            record.ManifestHash = manifestHash;
+            record.ManifestJson = manifestJson;
+        }
+
+        await db.SaveChangesAsync(ct);
+        return new BoltServiceManifestAdvertisementResponse { Accepted = true, Message = "Accepted" };
+    }
+
+    public async Task MarkConnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(connectionEvent.ClientId))
+        {
+            return;
+        }
+
+        await presenceTracker.UpdateAsync(
+            connectionEvent.ClientId,
+            async connectionIds =>
+            {
+                connectionIds.Add(connectionEvent.ConnectionId);
+                await UpsertConnectedRecordAsync(connectionEvent, connectionIds.Count, ct);
+                return true;
+            },
+            ct);
+    }
+
+    public async Task MarkDisconnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(connectionEvent.ClientId))
+        {
+            return;
+        }
+
+        await presenceTracker.UpdateAsync(
+            connectionEvent.ClientId,
+            async connectionIds =>
+            {
+                connectionIds.Remove(connectionEvent.ConnectionId);
+                await MarkDisconnectedRecordAsync(connectionEvent, connectionIds.Count, ct);
+                return true;
+            },
+            ct);
+    }
+
+    private async Task UpsertConnectedRecordAsync(
+        BoltClientConnectionEvent connectionEvent,
+        int connectionCount,
+        CancellationToken ct)
+    {
+        var now = connectionEvent.OccurredAt == default ? DateTime.UtcNow : connectionEvent.OccurredAt;
+        var record = await db.Set<BoltServiceManifestRecord>()
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ClientId == connectionEvent.ClientId, ct);
+
+        if (record is null)
+        {
+            var manifest = NormalizeManifest(
+                new BoltRequestContext(
+                    connectionEvent.ConnectionId,
+                    connectionEvent.ClientId,
+                    connectionEvent.ClientName,
+                    connectionEvent.ServiceHash,
+                    connectionEvent.TransportType),
+                new BoltServiceManifest());
+            var manifestJson = JsonSerializer.Serialize(manifest, JsonOptions);
+
+            record = new BoltServiceManifestRecord
+            {
+                Id = Guid.NewGuid(),
+                ClientId = connectionEvent.ClientId,
+                ClientName = connectionEvent.ClientName ?? connectionEvent.ClientId,
+                ServiceName = manifest.ServiceName,
+                DisplayName = manifest.DisplayName,
+                Version = manifest.Version,
+                ManifestJson = manifestJson,
+                ManifestHash = ComputeSha256(manifestJson),
+                CreatedAt = now
+            };
+            db.Add(record);
+        }
+
+        record.ClientName = connectionEvent.ClientName ?? connectionEvent.ClientId;
+        record.IsConnected = true;
+        record.ConnectionCount = Math.Max(1, connectionCount);
+        record.LastSeenAt = now;
+        record.LastConnectedAt = now;
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    private async Task MarkDisconnectedRecordAsync(
+        BoltClientConnectionEvent connectionEvent,
+        int connectionCount,
+        CancellationToken ct)
+    {
+        var record = await db.Set<BoltServiceManifestRecord>()
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ClientId == connectionEvent.ClientId, ct);
+
+        if (record is null)
+        {
+            return;
+        }
+
+        var count = Math.Max(0, connectionCount);
+        record.ConnectionCount = count;
+        record.IsConnected = count > 0;
+        record.LastSeenAt = DateTime.UtcNow;
+        if (count == 0)
+        {
+            record.LastDisconnectedAt = connectionEvent.OccurredAt == default
+                ? DateTime.UtcNow
+                : connectionEvent.OccurredAt;
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<BoltServiceRegistryResponse> GetServicesAsync(
+        BoltServiceRegistryRequest request,
+        CancellationToken ct)
+    {
+        var records = await LoadRecordsAsync(request.IncludeOffline, ct);
+        var items = records
+            .Select(record =>
+            {
+                var manifest = DeserializeManifest(record);
+                var dependencyStatuses = EvaluateDependencies(manifest.Dependencies, records);
+                var status = GetStatus(record, dependencyStatuses);
+
+                return new BoltServiceRegistryItem
+                {
+                    ClientId = record.ClientId,
+                    ClientName = record.ClientName,
+                    ServiceName = record.ServiceName,
+                    DisplayName = record.DisplayName,
+                    Version = record.Version,
+                    Status = status,
+                    ConnectionCount = record.ConnectionCount,
+                    LastSeenAt = record.LastSeenAt,
+                    LastConnectedAt = record.LastConnectedAt,
+                    LastDisconnectedAt = record.LastDisconnectedAt,
+                    Manifest = manifest,
+                    DependencyStatuses = dependencyStatuses
+                };
+            })
+            .OrderBy(item => item.DisplayName)
+            .ThenBy(item => item.ClientId)
+            .ToList();
+
+        return new BoltServiceRegistryResponse { Services = items };
+    }
+
+    public async Task<BoltModuleRegistryResponse> GetModulesAsync(
+        BoltModuleRegistryRequest request,
+        CancellationToken ct)
+    {
+        var records = await LoadRecordsAsync(request.IncludeOffline, ct);
+        var modules = new List<BoltModuleRegistryItem>();
+
+        foreach (var record in records)
+        {
+            var manifest = DeserializeManifest(record);
+            var serviceDependencies = EvaluateDependencies(manifest.Dependencies, records);
+            var serviceStatus = GetStatus(record, serviceDependencies);
+
+            foreach (var module in manifest.Modules)
+            {
+                var moduleDependencies = serviceDependencies
+                    .Concat(EvaluateDependencies(module.Dependencies, records))
+                    .ToList();
+                var moduleStatus = GetStatus(record, moduleDependencies);
+
+                modules.Add(new BoltModuleRegistryItem
+                {
+                    ModuleKey = module.ModuleKey,
+                    DisplayName = module.DisplayName,
+                    Description = module.Description,
+                    Version = module.Version ?? manifest.Version,
+                    IconName = module.IconName,
+                    ServiceName = manifest.ServiceName,
+                    ClientId = record.ClientId,
+                    ClientName = record.ClientName,
+                    Status = serviceStatus == BoltRegistryStatus.Offline ? serviceStatus : moduleStatus,
+                    DependencyStatuses = moduleDependencies,
+                    Features = module.Features
+                        .Select(feature => CreateFeatureItem(feature, record, records, moduleDependencies))
+                        .ToList()
+                });
+            }
+        }
+
+        return new BoltModuleRegistryResponse
+        {
+            Modules = modules
+                .OrderBy(module => module.DisplayName)
+                .ThenBy(module => module.ModuleKey)
+                .ToList()
+        };
+    }
+
+    private async Task<List<BoltServiceManifestRecord>> LoadRecordsAsync(bool includeOffline, CancellationToken ct) =>
+        await db.Set<BoltServiceManifestRecord>()
+            .AsNoTracking()
+            .Where(record => includeOffline || record.IsConnected)
+            .OrderBy(record => record.ServiceName)
+            .ToListAsync(ct);
+
+    private static BoltTenantModuleFeatureRegistryItem CreateFeatureItem(
+        BoltTenantModuleFeatureManifest feature,
+        BoltServiceManifestRecord owner,
+        IReadOnlyList<BoltServiceManifestRecord> allRecords,
+        IReadOnlyList<BoltDependencyStatus> inheritedDependencies)
+    {
+        var dependencyStatuses = inheritedDependencies
+            .Concat(EvaluateDependencies(feature.Dependencies, allRecords))
+            .ToList();
+
+        return new BoltTenantModuleFeatureRegistryItem
+        {
+            Key = feature.Key ?? CombineKey(feature.ModuleKey, feature.SubFeatureKey),
+            ModuleKey = feature.ModuleKey,
+            SubFeatureKey = feature.SubFeatureKey,
+            DisplayName = feature.DisplayName,
+            Description = feature.Description,
+            IconName = feature.IconName,
+            DefaultEnabled = feature.DefaultEnabled,
+            Dependencies = feature.Dependencies,
+            DependencyStatuses = dependencyStatuses,
+            Status = GetStatus(owner, dependencyStatuses)
+        };
+    }
+
+    private static BoltRegistryStatus GetStatus(
+        BoltServiceManifestRecord record,
+        IReadOnlyCollection<BoltDependencyStatus> dependencyStatuses)
+    {
+        if (!record.IsConnected || record.ConnectionCount <= 0)
+        {
+            return BoltRegistryStatus.Offline;
+        }
+
+        return dependencyStatuses.Any(status => status.Requirement.Required && !status.IsSatisfied)
+            ? BoltRegistryStatus.Degraded
+            : BoltRegistryStatus.Online;
+    }
+
+    private static List<BoltDependencyStatus> EvaluateDependencies(
+        IEnumerable<BoltDependencyRequirement> requirements,
+        IReadOnlyList<BoltServiceManifestRecord> records)
+    {
+        var onlineRecords = records
+            .Where(record => record.IsConnected && record.ConnectionCount > 0)
+            .ToList();
+
+        var serviceKeys = onlineRecords
+            .SelectMany(record => new[] { record.ClientId, record.ClientName, record.ServiceName })
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .Select(NormalizeLookupKey)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var moduleKeys = onlineRecords
+            .SelectMany(record => DeserializeManifest(record).Modules)
+            .Select(module => NormalizeLookupKey(module.ModuleKey))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var featureKeys = onlineRecords
+            .SelectMany(record => DeserializeManifest(record).Modules)
+            .SelectMany(module => module.Features)
+            .Select(feature => NormalizeLookupKey(feature.Key ?? CombineKey(feature.ModuleKey, feature.SubFeatureKey)))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return requirements
+            .Select(requirement => EvaluateDependency(requirement, serviceKeys, moduleKeys, featureKeys))
+            .ToList();
+    }
+
+    private static BoltDependencyStatus EvaluateDependency(
+        BoltDependencyRequirement requirement,
+        IReadOnlySet<string> serviceKeys,
+        IReadOnlySet<string> moduleKeys,
+        IReadOnlySet<string> featureKeys)
+    {
+        var key = NormalizeLookupKey(requirement.Key);
+        var satisfied = requirement.Kind switch
+        {
+            BoltDependencyKind.Service => serviceKeys.Contains(key),
+            BoltDependencyKind.Module => moduleKeys.Contains(key),
+            BoltDependencyKind.TenantFeature => featureKeys.Contains(key),
+            _ => false
+        };
+
+        var displayName = string.IsNullOrWhiteSpace(requirement.DisplayName)
+            ? requirement.Key
+            : requirement.DisplayName;
+
+        return new BoltDependencyStatus
+        {
+            Requirement = requirement,
+            IsSatisfied = satisfied,
+            MatchedKey = satisfied ? requirement.Key : null,
+            Message = satisfied
+                ? $"{displayName} is available."
+                : $"{displayName} is not available."
+        };
+    }
+
+    private static BoltServiceManifest NormalizeManifest(BoltRequestContext context, BoltServiceManifest manifest)
+    {
+        manifest.ServiceName = FirstNonEmpty(manifest.ServiceName, context.ClientName, context.ClientId, "unknown");
+        manifest.DisplayName = FirstNonEmpty(manifest.DisplayName, manifest.ServiceName);
+        manifest.Description ??= string.Empty;
+        manifest.Modules ??= [];
+        manifest.Dependencies ??= [];
+        manifest.Metadata ??= [];
+
+        foreach (var module in manifest.Modules)
+        {
+            module.ModuleKey = NormalizeLookupKey(module.ModuleKey);
+            module.DisplayName = FirstNonEmpty(module.DisplayName, module.ModuleKey);
+            module.Description ??= string.Empty;
+            module.IconName = FirstNonEmpty(module.IconName, "box");
+            module.Features ??= [];
+            module.Dependencies ??= [];
+
+            foreach (var feature in module.Features)
+            {
+                NormalizeFeature(module, feature);
+            }
+        }
+
+        return manifest;
+    }
+
+    private static void NormalizeFeature(BoltModuleManifest module, BoltTenantModuleFeatureManifest feature)
+    {
+        if (string.IsNullOrWhiteSpace(feature.ModuleKey))
+        {
+            feature.ModuleKey = module.ModuleKey;
+        }
+
+        if (!string.IsNullOrWhiteSpace(feature.Key))
+        {
+            var split = SplitCombinedKey(feature.Key);
+            if (string.IsNullOrWhiteSpace(feature.ModuleKey))
+            {
+                feature.ModuleKey = split.ModuleKey;
+            }
+
+            if (string.IsNullOrWhiteSpace(feature.SubFeatureKey))
+            {
+                feature.SubFeatureKey = split.SubFeatureKey;
+            }
+        }
+
+        feature.ModuleKey = NormalizeLookupKey(feature.ModuleKey);
+        feature.SubFeatureKey = NormalizeLookupKey(feature.SubFeatureKey);
+        feature.Key = CombineKey(feature.ModuleKey, feature.SubFeatureKey);
+        feature.DisplayName = FirstNonEmpty(feature.DisplayName, feature.Key);
+        feature.Description ??= string.Empty;
+        feature.IconName = FirstNonEmpty(feature.IconName, module.IconName, "box");
+        feature.Dependencies ??= [];
+    }
+
+    private static BoltServiceManifest DeserializeManifest(BoltServiceManifestRecord record)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<BoltServiceManifest>(record.ManifestJson, JsonOptions)
+                ?? new BoltServiceManifest
+                {
+                    ServiceName = record.ServiceName,
+                    DisplayName = record.DisplayName,
+                    Version = record.Version
+                };
+        }
+        catch (JsonException ex)
+        {
+            return new BoltServiceManifest
+            {
+                ServiceName = record.ServiceName,
+                DisplayName = record.DisplayName,
+                Version = record.Version,
+                Metadata = { ["manifestError"] = ex.Message }
+            };
+        }
+    }
+
+    private static string ComputeSha256(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    private static string FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
+
+    private static string NormalizeLookupKey(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : value.Trim().ToLowerInvariant();
+
+    private static (string ModuleKey, string SubFeatureKey) SplitCombinedKey(string key)
+    {
+        var normalized = NormalizeLookupKey(key);
+        var separatorIndex = normalized.IndexOf('.', StringComparison.Ordinal);
+        return separatorIndex > 0 && separatorIndex < normalized.Length - 1
+            ? (normalized[..separatorIndex], normalized[(separatorIndex + 1)..])
+            : (normalized, string.Empty);
+    }
+
+    private static string CombineKey(string moduleKey, string? subFeatureKey = null)
+    {
+        var normalizedModule = NormalizeLookupKey(moduleKey);
+        var normalizedSubFeature = NormalizeLookupKey(subFeatureKey);
+        return string.IsNullOrWhiteSpace(normalizedSubFeature)
+            ? normalizedModule
+            : $"{normalizedModule}.{normalizedSubFeature}";
+    }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServicePresenceTracker.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/BoltServicePresenceTracker.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+
+namespace Bolt.Hub.Services;
+
+public sealed class BoltServicePresenceTracker : IBoltServicePresenceTracker
+{
+    private readonly ConcurrentDictionary<string, ClientPresenceState> _states =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public async Task<TResult> UpdateAsync<TResult>(
+        string clientId,
+        Func<ISet<string>, Task<TResult>> update,
+        CancellationToken ct = default)
+    {
+        var state = _states.GetOrAdd(clientId, _ => new ClientPresenceState());
+        await state.Gate.WaitAsync(ct);
+        try
+        {
+            return await update(state.ConnectionIds);
+        }
+        finally
+        {
+            state.Gate.Release();
+        }
+    }
+
+    public void Clear() => _states.Clear();
+
+    private sealed class ClientPresenceState
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public HashSet<string> ConnectionIds { get; } = new(StringComparer.Ordinal);
+    }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/IBoltServiceDiscoveryRegistry.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/IBoltServiceDiscoveryRegistry.cs
@@ -1,0 +1,22 @@
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Server;
+
+namespace Bolt.Hub.Services;
+
+public interface IBoltServiceDiscoveryRegistry
+{
+    Task ResetPresenceAsync(CancellationToken ct);
+
+    Task<BoltServiceManifestAdvertisementResponse> AdvertiseAsync(
+        BoltRequestContext context,
+        BoltServiceManifest manifest,
+        CancellationToken ct);
+
+    Task MarkConnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct);
+
+    Task MarkDisconnectedAsync(BoltClientConnectionEvent connectionEvent, CancellationToken ct);
+
+    Task<BoltServiceRegistryResponse> GetServicesAsync(BoltServiceRegistryRequest request, CancellationToken ct);
+
+    Task<BoltModuleRegistryResponse> GetModulesAsync(BoltModuleRegistryRequest request, CancellationToken ct);
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/IBoltServicePresenceTracker.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/IBoltServicePresenceTracker.cs
@@ -1,0 +1,11 @@
+namespace Bolt.Hub.Services;
+
+public interface IBoltServicePresenceTracker
+{
+    Task<TResult> UpdateAsync<TResult>(
+        string clientId,
+        Func<ISet<string>, Task<TResult>> update,
+        CancellationToken ct = default);
+
+    void Clear();
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/BuiltInTenantModuleFeatureDefinitionProvider.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/BuiltInTenantModuleFeatureDefinitionProvider.cs
@@ -1,0 +1,6 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public sealed class BuiltInTenantModuleFeatureDefinitionProvider : ITenantModuleFeatureDefinitionProvider
+{
+    public IReadOnlyList<TenantModuleFeatureDefinition> Definitions => TenantModuleFeatureKeys.All;
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ConfigurationTenantModuleFeatureDefinitionProvider.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ConfigurationTenantModuleFeatureDefinitionProvider.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Configuration;
+
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public sealed class ConfigurationTenantModuleFeatureDefinitionProvider : ITenantModuleFeatureDefinitionProvider
+{
+    public const string SectionName = "TenantModuleFeatures:Definitions";
+
+    public ConfigurationTenantModuleFeatureDefinitionProvider(IConfiguration configuration)
+    {
+        Definitions = BuildDefinitions(configuration.GetSection(SectionName));
+    }
+
+    public IReadOnlyList<TenantModuleFeatureDefinition> Definitions { get; }
+
+    private static IReadOnlyList<TenantModuleFeatureDefinition> BuildDefinitions(IConfigurationSection section)
+    {
+        var definitions = new List<TenantModuleFeatureDefinition>();
+
+        foreach (var child in section.GetChildren())
+        {
+            var moduleKey = child["ModuleKey"] ?? string.Empty;
+            var subFeatureKey = child["SubFeatureKey"] ?? string.Empty;
+            var combinedKey = child["Key"];
+
+            if (string.IsNullOrWhiteSpace(moduleKey) && !string.IsNullOrWhiteSpace(combinedKey))
+            {
+                (moduleKey, subFeatureKey) = TenantModuleFeatureKeys.Normalize(combinedKey);
+            }
+
+            var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+            definitions.Add(new TenantModuleFeatureDefinition(
+                moduleKey,
+                subFeatureKey,
+                string.IsNullOrWhiteSpace(child["DisplayName"]) ? key : child["DisplayName"]!,
+                child["Description"] ?? string.Empty,
+                string.IsNullOrWhiteSpace(child["IconName"]) ? "box" : child["IconName"]!,
+                !bool.TryParse(child["DefaultEnabled"], out var defaultEnabled) || defaultEnabled));
+        }
+
+        return definitions;
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ITenantModuleFeatureCatalog.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ITenantModuleFeatureCatalog.cs
@@ -1,0 +1,8 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public interface ITenantModuleFeatureCatalog
+{
+    IReadOnlyList<TenantModuleFeatureDefinition> All { get; }
+
+    TenantModuleFeatureDefinition? Find(string moduleKey, string? subFeatureKey = null);
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ITenantModuleFeatureDefinitionProvider.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/ITenantModuleFeatureDefinitionProvider.cs
@@ -1,0 +1,6 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public interface ITenantModuleFeatureDefinitionProvider
+{
+    IReadOnlyList<TenantModuleFeatureDefinition> Definitions { get; }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureCatalog.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureCatalog.cs
@@ -1,0 +1,61 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public sealed class TenantModuleFeatureCatalog : ITenantModuleFeatureCatalog
+{
+    private readonly IReadOnlyList<TenantModuleFeatureDefinition> _definitions;
+
+    public TenantModuleFeatureCatalog(IEnumerable<ITenantModuleFeatureDefinitionProvider> providers)
+    {
+        _definitions = BuildDefinitions(providers);
+    }
+
+    public IReadOnlyList<TenantModuleFeatureDefinition> All => _definitions;
+
+    public TenantModuleFeatureDefinition? Find(string moduleKey, string? subFeatureKey = null)
+    {
+        var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+        return _definitions.FirstOrDefault(definition =>
+            string.Equals(definition.Key, key, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IReadOnlyList<TenantModuleFeatureDefinition> BuildDefinitions(
+        IEnumerable<ITenantModuleFeatureDefinitionProvider> providers)
+    {
+        var definitions = new List<TenantModuleFeatureDefinition>();
+        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var provider in providers)
+        {
+            foreach (var definition in provider.Definitions)
+            {
+                var normalizedDefinition = NormalizeDefinition(provider, definition);
+                if (keys.Add(normalizedDefinition.Key))
+                {
+                    definitions.Add(normalizedDefinition);
+                }
+            }
+        }
+
+        return definitions;
+    }
+
+    private static TenantModuleFeatureDefinition NormalizeDefinition(
+        ITenantModuleFeatureDefinitionProvider provider,
+        TenantModuleFeatureDefinition definition)
+    {
+        var (moduleKey, subFeatureKey) =
+            TenantModuleFeatureKeys.Normalize(definition.ModuleKey, definition.SubFeatureKey);
+
+        if (string.IsNullOrWhiteSpace(moduleKey))
+        {
+            throw new InvalidOperationException(
+                $"{provider.GetType().FullName} returned a tenant module feature definition with an empty module key.");
+        }
+
+        return definition with
+        {
+            ModuleKey = moduleKey,
+            SubFeatureKey = subFeatureKey
+        };
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureDefinitionServiceCollectionExtensions.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureDefinitionServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public static class TenantModuleFeatureDefinitionServiceCollectionExtensions
+{
+    public static IServiceCollection AddTenantModuleFeatureDefinitions(this IServiceCollection services)
+    {
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ITenantModuleFeatureDefinitionProvider, BuiltInTenantModuleFeatureDefinitionProvider>());
+        services.TryAddSingleton<ITenantModuleFeatureCatalog, TenantModuleFeatureCatalog>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddTenantModuleFeatureDefinitions(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddTenantModuleFeatureDefinitions();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ITenantModuleFeatureDefinitionProvider>(
+            new ConfigurationTenantModuleFeatureDefinitionProvider(configuration)));
+
+        return services;
+    }
+
+    public static IServiceCollection AddTenantModuleFeatureDefinitions(
+        this IServiceCollection services,
+        ITenantModuleFeatureDefinitionProvider provider)
+    {
+        services.AddTenantModuleFeatureDefinitions();
+        services.AddSingleton(provider);
+
+        return services;
+    }
+
+    public static IServiceCollection AddTenantModuleFeatureDefinitionProvider<TProvider>(
+        this IServiceCollection services)
+        where TProvider : class, ITenantModuleFeatureDefinitionProvider
+    {
+        services.AddTenantModuleFeatureDefinitions();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ITenantModuleFeatureDefinitionProvider, TProvider>());
+
+        return services;
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/IdentityServer.Domain.Shared.csproj
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/IdentityServer.Domain.Shared.csproj
@@ -11,6 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     </ItemGroup>
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -141,6 +141,10 @@ else
                                                     </div>
                                                     <div class="mt-1 text-sm text-muted-foreground">@row.Description</div>
                                                     <div class="mt-2 font-mono text-xs text-muted-foreground">@row.Key</div>
+                                                    @if (!string.IsNullOrWhiteSpace(row.DependencySummary))
+                                                    {
+                                                        <div class="mt-2 text-xs text-amber-600 dark:text-amber-400">@row.DependencySummary</div>
+                                                    }
                                                 </div>
                                             </div>
                                             <StatusBadge Text="@(row.IsEnabled ? "Enabled" : "Disabled")"
@@ -149,7 +153,7 @@ else
                                         <div class="mt-4 border-t pt-3">
                                             <BbFormFieldSwitch Checked="@row.IsEnabled"
                                                                CheckedChanged="@((bool enabled) => ToggleModuleFeature(row, enabled))"
-                                                               Disabled="@(_savingModuleFeatureIds.Contains(row.Id))"
+                                                               Disabled="@(_savingModuleFeatureIds.Contains(row.Id) || (!row.IsEnabled && row.IsBlocked))"
                                                                Label="Module enabled" />
                                         </div>
                                         @if (IsInventarioRootFeature(row) && _inventarioSubFeatureRows.Count > 0)
@@ -178,6 +182,10 @@ else
                                                                         </div>
                                                                         <div class="mt-1 text-sm text-muted-foreground">@childRow.Description</div>
                                                                         <div class="mt-2 font-mono text-xs text-muted-foreground">@childRow.Key</div>
+                                                                        @if (!string.IsNullOrWhiteSpace(childRow.DependencySummary))
+                                                                        {
+                                                                            <div class="mt-2 text-xs text-amber-600 dark:text-amber-400">@childRow.DependencySummary</div>
+                                                                        }
                                                                     </div>
                                                                 </div>
                                                                 <StatusBadge Text="@(childRow.IsEnabled ? "Enabled" : "Disabled")"
@@ -186,7 +194,7 @@ else
                                                             <div class="mt-3 border-t pt-3">
                                                                 <BbFormFieldSwitch Checked="@childRow.IsEnabled"
                                                                                    CheckedChanged="@((bool enabled) => ToggleModuleFeature(childRow, enabled))"
-                                                                                   Disabled="@(_savingModuleFeatureIds.Contains(childRow.Id))"
+                                                                                   Disabled="@(_savingModuleFeatureIds.Contains(childRow.Id) || (!childRow.IsEnabled && childRow.IsBlocked))"
                                                                                    Label="Feature enabled" />
                                                             </div>
                                                         </div>
@@ -378,6 +386,7 @@ else
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleFeatureDefinitionResolver ModuleFeatureDefinitionResolver { get; set; } = default!;
 
     private Tenant? _tenant;
     private bool _loading;
@@ -570,15 +579,17 @@ else
                     .ToListAsync())
                 .ToList();
 
-            var missingDefinitions = TenantModuleFeatureKeys.All
-                .Where(definition => _detailModuleFeatures.All(feature =>
-                    !string.Equals(feature.Key, definition.Key, StringComparison.OrdinalIgnoreCase)))
+            var resolvedDefinitions = await ModuleFeatureDefinitionResolver.ResolveAsync(_detailModuleFeatures);
+            var missingDefinitions = resolvedDefinitions
+                .Where(resolved => _detailModuleFeatures.All(feature =>
+                    !string.Equals(feature.Key, resolved.Definition.Key, StringComparison.OrdinalIgnoreCase)))
                 .ToList();
 
             if (missingDefinitions.Count > 0)
             {
-                foreach (var definition in missingDefinitions)
+                foreach (var resolved in missingDefinitions)
                 {
+                    var definition = resolved.Definition;
                     DataContext.Add(new TenantModuleFeature
                     {
                         Id = Guid.NewGuid(),
@@ -587,7 +598,7 @@ else
                         SubFeatureKey = definition.SubFeatureKey,
                         DisplayName = definition.DisplayName,
                         Description = definition.Description,
-                        IsEnabled = definition.DefaultEnabled,
+                        IsEnabled = definition.DefaultEnabled && !resolved.IsBlocked,
                         CreatedAt = DateTime.UtcNow
                     });
                 }
@@ -606,11 +617,14 @@ else
                         .ThenBy(x => x.SubFeatureKey)
                         .ToListAsync())
                     .ToList();
+
+                resolvedDefinitions = await ModuleFeatureDefinitionResolver.ResolveAsync(_detailModuleFeatures);
             }
 
-            _moduleFeatureRows = TenantModuleFeatureKeys.All
-                .Select(definition =>
+            _moduleFeatureRows = resolvedDefinitions
+                .Select(resolved =>
                 {
+                    var definition = resolved.Definition;
                     var feature = _detailModuleFeatures.FirstOrDefault(item =>
                         string.Equals(item.Key, definition.Key, StringComparison.OrdinalIgnoreCase));
 
@@ -622,7 +636,10 @@ else
                         feature?.DisplayName ?? definition.DisplayName,
                         feature?.Description ?? definition.Description,
                         definition.IconName,
-                        feature?.IsEnabled ?? false);
+                        feature?.IsEnabled ?? false,
+                        resolved.IsBlocked,
+                        resolved.MissingRequiredDependencies,
+                        resolved.MissingOptionalDependencies);
                 })
                 .ToList();
             ApplyModuleFeatureGrouping();
@@ -650,6 +667,12 @@ else
 
     private async Task ToggleModuleFeature(ModuleFeatureRow row, bool enabled)
     {
+        if (enabled && row.IsBlocked)
+        {
+            ToastService.Show($"Cannot enable {row.DisplayName}: {row.DependencySummary}");
+            return;
+        }
+
         if (row.Id == Guid.Empty)
         {
             ToastService.Show("Module toggle is still initializing. Refresh the page and try again.");
@@ -921,7 +944,10 @@ else
         string displayName,
         string description,
         string icon,
-        bool isEnabled)
+        bool isEnabled,
+        bool isBlocked,
+        IReadOnlyList<string> missingRequiredDependencies,
+        IReadOnlyList<string> missingOptionalDependencies)
     {
         public Guid Id { get; } = id;
         public string Key { get; } = key;
@@ -931,6 +957,13 @@ else
         public string Description { get; } = description;
         public string Icon { get; } = icon;
         public bool IsEnabled { get; set; } = isEnabled;
+        public bool IsBlocked { get; } = isBlocked;
+        public IReadOnlyList<string> MissingRequiredDependencies { get; } = missingRequiredDependencies;
+        public IReadOnlyList<string> MissingOptionalDependencies { get; } = missingOptionalDependencies;
+        public string DependencySummary =>
+            MissingRequiredDependencies.Count > 0
+                ? string.Join(" ", MissingRequiredDependencies)
+                : string.Join(" ", MissingOptionalDependencies);
     }
 
     public void Dispose()

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -5,6 +5,7 @@ using Community.Integration.Drivers;
 using ControlPanel.Server.Extensions;
 using ControlPanel.Server.Health;
 using ControlPanel.Server.Services;
+using IdentityServer.Domain.Shared.Contracts;
 using XFramework.Integration.Extensions;
 using IdentityServer.Integration.Drivers;
 using Inventario.Integration.Drivers;
@@ -70,6 +71,7 @@ builder.Services.AddIdentityServerWrapperServices();
 builder.Services.AddInventarioWrapperServices();
 builder.Services.AddMessagingWrapperServices();
 builder.Services.AddWalletsWrapperServices();
+builder.Services.AddTenantModuleFeatureDefinitions(builder.Configuration);
 
 // IDataContext — universal query layer routed through service wrappers
 builder.Services.AddScoped(sp =>
@@ -103,6 +105,7 @@ builder.Services.AddRemoteDataContext();
 // Tenant filter state (sidebar selection)
 builder.Services.AddScoped<TenantFilterService>();
 builder.Services.AddScoped<TenantModuleNavigationService>();
+builder.Services.AddScoped<TenantModuleFeatureDefinitionResolver>();
 builder.Services.AddScoped<MessagingControlPanelGuard>();
 builder.Services.AddScoped<NavigationHistoryService>();
 builder.Services.AddScoped<CommunityControlPanelAccessService>();

--- a/src/Presentation/ControlPanel.Server/Services/ResolvedTenantModuleFeatureDefinition.cs
+++ b/src/Presentation/ControlPanel.Server/Services/ResolvedTenantModuleFeatureDefinition.cs
@@ -1,0 +1,11 @@
+using IdentityServer.Domain.Shared.Contracts;
+
+namespace ControlPanel.Server.Services;
+
+public sealed record ResolvedTenantModuleFeatureDefinition(
+    TenantModuleFeatureDefinition Definition,
+    IReadOnlyList<string> MissingRequiredDependencies,
+    IReadOnlyList<string> MissingOptionalDependencies)
+{
+    public bool IsBlocked => MissingRequiredDependencies.Count > 0;
+}

--- a/src/Presentation/ControlPanel.Server/Services/TenantModuleFeatureDefinitionResolver.cs
+++ b/src/Presentation/ControlPanel.Server/Services/TenantModuleFeatureDefinitionResolver.cs
@@ -1,0 +1,203 @@
+using Bolt.Client;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using IdentityServer.Domain.Shared.Contracts;
+
+namespace ControlPanel.Server.Services;
+
+public sealed class TenantModuleFeatureDefinitionResolver(
+    ITenantModuleFeatureCatalog localCatalog,
+    BoltClient boltClient,
+    ILogger<TenantModuleFeatureDefinitionResolver> logger)
+{
+    public async Task<IReadOnlyList<ResolvedTenantModuleFeatureDefinition>> ResolveAsync(
+        IReadOnlyCollection<TenantModuleFeature> tenantFeatures,
+        CancellationToken ct = default)
+    {
+        var definitions = new List<ResolvedTenantModuleFeatureDefinition>();
+        var indexes = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var definition in localCatalog.All)
+        {
+            AddDefinition(
+                definitions,
+                indexes,
+                new ResolvedTenantModuleFeatureDefinition(definition, [], []));
+        }
+
+        var discoveredModules = await GetDiscoveredModulesAsync(ct);
+        if (discoveredModules is null)
+        {
+            return definitions;
+        }
+
+        var enabledTenantFeatureKeys = tenantFeatures
+            .Where(feature => feature.IsEnabled && !feature.IsDeleted)
+            .Select(feature => feature.Key)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var module in discoveredModules.Modules)
+        {
+            foreach (var feature in module.Features)
+            {
+                var resolved = CreateResolvedDefinition(module, feature, enabledTenantFeatureKeys);
+                AddDefinition(definitions, indexes, resolved);
+            }
+        }
+
+        return definitions;
+    }
+
+    private async Task<BoltModuleRegistryResponse?> GetDiscoveredModulesAsync(CancellationToken ct)
+    {
+        if (!boltClient.IsConnected)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await boltClient.SendAsync<BoltModuleRegistryRequest, BoltModuleRegistryResponse>(
+                string.Empty,
+                BoltServiceDiscoveryCommands.GetModuleRegistry,
+                new BoltModuleRegistryRequest { IncludeOffline = true },
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to query Bolt module registry");
+            return null;
+        }
+    }
+
+    public static ResolvedTenantModuleFeatureDefinition CreateResolvedDefinition(
+        BoltModuleRegistryItem module,
+        BoltTenantModuleFeatureRegistryItem feature,
+        ISet<string> enabledTenantFeatureKeys)
+    {
+        var (moduleKey, subFeatureKey) = NormalizeFeatureKey(feature.Key, feature.ModuleKey, feature.SubFeatureKey);
+        var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+        var missingRequired = new List<string>();
+        var missingOptional = new List<string>();
+
+        if (feature.Status == BoltRegistryStatus.Offline)
+        {
+            missingRequired.Add($"Service {module.ServiceName} is offline.");
+        }
+
+        foreach (var status in feature.DependencyStatuses)
+        {
+            if (status.Requirement.Kind == BoltDependencyKind.TenantFeature)
+            {
+                continue;
+            }
+
+            if (!status.IsSatisfied)
+            {
+                AddDependencyMessage(status, missingRequired, missingOptional);
+            }
+        }
+
+        foreach (var dependency in feature.Dependencies.Where(x => x.Kind == BoltDependencyKind.TenantFeature))
+        {
+            var dependencyKey = TenantModuleFeatureKeys.Combine(dependency.Key);
+            var isSatisfied = enabledTenantFeatureKeys.Contains(dependencyKey);
+            if (isSatisfied)
+            {
+                continue;
+            }
+
+            var message = $"{GetDependencyDisplayName(dependency)} is not enabled for this tenant.";
+            if (dependency.Required)
+            {
+                missingRequired.Add(message);
+            }
+            else
+            {
+                missingOptional.Add(message);
+            }
+        }
+
+        var isBlocked = missingRequired.Count > 0;
+        var definition = new TenantModuleFeatureDefinition(
+            moduleKey,
+            subFeatureKey,
+            string.IsNullOrWhiteSpace(feature.DisplayName) ? key : feature.DisplayName,
+            feature.Description,
+            string.IsNullOrWhiteSpace(feature.IconName) ? module.IconName : feature.IconName,
+            feature.DefaultEnabled && !isBlocked);
+
+        return new ResolvedTenantModuleFeatureDefinition(definition, missingRequired, missingOptional);
+    }
+
+    private static void AddDependencyMessage(
+        BoltDependencyStatus status,
+        ICollection<string> missingRequired,
+        ICollection<string> missingOptional)
+    {
+        var message = string.IsNullOrWhiteSpace(status.Message)
+            ? $"{GetDependencyDisplayName(status.Requirement)} is not available."
+            : status.Message;
+
+        if (status.Requirement.Required)
+        {
+            missingRequired.Add(message);
+        }
+        else
+        {
+            missingOptional.Add(message);
+        }
+    }
+
+    private static string GetDependencyDisplayName(BoltDependencyRequirement dependency) =>
+        string.IsNullOrWhiteSpace(dependency.DisplayName)
+            ? dependency.Key
+            : dependency.DisplayName;
+
+    private static void AddDefinition(
+        IList<ResolvedTenantModuleFeatureDefinition> definitions,
+        IDictionary<string, int> indexes,
+        ResolvedTenantModuleFeatureDefinition resolved)
+    {
+        if (!indexes.TryGetValue(resolved.Definition.Key, out var index))
+        {
+            indexes[resolved.Definition.Key] = definitions.Count;
+            definitions.Add(resolved);
+            return;
+        }
+
+        definitions[index] = MergeResolvedDefinition(definitions[index], resolved);
+    }
+
+    public static ResolvedTenantModuleFeatureDefinition MergeResolvedDefinition(
+        ResolvedTenantModuleFeatureDefinition existing,
+        ResolvedTenantModuleFeatureDefinition discovered)
+    {
+        var missingRequired = existing.MissingRequiredDependencies
+            .Concat(discovered.MissingRequiredDependencies)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var missingOptional = existing.MissingOptionalDependencies
+            .Concat(discovered.MissingOptionalDependencies)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return existing with
+        {
+            MissingRequiredDependencies = missingRequired,
+            MissingOptionalDependencies = missingOptional
+        };
+    }
+
+    private static (string ModuleKey, string SubFeatureKey) NormalizeFeatureKey(
+        string? key,
+        string moduleKey,
+        string subFeatureKey)
+    {
+        if (!string.IsNullOrWhiteSpace(moduleKey))
+        {
+            return TenantModuleFeatureKeys.Normalize(moduleKey, subFeatureKey);
+        }
+
+        return TenantModuleFeatureKeys.Normalize(key ?? string.Empty);
+    }
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Components/App.razor
+++ b/src/Presentation/XFramework.Operations.Dashboard/Components/App.razor
@@ -1,0 +1,69 @@
+@using Microsoft.AspNetCore.Components.Web
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <link href="_content/BlazorBlueprint.Components/css/themes.css" rel="stylesheet" />
+    <link href="_content/BlazorBlueprint.Components/blazorblueprint.css" rel="stylesheet" />
+    <link href="css/app.css" rel="stylesheet" />
+    <HeadOutlet @rendermode="InteractiveServer" />
+</head>
+<body>
+    <Routes @rendermode="InteractiveServer" />
+
+    <div id="blazor-error-ui" class="dashboard-error-ui">
+        An error has occurred. This application may no longer respond until reloaded.
+        <a href="">Reload</a>
+    </div>
+
+    <script>
+        (() => {
+            if (window.crypto?.randomUUID) {
+                return;
+            }
+
+            const bytesToHex = [];
+            for (let i = 0; i < 256; i += 1) {
+                bytesToHex.push((i + 0x100).toString(16).slice(1));
+            }
+
+            const createUuid = () => {
+                const bytes = new Uint8Array(16);
+                if (window.crypto?.getRandomValues) {
+                    window.crypto.getRandomValues(bytes);
+                } else {
+                    for (let i = 0; i < bytes.length; i += 1) {
+                        bytes[i] = Math.floor(Math.random() * 256);
+                    }
+                }
+
+                bytes[6] = (bytes[6] & 0x0f) | 0x40;
+                bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+                return `${bytesToHex[bytes[0]]}${bytesToHex[bytes[1]]}${bytesToHex[bytes[2]]}${bytesToHex[bytes[3]]}-${bytesToHex[bytes[4]]}${bytesToHex[bytes[5]]}-${bytesToHex[bytes[6]]}${bytesToHex[bytes[7]]}-${bytesToHex[bytes[8]]}${bytesToHex[bytes[9]]}-${bytesToHex[bytes[10]]}${bytesToHex[bytes[11]]}${bytesToHex[bytes[12]]}${bytesToHex[bytes[13]]}${bytesToHex[bytes[14]]}${bytesToHex[bytes[15]]}`;
+            };
+
+            if (!window.crypto) {
+                window.crypto = {};
+            }
+
+            try {
+                Object.defineProperty(window.crypto, "randomUUID", {
+                    value: createUuid,
+                    configurable: true
+                });
+            } catch {
+                window.crypto.randomUUID = createUuid;
+            }
+        })();
+    </script>
+    <script type="module">
+        import * as FloatingUI from 'https://cdn.jsdelivr.net/npm/@@floating-ui/dom@@1.5.3/+esm';
+        window.FloatingUIDOM = FloatingUI;
+    </script>
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>

--- a/src/Presentation/XFramework.Operations.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Presentation/XFramework.Operations.Dashboard/Components/Layout/MainLayout.razor
@@ -1,0 +1,53 @@
+@inherits LayoutComponentBase
+
+<div class="ops-shell">
+    <aside class="ops-sidebar">
+        <div class="ops-brand">
+            <div class="ops-brand-mark">X</div>
+            <div>
+                <div class="ops-brand-title">Operations</div>
+                <div class="ops-brand-subtitle">XFramework</div>
+            </div>
+        </div>
+
+        <nav class="ops-nav" aria-label="Operations navigation">
+            <a class="ops-nav-link active" href="/">
+                <LucideIcon Name="activity" class="ops-nav-icon" />
+                Services
+            </a>
+            <a class="ops-nav-link" href="http://localhost:5341" target="_blank" rel="noreferrer">
+                <LucideIcon Name="scroll-text" class="ops-nav-icon" />
+                Seq
+            </a>
+            <a class="ops-nav-link" href="http://localhost:16686" target="_blank" rel="noreferrer">
+                <LucideIcon Name="waypoints" class="ops-nav-icon" />
+                Jaeger
+            </a>
+        </nav>
+
+        <div class="ops-sidebar-footer">
+            <span>Internal dev</span>
+        </div>
+    </aside>
+
+    <div class="ops-main-shell">
+        <header class="ops-topbar">
+            <div>
+                <h1>XFramework Operations</h1>
+                <p>Service discovery, logs, and trace activity</p>
+            </div>
+            <div class="ops-topbar-actions">
+                <BbDarkModeToggle Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" />
+                <BbThemeSwitcher />
+            </div>
+        </header>
+
+        <main class="ops-main">
+            @Body
+        </main>
+    </div>
+</div>
+
+<BbToastProvider Position="ToastPosition.BottomRight" />
+<BbDialogProvider />
+<BbPortalHost />

--- a/src/Presentation/XFramework.Operations.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Presentation/XFramework.Operations.Dashboard/Components/Pages/Dashboard.razor
@@ -1,0 +1,549 @@
+@page "/"
+@implements IAsyncDisposable
+@using Microsoft.Extensions.Options
+
+<PageTitle>Operations - XFramework</PageTitle>
+
+<div class="dashboard-grid">
+    <section class="summary-grid" aria-label="Service summary">
+        <div class="metric-card">
+            <div class="metric-card-header">
+                <span class="metric-card-label">Services</span>
+                <LucideIcon Name="server" class="metric-card-icon" />
+            </div>
+            <div class="metric-card-value">@_snapshot.Summary.TotalServices</div>
+        </div>
+        <div class="metric-card">
+            <div class="metric-card-header">
+                <span class="metric-card-label">Online</span>
+                <LucideIcon Name="circle-check" class="metric-card-icon" />
+            </div>
+            <div class="metric-card-value">@_snapshot.Summary.OnlineServices</div>
+        </div>
+        <div class="metric-card">
+            <div class="metric-card-header">
+                <span class="metric-card-label">Degraded</span>
+                <LucideIcon Name="triangle-alert" class="metric-card-icon" />
+            </div>
+            <div class="metric-card-value">@_snapshot.Summary.DegradedServices</div>
+        </div>
+        <div class="metric-card">
+            <div class="metric-card-header">
+                <span class="metric-card-label">Offline</span>
+                <LucideIcon Name="circle-off" class="metric-card-icon" />
+            </div>
+            <div class="metric-card-value">@_snapshot.Summary.OfflineServices</div>
+        </div>
+        <div class="metric-card">
+            <div class="metric-card-header">
+                <span class="metric-card-label">Instances</span>
+                <LucideIcon Name="box" class="metric-card-icon" />
+            </div>
+            <div class="metric-card-value">@_snapshot.Summary.ActiveInstances</div>
+        </div>
+    </section>
+
+    @if (_snapshot.Warnings.Count > 0)
+    {
+        <BbAlert Variant="AlertVariant.Warning">
+            <BbAlertTitle>Registry</BbAlertTitle>
+            <BbAlertDescription>@string.Join(" ", _snapshot.Warnings)</BbAlertDescription>
+        </BbAlert>
+    }
+
+    <section class="dashboard-content-grid">
+        <div class="panel">
+            <div class="panel-header">
+                <div>
+                    <div class="panel-title">
+                        <LucideIcon Name="radio-tower" />
+                        Service Registry
+                    </div>
+                    <div class="panel-subtitle">Last updated @FormatRelative(_snapshot.CapturedAt)</div>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="RefreshAsync">
+                    <LucideIcon Name="refresh-cw" class="ops-nav-icon" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            @if (_loading && _snapshot.Services.Count == 0)
+            {
+                <div class="empty-state">
+                    <LucideIcon Name="loader-circle" class="empty-state-icon" />
+                    <h2>Loading services</h2>
+                </div>
+            }
+            else if (_snapshot.Services.Count == 0)
+            {
+                <div class="empty-state">
+                    <LucideIcon Name="unplug" class="empty-state-icon" />
+                    <h2>No services registered</h2>
+                    <p>Bolt Hub has not reported any service manifests yet.</p>
+                </div>
+            }
+            else
+            {
+                <div class="service-table-wrap">
+                    <table class="service-table">
+                        <thead>
+                        <tr>
+                            <th>Service</th>
+                            <th>Status</th>
+                            <th>Instances</th>
+                            <th>Modules</th>
+                            <th>Last Seen</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var service in _snapshot.Services)
+                        {
+                            <tr class="@SelectedRowClass(service)" @key="service.ClientId">
+                                <td>
+                                    <button type="button" class="service-row-button" @onclick="() => SelectServiceAsync(service)">
+                                        <span class="service-name">@service.DisplayName</span>
+                                        <span class="service-meta">@service.ClientName</span>
+                                    </button>
+                                </td>
+                                <td>
+                                    <span class="@StatusPillClass(service.Status)">
+                                        <span class="status-dot"></span>
+                                        @service.Status
+                                    </span>
+                                </td>
+                                <td>@service.ConnectionCount</td>
+                                <td>@service.Modules.Count</td>
+                                <td>@FormatRelative(service.LastSeenAt)</td>
+                            </tr>
+                        }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+
+        <aside class="service-detail">
+            @if (_selectedService is null)
+            {
+                <div class="empty-state">
+                    <LucideIcon Name="mouse-pointer-click" class="empty-state-icon" />
+                    <h2>Select a service</h2>
+                </div>
+            }
+            else
+            {
+                <div class="detail-heading">
+                    <div>
+                        <h2>@_selectedService.DisplayName</h2>
+                        <p>@_selectedService.ServiceName</p>
+                    </div>
+                    <span class="@StatusPillClass(_selectedService.Status)">
+                        <span class="status-dot"></span>
+                        @_selectedService.Status
+                    </span>
+                </div>
+
+                <div class="detail-grid">
+                    <div class="detail-item">
+                        <div class="detail-label">Client</div>
+                        <div class="detail-value">@_selectedService.ClientName</div>
+                    </div>
+                    <div class="detail-item">
+                        <div class="detail-label">Version</div>
+                        <div class="detail-value">@(_selectedService.Version ?? "unknown")</div>
+                    </div>
+                    <div class="detail-item">
+                        <div class="detail-label">Connections</div>
+                        <div class="detail-value">@_selectedService.ConnectionCount</div>
+                    </div>
+                    <div class="detail-item">
+                        <div class="detail-label">Last Connected</div>
+                        <div class="detail-value">@FormatOptionalTime(_selectedService.LastConnectedAt)</div>
+                    </div>
+                </div>
+
+                @if (_selectedService.Dependencies.Count > 0)
+                {
+                    <section>
+                        <div class="panel-title">
+                            <LucideIcon Name="git-branch" />
+                            Dependencies
+                        </div>
+                        <div class="dependency-list">
+                            @foreach (var dependency in _selectedService.Dependencies)
+                            {
+                                <div class="dependency-item" @key="dependency.Key">
+                                    <div class="item-title-row">
+                                        <div class="item-title">@dependency.DisplayName</div>
+                                        <BbBadge Variant="BadgeVariant.Outline">
+                                            @(dependency.IsSatisfied ? "Satisfied" : dependency.Required ? "Required missing" : "Optional missing")
+                                        </BbBadge>
+                                    </div>
+                                    <div class="item-description">@dependency.Kind / @dependency.Key</div>
+                                </div>
+                            }
+                        </div>
+                    </section>
+                }
+
+                <section>
+                    <div class="panel-title">
+                        <LucideIcon Name="blocks" />
+                        Modules
+                    </div>
+                    @if (_selectedService.Modules.Count == 0)
+                    {
+                        <div class="muted">No modules advertised.</div>
+                    }
+                    else
+                    {
+                        <div class="module-list">
+                            @foreach (var module in _selectedService.Modules)
+                            {
+                                <div class="module-item" @key="module.ModuleKey">
+                                    <div class="item-title-row">
+                                        <div class="item-title">@module.DisplayName</div>
+                                        <span class="@StatusPillClass(module.Status)">
+                                            <span class="status-dot"></span>
+                                            @module.Status
+                                        </span>
+                                    </div>
+                                    <div class="item-description">@module.ModuleKey - @module.FeatureCount feature(s)</div>
+                                </div>
+                            }
+                        </div>
+                    }
+                </section>
+            }
+        </aside>
+    </section>
+
+    <section class="dashboard-content-grid">
+        <div class="panel">
+            <div class="panel-header">
+                <div>
+                    <div class="panel-title">
+                        <LucideIcon Name="scroll-text" />
+                        Logs
+                    </div>
+                    <div class="panel-subtitle">@SelectedServiceLabel</div>
+                </div>
+            </div>
+            <div class="panel-body">
+                @if (_selectedService is null)
+                {
+                    <div class="empty-state">
+                        <LucideIcon Name="list" class="empty-state-icon" />
+                        <h2>No service selected</h2>
+                    </div>
+                }
+                else if (!_logs.IsAvailable)
+                {
+                    <div class="degraded-state">
+                        <LucideIcon Name="circle-alert" class="empty-state-icon" />
+                        <h2>Logs unavailable</h2>
+                        <p>@_logs.Message</p>
+                    </div>
+                }
+                else if (_logs.Data.Count == 0)
+                {
+                    <div class="empty-state">
+                        <LucideIcon Name="file-search" class="empty-state-icon" />
+                        <h2>No recent logs</h2>
+                    </div>
+                }
+                else
+                {
+                    <div class="log-list">
+                        @foreach (var log in _logs.Data)
+                        {
+                            <article class="log-item" @key="log.Timestamp.ToUnixTimeMilliseconds() + log.Message">
+                                <div class="item-title-row">
+                                    <div class="item-title">@log.Level</div>
+                                    <div class="muted">@FormatTime(log.Timestamp)</div>
+                                </div>
+                                <div class="log-message">@log.Message</div>
+                                <div class="item-description">@log.SourceContext</div>
+                                @if (log.Properties.Count > 0)
+                                {
+                                    <details class="item-description">
+                                        <summary>Properties</summary>
+                                        @foreach (var property in log.Properties)
+                                        {
+                                            <div><strong>@property.Key:</strong> @property.Value</div>
+                                        }
+                                    </details>
+                                }
+                            </article>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+
+        <div class="panel">
+            <div class="panel-header">
+                <div>
+                    <div class="panel-title">
+                        <LucideIcon Name="waypoints" />
+                        Trace Timeline
+                    </div>
+                    <div class="panel-subtitle">@SelectedServiceLabel</div>
+                </div>
+            </div>
+            <div class="panel-body">
+                @if (_selectedService is null)
+                {
+                    <div class="empty-state">
+                        <LucideIcon Name="workflow" class="empty-state-icon" />
+                        <h2>No service selected</h2>
+                    </div>
+                }
+                else if (!_traces.IsAvailable)
+                {
+                    <div class="degraded-state">
+                        <LucideIcon Name="circle-alert" class="empty-state-icon" />
+                        <h2>Traces unavailable</h2>
+                        <p>@_traces.Message</p>
+                    </div>
+                }
+                else if (_traces.Data.Count == 0)
+                {
+                    <div class="empty-state">
+                        <LucideIcon Name="git-compare-arrows" class="empty-state-icon" />
+                        <h2>No recent traces</h2>
+                    </div>
+                }
+                else
+                {
+                    <div class="trace-list">
+                        @foreach (var trace in _traces.Data)
+                        {
+                            <article class="trace-item" @key="trace.TraceId">
+                                <div class="item-title-row">
+                                    <div class="item-title">@trace.RootOperation</div>
+                                    <BbBadge Variant="@(trace.HasErrors ? BadgeVariant.Destructive : BadgeVariant.Outline)">
+                                        @FormatDuration(trace.Duration)
+                                    </BbBadge>
+                                </div>
+                                <div class="item-description">@trace.ServiceName - @trace.SpanCount span(s) - @FormatTime(trace.StartedAt)</div>
+                                <div class="timeline" aria-label="Trace span timeline">
+                                    @foreach (var span in trace.Spans)
+                                    {
+                                        <span class="@(span.HasError ? "timeline-span error" : "timeline-span")"
+                                              title="@($"{span.ServiceName}: {span.OperationName} ({FormatDuration(span.Duration)})")"
+                                              style="@TraceSpanStyle(trace, span)">
+                                        </span>
+                                    }
+                                </div>
+                            </article>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </section>
+</div>
+
+@code {
+    [Inject] private OperationsRegistryClient RegistryClient { get; set; } = default!;
+    [Inject] private SeqLogClient SeqLogClient { get; set; } = default!;
+    [Inject] private JaegerTraceClient JaegerTraceClient { get; set; } = default!;
+    [Inject] private IOptions<OperationsDashboardOptions> Options { get; set; } = default!;
+    [Inject] private ILogger<Dashboard> Logger { get; set; } = default!;
+
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private CancellationTokenSource? _refreshCts;
+    private Task? _refreshLoop;
+    private DashboardRegistrySnapshot _snapshot = DashboardRegistrySnapshot.EmptyDisconnected("Not loaded.");
+    private ExternalDataResult<IReadOnlyList<DashboardLogEvent>> _logs = ExternalDataResult<IReadOnlyList<DashboardLogEvent>>.Available([]);
+    private ExternalDataResult<IReadOnlyList<DashboardTraceSummary>> _traces = ExternalDataResult<IReadOnlyList<DashboardTraceSummary>>.Available([]);
+    private ServiceInstanceSummary? _selectedService;
+    private string? _selectedClientId;
+    private bool _loading = true;
+
+    private string SelectedServiceLabel => _selectedService?.DisplayName ?? "Select a service";
+
+    protected override async Task OnInitializedAsync()
+    {
+        _refreshCts = new CancellationTokenSource();
+        await RefreshAsync();
+        _refreshLoop = RunRefreshLoopAsync(_refreshCts.Token);
+    }
+
+    private async Task RunRefreshLoopAsync(CancellationToken ct)
+    {
+        using var timer = new PeriodicTimer(Options.Value.RefreshInterval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(ct))
+            {
+                await InvokeAsync(RefreshAsync);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task RefreshAsync()
+    {
+        if (!await _refreshGate.WaitAsync(0))
+        {
+            return;
+        }
+
+        try
+        {
+            _loading = true;
+            var ct = _refreshCts?.Token ?? CancellationToken.None;
+            _snapshot = await RegistryClient.GetSnapshotAsync(ct);
+
+            if (_selectedClientId is null && _snapshot.Services.Count > 0)
+            {
+                _selectedClientId = _snapshot.Services[0].ClientId;
+            }
+
+            _selectedService = _snapshot.Services.FirstOrDefault(x => x.ClientId == _selectedClientId);
+
+            if (_selectedService is not null)
+            {
+                await LoadServiceDetailsAsync(_selectedService, ct);
+            }
+            else
+            {
+                _logs = ExternalDataResult<IReadOnlyList<DashboardLogEvent>>.Available([]);
+                _traces = ExternalDataResult<IReadOnlyList<DashboardTraceSummary>>.Available([]);
+            }
+        }
+        catch (OperationCanceledException) when (_refreshCts?.IsCancellationRequested == true)
+        {
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Operations dashboard refresh failed");
+        }
+        finally
+        {
+            _loading = false;
+            _refreshGate.Release();
+        }
+    }
+
+    private async Task SelectServiceAsync(ServiceInstanceSummary service)
+    {
+        _selectedClientId = service.ClientId;
+        _selectedService = service;
+        await LoadServiceDetailsAsync(service, _refreshCts?.Token ?? CancellationToken.None);
+    }
+
+    private async Task LoadServiceDetailsAsync(ServiceInstanceSummary service, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var lookback = Options.Value.DefaultLookback;
+
+        _logs = await SeqLogClient.GetLogsAsync(
+            new DashboardLogQuery(
+                service.LogApplicationName,
+                service.MachineName,
+                now.Subtract(lookback),
+                now,
+                Options.Value.DefaultLogCount),
+            ct);
+
+        _traces = await JaegerTraceClient.GetTracesAsync(
+            new DashboardTraceQuery(
+                service.LogApplicationName,
+                lookback,
+                Options.Value.DefaultTraceLimit),
+            ct);
+    }
+
+    private string SelectedRowClass(ServiceInstanceSummary service) =>
+        string.Equals(service.ClientId, _selectedClientId, StringComparison.OrdinalIgnoreCase)
+            ? "selected"
+            : "";
+
+    private static string StatusPillClass(string status) =>
+        $"status-pill {OperationsRegistryMapper.StatusCssClass(status)}";
+
+    private static string FormatRelative(DateTimeOffset value)
+    {
+        if (value == DateTimeOffset.MinValue)
+        {
+            return "never";
+        }
+
+        var elapsed = DateTimeOffset.UtcNow - value.ToUniversalTime();
+        if (elapsed.TotalSeconds < 60)
+        {
+            return "just now";
+        }
+
+        if (elapsed.TotalMinutes < 60)
+        {
+            return $"{(int)elapsed.TotalMinutes}m ago";
+        }
+
+        if (elapsed.TotalHours < 24)
+        {
+            return $"{(int)elapsed.TotalHours}h ago";
+        }
+
+        return value.ToLocalTime().ToString("MMM d, HH:mm", CultureInfo.CurrentCulture);
+    }
+
+    private static string FormatOptionalTime(DateTimeOffset? value) =>
+        value is null ? "never" : FormatTime(value.Value);
+
+    private static string FormatTime(DateTimeOffset value) =>
+        value == DateTimeOffset.MinValue
+            ? "unknown"
+            : value.ToLocalTime().ToString("MMM d, HH:mm:ss", CultureInfo.CurrentCulture);
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalMilliseconds < 1000)
+        {
+            return $"{Math.Max(0, duration.TotalMilliseconds):0} ms";
+        }
+
+        if (duration.TotalSeconds < 60)
+        {
+            return $"{duration.TotalSeconds:0.0} s";
+        }
+
+        return $"{duration.TotalMinutes:0.0} m";
+    }
+
+    private static string TraceSpanStyle(DashboardTraceSummary trace, DashboardTraceSpan span)
+    {
+        var total = Math.Max(1, trace.Duration.TotalMilliseconds);
+        var left = Math.Clamp(span.Offset.TotalMilliseconds / total * 100, 0, 99);
+        var width = Math.Clamp(span.Duration.TotalMilliseconds / total * 100, 1, 100 - left);
+        return FormattableString.Invariant($"left:{left:0.##}%;width:{width:0.##}%;");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_refreshCts is not null)
+        {
+            await _refreshCts.CancelAsync();
+        }
+
+        if (_refreshLoop is not null)
+        {
+            try
+            {
+                await _refreshLoop;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        _refreshCts?.Dispose();
+        _refreshGate.Dispose();
+    }
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Components/Routes.razor
+++ b/src/Presentation/XFramework.Operations.Dashboard/Components/Routes.razor
@@ -1,0 +1,15 @@
+<Router AppAssembly="typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(MainLayout)">
+            <div class="empty-state">
+                <LucideIcon Name="circle-alert" class="empty-state-icon" />
+                <h1>Page not found</h1>
+                <p>The requested operations page does not exist.</p>
+            </div>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/Presentation/XFramework.Operations.Dashboard/Components/_Imports.razor
+++ b/src/Presentation/XFramework.Operations.Dashboard/Components/_Imports.razor
@@ -1,0 +1,13 @@
+@using System.Globalization
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.JSInterop
+@using BlazorBlueprint.Components
+@using BlazorBlueprint.Primitives
+@using BlazorBlueprint.Primitives.Services
+@using BlazorBlueprint.Icons.Lucide.Components
+@using XFramework.Operations.Dashboard.Components
+@using XFramework.Operations.Dashboard.Components.Layout
+@using XFramework.Operations.Dashboard.Models
+@using XFramework.Operations.Dashboard.Services

--- a/src/Presentation/XFramework.Operations.Dashboard/GlobalUsings.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using XFramework.Operations.Dashboard.Models;
+global using XFramework.Operations.Dashboard.Services;

--- a/src/Presentation/XFramework.Operations.Dashboard/Health/BoltClientHealthCheck.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Health/BoltClientHealthCheck.cs
@@ -1,0 +1,18 @@
+using Bolt.Client;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace XFramework.Operations.Dashboard.Health;
+
+public sealed class BoltClientHealthCheck(BoltClient client) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var result = client.IsConnected
+            ? HealthCheckResult.Healthy("Operations Dashboard is connected to Bolt.")
+            : HealthCheckResult.Unhealthy("Operations Dashboard is not connected to Bolt.");
+
+        return Task.FromResult(result);
+    }
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardLogEvent.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardLogEvent.cs
@@ -1,0 +1,10 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record DashboardLogEvent(
+    DateTimeOffset Timestamp,
+    string Level,
+    string Message,
+    string? SourceContext,
+    string? Application,
+    string? MachineName,
+    IReadOnlyDictionary<string, string> Properties);

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardLogQuery.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardLogQuery.cs
@@ -1,0 +1,8 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record DashboardLogQuery(
+    string? Application,
+    string? MachineName,
+    DateTimeOffset FromUtc,
+    DateTimeOffset ToUtc,
+    int Count);

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardRegistrySnapshot.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardRegistrySnapshot.cs
@@ -1,0 +1,17 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record DashboardRegistrySnapshot(
+    bool IsConnected,
+    DateTimeOffset CapturedAt,
+    RegistryStatusSummary Summary,
+    IReadOnlyList<ServiceInstanceSummary> Services,
+    IReadOnlyList<string> Warnings)
+{
+    public static DashboardRegistrySnapshot EmptyDisconnected(string warning) =>
+        new(
+            false,
+            DateTimeOffset.UtcNow,
+            new RegistryStatusSummary(0, 0, 0, 0, 0),
+            [],
+            [warning]);
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardTraceQuery.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardTraceQuery.cs
@@ -1,0 +1,6 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record DashboardTraceQuery(
+    string ServiceName,
+    TimeSpan Lookback,
+    int Limit);

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardTraceSpan.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardTraceSpan.cs
@@ -1,0 +1,10 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record DashboardTraceSpan(
+    string SpanId,
+    string OperationName,
+    string ServiceName,
+    DateTimeOffset StartedAt,
+    TimeSpan Duration,
+    TimeSpan Offset,
+    bool HasError);

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardTraceSummary.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/DashboardTraceSummary.cs
@@ -1,0 +1,11 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record DashboardTraceSummary(
+    string TraceId,
+    string RootOperation,
+    string ServiceName,
+    DateTimeOffset StartedAt,
+    TimeSpan Duration,
+    int SpanCount,
+    bool HasErrors,
+    IReadOnlyList<DashboardTraceSpan> Spans);

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/DependencySummary.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/DependencySummary.cs
@@ -1,0 +1,11 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record DependencySummary(
+    string Kind,
+    string Key,
+    string DisplayName,
+    string? MinVersion,
+    bool Required,
+    bool IsSatisfied,
+    string? MatchedKey,
+    string Message);

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/ExternalDataResult.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/ExternalDataResult.cs
@@ -1,0 +1,13 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record ExternalDataResult<T>(
+    bool IsAvailable,
+    T Data,
+    string? Message)
+{
+    public static ExternalDataResult<T> Available(T data, string? message = null) =>
+        new(true, data, message);
+
+    public static ExternalDataResult<T> Unavailable(T data, string message) =>
+        new(false, data, message);
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/OperationsDashboardOptions.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/OperationsDashboardOptions.cs
@@ -1,0 +1,14 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed class OperationsDashboardOptions
+{
+    public const string SectionName = "OperationsDashboard";
+
+    public int RefreshSeconds { get; set; } = 10;
+    public int DefaultLogCount { get; set; } = 50;
+    public int DefaultTraceLimit { get; set; } = 20;
+    public int DefaultLookbackMinutes { get; set; } = 30;
+
+    public TimeSpan RefreshInterval => TimeSpan.FromSeconds(Math.Max(5, RefreshSeconds));
+    public TimeSpan DefaultLookback => TimeSpan.FromMinutes(Math.Max(5, DefaultLookbackMinutes));
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/RegistryStatusSummary.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/RegistryStatusSummary.cs
@@ -1,0 +1,8 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record RegistryStatusSummary(
+    int TotalServices,
+    int OnlineServices,
+    int DegradedServices,
+    int OfflineServices,
+    int ActiveInstances);

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/ServiceInstanceSummary.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/ServiceInstanceSummary.cs
@@ -1,0 +1,23 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record ServiceInstanceSummary(
+    string ClientId,
+    string ClientName,
+    string ServiceName,
+    string DisplayName,
+    string? Version,
+    string? Description,
+    string Status,
+    string StatusCssClass,
+    int ConnectionCount,
+    DateTimeOffset LastSeenAt,
+    DateTimeOffset? LastConnectedAt,
+    DateTimeOffset? LastDisconnectedAt,
+    string? MachineName,
+    IReadOnlyList<ServiceModuleSummary> Modules,
+    IReadOnlyList<DependencySummary> Dependencies)
+{
+    public int MissingRequiredDependencies => Dependencies.Count(x => x is { Required: true, IsSatisfied: false });
+    public bool HasRequiredDependencyFailures => MissingRequiredDependencies > 0;
+    public string LogApplicationName => string.IsNullOrWhiteSpace(ClientName) ? ServiceName : ClientName;
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/ServiceModuleSummary.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/ServiceModuleSummary.cs
@@ -1,0 +1,15 @@
+namespace XFramework.Operations.Dashboard.Models;
+
+public sealed record ServiceModuleSummary(
+    string ModuleKey,
+    string DisplayName,
+    string Description,
+    string? Version,
+    string IconName,
+    string Status,
+    string StatusCssClass,
+    int FeatureCount,
+    IReadOnlyList<DependencySummary> Dependencies)
+{
+    public int MissingRequiredDependencies => Dependencies.Count(x => x is { Required: true, IsSatisfied: false });
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Program.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Program.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using BlazorBlueprint.Components;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using XFramework.Core.Extensions;
+using XFramework.Integration.Extensions;
+using XFramework.Operations.Dashboard.Components;
+using XFramework.Operations.Dashboard.Health;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.AddXFrameworkLogging(builder.Configuration);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+builder.Services.AddBlazorBlueprintComponents(configureTheme: options =>
+{
+    options.DefaultBaseColor = BaseColor.Slate;
+    options.DefaultPrimaryColor = PrimaryColor.Blue;
+    options.DefaultDarkMode = true;
+    options.DetectSystemPreference = true;
+    options.DefaultRadius = 0.5;
+    options.PersistToLocalStorage = true;
+});
+
+builder.Services.Configure<OperationsDashboardOptions>(
+    builder.Configuration.GetSection(OperationsDashboardOptions.SectionName));
+
+builder.Services.AddXFrameworkBoltClient(builder.Configuration);
+builder.Services.InstallOpenTelemetry(builder.Configuration, "XFramework.Operations.Dashboard");
+
+builder.Services.AddScoped<OperationsRegistryClient>();
+
+builder.Services.AddHttpClient<SeqLogClient>((sp, client) =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var seqUrl = configuration["Seq:Url"];
+    if (!string.IsNullOrWhiteSpace(seqUrl))
+    {
+        client.BaseAddress = new Uri(seqUrl.TrimEnd('/') + "/");
+    }
+
+    var apiKey = configuration["Seq:ApiKey"];
+    if (!string.IsNullOrWhiteSpace(apiKey))
+    {
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Seq-ApiKey", apiKey);
+    }
+});
+
+builder.Services.AddHttpClient<JaegerTraceClient>((sp, client) =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var jaegerUrl = configuration["Jaeger:QueryUrl"];
+    if (!string.IsNullOrWhiteSpace(jaegerUrl))
+    {
+        client.BaseAddress = new Uri(jaegerUrl.TrimEnd('/') + "/");
+    }
+});
+
+builder.Services.AddHealthChecks()
+    .AddCheck(
+        "operations-dashboard-live",
+        () => HealthCheckResult.Healthy("Operations Dashboard is running."),
+        tags: ["live"])
+    .AddCheck<BoltClientHealthCheck>(
+        "operations-dashboard-bolt",
+        failureStatus: HealthStatus.Unhealthy,
+        tags: ["ready"]);
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseAntiforgery();
+
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+    ResponseWriter = WriteHealthResponse,
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status200OK,
+        [HealthStatus.Degraded] = StatusCodes.Status200OK,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    }
+});
+
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("live"),
+    ResponseWriter = WriteHealthResponse,
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status200OK,
+        [HealthStatus.Degraded] = StatusCodes.Status200OK,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    }
+});
+
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready"),
+    ResponseWriter = WriteHealthResponse,
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status200OK,
+        [HealthStatus.Degraded] = StatusCodes.Status503ServiceUnavailable,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    }
+});
+
+app.MapStaticAssets();
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();
+
+static async Task WriteHealthResponse(HttpContext context, HealthReport report)
+{
+    context.Response.ContentType = "application/json";
+
+    var response = new
+    {
+        status = report.Status.ToString(),
+        duration = report.TotalDuration.TotalMilliseconds,
+        timestamp = DateTime.UtcNow,
+        checks = report.Entries.Select(entry => new
+        {
+            name = entry.Key,
+            status = entry.Value.Status.ToString(),
+            description = entry.Value.Description,
+            duration = entry.Value.Duration.TotalMilliseconds,
+            tags = entry.Value.Tags,
+            data = entry.Value.Data,
+            exception = entry.Value.Exception?.Message
+        })
+    };
+
+    await context.Response.WriteAsync(
+        JsonSerializer.Serialize(
+            response,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            }));
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Properties/launchSettings.json
+++ b/src/Presentation/XFramework.Operations.Dashboard/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "XFramework.Operations.Dashboard": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5050;https://localhost:7050",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Services/JaegerTraceClient.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Services/JaegerTraceClient.cs
@@ -1,0 +1,229 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace XFramework.Operations.Dashboard.Services;
+
+public sealed class JaegerTraceClient(
+    HttpClient httpClient,
+    ILogger<JaegerTraceClient> logger)
+{
+    public async Task<ExternalDataResult<IReadOnlyList<DashboardTraceSummary>>> GetTracesAsync(
+        DashboardTraceQuery query,
+        CancellationToken ct = default)
+    {
+        if (httpClient.BaseAddress is null)
+        {
+            return ExternalDataResult<IReadOnlyList<DashboardTraceSummary>>.Unavailable(
+                [],
+                "Jaeger is not configured.");
+        }
+
+        try
+        {
+            using var response = await httpClient.GetAsync(BuildTracesUri(query), ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                return ExternalDataResult<IReadOnlyList<DashboardTraceSummary>>.Unavailable(
+                    [],
+                    $"Jaeger returned {(int)response.StatusCode}.");
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+            var traces = ParseTraces(document.RootElement);
+
+            return ExternalDataResult<IReadOnlyList<DashboardTraceSummary>>.Available(traces);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read Jaeger traces");
+            return ExternalDataResult<IReadOnlyList<DashboardTraceSummary>>.Unavailable(
+                [],
+                "Jaeger traces are unavailable.");
+        }
+    }
+
+    public static string BuildTracesUri(DashboardTraceQuery query)
+    {
+        var service = Uri.EscapeDataString(query.ServiceName);
+        var lookback = Math.Max(1, (int)Math.Ceiling(query.Lookback.TotalHours));
+        var limit = Math.Clamp(query.Limit, 1, 100);
+
+        return $"api/traces?service={service}&lookback={lookback}h&limit={limit.ToString(CultureInfo.InvariantCulture)}";
+    }
+
+    public static IReadOnlyList<DashboardTraceSummary> ParseTraces(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object
+            || !root.TryGetProperty("data", out var data)
+            || data.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return data.EnumerateArray()
+            .Select(ParseTrace)
+            .Where(trace => trace is not null)
+            .Select(trace => trace!)
+            .OrderByDescending(trace => trace.StartedAt)
+            .ToList();
+    }
+
+    private static DashboardTraceSummary? ParseTrace(JsonElement trace)
+    {
+        var traceId = ReadString(trace, "traceID") ?? "";
+        if (string.IsNullOrWhiteSpace(traceId)
+            || !trace.TryGetProperty("spans", out var spansElement)
+            || spansElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var processServices = ReadProcessServices(trace);
+        var spans = new List<RawJaegerSpan>();
+
+        foreach (var span in spansElement.EnumerateArray())
+        {
+            var spanId = ReadString(span, "spanID") ?? "";
+            var operationName = ReadString(span, "operationName") ?? "unknown";
+            var processId = ReadString(span, "processID") ?? "";
+            var serviceName = processServices.GetValueOrDefault(processId, "unknown");
+            var startMicroseconds = ReadInt64(span, "startTime") ?? 0;
+            var durationMicroseconds = ReadInt64(span, "duration") ?? 0;
+
+            spans.Add(new RawJaegerSpan(
+                spanId,
+                operationName,
+                serviceName,
+                startMicroseconds,
+                durationMicroseconds,
+                HasError(span)));
+        }
+
+        if (spans.Count == 0)
+        {
+            return null;
+        }
+
+        var traceStart = spans.Min(x => x.StartMicroseconds);
+        var traceEnd = spans.Max(x => x.StartMicroseconds + x.DurationMicroseconds);
+        var startedAt = FromUnixMicroseconds(traceStart);
+        var duration = MicrosecondsToTimeSpan(Math.Max(0, traceEnd - traceStart));
+
+        var mappedSpans = spans
+            .OrderBy(x => x.StartMicroseconds)
+            .Select(span => new DashboardTraceSpan(
+                span.SpanId,
+                span.OperationName,
+                span.ServiceName,
+                FromUnixMicroseconds(span.StartMicroseconds),
+                MicrosecondsToTimeSpan(span.DurationMicroseconds),
+                MicrosecondsToTimeSpan(Math.Max(0, span.StartMicroseconds - traceStart)),
+                span.HasError))
+            .ToList();
+
+        var rootSpan = spans.OrderByDescending(x => x.DurationMicroseconds).First();
+
+        return new DashboardTraceSummary(
+            traceId,
+            rootSpan.OperationName,
+            rootSpan.ServiceName,
+            startedAt,
+            duration,
+            mappedSpans.Count,
+            mappedSpans.Any(x => x.HasError),
+            mappedSpans);
+    }
+
+    private static Dictionary<string, string> ReadProcessServices(JsonElement trace)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!trace.TryGetProperty("processes", out var processes) || processes.ValueKind != JsonValueKind.Object)
+        {
+            return result;
+        }
+
+        foreach (var process in processes.EnumerateObject())
+        {
+            var serviceName = ReadString(process.Value, "serviceName");
+            if (!string.IsNullOrWhiteSpace(serviceName))
+            {
+                result[process.Name] = serviceName;
+            }
+        }
+
+        return result;
+    }
+
+    private static bool HasError(JsonElement span)
+    {
+        if (!span.TryGetProperty("tags", out var tags) || tags.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        foreach (var tag in tags.EnumerateArray())
+        {
+            var key = ReadString(tag, "key");
+            if (!string.Equals(key, "error", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(key, "otel.status_code", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var value = ReadString(tag, "value");
+            if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "ERROR", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind == JsonValueKind.String ? value.GetString() : value.GetRawText();
+    }
+
+    private static long? ReadInt64(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var value))
+        {
+            return null;
+        }
+
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var number))
+        {
+            return number;
+        }
+
+        return long.TryParse(ReadString(element, propertyName), CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static DateTimeOffset FromUnixMicroseconds(long microseconds) =>
+        DateTimeOffset.FromUnixTimeMilliseconds(microseconds / 1000);
+
+    private static TimeSpan MicrosecondsToTimeSpan(long microseconds) =>
+        TimeSpan.FromTicks(Math.Max(0, microseconds) * 10);
+
+    private sealed record RawJaegerSpan(
+        string SpanId,
+        string OperationName,
+        string ServiceName,
+        long StartMicroseconds,
+        long DurationMicroseconds,
+        bool HasError);
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Services/OperationsRegistryClient.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Services/OperationsRegistryClient.cs
@@ -1,0 +1,48 @@
+using Bolt.Client;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+namespace XFramework.Operations.Dashboard.Services;
+
+public sealed class OperationsRegistryClient(
+    BoltClient client,
+    ILogger<OperationsRegistryClient> logger)
+{
+    public async Task<DashboardRegistrySnapshot> GetSnapshotAsync(CancellationToken ct = default)
+    {
+        if (!client.IsConnected)
+        {
+            return DashboardRegistrySnapshot.EmptyDisconnected("Bolt Hub is not connected.");
+        }
+
+        try
+        {
+            var services = await client.SendAsync<BoltServiceRegistryRequest, BoltServiceRegistryResponse>(
+                string.Empty,
+                BoltServiceDiscoveryCommands.GetServiceRegistry,
+                new BoltServiceRegistryRequest { IncludeOffline = true },
+                ct);
+
+            var modules = await client.SendAsync<BoltModuleRegistryRequest, BoltModuleRegistryResponse>(
+                string.Empty,
+                BoltServiceDiscoveryCommands.GetModuleRegistry,
+                new BoltModuleRegistryRequest { IncludeOffline = true },
+                ct);
+
+            var snapshot = OperationsRegistryMapper.CreateSnapshot(
+                services?.Services ?? [],
+                modules?.Modules ?? [],
+                DateTimeOffset.UtcNow);
+
+            return snapshot;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read Bolt service registry");
+            return DashboardRegistrySnapshot.EmptyDisconnected("Bolt service registry is unavailable.");
+        }
+    }
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Services/OperationsRegistryMapper.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Services/OperationsRegistryMapper.cs
@@ -1,0 +1,152 @@
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+
+namespace XFramework.Operations.Dashboard.Services;
+
+public static class OperationsRegistryMapper
+{
+    public static DashboardRegistrySnapshot CreateSnapshot(
+        IEnumerable<BoltServiceRegistryItem> serviceItems,
+        IEnumerable<BoltModuleRegistryItem> moduleItems,
+        DateTimeOffset capturedAt)
+    {
+        var modulesByClientId = moduleItems
+            .GroupBy(module => module.ClientId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        var services = serviceItems
+            .Select(service => MapService(service, modulesByClientId))
+            .OrderBy(service => StatusSortValue(service.Status))
+            .ThenBy(service => service.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var summary = new RegistryStatusSummary(
+            services.Count,
+            services.Count(x => string.Equals(x.Status, "Online", StringComparison.OrdinalIgnoreCase)),
+            services.Count(x => string.Equals(x.Status, "Degraded", StringComparison.OrdinalIgnoreCase)),
+            services.Count(x => string.Equals(x.Status, "Offline", StringComparison.OrdinalIgnoreCase)),
+            services.Where(x => !string.Equals(x.Status, "Offline", StringComparison.OrdinalIgnoreCase))
+                .Sum(x => Math.Max(0, x.ConnectionCount)));
+
+        return new DashboardRegistrySnapshot(
+            true,
+            capturedAt,
+            summary,
+            services,
+            []);
+    }
+
+    private static ServiceInstanceSummary MapService(
+        BoltServiceRegistryItem service,
+        IReadOnlyDictionary<string, List<BoltModuleRegistryItem>> modulesByClientId)
+    {
+        modulesByClientId.TryGetValue(service.ClientId, out var serviceModules);
+        serviceModules ??= [];
+
+        var dependencies = service.DependencyStatuses.Select(MapDependency).ToList();
+        var status = ResolveStatus(service.Status, dependencies);
+
+        service.Manifest.Metadata.TryGetValue("MachineName", out var machineName);
+
+        return new ServiceInstanceSummary(
+            service.ClientId,
+            service.ClientName,
+            service.ServiceName,
+            FirstNonEmpty(service.DisplayName, service.ServiceName, service.ClientName, service.ClientId),
+            service.Version,
+            service.Manifest.Description,
+            status,
+            StatusCssClass(status),
+            service.ConnectionCount,
+            AsOffset(service.LastSeenAt),
+            AsNullableOffset(service.LastConnectedAt),
+            AsNullableOffset(service.LastDisconnectedAt),
+            string.IsNullOrWhiteSpace(machineName) ? null : machineName,
+            serviceModules.Select(MapModule).ToList(),
+            dependencies);
+    }
+
+    private static ServiceModuleSummary MapModule(BoltModuleRegistryItem module)
+    {
+        var dependencies = module.DependencyStatuses.Select(MapDependency).ToList();
+        var status = ResolveStatus(module.Status, dependencies);
+
+        return new ServiceModuleSummary(
+            module.ModuleKey,
+            FirstNonEmpty(module.DisplayName, module.ModuleKey),
+            module.Description,
+            module.Version,
+            string.IsNullOrWhiteSpace(module.IconName) ? "box" : module.IconName,
+            status,
+            StatusCssClass(status),
+            module.Features.Count,
+            dependencies);
+    }
+
+    private static DependencySummary MapDependency(BoltDependencyStatus dependency)
+    {
+        var requirement = dependency.Requirement;
+
+        return new DependencySummary(
+            requirement.Kind.ToString(),
+            requirement.Key,
+            FirstNonEmpty(requirement.DisplayName, requirement.Key),
+            requirement.MinVersion,
+            requirement.Required,
+            dependency.IsSatisfied,
+            dependency.MatchedKey,
+            dependency.Message);
+    }
+
+    private static string ResolveStatus(BoltRegistryStatus status, IReadOnlyList<DependencySummary> dependencies)
+    {
+        if (status == BoltRegistryStatus.Offline)
+        {
+            return "Offline";
+        }
+
+        if (dependencies.Any(x => x is { Required: true, IsSatisfied: false }))
+        {
+            return "Degraded";
+        }
+
+        return status switch
+        {
+            BoltRegistryStatus.Online => "Online",
+            BoltRegistryStatus.Degraded => "Degraded",
+            _ => "Offline"
+        };
+    }
+
+    public static string StatusCssClass(string status) =>
+        status.ToLowerInvariant() switch
+        {
+            "online" => "status-online",
+            "degraded" => "status-degraded",
+            "offline" => "status-offline",
+            _ => "status-unavailable"
+        };
+
+    private static int StatusSortValue(string status) =>
+        status.ToLowerInvariant() switch
+        {
+            "degraded" => 0,
+            "online" => 1,
+            "offline" => 2,
+            _ => 3
+        };
+
+    private static DateTimeOffset AsOffset(DateTime value)
+    {
+        var utc = value.Kind == DateTimeKind.Utc
+            ? value
+            : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+
+        return new DateTimeOffset(utc);
+    }
+
+    private static DateTimeOffset? AsNullableOffset(DateTime? value) =>
+        value is null ? null : AsOffset(value.Value);
+
+    private static string FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? "";
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Services/SeqLogClient.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Services/SeqLogClient.cs
@@ -1,0 +1,219 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace XFramework.Operations.Dashboard.Services;
+
+public sealed class SeqLogClient(
+    HttpClient httpClient,
+    ILogger<SeqLogClient> logger)
+{
+    public async Task<ExternalDataResult<IReadOnlyList<DashboardLogEvent>>> GetLogsAsync(
+        DashboardLogQuery query,
+        CancellationToken ct = default)
+    {
+        if (httpClient.BaseAddress is null)
+        {
+            return ExternalDataResult<IReadOnlyList<DashboardLogEvent>>.Unavailable(
+                [],
+                "Seq is not configured.");
+        }
+
+        try
+        {
+            var uri = BuildEventsUri(query);
+            using var response = await httpClient.GetAsync(uri, ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return ExternalDataResult<IReadOnlyList<DashboardLogEvent>>.Unavailable(
+                    [],
+                    $"Seq returned {(int)response.StatusCode}.");
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+            var events = ParseEvents(document.RootElement);
+
+            return ExternalDataResult<IReadOnlyList<DashboardLogEvent>>.Available(events);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read Seq events");
+            return ExternalDataResult<IReadOnlyList<DashboardLogEvent>>.Unavailable(
+                [],
+                "Seq events are unavailable.");
+        }
+    }
+
+    public static string BuildEventsUri(DashboardLogQuery query)
+    {
+        var count = Math.Clamp(query.Count, 1, 500);
+        var parts = new List<string>
+        {
+            $"count={count.ToString(CultureInfo.InvariantCulture)}",
+            "render=true",
+            $"fromDateUtc={Uri.EscapeDataString(query.FromUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))}",
+            $"toDateUtc={Uri.EscapeDataString(query.ToUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))}"
+        };
+
+        var filter = BuildFilter(query.Application, query.MachineName);
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            parts.Add($"filter={Uri.EscapeDataString(filter)}");
+        }
+
+        return "api/events?" + string.Join('&', parts);
+    }
+
+    public static string BuildFilter(string? application, string? machineName)
+    {
+        var filters = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(application))
+        {
+            filters.Add($"Application = '{EscapeSeqString(application)}'");
+        }
+
+        if (!string.IsNullOrWhiteSpace(machineName))
+        {
+            filters.Add($"MachineName = '{EscapeSeqString(machineName)}'");
+        }
+
+        return string.Join(" and ", filters);
+    }
+
+    private static string EscapeSeqString(string value) =>
+        value.Replace("'", "''", StringComparison.Ordinal);
+
+    public static IReadOnlyList<DashboardLogEvent> ParseEvents(JsonElement root)
+    {
+        IEnumerable<JsonElement> source = root.ValueKind switch
+        {
+            JsonValueKind.Array => root.EnumerateArray(),
+            JsonValueKind.Object when TryGetProperty(root, "Events", out var upperEvents) && upperEvents.ValueKind == JsonValueKind.Array
+                => upperEvents.EnumerateArray(),
+            JsonValueKind.Object when TryGetProperty(root, "events", out var lowerEvents) && lowerEvents.ValueKind == JsonValueKind.Array
+                => lowerEvents.EnumerateArray(),
+            _ => []
+        };
+
+        return source.Select(ParseEvent).ToList();
+    }
+
+    private static DashboardLogEvent ParseEvent(JsonElement element)
+    {
+        var properties = ReadProperties(element);
+
+        var timestamp = ReadDateTimeOffset(element, "Timestamp")
+            ?? ReadDateTimeOffset(element, "@t")
+            ?? DateTimeOffset.MinValue;
+
+        var level = ReadString(element, "Level")
+            ?? ReadString(element, "@l")
+            ?? "Information";
+
+        var message = ReadString(element, "RenderedMessage")
+            ?? ReadString(element, "Message")
+            ?? ReadString(element, "@m")
+            ?? ReadString(element, "@mt")
+            ?? "";
+
+        var sourceContext = ReadString(element, "SourceContext")
+            ?? properties.GetValueOrDefault("SourceContext");
+
+        var application = ReadString(element, "Application")
+            ?? properties.GetValueOrDefault("Application");
+
+        var machineName = ReadString(element, "MachineName")
+            ?? properties.GetValueOrDefault("MachineName");
+
+        return new DashboardLogEvent(
+            timestamp,
+            level,
+            message,
+            sourceContext,
+            application,
+            machineName,
+            properties);
+    }
+
+    private static Dictionary<string, string> ReadProperties(JsonElement element)
+    {
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!TryGetProperty(element, "Properties", out var props))
+        {
+            return properties;
+        }
+
+        if (props.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in props.EnumerateObject())
+            {
+                properties[property.Name] = JsonValueToString(property.Value);
+            }
+        }
+        else if (props.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var property in props.EnumerateArray())
+            {
+                var name = ReadString(property, "Name");
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+
+                var value = TryGetProperty(property, "Value", out var valueElement)
+                    ? JsonValueToString(valueElement)
+                    : "";
+                properties[name] = value;
+            }
+        }
+
+        return properties;
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty(propertyName, out value))
+        {
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+    {
+        if (!TryGetProperty(element, propertyName, out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind == JsonValueKind.String ? value.GetString() : JsonValueToString(value);
+    }
+
+    private static DateTimeOffset? ReadDateTimeOffset(JsonElement element, string propertyName)
+    {
+        var raw = ReadString(element, propertyName);
+        return DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var value)
+            ? value.ToUniversalTime()
+            : null;
+    }
+
+    private static string JsonValueToString(JsonElement value) =>
+        value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? "",
+            JsonValueKind.Number => value.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => "",
+            _ => value.GetRawText()
+        };
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/XFramework.Operations.Dashboard.csproj
+++ b/src/Presentation/XFramework.Operations.Dashboard/XFramework.Operations.Dashboard.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <RootNamespace>XFramework.Operations.Dashboard</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BlazorBlueprint.Components" />
+        <PackageReference Include="BlazorBlueprint.Icons.Lucide" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
+        <ProjectReference Include="..\..\Kernel\XFramework.Core\XFramework.Core.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Bolt\Bolt.Domain.Shared\Bolt.Domain.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Presentation/XFramework.Operations.Dashboard/appsettings.Docker.json
+++ b/src/Presentation/XFramework.Operations.Dashboard/appsettings.Docker.json
@@ -1,0 +1,23 @@
+{
+  "BoltConfiguration": {
+    "ClientName": "OperationsDashboard",
+    "ServerUrls": [
+      "ws://bolt-hub:8080/bolt/ws"
+    ],
+    "RpcTimeoutSeconds": 30
+  },
+  "Seq": {
+    "Url": "http://seq:80"
+  },
+  "Jaeger": {
+    "QueryUrl": "http://jaeger:16686"
+  },
+  "OpenTelemetry": {
+    "Exporters": {
+      "OTLP": {
+        "Enabled": true,
+        "Endpoint": "http://jaeger:4317"
+      }
+    }
+  }
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/appsettings.json
+++ b/src/Presentation/XFramework.Operations.Dashboard/appsettings.json
@@ -1,0 +1,43 @@
+{
+  "BoltConfiguration": {
+    "ClientName": "OperationsDashboard",
+    "ServerUrls": [
+      "ws://localhost:7000/bolt/ws"
+    ],
+    "RpcTimeoutSeconds": 30
+  },
+  "BoltServiceDiscovery": {
+    "ManifestRefreshSeconds": 30
+  },
+  "XFrameworkServiceManifest": {
+    "ServiceName": "OperationsDashboard",
+    "DisplayName": "Operations Dashboard",
+    "Description": "Internal XFramework operations and service discovery dashboard."
+  },
+  "Seq": {
+    "Url": "http://localhost:5341"
+  },
+  "Jaeger": {
+    "QueryUrl": "http://localhost:16686"
+  },
+  "OperationsDashboard": {
+    "RefreshSeconds": 10,
+    "DefaultLogCount": 50,
+    "DefaultTraceLimit": 20,
+    "DefaultLookbackMinutes": 30
+  },
+  "OpenTelemetry": {
+    "Sampling": {
+      "Probability": 1.0
+    },
+    "Exporters": {
+      "Console": {
+        "Enabled": false
+      },
+      "OTLP": {
+        "Enabled": false,
+        "Endpoint": "http://localhost:4317"
+      }
+    }
+  }
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/wwwroot/css/app.css
+++ b/src/Presentation/XFramework.Operations.Dashboard/wwwroot/css/app.css
@@ -1,0 +1,538 @@
+:root {
+    color-scheme: light dark;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+    margin: 0;
+    background: var(--background);
+    color: var(--foreground);
+}
+
+button,
+input {
+    font: inherit;
+}
+
+.ops-shell {
+    display: grid;
+    grid-template-columns: 16rem minmax(0, 1fr);
+    min-height: 100vh;
+    background: var(--background);
+    color: var(--foreground);
+}
+
+.ops-sidebar {
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border);
+    background: var(--sidebar);
+    color: var(--sidebar-foreground);
+}
+
+.ops-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    height: 4rem;
+    padding: 0 1rem;
+    border-bottom: 1px solid var(--sidebar-border);
+}
+
+.ops-brand-mark {
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    place-items: center;
+    border-radius: calc(var(--radius) - 2px);
+    background: var(--sidebar-primary);
+    color: var(--sidebar-primary-foreground);
+    font-size: 0.875rem;
+    font-weight: 800;
+}
+
+.ops-brand-title {
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+.ops-brand-subtitle,
+.ops-sidebar-footer,
+.ops-topbar p,
+.muted {
+    color: var(--muted-foreground);
+}
+
+.ops-brand-subtitle {
+    font-size: 0.72rem;
+}
+
+.ops-nav {
+    display: grid;
+    gap: 0.25rem;
+    padding: 1rem 0.75rem;
+}
+
+.ops-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    min-height: 2.4rem;
+    padding: 0 0.75rem;
+    border-radius: calc(var(--radius) - 2px);
+    color: var(--sidebar-foreground);
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.ops-nav-link:hover,
+.ops-nav-link.active {
+    background: var(--sidebar-accent);
+    color: var(--sidebar-accent-foreground);
+}
+
+.ops-nav-icon {
+    width: 1rem;
+    height: 1rem;
+}
+
+.ops-sidebar-footer {
+    margin-top: auto;
+    padding: 1rem;
+    border-top: 1px solid var(--sidebar-border);
+    font-size: 0.75rem;
+}
+
+.ops-main-shell {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+}
+
+.ops-topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 4rem;
+    padding: 0.75rem 1.5rem;
+    border-bottom: 1px solid var(--border);
+    gap: 1rem;
+}
+
+.ops-topbar h1 {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 800;
+    letter-spacing: 0;
+}
+
+.ops-topbar p {
+    margin: 0.1rem 0 0;
+    font-size: 0.8rem;
+}
+
+.ops-topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.ops-main {
+    min-width: 0;
+    padding: 1.25rem;
+}
+
+.dashboard-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.metric-card,
+.panel,
+.service-detail {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--card);
+    color: var(--card-foreground);
+}
+
+.metric-card {
+    display: grid;
+    gap: 0.35rem;
+    min-height: 6.25rem;
+    padding: 1rem;
+}
+
+.metric-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.metric-card-label {
+    color: var(--muted-foreground);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.metric-card-icon {
+    width: 1rem;
+    height: 1rem;
+    color: var(--muted-foreground);
+}
+
+.metric-card-value {
+    font-size: 2rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0;
+}
+
+.panel {
+    overflow: hidden;
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.panel-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+    font-size: 1rem;
+    font-weight: 800;
+}
+
+.panel-title svg {
+    width: 1.05rem;
+    height: 1.05rem;
+}
+
+.panel-subtitle {
+    margin-top: 0.15rem;
+    color: var(--muted-foreground);
+    font-size: 0.78rem;
+}
+
+.panel-body {
+    padding: 1rem;
+}
+
+.dashboard-content-grid {
+    display: grid;
+    grid-template-columns: minmax(30rem, 1.15fr) minmax(22rem, 0.85fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.service-table-wrap {
+    overflow-x: auto;
+}
+
+.service-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.86rem;
+}
+
+.service-table th {
+    color: var(--muted-foreground);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-align: left;
+    text-transform: uppercase;
+}
+
+.service-table th,
+.service-table td {
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem;
+    vertical-align: middle;
+}
+
+.service-table tbody tr:hover {
+    background: var(--accent);
+}
+
+.service-table tbody tr.selected {
+    background: color-mix(in oklab, var(--accent) 70%, transparent);
+}
+
+.service-row-button {
+    display: grid;
+    width: 100%;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+    text-align: left;
+}
+
+.service-name {
+    font-weight: 800;
+}
+
+.service-meta {
+    margin-top: 0.15rem;
+    color: var(--muted-foreground);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 1.55rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0 0.55rem;
+    font-size: 0.75rem;
+    font-weight: 800;
+}
+
+.status-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 999px;
+    background: var(--muted-foreground);
+}
+
+.status-online .status-dot {
+    background: #22c55e;
+}
+
+.status-degraded .status-dot {
+    background: #f59e0b;
+}
+
+.status-offline .status-dot,
+.status-unavailable .status-dot {
+    background: #ef4444;
+}
+
+.service-detail {
+    display: grid;
+    gap: 1rem;
+    padding: 1rem;
+}
+
+.detail-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.detail-heading h2 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 800;
+}
+
+.detail-heading p {
+    margin: 0.2rem 0 0;
+    color: var(--muted-foreground);
+    font-size: 0.8rem;
+}
+
+.detail-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.detail-item {
+    border: 1px solid var(--border);
+    border-radius: calc(var(--radius) - 2px);
+    padding: 0.75rem;
+}
+
+.detail-label {
+    color: var(--muted-foreground);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.detail-value {
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    overflow-wrap: anywhere;
+}
+
+.dependency-list,
+.module-list,
+.log-list,
+.trace-list {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.dependency-item,
+.module-item,
+.log-item,
+.trace-item {
+    border: 1px solid var(--border);
+    border-radius: calc(var(--radius) - 2px);
+    padding: 0.75rem;
+}
+
+.item-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.item-title {
+    min-width: 0;
+    font-size: 0.86rem;
+    font-weight: 800;
+    overflow-wrap: anywhere;
+}
+
+.item-description,
+.log-message {
+    margin-top: 0.3rem;
+    color: var(--muted-foreground);
+    font-size: 0.78rem;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+}
+
+.utility-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.timeline {
+    position: relative;
+    height: 2.2rem;
+    border: 1px solid var(--border);
+    border-radius: calc(var(--radius) - 2px);
+    background: color-mix(in oklab, var(--muted) 45%, transparent);
+    overflow: hidden;
+}
+
+.timeline-span {
+    position: absolute;
+    top: 0.35rem;
+    height: 1.45rem;
+    min-width: 0.35rem;
+    border-radius: 999px;
+    background: var(--primary);
+}
+
+.timeline-span.error {
+    background: var(--destructive);
+}
+
+.empty-state,
+.degraded-state {
+    display: grid;
+    place-items: center;
+    gap: 0.5rem;
+    min-height: 12rem;
+    color: var(--muted-foreground);
+    text-align: center;
+}
+
+.empty-state h1,
+.empty-state h2,
+.degraded-state h2 {
+    margin: 0;
+    color: var(--foreground);
+    font-size: 1rem;
+    font-weight: 800;
+}
+
+.empty-state p,
+.degraded-state p {
+    margin: 0;
+    max-width: 30rem;
+    font-size: 0.86rem;
+}
+
+.empty-state-icon {
+    width: 2rem;
+    height: 2rem;
+}
+
+.dashboard-error-ui {
+    display: none;
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 50;
+    max-width: 28rem;
+    border: 1px solid var(--destructive);
+    border-radius: var(--radius);
+    background: var(--destructive);
+    color: var(--destructive-foreground);
+    padding: 0.9rem 1rem;
+}
+
+.dashboard-error-ui a {
+    color: inherit;
+    font-weight: 800;
+}
+
+.blazor-error-boundary ~ .dashboard-error-ui,
+.dashboard-error-ui:target {
+    display: block;
+}
+
+@media (max-width: 1100px) {
+    .summary-grid,
+    .dashboard-content-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 760px) {
+    .ops-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .ops-sidebar {
+        display: none;
+    }
+
+    .ops-topbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .ops-main {
+        padding: 0.8rem;
+    }
+
+    .detail-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/Tests/Bolt.Tests/Bolt.Tests.csproj
+++ b/src/Tests/Bolt.Tests/Bolt.Tests.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Tests/Bolt.Tests/BoltServiceDiscoveryIntegrationTests.cs
+++ b/src/Tests/Bolt.Tests/BoltServiceDiscoveryIntegrationTests.cs
@@ -1,0 +1,352 @@
+using Bolt.Client;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using Bolt.Hub.Services;
+using Bolt.Server;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System.Text.Json;
+using XFramework.Domain.Contexts;
+
+namespace Bolt.Tests;
+
+[TestFixture]
+[CancelAfter(30000)]
+public sealed class BoltServiceDiscoveryIntegrationTests
+{
+    private static int _portCounter = 20200;
+    private WebApplication _hubApp = null!;
+    private ILoggerFactory _loggerFactory = null!;
+    private string _databaseName = string.Empty;
+    private int _port;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _port = Interlocked.Increment(ref _portCounter);
+        _databaseName = $"bolt-discovery-{Guid.NewGuid():N}";
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls($"http://localhost:{_port}");
+        builder.Services.AddDbContext<DbContext, AppDbContext>(options =>
+            options.UseInMemoryDatabase(_databaseName));
+        builder.Services.AddBoltServer();
+        builder.Services.AddSingleton<IBoltServicePresenceTracker, BoltServicePresenceTracker>();
+        builder.Services.AddScoped<IBoltServiceDiscoveryRegistry, BoltServiceDiscoveryRegistry>();
+        builder.Services.AddHostedService<BoltServiceDiscoveryHostedService>();
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+        _hubApp = builder.Build();
+        _hubApp.UseWebSockets();
+        _hubApp.MapBolt("/bolt");
+        _hubApp.MapGet("/health", () => "ok");
+        _ = Task.Run(() => _hubApp.RunAsync());
+        await WaitForHealth($"http://localhost:{_port}/health");
+        _loggerFactory = _hubApp.Services.GetRequiredService<ILoggerFactory>();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        try { await _hubApp.StopAsync(); } catch { }
+        try { await _hubApp.DisposeAsync(); } catch { }
+    }
+
+    [Test]
+    public async Task AdvertiseServiceManifest_ThroughHubLocalHandler_PersistsSenderClientAndReturnsRegistry()
+    {
+        var client = CreateClient("discovery_client", "DiscoveryService");
+        await client.ConnectAsync();
+
+        var response = await client.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            CreateJuanBarangayManifest());
+
+        response.Should().NotBeNull();
+        response!.Accepted.Should().BeTrue();
+
+        var modules = await client.SendAsync<BoltModuleRegistryRequest, BoltModuleRegistryResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.GetModuleRegistry,
+            new BoltModuleRegistryRequest { IncludeOffline = true });
+
+        modules!.Modules.Should().ContainSingle(module => module.ModuleKey == "juan_barangay");
+        modules.Modules.Single(module => module.ModuleKey == "juan_barangay")
+            .Features.Should().Contain(feature => feature.Key == "juan_barangay.residents");
+
+        using var scope = _hubApp.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+        var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "discovery_client");
+        record.ClientName.Should().Be("DiscoveryService");
+        record.ServiceName.Should().Be("Juan_Barangay_Service");
+        record.IsConnected.Should().BeTrue();
+
+        await client.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Disconnect_AfterManifestAdvertisement_KeepsManifestAndMarksServiceOffline()
+    {
+        var client = CreateClient("disconnect_client", "DisconnectService");
+        await client.ConnectAsync();
+        await client.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            CreateJuanBarangayManifest());
+
+        await client.DisposeAsync();
+
+        await WaitUntilAsync(async () =>
+        {
+            using var scope = _hubApp.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "disconnect_client");
+            return !record.IsConnected && record.ConnectionCount == 0 && record.ManifestJson.Contains("juan_barangay");
+        });
+    }
+
+    [Test]
+    public async Task ResetPresenceAsync_KeepsManifestAndMarksPersistedOnlineServicesOffline()
+    {
+        var manifestJson = JsonSerializer.Serialize(
+            CreateJuanBarangayManifest(),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        using (var scope = _hubApp.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            db.Add(new BoltServiceManifestRecord
+            {
+                Id = Guid.NewGuid(),
+                ClientId = "stale_client",
+                ClientName = "StaleService",
+                ServiceName = "Juan_Barangay_Service",
+                DisplayName = "Juan Barangay",
+                Version = "1.0.0",
+                IsConnected = true,
+                ConnectionCount = 2,
+                LastSeenAt = DateTime.UtcNow.AddMinutes(-5),
+                LastConnectedAt = DateTime.UtcNow.AddMinutes(-5),
+                ManifestHash = "stale-hash",
+                ManifestJson = manifestJson,
+                CreatedAt = DateTime.UtcNow.AddMinutes(-5)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        using (var scope = _hubApp.Services.CreateScope())
+        {
+            var registry = scope.ServiceProvider.GetRequiredService<IBoltServiceDiscoveryRegistry>();
+            await registry.ResetPresenceAsync(CancellationToken.None);
+        }
+
+        using (var scope = _hubApp.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "stale_client");
+            record.IsConnected.Should().BeFalse();
+            record.ConnectionCount.Should().Be(0);
+            record.ManifestJson.Should().Be(manifestJson);
+            record.LastDisconnectedAt.Should().NotBeNull();
+        }
+    }
+
+    [Test]
+    public async Task MultipleConnectionsForSameClient_DisconnectingOneKeepsServiceOnlineUntilFinalConnectionCloses()
+    {
+        var firstClient = CreateClient("pooled_client", "PooledService");
+        var secondClient = CreateClient("pooled_client", "PooledService");
+
+        try
+        {
+            await Task.WhenAll(firstClient.ConnectAsync(), secondClient.ConnectAsync());
+
+            await WaitUntilAsync(async () =>
+            {
+                using var scope = _hubApp.Services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+                var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "pooled_client");
+                return record.IsConnected && record.ConnectionCount == 2;
+            });
+
+            await firstClient.DisposeAsync();
+
+            await WaitUntilAsync(async () =>
+            {
+                using var scope = _hubApp.Services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+                var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "pooled_client");
+                return record.IsConnected && record.ConnectionCount == 1;
+            });
+
+            await secondClient.DisposeAsync();
+
+            await WaitUntilAsync(async () =>
+            {
+                using var scope = _hubApp.Services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+                var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "pooled_client");
+                return !record.IsConnected && record.ConnectionCount == 0;
+            });
+        }
+        finally
+        {
+            await firstClient.DisposeAsync();
+            await secondClient.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Reconnect_AfterDisconnect_MarksServiceOnlineAndUpdatesLastSeen()
+    {
+        var firstClient = CreateClient("reconnect_client", "ReconnectService");
+        await firstClient.ConnectAsync();
+        await firstClient.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            CreateJuanBarangayManifest());
+        await firstClient.DisposeAsync();
+
+        await WaitUntilAsync(async () =>
+        {
+            using var scope = _hubApp.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "reconnect_client");
+            return !record.IsConnected;
+        });
+
+        DateTime offlineSeenAt;
+        using (var scope = _hubApp.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            offlineSeenAt = (await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "reconnect_client")).LastSeenAt;
+        }
+
+        var secondClient = CreateClient("reconnect_client", "ReconnectService");
+        await secondClient.ConnectAsync();
+
+        await WaitUntilAsync(async () =>
+        {
+            using var scope = _hubApp.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var record = await db.Set<BoltServiceManifestRecord>().SingleAsync(x => x.ClientId == "reconnect_client");
+            return record.IsConnected && record.ConnectionCount == 1 && record.LastSeenAt >= offlineSeenAt;
+        });
+
+        await secondClient.DisposeAsync();
+    }
+
+    [Test]
+    public async Task GetModuleRegistry_RequiredMissingServiceDependency_ReturnsDegradedModuleAndFeature()
+    {
+        var client = CreateClient("dependency_client", "DependencyService");
+        await client.ConnectAsync();
+        var manifest = CreateJuanBarangayManifest();
+        manifest.Modules[0].Dependencies.Add(new BoltDependencyRequirement
+        {
+            Kind = BoltDependencyKind.Service,
+            Key = "missing_service",
+            DisplayName = "Missing Service",
+            Required = true
+        });
+
+        await client.SendAsync<BoltServiceManifest, BoltServiceManifestAdvertisementResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.AdvertiseServiceManifest,
+            manifest);
+
+        var modules = await client.SendAsync<BoltModuleRegistryRequest, BoltModuleRegistryResponse>(
+            string.Empty,
+            BoltServiceDiscoveryCommands.GetModuleRegistry,
+            new BoltModuleRegistryRequest { IncludeOffline = true });
+
+        var module = modules!.Modules.Single(x => x.ModuleKey == "juan_barangay");
+        module.Status.Should().Be(BoltRegistryStatus.Degraded);
+        module.DependencyStatuses.Should().Contain(status =>
+            status.Requirement.Key == "missing_service" && !status.IsSatisfied && status.Requirement.Required);
+        module.Features.Should().Contain(feature =>
+            feature.Key == "juan_barangay.residents" && feature.Status == BoltRegistryStatus.Degraded);
+
+        await client.DisposeAsync();
+    }
+
+    private BoltClient CreateClient(string id, string name) =>
+        new(
+            new Uri($"ws://localhost:{_port}/bolt"),
+            id,
+            name,
+            new BoltClientOptions { RpcTimeoutSeconds = 5 },
+            _loggerFactory.CreateLogger<BoltClient>());
+
+    private static BoltServiceManifest CreateJuanBarangayManifest() =>
+        new()
+        {
+            ServiceName = "Juan_Barangay_Service",
+            DisplayName = "Juan Barangay",
+            Version = "1.0.0",
+            Modules =
+            [
+                new BoltModuleManifest
+                {
+                    ModuleKey = "Juan_Barangay",
+                    DisplayName = "Juan Barangay",
+                    Description = "Barangay resident operations.",
+                    IconName = "users",
+                    Features =
+                    [
+                        new BoltTenantModuleFeatureManifest
+                        {
+                            Key = "Juan_Barangay.Residents",
+                            DisplayName = "Residents",
+                            Description = "Resident registry.",
+                            IconName = "users"
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static async Task WaitForHealth(string url, int timeoutSeconds = 15)
+    {
+        using var client = new HttpClient();
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                if ((await client.GetAsync(url)).IsSuccessStatusCode)
+                {
+                    return;
+                }
+            }
+            catch
+            {
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Service at {url} not healthy within {timeoutSeconds}s");
+    }
+
+    private static async Task WaitUntilAsync(Func<Task<bool>> condition, int timeoutSeconds = 10)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException("Condition was not met before timeout.");
+    }
+}

--- a/src/Tests/OperationsDashboard.Tests/OperationsDashboard.Tests.csproj
+++ b/src/Tests/OperationsDashboard.Tests/OperationsDashboard.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>OperationsDashboard.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="FluentAssertions" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Presentation\XFramework.Operations.Dashboard\XFramework.Operations.Dashboard.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/OperationsDashboard.Tests/Services/JaegerTraceClientTests.cs
+++ b/src/Tests/OperationsDashboard.Tests/Services/JaegerTraceClientTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using XFramework.Operations.Dashboard.Models;
+using XFramework.Operations.Dashboard.Services;
+
+namespace OperationsDashboard.Tests.Services;
+
+[TestFixture]
+public sealed class JaegerTraceClientTests
+{
+    [Test]
+    public void BuildTracesUri_Query_EncodesServiceAndClampsLimit()
+    {
+        var uri = JaegerTraceClient.BuildTracesUri(new DashboardTraceQuery("Identity Server", TimeSpan.FromMinutes(30), 500));
+
+        uri.Should().Be("api/traces?service=Identity%20Server&lookback=1h&limit=100");
+    }
+
+    [Test]
+    public void ParseTraces_JaegerResponse_ReturnsTimelineSpans()
+    {
+        using var document = JsonDocument.Parse(
+            """
+            {
+              "data": [
+                {
+                  "traceID": "abc",
+                  "spans": [
+                    {
+                      "spanID": "root",
+                      "operationName": "GET /api/users",
+                      "processID": "p1",
+                      "startTime": 1781830800000000,
+                      "duration": 100000,
+                      "tags": []
+                    },
+                    {
+                      "spanID": "child",
+                      "operationName": "SELECT users",
+                      "processID": "p1",
+                      "startTime": 1781830800050000,
+                      "duration": 25000,
+                      "tags": [
+                        { "key": "otel.status_code", "value": "ERROR" }
+                      ]
+                    }
+                  ],
+                  "processes": {
+                    "p1": {
+                      "serviceName": "IdentityServer"
+                    }
+                  }
+                }
+              ]
+            }
+            """);
+
+        var traces = JaegerTraceClient.ParseTraces(document.RootElement);
+
+        traces.Should().ContainSingle();
+        traces[0].TraceId.Should().Be("abc");
+        traces[0].RootOperation.Should().Be("GET /api/users");
+        traces[0].Duration.Should().Be(TimeSpan.FromMilliseconds(100));
+        traces[0].HasErrors.Should().BeTrue();
+        traces[0].Spans[1].Offset.Should().Be(TimeSpan.FromMilliseconds(50));
+    }
+
+    [Test]
+    public async Task GetTracesAsync_JaegerNotConfigured_ReturnsUnavailable()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(HttpStatusCode.OK, "{}"));
+        var client = new JaegerTraceClient(httpClient, NullLogger<JaegerTraceClient>.Instance);
+
+        var result = await client.GetTracesAsync(new DashboardTraceQuery("IdentityServer", TimeSpan.FromMinutes(30), 20));
+
+        result.IsAvailable.Should().BeFalse();
+        result.Message.Should().Be("Jaeger is not configured.");
+    }
+
+    [Test]
+    public async Task GetTracesAsync_NonSuccessResponse_ReturnsUnavailable()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(HttpStatusCode.ServiceUnavailable, "{}"))
+        {
+            BaseAddress = new Uri("http://jaeger/")
+        };
+        var client = new JaegerTraceClient(httpClient, NullLogger<JaegerTraceClient>.Instance);
+
+        var result = await client.GetTracesAsync(new DashboardTraceQuery("IdentityServer", TimeSpan.FromMinutes(30), 20));
+
+        result.IsAvailable.Should().BeFalse();
+        result.Message.Should().Be("Jaeger returned 503.");
+    }
+
+    private sealed class StubHttpMessageHandler(HttpStatusCode statusCode, string content) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content, Encoding.UTF8, "application/json")
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/Tests/OperationsDashboard.Tests/Services/OperationsRegistryMapperTests.cs
+++ b/src/Tests/OperationsDashboard.Tests/Services/OperationsRegistryMapperTests.cs
@@ -1,0 +1,97 @@
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using FluentAssertions;
+using NUnit.Framework;
+using XFramework.Operations.Dashboard.Services;
+
+namespace OperationsDashboard.Tests.Services;
+
+[TestFixture]
+public sealed class OperationsRegistryMapperTests
+{
+    [Test]
+    public void CreateSnapshot_ServicesAndModules_ComputesSummaryAndGroupsModules()
+    {
+        var services = new[]
+        {
+            new BoltServiceRegistryItem
+            {
+                ClientId = "client-identity",
+                ClientName = "IdentityServer",
+                ServiceName = "IdentityServer",
+                DisplayName = "Identity Server",
+                Status = BoltRegistryStatus.Online,
+                ConnectionCount = 2,
+                LastSeenAt = DateTime.UtcNow
+            },
+            new BoltServiceRegistryItem
+            {
+                ClientId = "client-wallets",
+                ClientName = "Wallets",
+                ServiceName = "Wallets",
+                DisplayName = "Wallets",
+                Status = BoltRegistryStatus.Offline,
+                ConnectionCount = 0,
+                LastSeenAt = DateTime.UtcNow.AddMinutes(-5)
+            }
+        };
+
+        var modules = new[]
+        {
+            new BoltModuleRegistryItem
+            {
+                ClientId = "client-identity",
+                ModuleKey = "identity",
+                DisplayName = "Identity",
+                Status = BoltRegistryStatus.Online,
+                Features =
+                [
+                    new BoltTenantModuleFeatureRegistryItem { Key = "identity.users" }
+                ]
+            }
+        };
+
+        var snapshot = OperationsRegistryMapper.CreateSnapshot(services, modules, DateTimeOffset.UtcNow);
+
+        snapshot.Summary.TotalServices.Should().Be(2);
+        snapshot.Summary.OnlineServices.Should().Be(1);
+        snapshot.Summary.OfflineServices.Should().Be(1);
+        snapshot.Summary.ActiveInstances.Should().Be(2);
+        snapshot.Services.Single(x => x.ClientId == "client-identity").Modules.Should().ContainSingle()
+            .Which.FeatureCount.Should().Be(1);
+    }
+
+    [Test]
+    public void CreateSnapshot_RequiredDependencyMissing_MarksServiceDegraded()
+    {
+        var service = new BoltServiceRegistryItem
+        {
+            ClientId = "client-a",
+            ClientName = "Messaging",
+            ServiceName = "Messaging",
+            Status = BoltRegistryStatus.Online,
+            ConnectionCount = 1,
+            LastSeenAt = DateTime.UtcNow,
+            DependencyStatuses =
+            [
+                new BoltDependencyStatus
+                {
+                    Requirement = new BoltDependencyRequirement
+                    {
+                        Kind = BoltDependencyKind.Service,
+                        Key = "IdentityServer",
+                        DisplayName = "Identity Server",
+                        Required = true
+                    },
+                    IsSatisfied = false,
+                    Message = "Identity Server is missing."
+                }
+            ]
+        };
+
+        var snapshot = OperationsRegistryMapper.CreateSnapshot([service], [], DateTimeOffset.UtcNow);
+
+        snapshot.Summary.DegradedServices.Should().Be(1);
+        snapshot.Services.Single().Status.Should().Be("Degraded");
+        snapshot.Services.Single().MissingRequiredDependencies.Should().Be(1);
+    }
+}

--- a/src/Tests/OperationsDashboard.Tests/Services/SeqLogClientTests.cs
+++ b/src/Tests/OperationsDashboard.Tests/Services/SeqLogClientTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using XFramework.Operations.Dashboard.Models;
+using XFramework.Operations.Dashboard.Services;
+
+namespace OperationsDashboard.Tests.Services;
+
+[TestFixture]
+public sealed class SeqLogClientTests
+{
+    [Test]
+    public void BuildFilter_ApplicationAndMachineName_EscapesSeqStringLiterals()
+    {
+        var filter = SeqLogClient.BuildFilter("Identity'Server", "node-01");
+
+        filter.Should().Be("Application = 'Identity''Server' and MachineName = 'node-01'");
+    }
+
+    [Test]
+    public void BuildEventsUri_LogQuery_EncodesFilterAndClampsCount()
+    {
+        var uri = SeqLogClient.BuildEventsUri(new DashboardLogQuery(
+            "Wallets",
+            null,
+            new DateTimeOffset(2026, 6, 19, 1, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 6, 19, 1, 30, 0, TimeSpan.Zero),
+            1000));
+
+        uri.Should().StartWith("api/events?count=500&render=true");
+        uri.Should().Contain("filter=Application%20%3D%20%27Wallets%27");
+    }
+
+    [Test]
+    public void ParseEvents_SeqResponse_ReturnsLogEvents()
+    {
+        using var document = JsonDocument.Parse(
+            """
+            {
+              "Events": [
+                {
+                  "Timestamp": "2026-06-19T01:00:00.0000000Z",
+                  "Level": "Information",
+                  "RenderedMessage": "Service started",
+                  "Properties": {
+                    "Application": "IdentityServer",
+                    "MachineName": "node-01",
+                    "SourceContext": "Identity.Program"
+                  }
+                }
+              ]
+            }
+            """);
+
+        var events = SeqLogClient.ParseEvents(document.RootElement);
+
+        events.Should().ContainSingle();
+        events[0].Application.Should().Be("IdentityServer");
+        events[0].MachineName.Should().Be("node-01");
+        events[0].Message.Should().Be("Service started");
+    }
+
+    [Test]
+    public async Task GetLogsAsync_SeqNotConfigured_ReturnsUnavailable()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(HttpStatusCode.OK, "{}"));
+        var client = new SeqLogClient(httpClient, NullLogger<SeqLogClient>.Instance);
+
+        var result = await client.GetLogsAsync(new DashboardLogQuery(null, null, DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow, 50));
+
+        result.IsAvailable.Should().BeFalse();
+        result.Message.Should().Be("Seq is not configured.");
+    }
+
+    [Test]
+    public async Task GetLogsAsync_NonSuccessResponse_ReturnsUnavailable()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(HttpStatusCode.ServiceUnavailable, "{}"))
+        {
+            BaseAddress = new Uri("http://seq/")
+        };
+        var client = new SeqLogClient(httpClient, NullLogger<SeqLogClient>.Instance);
+
+        var result = await client.GetLogsAsync(new DashboardLogQuery("IdentityServer", null, DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow, 50));
+
+        result.IsAvailable.Should().BeFalse();
+        result.Message.Should().Be("Seq returned 503.");
+    }
+
+    private sealed class StubHttpMessageHandler(HttpStatusCode statusCode, string content) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content, Encoding.UTF8, "application/json")
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantModuleFeatureCatalogTests.cs
+++ b/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantModuleFeatureCatalogTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace XFramework.Core.Tests.Services.FeatureGates;
+
+[TestFixture]
+public sealed class TenantModuleFeatureCatalogTests
+{
+    [Test]
+    public void Definitions_BuiltInProvider_ReturnsTenantModuleFeatureKeysAll()
+    {
+        var provider = new BuiltInTenantModuleFeatureDefinitionProvider();
+
+        provider.Definitions.Should().Equal(TenantModuleFeatureKeys.All);
+    }
+
+    [Test]
+    public void All_ExternalProviderRegistered_IncludesExternalDefinitions()
+    {
+        var catalog = new TenantModuleFeatureCatalog(
+        [
+            new BuiltInTenantModuleFeatureDefinitionProvider(),
+            new TestTenantModuleFeatureDefinitionProvider(
+                new TenantModuleFeatureDefinition(
+                    "juan_barangay",
+                    "residents",
+                    "Residents",
+                    "Resident registry and household records.",
+                    "users"))
+        ]);
+
+        catalog.All.Should().Contain(definition =>
+            definition.Key == "juan_barangay.residents" &&
+            definition.DisplayName == "Residents");
+    }
+
+    [Test]
+    public void Find_CombinedAndSplitKeys_ReturnsMatchingDefinition()
+    {
+        var catalog = new TenantModuleFeatureCatalog(
+        [
+            new TestTenantModuleFeatureDefinitionProvider(
+                new TenantModuleFeatureDefinition(
+                    "juan_barangay",
+                    "health_services",
+                    "Health Services",
+                    "Health service case management.",
+                    "heart-pulse"))
+        ]);
+
+        var combinedResult = catalog.Find("Juan_Barangay.Health_Services");
+        var splitResult = catalog.Find("juan_barangay", "health_services");
+
+        combinedResult.Should().NotBeNull();
+        splitResult.Should().BeSameAs(combinedResult);
+    }
+
+    [Test]
+    public void All_DuplicateNormalizedKeys_KeepsFirstDefinition()
+    {
+        var catalog = new TenantModuleFeatureCatalog(
+        [
+            new TestTenantModuleFeatureDefinitionProvider(
+                new TenantModuleFeatureDefinition(
+                    "Juan_Barangay",
+                    "Residents",
+                    "First Residents",
+                    "First definition wins.",
+                    "users")),
+            new TestTenantModuleFeatureDefinitionProvider(
+                new TenantModuleFeatureDefinition(
+                    "juan_barangay.residents",
+                    string.Empty,
+                    "Second Residents",
+                    "Duplicate definition should be ignored.",
+                    "user-x"))
+        ]);
+
+        var matchingDefinitions = catalog.All
+            .Where(definition => definition.Key == "juan_barangay.residents")
+            .ToList();
+
+        matchingDefinitions.Should().ContainSingle();
+        matchingDefinitions[0].DisplayName.Should().Be("First Residents");
+        matchingDefinitions[0].ModuleKey.Should().Be("juan_barangay");
+        matchingDefinitions[0].SubFeatureKey.Should().Be("residents");
+    }
+
+    [Test]
+    public void AddTenantModuleFeatureDefinitions_ConfigurationContainsDefinitions_RegistersConfigDefinitions()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TenantModuleFeatures:Definitions:0:Key"] = "juan_barangay.residents",
+                ["TenantModuleFeatures:Definitions:0:DisplayName"] = "Residents",
+                ["TenantModuleFeatures:Definitions:0:Description"] = "Resident registry and household records.",
+                ["TenantModuleFeatures:Definitions:0:IconName"] = "users",
+                ["TenantModuleFeatures:Definitions:1:ModuleKey"] = "juan_barangay",
+                ["TenantModuleFeatures:Definitions:1:SubFeatureKey"] = "health_services",
+                ["TenantModuleFeatures:Definitions:1:DisplayName"] = "Health Services",
+                ["TenantModuleFeatures:Definitions:1:DefaultEnabled"] = "false"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddTenantModuleFeatureDefinitions(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var catalog = provider.GetRequiredService<ITenantModuleFeatureCatalog>();
+
+        catalog.All.Should().Contain(definition =>
+            definition.Key == "juan_barangay.residents" &&
+            definition.DisplayName == "Residents" &&
+            definition.DefaultEnabled);
+        catalog.All.Should().Contain(definition =>
+            definition.Key == "juan_barangay.health_services" &&
+            definition.DisplayName == "Health Services" &&
+            !definition.DefaultEnabled);
+    }
+
+    private sealed class TestTenantModuleFeatureDefinitionProvider(
+        params TenantModuleFeatureDefinition[] definitions) : ITenantModuleFeatureDefinitionProvider
+    {
+        public IReadOnlyList<TenantModuleFeatureDefinition> Definitions { get; } = definitions;
+    }
+}

--- a/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantModuleFeatureDefinitionResolverTests.cs
+++ b/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantModuleFeatureDefinitionResolverTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using Bolt.Domain.Shared.Contracts.ServiceDiscovery;
+using ControlPanel.Server.Services;
+using FluentAssertions;
+using IdentityServer.Domain.Shared.Contracts;
+using NUnit.Framework;
+
+namespace XFramework.Core.Tests.Services.FeatureGates;
+
+[TestFixture]
+public sealed class TenantModuleFeatureDefinitionResolverTests
+{
+    [Test]
+    public void CreateResolvedDefinition_RequiredTenantFeatureDependencyMissing_BlocksDefinitionAndDisablesDefault()
+    {
+        var module = new BoltModuleRegistryItem
+        {
+            ModuleKey = "juan_barangay",
+            DisplayName = "Juan Barangay",
+            ServiceName = "JuanBarangay",
+            Status = BoltRegistryStatus.Online
+        };
+        var feature = new BoltTenantModuleFeatureRegistryItem
+        {
+            Key = "juan_barangay.health_services",
+            ModuleKey = "juan_barangay",
+            SubFeatureKey = "health_services",
+            DisplayName = "Health Services",
+            Description = "Health service case management.",
+            IconName = "heart-pulse",
+            DefaultEnabled = true,
+            Status = BoltRegistryStatus.Online,
+            Dependencies =
+            [
+                new BoltDependencyRequirement
+                {
+                    Kind = BoltDependencyKind.TenantFeature,
+                    Key = "juan_barangay.residents",
+                    DisplayName = "Residents",
+                    Required = true
+                }
+            ]
+        };
+
+        var resolved = TenantModuleFeatureDefinitionResolver.CreateResolvedDefinition(
+            module,
+            feature,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        resolved.IsBlocked.Should().BeTrue();
+        resolved.Definition.DefaultEnabled.Should().BeFalse();
+        resolved.MissingRequiredDependencies.Should().ContainSingle()
+            .Which.Should().Contain("Residents");
+    }
+
+    [Test]
+    public void CreateResolvedDefinition_RequiredTenantFeatureDependencyEnabled_AllowsDefinitionDefault()
+    {
+        var module = new BoltModuleRegistryItem
+        {
+            ModuleKey = "juan_barangay",
+            DisplayName = "Juan Barangay",
+            ServiceName = "JuanBarangay",
+            Status = BoltRegistryStatus.Online
+        };
+        var feature = new BoltTenantModuleFeatureRegistryItem
+        {
+            Key = "juan_barangay.health_services",
+            ModuleKey = "juan_barangay",
+            SubFeatureKey = "health_services",
+            DisplayName = "Health Services",
+            Description = "Health service case management.",
+            IconName = "heart-pulse",
+            DefaultEnabled = true,
+            Status = BoltRegistryStatus.Online,
+            Dependencies =
+            [
+                new BoltDependencyRequirement
+                {
+                    Kind = BoltDependencyKind.TenantFeature,
+                    Key = "juan_barangay.residents",
+                    DisplayName = "Residents",
+                    Required = true
+                }
+            ]
+        };
+
+        var resolved = TenantModuleFeatureDefinitionResolver.CreateResolvedDefinition(
+            module,
+            feature,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "juan_barangay.residents" });
+
+        resolved.IsBlocked.Should().BeFalse();
+        resolved.Definition.DefaultEnabled.Should().BeTrue();
+        resolved.MissingRequiredDependencies.Should().BeEmpty();
+    }
+
+    [Test]
+    public void MergeResolvedDefinition_DuplicateDiscoveredKey_PreservesFirstDefinitionAndMergesDependencyState()
+    {
+        var builtIn = new ResolvedTenantModuleFeatureDefinition(
+            new TenantModuleFeatureDefinition(
+                "wallets",
+                string.Empty,
+                "Wallets",
+                "Built-in wallet module.",
+                "wallet"),
+            [],
+            ["Optional accounting service is not available."]);
+        var discovered = new ResolvedTenantModuleFeatureDefinition(
+            new TenantModuleFeatureDefinition(
+                "wallets",
+                string.Empty,
+                "Discovered Wallets",
+                "Discovered wallet module.",
+                "credit-card"),
+            ["Service Wallets is offline."],
+            ["Optional accounting service is not available."]);
+
+        var merged = TenantModuleFeatureDefinitionResolver.MergeResolvedDefinition(builtIn, discovered);
+
+        merged.Definition.DisplayName.Should().Be("Wallets");
+        merged.Definition.Description.Should().Be("Built-in wallet module.");
+        merged.MissingRequiredDependencies.Should().ContainSingle()
+            .Which.Should().Be("Service Wallets is offline.");
+        merged.MissingOptionalDependencies.Should().ContainSingle()
+            .Which.Should().Be("Optional accounting service is not available.");
+        merged.IsBlocked.Should().BeTrue();
+    }
+}

--- a/src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj
+++ b/src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj
@@ -26,6 +26,7 @@
         <ProjectReference Include="..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Integration\IdentityServer.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Integration\Wallets.Integration.csproj" />
+        <ProjectReference Include="..\..\Presentation\ControlPanel.Server\ControlPanel.Server.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- adds `XFramework.Operations.Dashboard`, a standalone .NET 10 Blazor Server operations UI
- shows Bolt-discovered services, status, instance counts, modules, dependencies, Seq logs, and Jaeger trace timelines
- wires Docker Compose, Jaeger/OTLP dev tracing, Xeon dev deployment workflow, and focused dashboard tests

## Dependency
- This branch is based on the Bolt service discovery work and depends on PR #257 for the registry contracts/commands.

## Verification
- `dotnet build src/Presentation/XFramework.Operations.Dashboard/XFramework.Operations.Dashboard.csproj -m:1 /nr:false`
- `dotnet test src/Tests/OperationsDashboard.Tests/OperationsDashboard.Tests.csproj -m:1 /nr:false`
- `dotnet test src/Tests/Bolt.Tests/Bolt.Tests.csproj -m:1 /nr:false`
- `dotnet test src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj -m:1 /nr:false`
- `docker-compose config --quiet` with dummy required secrets

## Review
- Sub-agent review found no P0/P1 issues.

## Limitations
- Full Docker stack startup and browser visual verification were not run locally.