### PR TITLE
Add Inventario lot traceability foundation

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260619100305_AddInventarioTraceabilityLots.Designer.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619100305_AddInventarioTraceabilityLots.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XFramework.Domain.Contexts;
@@ -11,9 +12,11 @@ using XFramework.Domain.Contexts;
 namespace XFramework.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619100305_AddInventarioTraceabilityLots")]
+    partial class AddInventarioTraceabilityLots
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kernel/XFramework.Domain/Migrations/20260619100305_AddInventarioTraceabilityLots.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619100305_AddInventarioTraceabilityLots.cs
@@ -1,0 +1,261 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInventarioTraceabilityLots : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InventoryLot",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LotNumber = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    SupplierReference = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    SourceReferenceType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    SourceReferenceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ReceivedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ManufacturedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UnitCost = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_InventoryLot", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryLot_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "LotId",
+                schema: "Inventario",
+                table: "StockBalance",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "LotId",
+                schema: "Inventario",
+                table: "InventoryMovement",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "IdempotencyKey",
+                schema: "Inventario",
+                table: "InventoryMovement",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RequestHash",
+                schema: "Inventario",
+                table: "InventoryMovement",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.DropIndex(
+                name: "IX_StockBalance_TenantId_ProductId_WarehouseId_LocationId",
+                schema: "Inventario",
+                table: "StockBalance");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryLot_ProductId",
+                schema: "Inventario",
+                table: "InventoryLot",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryLot_TenantId",
+                schema: "Inventario",
+                table: "InventoryLot",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryLot_TenantId_IsDeleted",
+                schema: "Inventario",
+                table: "InventoryLot",
+                columns: new[] { "TenantId", "IsDeleted" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryLot_TenantId_ProductId_ExpiresAt",
+                schema: "Inventario",
+                table: "InventoryLot",
+                columns: new[] { "TenantId", "ProductId", "ExpiresAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryLot_TenantId_ProductId_LotNumber",
+                schema: "Inventario",
+                table: "InventoryLot",
+                columns: new[] { "TenantId", "ProductId", "LotNumber" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryLot_TenantId_Status",
+                schema: "Inventario",
+                table: "InventoryLot",
+                columns: new[] { "TenantId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryMovement_LotId",
+                schema: "Inventario",
+                table: "InventoryMovement",
+                column: "LotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryMovement_TenantId_IdempotencyKey",
+                schema: "Inventario",
+                table: "InventoryMovement",
+                columns: new[] { "TenantId", "IdempotencyKey" },
+                unique: true,
+                filter: "\"IdempotencyKey\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryMovement_TenantId_LotId_MovementDate",
+                schema: "Inventario",
+                table: "InventoryMovement",
+                columns: new[] { "TenantId", "LotId", "MovementDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockBalance_LotId",
+                schema: "Inventario",
+                table: "StockBalance",
+                column: "LotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockBalance_TenantId_ProductId_WarehouseId_LocationId",
+                schema: "Inventario",
+                table: "StockBalance",
+                columns: new[] { "TenantId", "ProductId", "WarehouseId", "LocationId" },
+                unique: true,
+                filter: "\"LotId\" IS NULL AND \"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockBalance_TenantId_ProductId_WarehouseId_LocationId_LotId",
+                schema: "Inventario",
+                table: "StockBalance",
+                columns: new[] { "TenantId", "ProductId", "WarehouseId", "LocationId", "LotId" },
+                unique: true,
+                filter: "\"LotId\" IS NOT NULL AND \"IsDeleted\" = false");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Inventario_InventoryMovement_Lot",
+                schema: "Inventario",
+                table: "InventoryMovement",
+                column: "LotId",
+                principalSchema: "Inventario",
+                principalTable: "InventoryLot",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Inventario_StockBalance_Lot",
+                schema: "Inventario",
+                table: "StockBalance",
+                column: "LotId",
+                principalSchema: "Inventario",
+                principalTable: "InventoryLot",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Inventario_InventoryMovement_Lot",
+                schema: "Inventario",
+                table: "InventoryMovement");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Inventario_StockBalance_Lot",
+                schema: "Inventario",
+                table: "StockBalance");
+
+            migrationBuilder.DropTable(
+                name: "InventoryLot",
+                schema: "Inventario");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InventoryMovement_TenantId_IdempotencyKey",
+                schema: "Inventario",
+                table: "InventoryMovement");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InventoryMovement_TenantId_LotId_MovementDate",
+                schema: "Inventario",
+                table: "InventoryMovement");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InventoryMovement_LotId",
+                schema: "Inventario",
+                table: "InventoryMovement");
+
+            migrationBuilder.DropIndex(
+                name: "IX_StockBalance_TenantId_ProductId_WarehouseId_LocationId",
+                schema: "Inventario",
+                table: "StockBalance");
+
+            migrationBuilder.DropIndex(
+                name: "IX_StockBalance_TenantId_ProductId_WarehouseId_LocationId_LotId",
+                schema: "Inventario",
+                table: "StockBalance");
+
+            migrationBuilder.DropIndex(
+                name: "IX_StockBalance_LotId",
+                schema: "Inventario",
+                table: "StockBalance");
+
+            migrationBuilder.DropColumn(
+                name: "LotId",
+                schema: "Inventario",
+                table: "StockBalance");
+
+            migrationBuilder.DropColumn(
+                name: "IdempotencyKey",
+                schema: "Inventario",
+                table: "InventoryMovement");
+
+            migrationBuilder.DropColumn(
+                name: "LotId",
+                schema: "Inventario",
+                table: "InventoryMovement");
+
+            migrationBuilder.DropColumn(
+                name: "RequestHash",
+                schema: "Inventario",
+                table: "InventoryMovement");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockBalance_TenantId_ProductId_WarehouseId_LocationId",
+                schema: "Inventario",
+                table: "StockBalance",
+                columns: new[] { "TenantId", "ProductId", "WarehouseId", "LocationId" },
+                unique: true);
+        }
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/Create/CreateInventoryLotValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/Create/CreateInventoryLotValidator.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+
+namespace Inventario.Api.Features.Lots.Create;
+
+public sealed class CreateInventoryLotValidator : AbstractValidator<CreateInventoryLotRequest>
+{
+    public CreateInventoryLotValidator()
+    {
+        RuleFor(x => x.ProductId)
+            .NotEmpty().WithMessage("Product is required.");
+
+        RuleFor(x => x.LotNumber)
+            .NotEmpty().WithMessage("Lot number is required.")
+            .MaximumLength(100).WithMessage("Lot number cannot exceed 100 characters.");
+
+        RuleFor(x => x.SupplierReference)
+            .MaximumLength(200).WithMessage("Supplier reference cannot exceed 200 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.SupplierReference));
+
+        RuleFor(x => x.SourceReferenceType)
+            .MaximumLength(100).WithMessage("Source reference type cannot exceed 100 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.SourceReferenceType));
+
+        RuleFor(x => x.UnitCost)
+            .GreaterThanOrEqualTo(0).WithMessage("Unit cost cannot be negative.")
+            .When(x => x.UnitCost.HasValue);
+
+        RuleFor(x => x)
+            .Must(x => x.ExpiresAt is null || x.ManufacturedAt is null || x.ExpiresAt > x.ManufacturedAt)
+            .WithMessage("Expiration date must be after manufacture date.");
+
+        RuleFor(x => x)
+            .Must(x => x.ReceivedAt is null || x.ManufacturedAt is null || x.ReceivedAt >= x.ManufacturedAt)
+            .WithMessage("Received date must be on or after manufacture date.");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/Create/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/Create/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+
+namespace Inventario.Api.Features.Lots.Create;
+
+public static class CreateInventoryLotEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/lots", Tags = ["Inventario Traceability"],
+        Summary = "Create inventory lot",
+        Description = "Creates a traceability lot or batch for the authenticated tenant.")]
+    public static async Task<Result<InventoryLot>> Handle(
+        CreateInventoryLotRequest request,
+        InventoryLotService lotService,
+        CancellationToken ct)
+    {
+        return await lotService.CreateLotAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/Get/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/Get/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+
+namespace Inventario.Api.Features.Lots.Get;
+
+public static class GetInventoryLotEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/lots/{id:guid}", Tags = ["Inventario Traceability"],
+        Summary = "Get inventory lot",
+        Description = "Gets a traceability lot or batch for the authenticated tenant.")]
+    public static async Task<Result<InventoryLot>> Handle(
+        GetInventoryLotRequest request,
+        InventoryLotService lotService,
+        CancellationToken ct)
+    {
+        return await lotService.GetLotAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/GetList/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/GetList/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+
+namespace Inventario.Api.Features.Lots.GetList;
+
+public static class GetInventoryLotsEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/lots", Tags = ["Inventario Traceability"],
+        Summary = "Get inventory lots",
+        Description = "Gets traceability lots or batches for the authenticated tenant.")]
+    public static async Task<Result<List<InventoryLot>>> Handle(
+        GetInventoryLotsRequest request,
+        InventoryLotService lotService,
+        CancellationToken ct)
+    {
+        return await lotService.GetLotsAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/Post/PostStockMovementValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/Post/PostStockMovementValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+
+namespace Inventario.Api.Features.Stock.Post;
+
+public sealed class PostStockMovementValidator : AbstractValidator<PostStockMovementRequest>
+{
+    public PostStockMovementValidator()
+    {
+        RuleFor(x => x.ProductId).NotEmpty().WithMessage("Product is required.");
+        RuleFor(x => x.WarehouseId).NotEmpty().WithMessage("Warehouse is required.");
+        RuleFor(x => x.LocationId).NotEmpty().WithMessage("Location is required.");
+        RuleFor(x => x.Quantity).NotEqual(0).WithMessage("Quantity must not be zero.");
+        RuleFor(x => x.UnitOfMeasure).MaximumLength(25).When(x => !string.IsNullOrWhiteSpace(x.UnitOfMeasure));
+        RuleFor(x => x.ReferenceType).MaximumLength(100).When(x => !string.IsNullOrWhiteSpace(x.ReferenceType));
+        RuleFor(x => x.Reason).MaximumLength(1000).When(x => !string.IsNullOrWhiteSpace(x.Reason));
+        RuleFor(x => x.IdempotencyKey).MaximumLength(200).When(x => !string.IsNullOrWhiteSpace(x.IdempotencyKey));
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj
@@ -22,6 +22,10 @@
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     </ItemGroup>
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
@@ -45,6 +45,7 @@ app.UseTenantModuleFeatureGate(options =>
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/movements", "movements");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/post", "movements");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reservations", "reservations");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/lots", "traceability");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api");
 });
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryLotService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryLotService.cs
@@ -1,0 +1,144 @@
+using Microsoft.AspNetCore.Http;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+
+namespace XFramework.Inventario.Api.Services;
+
+public sealed class InventoryLotService(
+    IDataContext dataContext,
+    IHttpContextAccessor httpContextAccessor)
+{
+    public async Task<Result<List<InventoryLot>>> GetLotsAsync(
+        GetInventoryLotsRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<InventoryLot>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var query = dataContext.Query<InventoryLot>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
+
+        if (request.ProductId is { } productId)
+            query = query.Where(x => x.ProductId == productId);
+
+        if (request.Status is { } status)
+            query = query.Where(x => x.Status == status);
+
+        if (!request.IncludeExpired)
+            query = query.Where(x => x.ExpiresAt == null || x.ExpiresAt >= DateTime.UtcNow);
+
+        var lots = await query
+            .OrderBy(x => x.ExpiresAt ?? DateTime.MaxValue)
+            .ThenBy(x => x.ReceivedAt)
+            .ThenBy(x => x.LotNumber)
+            .Take(500)
+            .ToListAsync(ct);
+
+        return Result<List<InventoryLot>>.Success(lots);
+    }
+
+    public async Task<Result<InventoryLot>> GetLotAsync(
+        GetInventoryLotRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<InventoryLot>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var lot = await dataContext.Query<InventoryLot>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantResult.Data && x.Id == request.Id && !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+
+        return lot is null
+            ? Result<InventoryLot>.NotFound("Lot not found.")
+            : Result<InventoryLot>.Success(lot);
+    }
+
+    public async Task<Result<InventoryLot>> CreateLotAsync(
+        CreateInventoryLotRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<InventoryLot>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var lotNumber = NormalizeRequired(request.LotNumber);
+        if (lotNumber is null)
+            return Result<InventoryLot>.Failure("Lot number is required.", 400);
+
+        var productExists = await dataContext.Query<Product>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x => x.TenantId == tenantId && x.Id == request.ProductId && !x.IsDeleted, ct);
+        if (!productExists)
+            return Result<InventoryLot>.NotFound("Product not found.");
+
+        var duplicate = await dataContext.Query<InventoryLot>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x =>
+                x.TenantId == tenantId &&
+                x.ProductId == request.ProductId &&
+                x.LotNumber == lotNumber &&
+                !x.IsDeleted,
+                ct);
+        if (duplicate)
+            return Result<InventoryLot>.Conflict("A lot with the same number already exists for this product.");
+
+        var lot = new InventoryLot
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = request.ProductId,
+            LotNumber = lotNumber,
+            SupplierReference = NormalizeOptional(request.SupplierReference),
+            SourceReferenceType = NormalizeOptional(request.SourceReferenceType),
+            SourceReferenceId = request.SourceReferenceId,
+            ReceivedAt = request.ReceivedAt ?? DateTime.UtcNow,
+            ManufacturedAt = request.ManufacturedAt,
+            ExpiresAt = request.ExpiresAt,
+            UnitCost = request.UnitCost,
+            Status = request.Status,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        dataContext.Add(lot);
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<InventoryLot>.Failure(saveResult.Message ?? "Lot save failed.", saveResult.StatusCode);
+
+        return Result<InventoryLot>.Success(lot, 201, "Lot created.");
+    }
+
+    private Result<Guid> GetCurrentTenantId(RequestBase? request)
+    {
+        if (request?.Metadata?.TenantId is { } metadataTenantId && metadataTenantId != Guid.Empty)
+            return Result<Guid>.Success(metadataTenantId);
+
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return Result<Guid>.Unauthorized("Authentication is required for lot operations.");
+
+        var tenantIdClaim = user.FindFirst("tenantId")?.Value
+            ?? user.FindFirst("TenantId")?.Value
+            ?? user.FindFirst("tid")?.Value;
+
+        if (Guid.TryParse(tenantIdClaim, out var tenantId) && tenantId != Guid.Empty)
+            return Result<Guid>.Success(tenantId);
+
+        return Result<Guid>.Forbidden("Authenticated user does not have a valid tenant context.");
+    }
+
+    private static string? NormalizeRequired(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
@@ -1,4 +1,7 @@
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using XFramework.Core.Patterns;
 using XFramework.Domain.Shared.Contracts.Requests;
@@ -14,6 +17,8 @@ public sealed class StockPostingService(
     IDataContext dataContext,
     IHttpContextAccessor httpContextAccessor)
 {
+    private static readonly JsonSerializerOptions HashJsonOptions = new(JsonSerializerDefaults.Web);
+
     public async Task<Result<StockPostingResponse>> PostAsync(
         PostStockMovementRequest request,
         CancellationToken ct = default) =>
@@ -40,14 +45,29 @@ public sealed class StockPostingService(
         if (request.MovementType != InventoryMovementType.Adjustment && request.Quantity < 0)
             return Result<StockPostingResponse>.Failure("Quantity must be positive for this movement type.", 400);
 
+        var requestHash = ComputeRequestHash(tenantId, request);
+        var replay = await FindIdempotentReplayAsync(tenantId, request, requestHash, ct);
+        if (replay is not null)
+            return replay;
+
         if (request.MovementType == InventoryMovementType.Transfer)
-            return await PostTransferAsync(tenantId, request, saveChanges, ct);
+            return await PostTransferAsync(tenantId, request, requestHash, saveChanges, ct);
 
         var product = await GetProduct(tenantId, request.ProductId, ct);
         if (product is null)
             return Result<StockPostingResponse>.NotFound("Product not found.");
 
-        var balanceResult = await GetOrCreateBalance(tenantId, request.ProductId, request.WarehouseId, request.LocationId, ct);
+        var lotResult = await ValidateLotAsync(tenantId, request.ProductId, request.LotId, ct);
+        if (!lotResult.IsSuccess)
+            return Result<StockPostingResponse>.Failure(lotResult.Message!, lotResult.StatusCode);
+
+        var balanceResult = await GetOrCreateBalance(
+            tenantId,
+            request.ProductId,
+            request.WarehouseId,
+            request.LocationId,
+            request.LotId,
+            ct);
         if (!balanceResult.IsSuccess)
             return Result<StockPostingResponse>.Failure(balanceResult.Message!, balanceResult.StatusCode);
 
@@ -66,7 +86,15 @@ public sealed class StockPostingService(
             dataContext.Update(balance);
 
         ApplyBalance(balance, afterOnHand, afterReserved);
-        AddMovement(tenantId, request, balance.Id, delta == 0 ? reservedDelta : delta, before, afterOnHand);
+        AddMovement(
+            tenantId,
+            request,
+            balance.Id,
+            delta == 0 ? reservedDelta : delta,
+            before,
+            afterOnHand,
+            requestHash,
+            includeIdempotency: true);
         await UpdateProductSnapshot(tenantId, product, request.ProductId, delta, ct);
 
         if (saveChanges)
@@ -76,14 +104,17 @@ public sealed class StockPostingService(
                 return Result<StockPostingResponse>.Failure(saveResult.Message ?? "Stock posting failed.", saveResult.StatusCode);
         }
 
-        return Result<StockPostingResponse>.Success(new StockPostingResponse(
+        return Result<StockPostingResponse>.Success(CreateResponse(
             balance.Id,
             request.ProductId,
             balance.WarehouseId,
             balance.LocationId,
             balance.OnHandQuantity,
             balance.ReservedQuantity,
-            balance.AvailableQuantity));
+            balance.AvailableQuantity,
+            request.LotId,
+            NormalizeIdempotencyKey(request.IdempotencyKey),
+            isReplay: false));
     }
 
     public async Task<Result<List<StockBalance>>> GetBalancesAsync(
@@ -101,6 +132,15 @@ public sealed class StockPostingService(
 
         if (request.ProductId is { } id)
             query = query.Where(x => x.ProductId == id);
+
+        if (request.WarehouseId is { } warehouseId)
+            query = query.Where(x => x.WarehouseId == warehouseId);
+
+        if (request.LocationId is { } locationId)
+            query = query.Where(x => x.LocationId == locationId);
+
+        if (request.LotId is { } lotId)
+            query = query.Where(x => x.LotId == lotId);
 
         var balances = await query
             .OrderBy(x => x.ProductId)
@@ -126,6 +166,19 @@ public sealed class StockPostingService(
         if (request.ProductId is { } id)
             query = query.Where(x => x.ProductId == id);
 
+        if (request.WarehouseId is { } warehouseId)
+            query = query.Where(x => x.WarehouseId == warehouseId);
+
+        if (request.LocationId is { } locationId)
+            query = query.Where(x => x.LocationId == locationId);
+
+        if (request.LotId is { } lotId)
+            query = query.Where(x => x.LotId == lotId);
+
+        var idempotencyKey = NormalizeIdempotencyKey(request.IdempotencyKey);
+        if (idempotencyKey is not null)
+            query = query.Where(x => x.IdempotencyKey == idempotencyKey);
+
         var movements = await query
             .OrderByDescending(x => x.MovementDate)
             .Take(500)
@@ -137,6 +190,7 @@ public sealed class StockPostingService(
     private async Task<Result<StockPostingResponse>> PostTransferAsync(
         Guid tenantId,
         PostStockMovementRequest request,
+        string requestHash,
         bool saveChanges,
         CancellationToken ct)
     {
@@ -150,11 +204,27 @@ public sealed class StockPostingService(
         if (product is null)
             return Result<StockPostingResponse>.NotFound("Product not found.");
 
-        var sourceResult = await GetOrCreateBalance(tenantId, request.ProductId, request.WarehouseId, request.LocationId, ct);
+        var lotResult = await ValidateLotAsync(tenantId, request.ProductId, request.LotId, ct);
+        if (!lotResult.IsSuccess)
+            return Result<StockPostingResponse>.Failure(lotResult.Message!, lotResult.StatusCode);
+
+        var sourceResult = await GetOrCreateBalance(
+            tenantId,
+            request.ProductId,
+            request.WarehouseId,
+            request.LocationId,
+            request.LotId,
+            ct);
         if (!sourceResult.IsSuccess)
             return Result<StockPostingResponse>.Failure(sourceResult.Message!, sourceResult.StatusCode);
 
-        var destinationResult = await GetOrCreateBalance(tenantId, request.ProductId, destinationWarehouseId, destinationLocationId, ct);
+        var destinationResult = await GetOrCreateBalance(
+            tenantId,
+            request.ProductId,
+            destinationWarehouseId,
+            destinationLocationId,
+            request.LotId,
+            ct);
         if (!destinationResult.IsSuccess)
             return Result<StockPostingResponse>.Failure(destinationResult.Message!, destinationResult.StatusCode);
 
@@ -177,12 +247,20 @@ public sealed class StockPostingService(
         ApplyBalance(source, sourceAfter, source.ReservedQuantity, now);
         ApplyBalance(destination, destination.OnHandQuantity + request.Quantity, destination.ReservedQuantity, now);
 
-        AddMovement(tenantId, request, source.Id, -request.Quantity, sourceBefore, source.OnHandQuantity);
+        AddMovement(
+            tenantId,
+            request,
+            source.Id,
+            -request.Quantity,
+            sourceBefore,
+            source.OnHandQuantity,
+            requestHash,
+            includeIdempotency: true);
         AddMovement(tenantId, request with
         {
             WarehouseId = destinationWarehouseId,
             LocationId = destinationLocationId
-        }, destination.Id, request.Quantity, destinationBefore, destination.OnHandQuantity);
+        }, destination.Id, request.Quantity, destinationBefore, destination.OnHandQuantity, requestHash, includeIdempotency: false);
 
         await UpdateProductSnapshot(tenantId, product, request.ProductId, 0, ct);
 
@@ -193,14 +271,17 @@ public sealed class StockPostingService(
                 return Result<StockPostingResponse>.Failure(saveResult.Message ?? "Stock transfer failed.", saveResult.StatusCode);
         }
 
-        return Result<StockPostingResponse>.Success(new StockPostingResponse(
+        return Result<StockPostingResponse>.Success(CreateResponse(
             destination.Id,
             request.ProductId,
             destination.WarehouseId,
             destination.LocationId,
             destination.OnHandQuantity,
             destination.ReservedQuantity,
-            destination.AvailableQuantity));
+            destination.AvailableQuantity,
+            request.LotId,
+            NormalizeIdempotencyKey(request.IdempotencyKey),
+            isReplay: false));
     }
 
     private async Task<Product?> GetProduct(Guid tenantId, Guid productId, CancellationToken ct) =>
@@ -209,11 +290,38 @@ public sealed class StockPostingService(
             .Where(x => x.TenantId == tenantId && x.Id == productId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
 
+    private async Task<Result<InventoryLot?>> ValidateLotAsync(
+        Guid tenantId,
+        Guid productId,
+        Guid? lotId,
+        CancellationToken ct)
+    {
+        if (lotId is null)
+            return Result<InventoryLot?>.Success(null);
+
+        var lot = await dataContext.Query<InventoryLot>()
+            .IgnoreQueryFilters()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                x.Id == lotId.Value &&
+                !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+
+        if (lot is null)
+            return Result<InventoryLot?>.NotFound("Lot not found.");
+
+        if (lot.ProductId != productId)
+            return Result<InventoryLot?>.Failure("Lot does not belong to the requested product.", 400);
+
+        return Result<InventoryLot?>.Success(lot);
+    }
+
     private async Task<Result<StockBalanceLookup>> GetOrCreateBalance(
         Guid tenantId,
         Guid productId,
         Guid warehouseId,
         Guid locationId,
+        Guid? lotId,
         CancellationToken ct)
     {
         var warehouseExists = await dataContext.Query<Warehouse>()
@@ -235,6 +343,7 @@ public sealed class StockPostingService(
                 x.ProductId == productId &&
                 x.WarehouseId == warehouseId &&
                 x.LocationId == locationId &&
+                x.LotId == lotId &&
                 !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
 
@@ -248,6 +357,7 @@ public sealed class StockPostingService(
             ProductId = productId,
             WarehouseId = warehouseId,
             LocationId = locationId,
+            LotId = lotId,
             IsEnabled = true,
             CreatedAt = DateTime.UtcNow,
             ConcurrencyStamp = Guid.NewGuid()
@@ -293,8 +403,14 @@ public sealed class StockPostingService(
         Guid stockBalanceId,
         decimal quantityDelta,
         decimal quantityBefore,
-        decimal quantityAfter)
+        decimal quantityAfter,
+        string requestHash,
+        bool includeIdempotency)
     {
+        var idempotencyKey = includeIdempotency
+            ? NormalizeIdempotencyKey(request.IdempotencyKey)
+            : null;
+
         dataContext.Add(new InventoryMovement
         {
             Id = Guid.NewGuid(),
@@ -303,6 +419,7 @@ public sealed class StockPostingService(
             WarehouseId = request.WarehouseId,
             LocationId = request.LocationId,
             StockBalanceId = stockBalanceId,
+            LotId = request.LotId,
             MovementType = request.MovementType,
             QuantityDelta = quantityDelta,
             QuantityBefore = quantityBefore,
@@ -312,6 +429,8 @@ public sealed class StockPostingService(
             ReferenceType = request.ReferenceType,
             ReferenceId = request.ReferenceId,
             Reason = request.Reason,
+            IdempotencyKey = idempotencyKey,
+            RequestHash = idempotencyKey is null ? null : requestHash,
             IsEnabled = true,
             CreatedAt = DateTime.UtcNow
         });
@@ -348,6 +467,111 @@ public sealed class StockPostingService(
 
         return Result<Guid>.Forbidden("Authenticated user does not have a valid tenant context.");
     }
+
+    private async Task<Result<StockPostingResponse>?> FindIdempotentReplayAsync(
+        Guid tenantId,
+        PostStockMovementRequest request,
+        string requestHash,
+        CancellationToken ct)
+    {
+        var idempotencyKey = NormalizeIdempotencyKey(request.IdempotencyKey);
+        if (idempotencyKey is null)
+            return null;
+
+        var existing = await dataContext.Query<InventoryMovement>()
+            .IgnoreQueryFilters()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                !x.IsDeleted &&
+                x.IdempotencyKey == idempotencyKey)
+            .OrderByDescending(x => x.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (existing is null)
+            return null;
+
+        if (!string.Equals(existing.RequestHash, requestHash, StringComparison.Ordinal))
+        {
+            return Result<StockPostingResponse>.Conflict(
+                "Idempotency key was already used with a different request");
+        }
+
+        if (existing.StockBalanceId is not { } stockBalanceId)
+            return Result<StockPostingResponse>.Conflict("Processed stock movement is missing a stock balance.");
+
+        var balance = await dataContext.Query<StockBalance>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && x.Id == stockBalanceId && !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+
+        if (balance is null)
+            return Result<StockPostingResponse>.Conflict("Processed stock movement balance was not found.");
+
+        return Result<StockPostingResponse>.Success(CreateResponse(
+            balance.Id,
+            balance.ProductId,
+            balance.WarehouseId,
+            balance.LocationId,
+            balance.OnHandQuantity,
+            balance.ReservedQuantity,
+            balance.AvailableQuantity,
+            balance.LotId,
+            idempotencyKey,
+            isReplay: true), "Stock movement already processed.");
+    }
+
+    private static string? NormalizeIdempotencyKey(string? idempotencyKey) =>
+        string.IsNullOrWhiteSpace(idempotencyKey) ? null : idempotencyKey.Trim();
+
+    private static string ComputeRequestHash(Guid tenantId, PostStockMovementRequest request)
+    {
+        var hashPayload = new
+        {
+            tenantId,
+            request.ProductId,
+            request.WarehouseId,
+            request.LocationId,
+            request.LotId,
+            request.DestinationWarehouseId,
+            request.DestinationLocationId,
+            request.MovementType,
+            request.Quantity,
+            request.UnitOfMeasure,
+            request.ReferenceType,
+            request.ReferenceId,
+            request.Reason,
+            request.AllowNegativeStock
+        };
+
+        var json = JsonSerializer.Serialize(hashPayload, HashJsonOptions);
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+        return Convert.ToHexString(bytes);
+    }
+
+    private static StockPostingResponse CreateResponse(
+        Guid stockBalanceId,
+        Guid productId,
+        Guid warehouseId,
+        Guid locationId,
+        decimal onHandQuantity,
+        decimal reservedQuantity,
+        decimal availableQuantity,
+        Guid? lotId,
+        string? idempotencyKey,
+        bool isReplay) =>
+        new(
+            stockBalanceId,
+            productId,
+            warehouseId,
+            locationId,
+            onHandQuantity,
+            reservedQuantity,
+            availableQuantity)
+        {
+            LotId = lotId,
+            IdempotencyKey = idempotencyKey,
+            IsIdempotentReplay = isReplay
+        };
 
     private sealed record StockBalanceLookup(StockBalance Balance, bool IsNew);
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryLotConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryLotConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class InventoryLotConfiguration : IEntityTypeConfiguration<InventoryLot>
+{
+    public void Configure(EntityTypeBuilder<InventoryLot> entity)
+    {
+        entity.ToTable("InventoryLot", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_InventoryLot");
+
+        entity.Property(e => e.LotNumber).HasMaxLength(100).IsRequired();
+        entity.Property(e => e.SupplierReference).HasMaxLength(200);
+        entity.Property(e => e.SourceReferenceType).HasMaxLength(100);
+        entity.Property(e => e.ReceivedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.UnitCost).HasPrecision(18, 4);
+        entity.Property(e => e.Status).HasDefaultValue(InventoryLotStatus.Available);
+
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.LotNumber })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.ExpiresAt });
+        entity.HasIndex(e => new { e.TenantId, e.Status });
+
+        entity.HasOne(e => e.Product)
+            .WithMany()
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryLot_Product");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryMovementConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryMovementConfiguration.cs
@@ -18,9 +18,15 @@ public class InventoryMovementConfiguration : IEntityTypeConfiguration<Inventory
         entity.Property(e => e.UnitOfMeasure).HasMaxLength(25);
         entity.Property(e => e.ReferenceType).HasMaxLength(100);
         entity.Property(e => e.Reason).HasMaxLength(1000);
+        entity.Property(e => e.IdempotencyKey).HasMaxLength(200);
+        entity.Property(e => e.RequestHash).HasMaxLength(128);
 
         entity.HasIndex(e => new { e.TenantId, e.ProductId, e.MovementDate });
+        entity.HasIndex(e => new { e.TenantId, e.LotId, e.MovementDate });
         entity.HasIndex(e => new { e.TenantId, e.ReferenceType, e.ReferenceId });
+        entity.HasIndex(e => new { e.TenantId, e.IdempotencyKey })
+            .IsUnique()
+            .HasFilter("\"IdempotencyKey\" IS NOT NULL");
 
         entity.HasOne(e => e.Product)
             .WithMany()
@@ -45,5 +51,11 @@ public class InventoryMovementConfiguration : IEntityTypeConfiguration<Inventory
             .HasForeignKey(e => e.StockBalanceId)
             .OnDelete(DeleteBehavior.Restrict)
             .HasConstraintName("FK_Inventario_InventoryMovement_StockBalance");
+
+        entity.HasOne(e => e.Lot)
+            .WithMany()
+            .HasForeignKey(e => e.LotId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryMovement_Lot");
     }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/StockBalanceConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/StockBalanceConfiguration.cs
@@ -15,7 +15,12 @@ public class StockBalanceConfiguration : IEntityTypeConfiguration<StockBalance>
         entity.Property(e => e.ReservedQuantity).HasPrecision(18, 4);
         entity.Property(e => e.AvailableQuantity).HasPrecision(18, 4);
 
-        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.WarehouseId, e.LocationId }).IsUnique();
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.WarehouseId, e.LocationId })
+            .IsUnique()
+            .HasFilter("\"LotId\" IS NULL AND \"IsDeleted\" = false");
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.WarehouseId, e.LocationId, e.LotId })
+            .IsUnique()
+            .HasFilter("\"LotId\" IS NOT NULL AND \"IsDeleted\" = false");
 
         entity.HasOne(e => e.Product)
             .WithMany()
@@ -34,5 +39,11 @@ public class StockBalanceConfiguration : IEntityTypeConfiguration<StockBalance>
             .HasForeignKey(e => e.LocationId)
             .OnDelete(DeleteBehavior.Restrict)
             .HasConstraintName("FK_Inventario_StockBalance_Location");
+
+        entity.HasOne(e => e.Lot)
+            .WithMany()
+            .HasForeignKey(e => e.LotId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_StockBalance_Lot");
     }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryLot.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryLot.cs
@@ -1,0 +1,40 @@
+using XFramework.Domain.Shared.Attributes;
+using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/lots",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-lots"
+)]
+public partial class InventoryLot : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid ProductId { get; set; }
+    [MemoryPackIgnore]
+    public Product? Product { get; set; }
+    [MemoryPackOrder(1)]
+    public string? LotNumber { get; set; }
+    [MemoryPackOrder(2)]
+    public string? SupplierReference { get; set; }
+    [MemoryPackOrder(3)]
+    public string? SourceReferenceType { get; set; }
+    [MemoryPackOrder(4)]
+    public Guid? SourceReferenceId { get; set; }
+    [MemoryPackOrder(5)]
+    public DateTime ReceivedAt { get; set; }
+    [MemoryPackOrder(6)]
+    public DateTime? ManufacturedAt { get; set; }
+    [MemoryPackOrder(7)]
+    public DateTime? ExpiresAt { get; set; }
+    [MemoryPackOrder(8)]
+    public decimal? UnitCost { get; set; }
+    [MemoryPackOrder(9)]
+    public InventoryLotStatus Status { get; set; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryMovement.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryMovement.cs
@@ -32,21 +32,29 @@ public partial class InventoryMovement : BaseModel
     [MemoryPackIgnore]
     public StockBalance? StockBalance { get; set; }
     [MemoryPackOrder(4)]
-    public InventoryMovementType MovementType { get; set; }
+    public Guid? LotId { get; set; }
+    [MemoryPackIgnore]
+    public InventoryLot? Lot { get; set; }
     [MemoryPackOrder(5)]
-    public decimal QuantityDelta { get; set; }
+    public InventoryMovementType MovementType { get; set; }
     [MemoryPackOrder(6)]
-    public decimal QuantityBefore { get; set; }
+    public decimal QuantityDelta { get; set; }
     [MemoryPackOrder(7)]
-    public decimal QuantityAfter { get; set; }
+    public decimal QuantityBefore { get; set; }
     [MemoryPackOrder(8)]
-    public DateTime MovementDate { get; set; }
+    public decimal QuantityAfter { get; set; }
     [MemoryPackOrder(9)]
-    public string? UnitOfMeasure { get; set; }
+    public DateTime MovementDate { get; set; }
     [MemoryPackOrder(10)]
-    public string? ReferenceType { get; set; }
+    public string? UnitOfMeasure { get; set; }
     [MemoryPackOrder(11)]
-    public Guid? ReferenceId { get; set; }
+    public string? ReferenceType { get; set; }
     [MemoryPackOrder(12)]
+    public Guid? ReferenceId { get; set; }
+    [MemoryPackOrder(13)]
     public string? Reason { get; set; }
+    [MemoryPackOrder(14)]
+    public string? IdempotencyKey { get; set; }
+    [MemoryPackOrder(15)]
+    public string? RequestHash { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Lots/CreateInventoryLotRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Lots/CreateInventoryLotRequest.cs
@@ -1,0 +1,26 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+
+using TRequest = CreateInventoryLotRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreateInventoryLotRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid ProductId { get; init; }
+    public string? LotNumber { get; init; }
+    public string? SupplierReference { get; init; }
+    public string? SourceReferenceType { get; init; }
+    public Guid? SourceReferenceId { get; init; }
+    public DateTime? ReceivedAt { get; init; }
+    public DateTime? ManufacturedAt { get; init; }
+    public DateTime? ExpiresAt { get; init; }
+    public decimal? UnitCost { get; init; }
+    public InventoryLotStatus Status { get; init; } = InventoryLotStatus.Available;
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Lots/GetInventoryLotRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Lots/GetInventoryLotRequest.cs
@@ -1,0 +1,17 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+
+using TRequest = GetInventoryLotRequest;
+using TResponse = QueryResponse<InventoryLot>;
+
+[MemoryPackable]
+public partial record GetInventoryLotRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid Id { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Lots/GetInventoryLotsRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Lots/GetInventoryLotsRequest.cs
@@ -1,0 +1,20 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+
+using TRequest = GetInventoryLotsRequest;
+using TResponse = QueryResponse<List<InventoryLot>>;
+
+[MemoryPackable]
+public partial record GetInventoryLotsRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+    public InventoryLotStatus? Status { get; init; }
+    public bool IncludeExpired { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/GetInventoryMovementsRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/GetInventoryMovementsRequest.cs
@@ -14,4 +14,8 @@ public partial record GetInventoryMovementsRequest : RequestBase,
     IBoltRequest<TRequest, TResponse>
 {
     public Guid? ProductId { get; init; }
+    public Guid? WarehouseId { get; init; }
+    public Guid? LocationId { get; init; }
+    public Guid? LotId { get; init; }
+    public string? IdempotencyKey { get; init; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/GetStockBalancesRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/GetStockBalancesRequest.cs
@@ -14,4 +14,7 @@ public partial record GetStockBalancesRequest : RequestBase,
     IBoltRequest<TRequest, TResponse>
 {
     public Guid? ProductId { get; init; }
+    public Guid? WarehouseId { get; init; }
+    public Guid? LocationId { get; init; }
+    public Guid? LotId { get; init; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/PostStockMovementRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Stock/PostStockMovementRequest.cs
@@ -16,6 +16,7 @@ public partial record PostStockMovementRequest : RequestBase,
     public Guid ProductId { get; init; }
     public Guid WarehouseId { get; init; }
     public Guid LocationId { get; init; }
+    public Guid? LotId { get; init; }
     public Guid? DestinationWarehouseId { get; init; }
     public Guid? DestinationLocationId { get; init; }
     public InventoryMovementType MovementType { get; init; }
@@ -25,4 +26,5 @@ public partial record PostStockMovementRequest : RequestBase,
     public Guid? ReferenceId { get; init; }
     public string? Reason { get; init; }
     public bool AllowNegativeStock { get; init; }
+    public string? IdempotencyKey { get; init; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Responses/StockPostingResponse.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Responses/StockPostingResponse.cs
@@ -8,4 +8,9 @@ public partial record StockPostingResponse(
     Guid LocationId,
     decimal OnHandQuantity,
     decimal ReservedQuantity,
-    decimal AvailableQuantity);
+    decimal AvailableQuantity)
+{
+    public Guid? LotId { get; init; }
+    public string? IdempotencyKey { get; init; }
+    public bool IsIdempotentReplay { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/StockBalance.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/StockBalance.cs
@@ -27,11 +27,15 @@ public partial class StockBalance : BaseModel
     [MemoryPackIgnore]
     public InventoryLocation? Location { get; set; }
     [MemoryPackOrder(3)]
-    public decimal OnHandQuantity { get; set; }
+    public Guid? LotId { get; set; }
+    [MemoryPackIgnore]
+    public InventoryLot? Lot { get; set; }
     [MemoryPackOrder(4)]
-    public decimal ReservedQuantity { get; set; }
+    public decimal OnHandQuantity { get; set; }
     [MemoryPackOrder(5)]
-    public decimal AvailableQuantity { get; set; }
+    public decimal ReservedQuantity { get; set; }
     [MemoryPackOrder(6)]
+    public decimal AvailableQuantity { get; set; }
+    [MemoryPackOrder(7)]
     public DateTime? LastMovementAt { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/InventoryLotStatus.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/InventoryLotStatus.cs
@@ -1,0 +1,10 @@
+namespace XFramework.Inventario.Domain.Shared.Enums;
+
+public enum InventoryLotStatus
+{
+    Available = 0,
+    Quarantined = 1,
+    Expired = 2,
+    Consumed = 3,
+    Rejected = 4
+}

--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -45,6 +45,12 @@
                     <LucideIcon Name="warehouse" class="h-4 w-4" /> Warehouses
                 </NavLink>
             }
+            @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability"))
+            {
+                <NavLink href="/inventario/lots" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="scan-barcode" class="h-4 w-4" /> Lots
+                </NavLink>
+            }
             @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances")
                  || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "movements"))
             {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LotDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LotDetail.razor
@@ -1,0 +1,320 @@
+@page "/inventario/lots/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Lot - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_traceabilityEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Traceability" />
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/lots"))">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Lots
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Lot Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to this lot's tenant to view its details.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_lot is null)
+{
+    <BbTypographyMuted>Lot not found.</BbTypographyMuted>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex items-center gap-4">
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                          OnClick="@(() => Navigation.NavigateTo("/inventario/lots"))">
+                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                </BbButton>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <BbTypographyH3>@_lot.LotNumber</BbTypographyH3>
+                        <StatusBadge Text="@_lot.Status.ToString()" Status="@GetStatusBadge(_lot.Status)" />
+                    </div>
+                    <BbTypographyMuted>@GetProductLabel() - ID: @_lot.Id</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>On Hand</BbTypographyMuted>
+                            <BbTypographyH3>@TotalOnHand.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Reserved</BbTypographyMuted>
+                            <BbTypographyH3>@TotalReserved.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Available</BbTypographyMuted>
+                            <BbTypographyH3>@TotalAvailable.ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Lot Summary</BbCardTitle>
+                    <BbCardDescription>Traceability metadata and source details.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <BbTypographyMuted>Product</BbTypographyMuted>
+                            <div>@GetProductLabel()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Supplier / Source Ref</BbTypographyMuted>
+                            <div>@(_lot.SupplierReference ?? "N/A")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Received</BbTypographyMuted>
+                            <div>@FormatDate(_lot.ReceivedAt)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Manufactured</BbTypographyMuted>
+                            <div>@FormatDate(_lot.ManufacturedAt)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Expiration</BbTypographyMuted>
+                            <div>@FormatDate(_lot.ExpiresAt)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Unit Cost</BbTypographyMuted>
+                            <div>@(_lot.UnitCost?.ToString("N4") ?? "N/A")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Source</BbTypographyMuted>
+                            <div>@FormatSource()</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@_lot.CreatedAt.ToLocalTime().ToString("g")</div>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Stock Balances</BbCardTitle>
+                    <BbCardDescription>Warehouse and location balances for this lot.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Warehouse">
+                                <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Location">
+                                <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Movement Ledger</BbCardTitle>
+                    <BbCardDescription>Append-only movement rows associated with this lot.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceType)" Title="Reference" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private InventoryLot? _lot;
+    private Product? _product;
+    private List<Warehouse> _warehouses = [];
+    private List<InventoryLocation> _locations = [];
+    private List<StockBalance> _balances = [];
+    private List<InventoryMovement> _movements = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _traceabilityEnabled;
+    private bool _outsideTenantContext;
+    private Guid? _loadedId;
+
+    private decimal TotalOnHand => _balances.Sum(x => x.OnHandQuantity);
+    private decimal TotalReserved => _balances.Sum(x => x.ReservedQuantity);
+    private decimal TotalAvailable => _balances.Sum(x => x.AvailableQuantity);
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedId == Id) return;
+        _loadedId = Id;
+        await Reload();
+    }
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _traceabilityEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability");
+            _outsideTenantContext = false;
+            _lot = null;
+            _product = null;
+            _warehouses = [];
+            _locations = [];
+            _balances = [];
+            _movements = [];
+
+            if (!_hasTenant || !_traceabilityEnabled) return;
+
+            _lot = await DataContext.Query<InventoryLot>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _outsideTenantContext = _lot is not null && _lot.TenantId != TenantFilter.SelectedTenantId;
+            if (_lot is null || _outsideTenantContext) return;
+
+            var tenantId = _lot.TenantId;
+            _product = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.Id == _lot.ProductId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            _warehouses = await DataContext.Query<Warehouse>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(200)
+                .ToListAsync();
+
+            _locations = await DataContext.Query<InventoryLocation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(500)
+                .ToListAsync();
+
+            _balances = await DataContext.Query<StockBalance>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.LotId == Id && !x.IsDeleted)
+                .OrderBy(x => x.WarehouseId)
+                .Take(500)
+                .ToListAsync();
+
+            _movements = await DataContext.Query<InventoryMovement>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.LotId == Id && !x.IsDeleted)
+                .OrderByDescending(x => x.MovementDate)
+                .Take(500)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load lot: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private string GetProductLabel() =>
+        _product is null
+            ? _lot?.ProductId.ToString()[..8] ?? "N/A"
+            : string.IsNullOrWhiteSpace(_product.SKU) ? _product.Name ?? _product.Id.ToString()[..8] : $"{_product.Name} ({_product.SKU})";
+
+    private string GetWarehouseName(Guid warehouseId) =>
+        _warehouses.FirstOrDefault(x => x.Id == warehouseId)?.Name ?? warehouseId.ToString()[..8];
+
+    private string GetLocationName(Guid locationId) =>
+        _locations.FirstOrDefault(x => x.Id == locationId)?.Name ?? locationId.ToString()[..8];
+
+    private string FormatSource()
+    {
+        if (_lot is null) return "N/A";
+        if (string.IsNullOrWhiteSpace(_lot.SourceReferenceType) && _lot.SourceReferenceId is null) return "N/A";
+        return $"{_lot.SourceReferenceType ?? "Source"} {_lot.SourceReferenceId?.ToString()[..8] ?? ""}".Trim();
+    }
+
+    private static string FormatDate(DateTime? value) =>
+        value.HasValue ? value.Value.ToLocalTime().ToString("g") : "N/A";
+
+    private static string GetStatusBadge(InventoryLotStatus status) =>
+        status is InventoryLotStatus.Available ? "active" : "inactive";
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
@@ -1,0 +1,316 @@
+@page "/inventario/lots"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Lots - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_traceabilityEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Traceability" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Lots and Batches</BbTypographyH3>
+                    <BbTypographyMuted>Track inventory by product, source, received date, and expiry.</BbTypographyMuted>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <BbButton OnClick="@OpenCreateDialog" Disabled="@(_products.Count == 0)">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Create Lot
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                </div>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Lot List</BbCardTitle>
+                    <BbCardDescription>@_lots.Count lot(s) loaded</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_lots" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((InventoryLot item) => Navigation.NavigateTo($"/inventario/lots/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot / Batch" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@item.Status.ToString()" Status="@GetStatusBadge(item.Status)" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="On Hand">
+                                <ChildContent Context="item">@GetLotOnHand(item.Id).ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              OnClick="@(() => Navigation.NavigateTo($"/inventario/lots/{item.Id}"))">
+                                        <LucideIcon Name="eye" class="h-4 w-4" />
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_createDialogOpen" OpenChanged="@(v => _createDialogOpen = v)">
+    <BbDialogContent TrapFocus="false">
+        <BbDialogHeader>
+            <BbDialogTitle>Create Lot</BbDialogTitle>
+            <BbDialogDescription>Lot numbers are unique per product inside the selected tenant.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="xf-form-field">
+                <BbLabel>Product</BbLabel>
+                <BbCombobox TValue="string"
+                             @bind-Value="_form.ProductId"
+                             Options="@ProductOptions"
+                             Placeholder="Select product"
+                             SearchPlaceholder="Search products..."
+                             EmptyMessage="No products found."
+                             Class="xf-entity-combobox"
+                             MatchTriggerWidth="true" />
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.LotNumber" Label="Lot / Batch Number" Required="true" />
+                <BbFormFieldSelect TValue="string" @bind-Value="_form.Status" Label="Status">
+                    @foreach (var status in Enum.GetValues<InventoryLotStatus>())
+                    {
+                        <BbSelectItem Value="@status.ToString()">@status</BbSelectItem>
+                    }
+                </BbFormFieldSelect>
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.SupplierReference" Label="Supplier / Source Ref" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.UnitCost" Label="Unit Cost" />
+            </div>
+            <div class="grid gap-3 md:grid-cols-3">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ReceivedAt" Label="Received Date" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ManufacturedAt" Label="Manufacture Date" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ExpiresAt" Label="Expiration Date" />
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.SourceReferenceType" Label="Source Type" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.SourceReferenceId" Label="Source ID" />
+            </div>
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _createDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@CreateLot" Disabled="@IsCreateDisabled">Create</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private readonly LotForm _form = new();
+    private List<Product> _products = [];
+    private List<InventoryLot> _lots = [];
+    private List<StockBalance> _balances = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _traceabilityEnabled;
+    private bool _saving;
+    private bool _createDialogOpen;
+    private bool IsCreateDisabled => _saving || _products.Count == 0 || string.IsNullOrWhiteSpace(_form.ProductId) || string.IsNullOrWhiteSpace(_form.LotNumber);
+
+    private List<SelectOption<string>> ProductOptions =>
+        _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _traceabilityEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability");
+            _products = [];
+            _lots = [];
+            _balances = [];
+
+            if (!_hasTenant || !_traceabilityEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(250)
+                .ToListAsync();
+
+            _lots = await DataContext.Query<InventoryLot>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.LotNumber)
+                .Take(500)
+                .ToListAsync();
+
+            _balances = await DataContext.Query<StockBalance>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.LotId != null && !x.IsDeleted)
+                .Take(500)
+                .ToListAsync();
+
+            _form.ProductId = _products.FirstOrDefault()?.Id.ToString() ?? "";
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load lots: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OpenCreateDialog()
+    {
+        _form.Reset(_products.FirstOrDefault()?.Id.ToString() ?? "");
+        _createDialogOpen = true;
+    }
+
+    private async Task CreateLot()
+    {
+        if (!Guid.TryParse(_form.ProductId, out var productId))
+        {
+            ToastService.Show("Select a product.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var result = await Inventario.CreateInventoryLot(new CreateInventoryLotRequest
+            {
+                Metadata = BuildMetadata(),
+                ProductId = productId,
+                LotNumber = NullIfEmpty(_form.LotNumber),
+                SupplierReference = NullIfEmpty(_form.SupplierReference),
+                SourceReferenceType = NullIfEmpty(_form.SourceReferenceType),
+                SourceReferenceId = Guid.TryParse(_form.SourceReferenceId, out var sourceId) ? sourceId : null,
+                ReceivedAt = ParseDate(_form.ReceivedAt),
+                ManufacturedAt = ParseDate(_form.ManufacturedAt),
+                ExpiresAt = ParseDate(_form.ExpiresAt),
+                UnitCost = decimal.TryParse(_form.UnitCost, out var unitCost) ? unitCost : null,
+                Status = Enum.TryParse<InventoryLotStatus>(_form.Status, out var status) ? status : InventoryLotStatus.Available
+            });
+
+            ToastService.Show(result.IsSuccess ? "Lot created." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _createDialogOpen = false;
+                await Reload();
+            }
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private RequestMetadata BuildMetadata() => new()
+    {
+        TenantId = TenantFilter.SelectedTenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "ControlPanel"
+    };
+
+    private string GetProductName(Guid productId) =>
+        _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
+
+    private static string GetProductLabel(Product product) =>
+        string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
+
+    private decimal GetLotOnHand(Guid lotId) =>
+        _balances.Where(x => x.LotId == lotId).Sum(x => x.OnHandQuantity);
+
+    private static string GetStatusBadge(InventoryLotStatus status) =>
+        status is InventoryLotStatus.Available ? "active" : "inactive";
+
+    private static DateTime? ParseDate(string? value) =>
+        DateTime.TryParse(value, out var parsed) ? parsed : null;
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class LotForm
+    {
+        public string ProductId { get; set; } = "";
+        public string LotNumber { get; set; } = "";
+        public string SupplierReference { get; set; } = "";
+        public string SourceReferenceType { get; set; } = "";
+        public string SourceReferenceId { get; set; } = "";
+        public string ReceivedAt { get; set; } = "";
+        public string ManufacturedAt { get; set; } = "";
+        public string ExpiresAt { get; set; } = "";
+        public string UnitCost { get; set; } = "";
+        public string Status { get; set; } = InventoryLotStatus.Available.ToString();
+
+        public void Reset(string productId)
+        {
+            ProductId = productId;
+            LotNumber = "";
+            SupplierReference = "";
+            SourceReferenceType = "";
+            SourceReferenceId = "";
+            ReceivedAt = DateTime.Today.ToString("yyyy-MM-dd");
+            ManufacturedAt = "";
+            ExpiresAt = "";
+            UnitCost = "";
+            Status = InventoryLotStatus.Available.ToString();
+        }
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -1,5 +1,6 @@
 @page "/inventario/stock"
 @using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots
 @using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations
 @using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock
 @using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses
@@ -65,6 +66,12 @@ else
                                 <BbDataGridTemplateColumn Title="Location">
                                     <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
                                 </BbDataGridTemplateColumn>
+                                @if (_traceabilityEnabled)
+                                {
+                                    <BbDataGridTemplateColumn Title="Lot">
+                                        <ChildContent Context="item">@GetLotLabel(item.LotId)</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                }
                                 <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
                                 <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
                                 <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
@@ -98,6 +105,12 @@ else
                                 <BbDataGridTemplateColumn Title="Product">
                                     <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                                 </BbDataGridTemplateColumn>
+                                @if (_traceabilityEnabled)
+                                {
+                                    <BbDataGridTemplateColumn Title="Lot">
+                                        <ChildContent Context="item">@GetLotLabel(item.LotId)</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                }
                                 <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
                                 <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
                                 <BbDataGridPropertyColumn Property="@(x => x.QuantityBefore)" Title="Before" Sortable="true" />
@@ -132,7 +145,8 @@ else
                 <div class="xf-form-field">
                     <BbLabel>Product</BbLabel>
                     <BbCombobox TValue="string"
-                                 @bind-Value="_movementForm.ProductId"
+                                 Value="@_movementForm.ProductId"
+                                 ValueChanged="@OnMovementProductChanged"
                                  Options="@ProductOptions"
                                  Placeholder="Select product"
                                  SearchPlaceholder="Search products..."
@@ -140,6 +154,20 @@ else
                                  Class="xf-entity-combobox"
                                  MatchTriggerWidth="true" />
                 </div>
+                @if (_traceabilityEnabled)
+                {
+                    <div class="xf-form-field">
+                        <BbLabel>Lot / Batch</BbLabel>
+                        <BbCombobox TValue="string"
+                                     @bind-Value="_movementForm.LotId"
+                                     Options="@MovementLotOptions"
+                                     Placeholder="No lot"
+                                     SearchPlaceholder="Search lots..."
+                                     EmptyMessage="No lots found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                }
                 <div class="xf-form-field">
                     <BbLabel>Warehouse</BbLabel>
                     <BbCombobox TValue="string"
@@ -201,12 +229,14 @@ else
     private List<Product> _products = [];
     private List<Warehouse> _warehouses = [];
     private List<InventoryLocation> _locations = [];
+    private List<InventoryLot> _lots = [];
     private List<StockBalance> _balances = [];
     private List<InventoryMovement> _movements = [];
     private bool _loading = true;
     private bool _hasTenant;
     private bool _stockEnabled;
     private bool _movementsEnabled;
+    private bool _traceabilityEnabled;
     private bool _postingMovement;
     private bool _movementDialogOpen;
     private bool IsPostMovementDisabled => _postingMovement || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
@@ -216,6 +246,19 @@ else
         _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
     private List<SelectOption<string>> MovementLocationOptions =>
         LocationsForSelectedWarehouse().Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
+    private List<SelectOption<string>> MovementLotOptions
+    {
+        get
+        {
+            var options = new List<SelectOption<string>>
+            {
+                new("", "No lot / untracked")
+            };
+            options.AddRange(LotsForSelectedProduct()
+                .Select(lot => new SelectOption<string>(lot.Id.ToString(), GetLotLabel(lot))));
+            return options;
+        }
+    }
 
     protected override void OnInitialized()
     {
@@ -236,9 +279,11 @@ else
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
             _stockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances");
             _movementsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "movements");
+            _traceabilityEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability");
             _products = [];
             _warehouses = [];
             _locations = [];
+            _lots = [];
             _balances = [];
             _movements = [];
 
@@ -268,6 +313,15 @@ else
                 .OrderBy(x => x.Code)
                 .Take(500)
                 .ToListAsync();
+
+            if (_traceabilityEnabled)
+                _lots = await DataContext.Query<InventoryLot>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                    .OrderBy(x => x.LotNumber)
+                    .Take(500)
+                    .ToListAsync();
 
             if (_stockEnabled)
                 _balances = await DataContext.Query<StockBalance>()
@@ -325,6 +379,7 @@ else
                 ProductId = productId,
                 WarehouseId = warehouseId,
                 LocationId = locationId,
+                LotId = Guid.TryParse(_movementForm.LotId, out var lotId) ? lotId : null,
                 MovementType = Enum.TryParse<InventoryMovementType>(_movementForm.MovementType, out var type) ? type : InventoryMovementType.Adjustment,
                 Quantity = quantity,
                 UnitOfMeasure = NullIfEmpty(_movementForm.UnitOfMeasure),
@@ -369,12 +424,26 @@ else
         _movementForm.LocationId = location?.Id.ToString() ?? "";
     }
 
+    private void OnMovementProductChanged(string? value)
+    {
+        _movementForm.ProductId = value ?? "";
+        _movementForm.LotId = "";
+    }
+
     private void ApplyDefaultMovementSelections()
     {
         _movementForm.ProductId = _movementForm.ProductId.Length > 0 ? _movementForm.ProductId : _products.FirstOrDefault()?.Id.ToString() ?? "";
         _movementForm.WarehouseId = _movementForm.WarehouseId.Length > 0 ? _movementForm.WarehouseId : _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
         var location = LocationsForSelectedWarehouse().FirstOrDefault() ?? _locations.FirstOrDefault();
         _movementForm.LocationId = _movementForm.LocationId.Length > 0 ? _movementForm.LocationId : location?.Id.ToString() ?? "";
+    }
+
+    private IEnumerable<InventoryLot> LotsForSelectedProduct()
+    {
+        if (!Guid.TryParse(_movementForm.ProductId, out var productId))
+            return _lots;
+
+        return _lots.Where(x => x.ProductId == productId);
     }
 
     private RequestMetadata BuildMetadata() => new()
@@ -400,6 +469,14 @@ else
 
     private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
 
+    private string GetLotLabel(Guid? lotId) =>
+        lotId is { } id
+            ? _lots.FirstOrDefault(x => x.Id == id)?.LotNumber ?? id.ToString()[..8]
+            : "No lot";
+
+    private string GetLotLabel(InventoryLot lot) =>
+        string.IsNullOrWhiteSpace(lot.LotNumber) ? lot.Id.ToString()[..8] : lot.LotNumber;
+
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
@@ -414,6 +491,7 @@ else
         public string ProductId { get; set; } = "";
         public string WarehouseId { get; set; } = "";
         public string LocationId { get; set; } = "";
+        public string LotId { get; set; } = "";
         public string MovementType { get; set; } = InventoryMovementType.Adjustment.ToString();
         public string Quantity { get; set; } = "0";
         public string UnitOfMeasure { get; set; } = "each";

--- a/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
@@ -89,6 +89,150 @@ public sealed class StockPostingServiceTests
         dataContext.SaveCount.Should().Be(0);
     }
 
+    [Test]
+    public async Task PostAsync_SameProductLocationWithDifferentLots_CreatesSeparateBalances()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var firstLotId = Guid.NewGuid();
+        var secondLotId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        dataContext.Set<InventoryLot>().AddRange([
+            CreateLot(tenantId, productId, firstLotId, "LOT-A"),
+            CreateLot(tenantId, productId, secondLotId, "LOT-B")
+        ]);
+        var service = CreateService(dataContext, tenantId);
+
+        var firstResult = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            LotId = firstLotId,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 10
+        });
+        var secondResult = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            LotId = secondLotId,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 5
+        });
+
+        firstResult.IsSuccess.Should().BeTrue(firstResult.Message);
+        secondResult.IsSuccess.Should().BeTrue(secondResult.Message);
+        dataContext.Set<StockBalance>().Should().HaveCount(2);
+        dataContext.Set<StockBalance>().Should().ContainSingle(x => x.LotId == firstLotId && x.OnHandQuantity == 10);
+        dataContext.Set<StockBalance>().Should().ContainSingle(x => x.LotId == secondLotId && x.OnHandQuantity == 5);
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x => x.LotId == firstLotId && x.QuantityDelta == 10);
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x => x.LotId == secondLotId && x.QuantityDelta == 5);
+        dataContext.Set<Product>().Single().StockQuantity.Should().Be(15);
+    }
+
+    [Test]
+    public async Task PostAsync_LotForDifferentProduct_ReturnsBadRequestWithoutSaving()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var lotId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        dataContext.Set<InventoryLot>().Add(CreateLot(tenantId, Guid.NewGuid(), lotId, "OTHER-PRODUCT"));
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            LotId = lotId,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 10
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(400);
+        dataContext.Set<StockBalance>().Should().BeEmpty();
+        dataContext.SaveCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task PostAsync_SameIdempotencyKeyAndPayload_ReplaysWithoutDoublePosting()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        var service = CreateService(dataContext, tenantId);
+        var request = new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 25,
+            Reason = "Initial count",
+            IdempotencyKey = "stock-open-1"
+        };
+
+        var firstResult = await service.PostAsync(request);
+        var replayResult = await service.PostAsync(request);
+
+        firstResult.IsSuccess.Should().BeTrue(firstResult.Message);
+        replayResult.IsSuccess.Should().BeTrue(replayResult.Message);
+        replayResult.Data!.IsIdempotentReplay.Should().BeTrue();
+        replayResult.Data.IdempotencyKey.Should().Be("stock-open-1");
+        replayResult.Data.OnHandQuantity.Should().Be(25);
+        dataContext.Set<StockBalance>().Should().ContainSingle(x => x.OnHandQuantity == 25);
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x => x.IdempotencyKey == "stock-open-1");
+        dataContext.Set<Product>().Single().StockQuantity.Should().Be(25);
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task PostAsync_SameIdempotencyKeyWithDifferentPayload_ReturnsConflict()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        var service = CreateService(dataContext, tenantId);
+
+        var firstResult = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 25,
+            IdempotencyKey = "stock-open-1"
+        });
+        var conflictResult = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 30,
+            IdempotencyKey = "stock-open-1"
+        });
+
+        firstResult.IsSuccess.Should().BeTrue(firstResult.Message);
+        conflictResult.IsSuccess.Should().BeFalse();
+        conflictResult.StatusCode.Should().Be(409);
+        dataContext.Set<StockBalance>().Should().ContainSingle(x => x.OnHandQuantity == 25);
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x => x.IdempotencyKey == "stock-open-1");
+        dataContext.SaveCount.Should().Be(1);
+    }
+
     private static FakeDataContext SeedStockData(Guid tenantId, Guid productId, Guid warehouseId, Guid locationId)
     {
         var dataContext = new FakeDataContext();
@@ -120,6 +264,18 @@ public sealed class StockPostingServiceTests
 
         return dataContext;
     }
