### PR TITLE
Fix operations dashboard runtime integrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ x-common-env: &common-env
   ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Docker}
   DefaultDatabaseConnection: Host=${DB_HOST:-postgres};Port=${DB_PORT:-5432};Database=${DB_NAME:-XFramework};Username=${DB_USER:-dbAdmin};Password=${DB_PASSWORD:?Set DB_PASSWORD in .env}
   JwtOptions__Secret: ${JWT_SECRET:?Set JWT_SECRET in .env}
+  Seq__ApiKey: ${SEQ_API_KEY:-}
   OpenTelemetry__Sampling__Probability: ${OTEL_SAMPLING_PROBABILITY:-1.0}
   OpenTelemetry__Exporters__OTLP__Enabled: ${OTEL_OTLP_ENABLED:-true}
   OpenTelemetry__Exporters__OTLP__Endpoint: ${OTEL_OTLP_ENDPOINT:-http://jaeger:4317}
@@ -245,6 +246,7 @@ services:
       BoltConfiguration__ServerUrls__0: ws://bolt-hub:8080/bolt/ws
       BoltConfiguration__RpcTimeoutSeconds: 30
       Seq__Url: http://seq:80
+      Seq__ApiKey: ${SEQ_API_KEY:-}
       Jaeger__QueryUrl: http://jaeger:16686
       OpenTelemetry__Sampling__Probability: ${OTEL_SAMPLING_PROBABILITY:-1.0}
       OpenTelemetry__Exporters__OTLP__Enabled: ${OTEL_OTLP_ENABLED:-true}

--- a/src/Presentation/XFramework.Operations.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Presentation/XFramework.Operations.Dashboard/Components/Layout/MainLayout.razor
@@ -1,4 +1,5 @@
 @inherits LayoutComponentBase
+@inject NavigationManager Navigation
 
 <div class="ops-shell">
     <aside class="ops-sidebar">
@@ -15,11 +16,11 @@
                 <LucideIcon Name="activity" class="ops-nav-icon" />
                 Services
             </a>
-            <a class="ops-nav-link" href="http://localhost:5341" target="_blank" rel="noreferrer">
+            <a class="ops-nav-link" href="@BuildPeerServiceUrl(5341)" target="_blank" rel="noreferrer">
                 <LucideIcon Name="scroll-text" class="ops-nav-icon" />
                 Seq
             </a>
-            <a class="ops-nav-link" href="http://localhost:16686" target="_blank" rel="noreferrer">
+            <a class="ops-nav-link" href="@BuildPeerServiceUrl(16686)" target="_blank" rel="noreferrer">
                 <LucideIcon Name="waypoints" class="ops-nav-icon" />
                 Jaeger
             </a>
@@ -51,3 +52,11 @@
 <BbToastProvider Position="ToastPosition.BottomRight" />
 <BbDialogProvider />
 <BbPortalHost />
+
+@code {
+    private string BuildPeerServiceUrl(int port)
+    {
+        var current = new Uri(Navigation.Uri);
+        return new UriBuilder(current.Scheme, current.Host, port).Uri.ToString();
+    }
+}

--- a/src/Presentation/XFramework.Operations.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Presentation/XFramework.Operations.Dashboard/Components/Pages/Dashboard.razor
@@ -454,7 +454,7 @@
 
         _traces = await JaegerTraceClient.GetTracesAsync(
             new DashboardTraceQuery(
-                service.LogApplicationName,
+                service.TraceServiceName,
                 lookback,
                 Options.Value.DefaultTraceLimit),
             ct);

--- a/src/Presentation/XFramework.Operations.Dashboard/Models/ServiceInstanceSummary.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Models/ServiceInstanceSummary.cs
@@ -14,6 +14,7 @@ public sealed record ServiceInstanceSummary(
     DateTimeOffset? LastConnectedAt,
     DateTimeOffset? LastDisconnectedAt,
     string? MachineName,
+    string TraceServiceName,
     IReadOnlyList<ServiceModuleSummary> Modules,
     IReadOnlyList<DependencySummary> Dependencies)
 {

--- a/src/Presentation/XFramework.Operations.Dashboard/Services/OperationsRegistryMapper.cs
+++ b/src/Presentation/XFramework.Operations.Dashboard/Services/OperationsRegistryMapper.cs
@@ -4,6 +4,19 @@ namespace XFramework.Operations.Dashboard.Services;
 
 public static class OperationsRegistryMapper
 {
+    private static readonly HashSet<string> BuiltInApiServiceNames =
+    [
+        "IdentityServer",
+        "Inventario",
+        "Messaging",
+        "Notifications",
+        "SmsGateway",
+        "Wallets",
+        "XFramework.Messaging",
+        "XFramework.Notifications",
+        "XFramework.SmsGateway"
+    ];
+
     public static DashboardRegistrySnapshot CreateSnapshot(
         IEnumerable<BoltServiceRegistryItem> serviceItems,
         IEnumerable<BoltModuleRegistryItem> moduleItems,
@@ -61,8 +74,47 @@ public static class OperationsRegistryMapper
             AsNullableOffset(service.LastConnectedAt),
             AsNullableOffset(service.LastDisconnectedAt),
             string.IsNullOrWhiteSpace(machineName) ? null : machineName,
+            ResolveTraceServiceName(service),
             serviceModules.Select(MapModule).ToList(),
             dependencies);
+    }
+
+    public static string ResolveTraceServiceName(BoltServiceRegistryItem service)
+    {
+        if (service.Manifest.Metadata.TryGetValue("TraceServiceName", out var traceServiceName)
+            && !string.IsNullOrWhiteSpace(traceServiceName))
+        {
+            return traceServiceName;
+        }
+
+        if (service.Manifest.Metadata.TryGetValue("OpenTelemetryServiceName", out var openTelemetryServiceName)
+            && !string.IsNullOrWhiteSpace(openTelemetryServiceName))
+        {
+            return openTelemetryServiceName;
+        }
+
+        var candidate = FirstNonEmpty(service.ServiceName, service.ClientName);
+        if (string.Equals(candidate, "OperationsDashboard", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(service.ClientName, "OperationsDashboard", StringComparison.OrdinalIgnoreCase))
+        {
+            return "XFramework.Operations.Dashboard";
+        }
+
+        if (candidate.StartsWith("XFramework.", StringComparison.OrdinalIgnoreCase))
+        {
+            return candidate.EndsWith(".Api", StringComparison.OrdinalIgnoreCase)
+                || candidate.EndsWith(".Dashboard", StringComparison.OrdinalIgnoreCase)
+                    ? candidate
+                    : $"{candidate}.Api";
+        }
+
+        if (BuiltInApiServiceNames.Contains(candidate)
+            || BuiltInApiServiceNames.Contains(service.ClientName))
+        {
+            return $"XFramework.{candidate}.Api";
+        }
+
+        return candidate;
     }
 
     private static ServiceModuleSummary MapModule(BoltModuleRegistryItem module)

--- a/src/Tests/OperationsDashboard.Tests/Services/OperationsRegistryMapperTests.cs
+++ b/src/Tests/OperationsDashboard.Tests/Services/OperationsRegistryMapperTests.cs
@@ -94,4 +94,47 @@ public sealed class OperationsRegistryMapperTests
         snapshot.Services.Single().Status.Should().Be("Degraded");
         snapshot.Services.Single().MissingRequiredDependencies.Should().Be(1);
     }
+
+    [Test]
+    public void CreateSnapshot_BuiltInService_MapsTraceServiceNameToOpenTelemetryName()
+    {
+        var service = new BoltServiceRegistryItem
+        {
+            ClientId = "client-identity",
+            ClientName = "IdentityServer",
+            ServiceName = "IdentityServer",
+            Status = BoltRegistryStatus.Online,
+            ConnectionCount = 1,
+            LastSeenAt = DateTime.UtcNow
+        };
+
+        var snapshot = OperationsRegistryMapper.CreateSnapshot([service], [], DateTimeOffset.UtcNow);
+
+        snapshot.Services.Single().TraceServiceName.Should().Be("XFramework.IdentityServer.Api");
+    }
+
+    [Test]
+    public void CreateSnapshot_MetadataTraceServiceName_PreservesExternalModuleName()
+    {
+        var service = new BoltServiceRegistryItem
+        {
+            ClientId = "client-barangay",
+            ClientName = "JuanBarangay",
+            ServiceName = "JuanBarangay",
+            Status = BoltRegistryStatus.Online,
+            ConnectionCount = 1,
+            LastSeenAt = DateTime.UtcNow,
+            Manifest =
+            {
+                Metadata =
+                {
+                    ["TraceServiceName"] = "JuanBarangay.Api"
+                }
+            }
+        };
+
+        var snapshot = OperationsRegistryMapper.CreateSnapshot([service], [], DateTimeOffset.UtcNow);
+
+        snapshot.Services.Single().TraceServiceName.Should().Be("JuanBarangay.Api");
+    }
 }


### PR DESCRIPTION
## Summary
- Make dashboard Seq/Jaeger sidebar links resolve against the current host instead of localhost.
- Add trace service-name mapping so dashboard trace queries match the OpenTelemetry service names seen in Jaeger.
- Wire optional `SEQ_API_KEY` into compose and add mapper tests for built-in/external trace names.

## Verification
- `dotnet build src/Presentation/XFramework.Operations.Dashboard/XFramework.Operations.Dashboard.csproj -m:1 /nr:false`
- `dotnet test src/Tests/OperationsDashboard.Tests/OperationsDashboard.Tests.csproj -m:1 /nr:false`
- `docker-compose config --quiet`