### PR TITLE
Add Inventario category detail page

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
@@ -37,7 +37,9 @@ else
                     <BbCardDescription>@_categories.Count category(s) loaded</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_categories" ShowPagination="true" InitialPageSize="20">
+                    <BbDataGrid Items="@_categories" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((ProductCategory item) => Navigation.NavigateTo($"/inventario/categories/{item.Id}"))"
+                                Class="cursor-pointer">
                         <Columns>
                             <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
                             <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" />
@@ -47,7 +49,11 @@ else
                             <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
-                                    <div class="flex items-center gap-1">
+                                    <div class="flex items-center gap-1" @onclick:stopPropagation="true">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/inventario/categories/{item.Id}"))">
+                                            <LucideIcon Name="eye" class="h-4 w-4" />
+                                        </BbButton>
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
                                                   OnClick="@(() => OpenEditDialog(item))">
                                             <LucideIcon Name="pencil" class="h-4 w-4" />
@@ -91,6 +97,7 @@ else
 
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/CategoryDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/CategoryDetail.razor
@@ -1,0 +1,206 @@
+@page "/inventario/categories/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Category - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_moduleEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/categories"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Categories
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Category Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this category's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_category is null)
+{
+    <BbTypographyMuted>Category not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/categories"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <BbTypographyH3>@(_category.Name ?? "Unnamed Category")</BbTypographyH3>
+                        <StatusBadge Text="@(_category.IsEnabled ? "Enabled" : "Disabled")"
+                                     Status="@(_category.IsEnabled ? "active" : "inactive")" />
+                    </div>
+                    <BbTypographyMuted>ID: @_category.Id</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Category Summary</BbCardTitle>
+                    <BbCardDescription>Catalog category details for the selected tenant.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Name</BbTypographyMuted>
+                            <div>@(_category.Name ?? "Unnamed Category")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Products</BbTypographyMuted>
+                            <div>@_products.Count</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@_category.CreatedAt.ToLocalTime().ToString("g")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Last Modified</BbTypographyMuted>
+                            <div>@(_category.ModifiedAt?.ToLocalTime().ToString("g") ?? "Never")</div>
+                        </div>
+                        <div class="md:col-span-2">
+                            <BbTypographyMuted>Description</BbTypographyMuted>
+                            <div>@(_category.Description ?? "No description")</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Products</BbCardTitle>
+                    <BbCardDescription>Products assigned to this category.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_products" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((Product item) => Navigation.NavigateTo($"/inventario/products/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="SKU">
+                                <ChildContent Context="item">
+                                    <span class="font-mono text-xs">@(item.SKU ?? "N/A")</span>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Price" Sortable="true">
+                                <ChildContent Context="item">@item.Price.ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Stock" Sortable="true">
+                                <ChildContent Context="item">@item.StockQuantity</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsAvailable ? "Available" : "Unavailable")"
+                                                 Status="@(item.IsAvailable ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+
+    private ProductCategory? _category;
+    private List<Product> _products = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _moduleEnabled;
+    private bool _outsideTenantContext;
+    private Guid? _loadedId;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _outsideTenantContext = false;
+            _category = null;
+            _products = [];
+
+            if (!_hasTenant || !_moduleEnabled) return;
+
+            _category = await DataContext.Query<ProductCategory>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _category is not null && _category.TenantId != TenantFilter.SelectedTenantId;
+            if (_category is null || _outsideTenantContext) return;
+
+            _products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == _category.TenantId && x.CategoryId == Id && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(250)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load category: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}


### PR DESCRIPTION
## Summary
- Add list-to-detail navigation for Inventario categories
- Add a read-only category detail page with assigned products
- Keep category create/edit/delete actions scoped to the list-page dialogs

## Tests
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly
- dotnet build src/Modules/XFramework.Blazor/XFramework.Blazor.csproj -m:1 /nr:false --nologo -v:minimal -clp:ErrorsOnly