+
+    private static InventoryLot CreateLot(Guid tenantId, Guid productId, Guid lotId, string lotNumber) =>
+        new()
+        {
+            Id = lotId,
+            TenantId = tenantId,
+            ProductId = productId,
+            LotNumber = lotNumber,
+            ReceivedAt = DateTime.UtcNow,
+            Status = InventoryLotStatus.Available,
+            IsEnabled = true
+        };
 
     private static StockPostingService CreateService(FakeDataContext dataContext, Guid tenantId)
     {

--- a/src/Tools/XFramework.MigrationRunner/DesignTimeAppDbContextFactory.cs
+++ b/src/Tools/XFramework.MigrationRunner/DesignTimeAppDbContextFactory.cs
@@ -13,6 +13,7 @@ public sealed class DesignTimeAppDbContextFactory : IDesignTimeDbContextFactory<
         "Bolt.Domain.Shared",
         "Community.Domain.Shared",
         "IdentityServer.Domain.Shared",
+        "Inventario.Domain.Shared",
         "Messaging.Domain.Shared",
         "Wallets.Domain.Shared"
     ];

--- a/src/Tools/XFramework.MigrationRunner/XFramework.MigrationRunner.csproj
+++ b/src/Tools/XFramework.MigrationRunner/XFramework.MigrationRunner.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\Modules\XFramework.Bolt\Bolt.Domain.Shared\Bolt.Domain.Shared.csproj" />
     <ProjectReference Include="..\..\Modules\XFramework.Community\Community.Domain.Shared\Community.Domain.Shared.csproj" />
     <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Domain.Shared\IdentityServer.Domain.Shared.csproj" />
+    <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
     <ProjectReference Include="..\..\Modules\XFramework.Messaging\Messaging.Domain.Shared\Messaging.Domain.Shared.csproj" />
     <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Domain.Shared\Wallets.Domain.Shared.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add Inventario lots/batches with tenant/product uniqueness, status, dates, supplier/source references, and optional unit cost
- make stock balances and inventory movements lot-aware while preserving existing non-lot balances
- add stock-posting idempotency keys/request hashes with replay/conflict semantics matching the Wallets pattern
- expose lot list/detail/create APIs and ControlPanel lot list/detail UI behind the Inventario traceability feature gate

## Verification
- dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false
- dotnet build XFramework.slnx -m:1 /nr:false

## Notes
- Existing non-lot stock remains valid with LotId = null.
- The migration is intentionally additive except for replacing the old stock-balance uniqueness index with filtered lot/non-lot uniqueness indexes.
- FEFO allocation, purchasing, planning, and reporting remain for the next staged PRs.