### PR TITLE
Add Inventario planning and reporting

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260619103451_AddInventarioPlanningReports.Designer.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619103451_AddInventarioPlanningReports.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XFramework.Domain.Contexts;
@@ -11,9 +12,11 @@ using XFramework.Domain.Contexts;
 namespace XFramework.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619103451_AddInventarioPlanningReports")]
+    partial class AddInventarioPlanningReports
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kernel/XFramework.Domain/Migrations/20260619103451_AddInventarioPlanningReports.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619103451_AddInventarioPlanningReports.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInventarioPlanningReports : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InventoryReorderRule",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    WarehouseId = table.Column<Guid>(type: "uuid", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MinimumQuantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    MaximumQuantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: true),
+                    ReorderPoint = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    ReorderQuantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    PreferredSupplier = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_InventoryReorderRule", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryReorderRule_Location",
+                        column: x => x.LocationId,
+                        principalSchema: "Inventario",
+                        principalTable: "InventoryLocation",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryReorderRule_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_InventoryReorderRule_Warehouse",
+                        column: x => x.WarehouseId,
+                        principalSchema: "Inventario",
+                        principalTable: "Warehouse",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_LocationId",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                column: "LocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_ProductId",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_TenantId",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_TenantId_IsActive",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                columns: new[] { "TenantId", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_TenantId_IsDeleted",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                columns: new[] { "TenantId", "IsDeleted" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_TenantId_ProductId_WarehouseId_Locatio~",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                columns: new[] { "TenantId", "ProductId", "WarehouseId", "LocationId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_WarehouseId",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                column: "WarehouseId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "InventoryReorderRule",
+                schema: "Inventario");
+        }
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/CreateReorderRule/CreateInventoryReorderRuleValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/CreateReorderRule/CreateInventoryReorderRuleValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+
+namespace Inventario.Api.Features.Planning.CreateReorderRule;
+
+public sealed class CreateInventoryReorderRuleValidator : AbstractValidator<CreateInventoryReorderRuleRequest>
+{
+    public CreateInventoryReorderRuleValidator()
+    {
+        RuleFor(x => x.ProductId).NotEmpty();
+        RuleFor(x => x.MinimumQuantity).GreaterThanOrEqualTo(0);
+        RuleFor(x => x.ReorderPoint).GreaterThanOrEqualTo(0);
+        RuleFor(x => x.ReorderQuantity).GreaterThan(0);
+        RuleFor(x => x.MaximumQuantity)
+            .GreaterThanOrEqualTo(x => x.MinimumQuantity)
+            .When(x => x.MaximumQuantity is not null);
+        RuleFor(x => x.PreferredSupplier).MaximumLength(200);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/CreateReorderRule/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/CreateReorderRule/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+
+namespace Inventario.Api.Features.Planning.CreateReorderRule;
+
+public static class CreateInventoryReorderRuleEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/reorder-rules", Tags = ["Inventario Planning"],
+        Summary = "Create inventory reorder rule",
+        Description = "Creates a tenant-scoped reorder rule for product, warehouse, or location planning.")]
+    public static async Task<Result<InventoryReorderRule>> Handle(
+        CreateInventoryReorderRuleRequest request,
+        InventoryPlanningService planningService,
+        CancellationToken ct)
+    {
+        return await planningService.CreateRuleAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/GetLowStock/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/GetLowStock/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace Inventario.Api.Features.Planning.GetLowStock;
+
+public static class GetPlanningLowStockEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/planning/low-stock", Tags = ["Inventario Planning"],
+        Summary = "Get low-stock planning rows",
+        Description = "Returns products and scoped stock positions at or below active reorder thresholds.")]
+    public static async Task<Result<List<LowStockReportRow>>> Handle(
+        GetLowStockReportRequest request,
+        InventoryPlanningService planningService,
+        CancellationToken ct)
+    {
+        return await planningService.GetLowStockAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/GetReorderRules/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/GetReorderRules/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+
+namespace Inventario.Api.Features.Planning.GetReorderRules;
+
+public static class GetInventoryReorderRulesEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/reorder-rules", Tags = ["Inventario Planning"],
+        Summary = "Get inventory reorder rules",
+        Description = "Gets active or inactive reorder rules for the authenticated tenant.")]
+    public static async Task<Result<List<InventoryReorderRule>>> Handle(
+        GetInventoryReorderRulesRequest request,
+        InventoryPlanningService planningService,
+        CancellationToken ct)
+    {
+        return await planningService.GetRulesAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/GetReorderSuggestions/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Planning/GetReorderSuggestions/Endpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace Inventario.Api.Features.Planning.GetReorderSuggestions;
+
+public static class GetReorderSuggestionsEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/planning/reorder-suggestions", Tags = ["Inventario Planning"],
+        Summary = "Get reorder suggestions",
+        Description = "Returns reorder suggestions from active product, warehouse, and location rules.")]
+    public static async Task<Result<List<ReorderSuggestionRow>>> Handle(
+        GetReorderSuggestionsRequest request,
+        InventoryPlanningService planningService,
+        CancellationToken ct)
+    {
+        return await planningService.GetReorderSuggestionsAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/AllocationStatus/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/AllocationStatus/Endpoint.cs
@@ -1,0 +1,18 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace Inventario.Api.Features.Reports.AllocationStatus;
+
+public static class AllocationStatusReportEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/reports/reservation-allocations", Tags = ["Inventario Reports"])]
+    public static async Task<Result<List<ReservationAllocationStatusReportRow>>> Handle(
+        GetReservationAllocationStatusReportRequest request,
+        InventoryReportingService reportingService,
+        CancellationToken ct) =>
+        await reportingService.GetAllocationStatusAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/ExpiredStock/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/ExpiredStock/Endpoint.cs
@@ -1,0 +1,18 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace Inventario.Api.Features.Reports.ExpiredStock;
+
+public static class ExpiredStockReportEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/reports/expired-stock", Tags = ["Inventario Reports"])]
+    public static async Task<Result<List<NearExpiryStockReportRow>>> Handle(
+        GetExpiredStockReportRequest request,
+        InventoryReportingService reportingService,
+        CancellationToken ct) =>
+        await reportingService.GetExpiredAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/LowStock/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/LowStock/Endpoint.cs
@@ -1,0 +1,18 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace Inventario.Api.Features.Reports.LowStock;
+
+public static class LowStockReportEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/reports/low-stock", Tags = ["Inventario Reports"])]
+    public static async Task<Result<List<LowStockReportRow>>> Handle(
+        GetLowStockReportRequest request,
+        InventoryReportingService reportingService,
+        CancellationToken ct) =>
+        await reportingService.GetLowStockAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/MovementLedger/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/MovementLedger/Endpoint.cs
@@ -1,0 +1,18 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace Inventario.Api.Features.Reports.MovementLedger;
+
+public static class MovementLedgerReportEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/reports/movement-ledger", Tags = ["Inventario Reports"])]
+    public static async Task<Result<List<MovementLedgerReportRow>>> Handle(
+        GetMovementLedgerReportRequest request,
+        InventoryReportingService reportingService,
+        CancellationToken ct) =>
+        await reportingService.GetMovementLedgerAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/NearExpiry/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/NearExpiry/Endpoint.cs
@@ -1,0 +1,18 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace Inventario.Api.Features.Reports.NearExpiry;
+
+public static class NearExpiryReportEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/reports/near-expiry", Tags = ["Inventario Reports"])]
+    public static async Task<Result<List<NearExpiryStockReportRow>>> Handle(
+        GetNearExpiryStockReportRequest request,
+        InventoryReportingService reportingService,
+        CancellationToken ct) =>
+        await reportingService.GetNearExpiryAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/StockPositions/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reports/StockPositions/Endpoint.cs
@@ -1,0 +1,18 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace Inventario.Api.Features.Reports.StockPositions;
+
+public static class StockPositionsReportEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/reports/stock-positions", Tags = ["Inventario Reports"])]
+    public static async Task<Result<List<StockPositionReportRow>>> Handle(
+        GetStockPositionReportRequest request,
+        InventoryReportingService reportingService,
+        CancellationToken ct) =>
+        await reportingService.GetStockPositionsAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Installers/ServicesInstaller.cs
@@ -20,6 +20,8 @@ public class ServicesInstaller : IInstaller
         services.AddScoped<WarehouseService>();
         services.AddScoped<ReservationService>();
         services.AddScoped<InventoryAllocationService>();
+        services.AddScoped<InventoryPlanningService>();
+        services.AddScoped<InventoryReportingService>();
 
         // Register FluentValidation validators
         services.AddValidatorsFromAssemblyContaining<Program>();

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
@@ -47,6 +47,9 @@ app.UseTenantModuleFeatureGate(options =>
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reservations", "reservations");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/allocations", "reservations");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/lots", "traceability");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reorder-rules", "planning");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/planning", "planning");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports", "reporting");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api");
 });
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryPlanningService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryPlanningService.cs
@@ -1,0 +1,279 @@
+using Microsoft.AspNetCore.Http;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace XFramework.Inventario.Api.Services;
+
+public sealed class InventoryPlanningService(
+    IDataContext dataContext,
+    IHttpContextAccessor httpContextAccessor)
+{
+    public async Task<Result<List<InventoryReorderRule>>> GetRulesAsync(
+        GetInventoryReorderRulesRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<InventoryReorderRule>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var query = dataContext.Query<InventoryReorderRule>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted);
+
+        if (request.ProductId is { } productId)
+            query = query.Where(x => x.ProductId == productId);
+
+        if (!request.IncludeInactive)
+            query = query.Where(x => x.IsActive);
+
+        var rules = await query
+            .OrderBy(x => x.ProductId)
+            .Take(500)
+            .ToListAsync(ct);
+
+        return Result<List<InventoryReorderRule>>.Success(rules);
+    }
+
+    public async Task<Result<InventoryReorderRule>> CreateRuleAsync(
+        CreateInventoryReorderRuleRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<InventoryReorderRule>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        if (request.MinimumQuantity < 0 || request.ReorderPoint < 0 || request.ReorderQuantity <= 0)
+            return Result<InventoryReorderRule>.Failure("Reorder quantities must be valid positive values.", 400);
+
+        if (request.MaximumQuantity is { } maximum && maximum < request.MinimumQuantity)
+            return Result<InventoryReorderRule>.Failure("Maximum quantity must be greater than or equal to minimum quantity.", 400);
+
+        var tenantId = tenantResult.Data;
+        var productExists = await dataContext.Query<Product>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x => x.TenantId == tenantId && x.Id == request.ProductId && !x.IsDeleted, ct);
+        if (!productExists)
+            return Result<InventoryReorderRule>.NotFound("Product not found.");
+
+        if (request.WarehouseId is { } warehouseId)
+        {
+            var warehouseExists = await dataContext.Query<Warehouse>()
+                .IgnoreQueryFilters()
+                .AnyAsync(x => x.TenantId == tenantId && x.Id == warehouseId && !x.IsDeleted, ct);
+            if (!warehouseExists)
+                return Result<InventoryReorderRule>.NotFound("Warehouse not found.");
+        }
+
+        if (request.LocationId is { } locationId)
+        {
+            var locationExists = await dataContext.Query<InventoryLocation>()
+                .IgnoreQueryFilters()
+                .AnyAsync(x =>
+                    x.TenantId == tenantId &&
+                    x.Id == locationId &&
+                    (request.WarehouseId == null || x.WarehouseId == request.WarehouseId) &&
+                    !x.IsDeleted, ct);
+            if (!locationExists)
+                return Result<InventoryReorderRule>.NotFound("Location not found.");
+        }
+
+        var duplicate = await dataContext.Query<InventoryReorderRule>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x =>
+                x.TenantId == tenantId &&
+                x.ProductId == request.ProductId &&
+                x.WarehouseId == request.WarehouseId &&
+                x.LocationId == request.LocationId &&
+                !x.IsDeleted, ct);
+        if (duplicate)
+            return Result<InventoryReorderRule>.Conflict("A reorder rule already exists for this product scope.");
+
+        var now = DateTime.UtcNow;
+        var rule = new InventoryReorderRule
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = request.ProductId,
+            WarehouseId = request.WarehouseId,
+            LocationId = request.LocationId,
+            MinimumQuantity = request.MinimumQuantity,
+            MaximumQuantity = request.MaximumQuantity,
+            ReorderPoint = request.ReorderPoint,
+            ReorderQuantity = request.ReorderQuantity,
+            PreferredSupplier = NormalizeOptional(request.PreferredSupplier),
+            IsActive = request.IsActive,
+            IsEnabled = true,
+            CreatedAt = now,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        dataContext.Add(rule);
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<InventoryReorderRule>.Failure(saveResult.Message ?? "Reorder rule save failed.", saveResult.StatusCode);
+
+        return Result<InventoryReorderRule>.Success(rule, 201, "Reorder rule created.");
+    }
+
+    public async Task<Result<List<LowStockReportRow>>> GetLowStockAsync(
+        GetLowStockReportRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<LowStockReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var rows = await BuildLowStockRows(tenantResult.Data, request.ProductId, request.WarehouseId, request.LocationId, ct);
+        return Result<List<LowStockReportRow>>.Success(rows);
+    }
+
+    public async Task<Result<List<ReorderSuggestionRow>>> GetReorderSuggestionsAsync(
+        GetReorderSuggestionsRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<ReorderSuggestionRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var lowStock = await BuildLowStockRows(tenantResult.Data, request.ProductId, request.WarehouseId, request.LocationId, ct);
+        var rules = await LoadRules(tenantResult.Data, request.ProductId, request.WarehouseId, request.LocationId, ct);
+
+        var suggestions = lowStock.Select(row =>
+        {
+            var rule = rules.First(x =>
+                x.ProductId == row.ProductId &&
+                x.WarehouseId == row.WarehouseId &&
+                x.LocationId == row.LocationId);
+            var targetQuantity = rule.MaximumQuantity ?? row.ReorderPoint + rule.ReorderQuantity;
+            var neededToTarget = Math.Max(0, targetQuantity - row.AvailableQuantity);
+            var suggested = Math.Max(rule.ReorderQuantity, neededToTarget);
+            return new ReorderSuggestionRow(
+                row.ProductId,
+                row.ProductName,
+                row.WarehouseId,
+                row.WarehouseName,
+                row.LocationId,
+                row.LocationName,
+                row.AvailableQuantity,
+                row.ReorderPoint,
+                suggested,
+                rule.PreferredSupplier);
+        }).ToList();
+
+        return Result<List<ReorderSuggestionRow>>.Success(suggestions);
+    }
+
+    private async Task<List<LowStockReportRow>> BuildLowStockRows(
+        Guid tenantId,
+        Guid? productId,
+        Guid? warehouseId,
+        Guid? locationId,
+        CancellationToken ct)
+    {
+        var rules = await LoadRules(tenantId, productId, warehouseId, locationId, ct);
+        if (rules.Count == 0)
+            return [];
+
+        var products = await dataContext.Query<Product>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+        var warehouses = await dataContext.Query<Warehouse>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+        var locations = await dataContext.Query<InventoryLocation>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+        var balances = await dataContext.Query<StockBalance>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+
+        var productNames = products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]);
+        var warehouseNames = warehouses.ToDictionary(x => x.Id, x => $"{x.Code} - {x.Name}");
+        var locationNames = locations.ToDictionary(x => x.Id, x => $"{x.Code} - {x.Name}");
+        var rows = new List<LowStockReportRow>();
+
+        foreach (var rule in rules)
+        {
+            var available = balances
+                .Where(x =>
+                    x.ProductId == rule.ProductId &&
+                    (rule.WarehouseId is null || x.WarehouseId == rule.WarehouseId) &&
+                    (rule.LocationId is null || x.LocationId == rule.LocationId))
+                .Sum(x => x.AvailableQuantity);
+            var reorderPoint = rule.ReorderPoint > 0 ? rule.ReorderPoint : rule.MinimumQuantity;
+            if (available > reorderPoint)
+                continue;
+
+            rows.Add(new LowStockReportRow(
+                rule.ProductId,
+                productNames.GetValueOrDefault(rule.ProductId, rule.ProductId.ToString()[..8]),
+                rule.WarehouseId,
+                rule.WarehouseId is { } wh ? warehouseNames.GetValueOrDefault(wh, wh.ToString()[..8]) : null,
+                rule.LocationId,
+                rule.LocationId is { } loc ? locationNames.GetValueOrDefault(loc, loc.ToString()[..8]) : null,
+                available,
+                reorderPoint,
+                rule.MinimumQuantity));
+        }
+
+        return rows
+            .OrderBy(x => x.ProductName)
+            .ThenBy(x => x.WarehouseName)
+            .ThenBy(x => x.LocationName)
+            .ToList();
+    }
+
+    private async Task<List<InventoryReorderRule>> LoadRules(
+        Guid tenantId,
+        Guid? productId,
+        Guid? warehouseId,
+        Guid? locationId,
+        CancellationToken ct)
+    {
+        var rules = await dataContext.Query<InventoryReorderRule>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && x.IsActive && !x.IsDeleted)
+            .ToListAsync(ct);
+
+        if (productId is not null)
+            rules = rules.Where(x => x.ProductId == productId).ToList();
+        if (warehouseId is not null)
+            rules = rules.Where(x => x.WarehouseId == null || x.WarehouseId == warehouseId).ToList();
+        if (locationId is not null)
+            rules = rules.Where(x => x.LocationId == null || x.LocationId == locationId).ToList();
+
+        return rules;
+    }
+
+    private Result<Guid> GetCurrentTenantId(RequestBase? request)
+    {
+        if (request?.Metadata?.TenantId is { } metadataTenantId && metadataTenantId != Guid.Empty)
+            return Result<Guid>.Success(metadataTenantId);
+
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return Result<Guid>.Unauthorized("Authentication is required for inventory planning operations.");
+
+        var tenantIdClaim = user.FindFirst("tenantId")?.Value
+            ?? user.FindFirst("TenantId")?.Value
+            ?? user.FindFirst("tid")?.Value;
+
+        if (Guid.TryParse(tenantIdClaim, out var tenantId) && tenantId != Guid.Empty)
+            return Result<Guid>.Success(tenantId);
+
+        return Result<Guid>.Forbidden("Authenticated user does not have a valid tenant context.");
+    }
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryReportingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryReportingService.cs
@@ -1,0 +1,298 @@
+using Microsoft.AspNetCore.Http;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Api.Services;
+
+public sealed class InventoryReportingService(
+    IDataContext dataContext,
+    IHttpContextAccessor httpContextAccessor,
+    InventoryPlanningService planningService)
+{
+    public async Task<Result<List<LowStockReportRow>>> GetLowStockAsync(
+        GetLowStockReportRequest request,
+        CancellationToken ct = default) =>
+        await planningService.GetLowStockAsync(request, ct);
+
+    public async Task<Result<List<NearExpiryStockReportRow>>> GetNearExpiryAsync(
+        GetNearExpiryStockReportRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<NearExpiryStockReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var now = DateTime.UtcNow;
+        var cutoff = now.AddDays(Math.Clamp(request.DaysAhead, 1, 365));
+        var rows = await BuildExpiryRows(tenantResult.Data, request.ProductId, lot =>
+            lot.ExpiresAt is not null && lot.ExpiresAt > now && lot.ExpiresAt <= cutoff, ct);
+
+        return Result<List<NearExpiryStockReportRow>>.Success(rows);
+    }
+
+    public async Task<Result<List<NearExpiryStockReportRow>>> GetExpiredAsync(
+        GetExpiredStockReportRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<NearExpiryStockReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var now = DateTime.UtcNow;
+        var rows = await BuildExpiryRows(tenantResult.Data, request.ProductId, lot =>
+            lot.Status == InventoryLotStatus.Expired || lot.ExpiresAt is not null && lot.ExpiresAt <= now, ct);
+
+        return Result<List<NearExpiryStockReportRow>>.Success(rows);
+    }
+
+    public async Task<Result<List<StockPositionReportRow>>> GetStockPositionsAsync(
+        GetStockPositionReportRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<StockPositionReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var balances = await dataContext.Query<StockBalance>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+
+        if (request.ProductId is { } productId)
+            balances = balances.Where(x => x.ProductId == productId).ToList();
+        if (request.WarehouseId is { } warehouseId)
+            balances = balances.Where(x => x.WarehouseId == warehouseId).ToList();
+        if (request.LocationId is { } locationId)
+            balances = balances.Where(x => x.LocationId == locationId).ToList();
+        if (request.LotId is { } lotId)
+            balances = balances.Where(x => x.LotId == lotId).ToList();
+
+        var lookups = await LoadLookups(tenantId, ct);
+        var rows = balances.Select(balance => new StockPositionReportRow(
+                balance.Id,
+                balance.ProductId,
+                lookups.ProductNames.GetValueOrDefault(balance.ProductId, balance.ProductId.ToString()[..8]),
+                balance.WarehouseId,
+                lookups.WarehouseNames.GetValueOrDefault(balance.WarehouseId, balance.WarehouseId.ToString()[..8]),
+                balance.LocationId,
+                lookups.LocationNames.GetValueOrDefault(balance.LocationId, balance.LocationId.ToString()[..8]),
+                balance.LotId,
+                balance.LotId is { } lotId ? lookups.LotNumbers.GetValueOrDefault(lotId, lotId.ToString()[..8]) : null,
+                balance.OnHandQuantity,
+                balance.ReservedQuantity,
+                balance.AvailableQuantity))
+            .OrderBy(x => x.ProductName)
+            .ThenBy(x => x.WarehouseName)
+            .ThenBy(x => x.LocationName)
+            .ToList();
+
+        return Result<List<StockPositionReportRow>>.Success(rows);
+    }
+
+    public async Task<Result<List<MovementLedgerReportRow>>> GetMovementLedgerAsync(
+        GetMovementLedgerReportRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<MovementLedgerReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var movements = await dataContext.Query<InventoryMovement>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+
+        if (request.ProductId is { } productId)
+            movements = movements.Where(x => x.ProductId == productId).ToList();
+        if (request.WarehouseId is { } warehouseId)
+            movements = movements.Where(x => x.WarehouseId == warehouseId).ToList();
+        if (request.LocationId is { } locationId)
+            movements = movements.Where(x => x.LocationId == locationId).ToList();
+        if (request.LotId is { } lotId)
+            movements = movements.Where(x => x.LotId == lotId).ToList();
+        if (!string.IsNullOrWhiteSpace(request.ReferenceType))
+            movements = movements.Where(x => x.ReferenceType == request.ReferenceType).ToList();
+        if (request.ReferenceId is { } referenceId)
+            movements = movements.Where(x => x.ReferenceId == referenceId).ToList();
+        if (request.From is { } from)
+            movements = movements.Where(x => x.MovementDate >= from).ToList();
+        if (request.To is { } to)
+            movements = movements.Where(x => x.MovementDate <= to).ToList();
+
+        var lookups = await LoadLookups(tenantId, ct);
+        var rows = movements
+            .OrderByDescending(x => x.MovementDate)
+            .Take(1000)
+            .Select(movement => new MovementLedgerReportRow(
+                movement.Id,
+                movement.ProductId,
+                lookups.ProductNames.GetValueOrDefault(movement.ProductId, movement.ProductId.ToString()[..8]),
+                movement.WarehouseId,
+                movement.WarehouseId is { } warehouseId
+                    ? lookups.WarehouseNames.GetValueOrDefault(warehouseId, warehouseId.ToString()[..8])
+                    : "N/A",
+                movement.LocationId,
+                movement.LocationId is { } locationId
+                    ? lookups.LocationNames.GetValueOrDefault(locationId, locationId.ToString()[..8])
+                    : "N/A",
+                movement.LotId,
+                movement.LotId is { } lotId ? lookups.LotNumbers.GetValueOrDefault(lotId, lotId.ToString()[..8]) : null,
+                movement.MovementType,
+                movement.QuantityDelta,
+                movement.ReferenceType,
+                movement.ReferenceId,
+                movement.MovementDate))
+            .ToList();
+
+        return Result<List<MovementLedgerReportRow>>.Success(rows);
+    }
+
+    public async Task<Result<List<ReservationAllocationStatusReportRow>>> GetAllocationStatusAsync(
+        GetReservationAllocationStatusReportRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<ReservationAllocationStatusReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var allocations = await dataContext.Query<ReservationAllocation>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+
+        if (request.ProductId is { } productId)
+            allocations = allocations.Where(x => x.ProductId == productId).ToList();
+        if (request.LotId is { } lotId)
+            allocations = allocations.Where(x => x.LotId == lotId).ToList();
+        if (request.Status is { } status)
+            allocations = allocations.Where(x => x.Status == status).ToList();
+
+        var lookups = await LoadLookups(tenantId, ct);
+        var rows = allocations
+            .OrderByDescending(x => x.ReservedAt)
+            .Take(1000)
+            .Select(allocation => new ReservationAllocationStatusReportRow(
+                allocation.Id,
+                allocation.ReservationId,
+                allocation.ProductId,
+                lookups.ProductNames.GetValueOrDefault(allocation.ProductId, allocation.ProductId.ToString()[..8]),
+                allocation.LotId,
+                allocation.LotId is { } lotId ? lookups.LotNumbers.GetValueOrDefault(lotId, lotId.ToString()[..8]) : null,
+                allocation.Quantity,
+                allocation.Status,
+                allocation.ReservedAt,
+                allocation.ReleasedAt,
+                allocation.FulfilledAt))
+            .ToList();
+
+        return Result<List<ReservationAllocationStatusReportRow>>.Success(rows);
+    }
+
+    private async Task<List<NearExpiryStockReportRow>> BuildExpiryRows(
+        Guid tenantId,
+        Guid? productId,
+        Func<InventoryLot, bool> lotFilter,
+        CancellationToken ct)
+    {
+        var lots = await dataContext.Query<InventoryLot>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+        if (productId is { } id)
+            lots = lots.Where(x => x.ProductId == id).ToList();
+
+        lots = lots.Where(lotFilter).ToList();
+        if (lots.Count == 0)
+            return [];
+
+        var lotIds = lots.Select(x => x.Id).ToHashSet();
+        var balances = await dataContext.Query<StockBalance>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && x.LotId != null && !x.IsDeleted)
+            .ToListAsync(ct);
+        balances = balances.Where(x => x.LotId is { } lotId && lotIds.Contains(lotId) && x.OnHandQuantity > 0).ToList();
+
+        var lotMap = lots.ToDictionary(x => x.Id);
+        var lookups = await LoadLookups(tenantId, ct);
+
+        return balances.Select(balance =>
+            {
+                var lot = lotMap[balance.LotId!.Value];
+                return new NearExpiryStockReportRow(
+                    lot.Id,
+                    lot.LotNumber ?? lot.Id.ToString()[..8],
+                    lot.ProductId,
+                    lookups.ProductNames.GetValueOrDefault(lot.ProductId, lot.ProductId.ToString()[..8]),
+                    balance.WarehouseId,
+                    lookups.WarehouseNames.GetValueOrDefault(balance.WarehouseId, balance.WarehouseId.ToString()[..8]),
+                    balance.LocationId,
+                    lookups.LocationNames.GetValueOrDefault(balance.LocationId, balance.LocationId.ToString()[..8]),
+                    balance.OnHandQuantity,
+                    balance.AvailableQuantity,
+                    lot.ExpiresAt,
+                    lot.Status);
+            })
+            .OrderBy(x => x.ExpiresAt)
+            .ThenBy(x => x.ProductName)
+            .ToList();
+    }
+
+    private async Task<LookupMaps> LoadLookups(Guid tenantId, CancellationToken ct)
+    {
+        var products = await dataContext.Query<Product>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+        var warehouses = await dataContext.Query<Warehouse>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+        var locations = await dataContext.Query<InventoryLocation>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+        var lots = await dataContext.Query<InventoryLot>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .ToListAsync(ct);
+
+        return new LookupMaps(
+            products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]),
+            warehouses.ToDictionary(x => x.Id, x => $"{x.Code} - {x.Name}"),
+            locations.ToDictionary(x => x.Id, x => $"{x.Code} - {x.Name}"),
+            lots.ToDictionary(x => x.Id, x => x.LotNumber ?? x.Id.ToString()[..8]));
+    }
+
+    private Result<Guid> GetCurrentTenantId(RequestBase? request)
+    {
+        if (request?.Metadata?.TenantId is { } metadataTenantId && metadataTenantId != Guid.Empty)
+            return Result<Guid>.Success(metadataTenantId);
+
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return Result<Guid>.Unauthorized("Authentication is required for inventory reporting operations.");
+
+        var tenantIdClaim = user.FindFirst("tenantId")?.Value
+            ?? user.FindFirst("TenantId")?.Value
+            ?? user.FindFirst("tid")?.Value;
+
+        if (Guid.TryParse(tenantIdClaim, out var tenantId) && tenantId != Guid.Empty)
+            return Result<Guid>.Success(tenantId);
+
+        return Result<Guid>.Forbidden("Authenticated user does not have a valid tenant context.");
+    }
+
+    private sealed record LookupMaps(
+        Dictionary<Guid, string> ProductNames,
+        Dictionary<Guid, string> WarehouseNames,
+        Dictionary<Guid, string> LocationNames,
+        Dictionary<Guid, string> LotNumbers);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryReorderRuleConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryReorderRuleConfiguration.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class InventoryReorderRuleConfiguration : IEntityTypeConfiguration<InventoryReorderRule>
+{
+    public void Configure(EntityTypeBuilder<InventoryReorderRule> entity)
+    {
+        entity.ToTable("InventoryReorderRule", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_InventoryReorderRule");
+
+        entity.Property(e => e.MinimumQuantity).HasPrecision(18, 4);
+        entity.Property(e => e.MaximumQuantity).HasPrecision(18, 4);
+        entity.Property(e => e.ReorderPoint).HasPrecision(18, 4);
+        entity.Property(e => e.ReorderQuantity).HasPrecision(18, 4);
+        entity.Property(e => e.PreferredSupplier).HasMaxLength(200);
+        entity.Property(e => e.IsActive).HasDefaultValue(true);
+
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.WarehouseId, e.LocationId });
+        entity.HasIndex(e => new { e.TenantId, e.IsActive });
+
+        entity.HasOne(e => e.Product)
+            .WithMany()
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryReorderRule_Product");
+
+        entity.HasOne(e => e.Warehouse)
+            .WithMany()
+            .HasForeignKey(e => e.WarehouseId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryReorderRule_Warehouse");
+
+        entity.HasOne(e => e.Location)
+            .WithMany()
+            .HasForeignKey(e => e.LocationId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_InventoryReorderRule_Location");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryReorderRule.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/InventoryReorderRule.cs
@@ -1,0 +1,41 @@
+using XFramework.Domain.Shared.Attributes;
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/reorder-rules",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-reorder-rules"
+)]
+public partial class InventoryReorderRule : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid ProductId { get; set; }
+    [MemoryPackIgnore]
+    public Product? Product { get; set; }
+    [MemoryPackOrder(1)]
+    public Guid? WarehouseId { get; set; }
+    [MemoryPackIgnore]
+    public Warehouse? Warehouse { get; set; }
+    [MemoryPackOrder(2)]
+    public Guid? LocationId { get; set; }
+    [MemoryPackIgnore]
+    public InventoryLocation? Location { get; set; }
+    [MemoryPackOrder(3)]
+    public decimal MinimumQuantity { get; set; }
+    [MemoryPackOrder(4)]
+    public decimal? MaximumQuantity { get; set; }
+    [MemoryPackOrder(5)]
+    public decimal ReorderPoint { get; set; }
+    [MemoryPackOrder(6)]
+    public decimal ReorderQuantity { get; set; }
+    [MemoryPackOrder(7)]
+    public string? PreferredSupplier { get; set; }
+    [MemoryPackOrder(8)]
+    public bool IsActive { get; set; } = true;
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Planning/CreateInventoryReorderRuleRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Planning/CreateInventoryReorderRuleRequest.cs
@@ -1,0 +1,24 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+
+using TRequest = CreateInventoryReorderRuleRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreateInventoryReorderRuleRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid ProductId { get; init; }
+    public Guid? WarehouseId { get; init; }
+    public Guid? LocationId { get; init; }
+    public decimal MinimumQuantity { get; init; }
+    public decimal? MaximumQuantity { get; init; }
+    public decimal ReorderPoint { get; init; }
+    public decimal ReorderQuantity { get; init; }
+    public string? PreferredSupplier { get; init; }
+    public bool IsActive { get; init; } = true;
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Planning/GetInventoryReorderRulesRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Planning/GetInventoryReorderRulesRequest.cs
@@ -1,0 +1,17 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+
+using TRequest = GetInventoryReorderRulesRequest;
+using TResponse = QueryResponse<List<InventoryReorderRule>>;
+
+[MemoryPackable]
+public partial record GetInventoryReorderRulesRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+    public bool IncludeInactive { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Planning/GetReorderSuggestionsRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Planning/GetReorderSuggestionsRequest.cs
@@ -1,0 +1,19 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+
+using TRequest = GetReorderSuggestionsRequest;
+using TResponse = QueryResponse<List<ReorderSuggestionRow>>;
+
+[MemoryPackable]
+public partial record GetReorderSuggestionsRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+    public Guid? WarehouseId { get; init; }
+    public Guid? LocationId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetExpiredStockReportRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetExpiredStockReportRequest.cs
@@ -1,0 +1,17 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+
+using TRequest = GetExpiredStockReportRequest;
+using TResponse = QueryResponse<List<NearExpiryStockReportRow>>;
+
+[MemoryPackable]
+public partial record GetExpiredStockReportRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetLowStockReportRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetLowStockReportRequest.cs
@@ -1,0 +1,19 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+
+using TRequest = GetLowStockReportRequest;
+using TResponse = QueryResponse<List<LowStockReportRow>>;
+
+[MemoryPackable]
+public partial record GetLowStockReportRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+    public Guid? WarehouseId { get; init; }
+    public Guid? LocationId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetMovementLedgerReportRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetMovementLedgerReportRequest.cs
@@ -1,0 +1,24 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+
+using TRequest = GetMovementLedgerReportRequest;
+using TResponse = QueryResponse<List<MovementLedgerReportRow>>;
+
+[MemoryPackable]
+public partial record GetMovementLedgerReportRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+    public Guid? WarehouseId { get; init; }
+    public Guid? LocationId { get; init; }
+    public Guid? LotId { get; init; }
+    public string? ReferenceType { get; init; }
+    public Guid? ReferenceId { get; init; }
+    public DateTime? From { get; init; }
+    public DateTime? To { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetNearExpiryStockReportRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetNearExpiryStockReportRequest.cs
@@ -1,0 +1,18 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+
+using TRequest = GetNearExpiryStockReportRequest;
+using TResponse = QueryResponse<List<NearExpiryStockReportRow>>;
+
+[MemoryPackable]
+public partial record GetNearExpiryStockReportRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public int DaysAhead { get; init; } = 30;
+    public Guid? ProductId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetReservationAllocationStatusReportRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetReservationAllocationStatusReportRequest.cs
@@ -1,0 +1,20 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+
+using TRequest = GetReservationAllocationStatusReportRequest;
+using TResponse = QueryResponse<List<ReservationAllocationStatusReportRow>>;
+
+[MemoryPackable]
+public partial record GetReservationAllocationStatusReportRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+    public Guid? LotId { get; init; }
+    public ReservationAllocationStatus? Status { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetStockPositionReportRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reports/GetStockPositionReportRequest.cs
@@ -1,0 +1,20 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+
+using TRequest = GetStockPositionReportRequest;
+using TResponse = QueryResponse<List<StockPositionReportRow>>;
+
+[MemoryPackable]
+public partial record GetStockPositionReportRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? ProductId { get; init; }
+    public Guid? WarehouseId { get; init; }
+    public Guid? LocationId { get; init; }
+    public Guid? LotId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Responses/Reports/InventoryReportRows.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Responses/Reports/InventoryReportRows.cs
@@ -1,0 +1,89 @@
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Responses.Reports;
+
+[MemoryPackable]
+public partial record LowStockReportRow(
+    Guid ProductId,
+    string ProductName,
+    Guid? WarehouseId,
+    string? WarehouseName,
+    Guid? LocationId,
+    string? LocationName,
+    decimal AvailableQuantity,
+    decimal ReorderPoint,
+    decimal MinimumQuantity);
+
+[MemoryPackable]
+public partial record ReorderSuggestionRow(
+    Guid ProductId,
+    string ProductName,
+    Guid? WarehouseId,
+    string? WarehouseName,
+    Guid? LocationId,
+    string? LocationName,
+    decimal AvailableQuantity,
+    decimal ReorderPoint,
+    decimal SuggestedQuantity,
+    string? PreferredSupplier);
+
+[MemoryPackable]
+public partial record NearExpiryStockReportRow(
+    Guid LotId,
+    string LotNumber,
+    Guid ProductId,
+    string ProductName,
+    Guid? WarehouseId,
+    string? WarehouseName,
+    Guid? LocationId,
+    string? LocationName,
+    decimal OnHandQuantity,
+    decimal AvailableQuantity,
+    DateTime? ExpiresAt,
+    InventoryLotStatus LotStatus);
+
+[MemoryPackable]
+public partial record StockPositionReportRow(
+    Guid StockBalanceId,
+    Guid ProductId,
+    string ProductName,
+    Guid WarehouseId,
+    string WarehouseName,
+    Guid LocationId,
+    string LocationName,
+    Guid? LotId,
+    string? LotNumber,
+    decimal OnHandQuantity,
+    decimal ReservedQuantity,
+    decimal AvailableQuantity);
+
+[MemoryPackable]
+public partial record MovementLedgerReportRow(
+    Guid MovementId,
+    Guid ProductId,
+    string ProductName,
+    Guid? WarehouseId,
+    string WarehouseName,
+    Guid? LocationId,
+    string LocationName,
+    Guid? LotId,
+    string? LotNumber,
+    InventoryMovementType MovementType,
+    decimal QuantityDelta,
+    string? ReferenceType,
+    Guid? ReferenceId,
+    DateTime MovementDate);
+
+[MemoryPackable]
+public partial record ReservationAllocationStatusReportRow(
+    Guid AllocationId,
+    Guid ReservationId,
+    Guid ProductId,
+    string ProductName,
+    Guid? LotId,
+    string? LotNumber,
+    decimal Quantity,
+    ReservationAllocationStatus Status,
+    DateTime ReservedAt,
+    DateTime? ReleasedAt,
+    DateTime? FulfilledAt);

--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -64,6 +64,18 @@
                     <LucideIcon Name="clipboard-check" class="h-4 w-4" /> Reservations
                 </NavLink>
             }
+            @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "planning"))
+            {
+                <NavLink href="/inventario/planning" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="chart-no-axes-combined" class="h-4 w-4" /> Planning
+                </NavLink>
+            }
+            @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "reporting"))
+            {
+                <NavLink href="/inventario/reports" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="file-chart-column" class="h-4 w-4" /> Reports
+                </NavLink>
+            }
             @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "transactions"))
             {
                 <NavLink href="/inventario/transactions" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
@@ -1,0 +1,448 @@
+@page "/inventario/planning"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Inventario Planning - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_planningEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Planning" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Replenishment Planning</BbTypographyH3>
+                    <BbTypographyMuted>Maintain reorder rules and review suggested replenishment quantities.</BbTypographyMuted>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <BbButton OnClick="@OpenRuleDialog">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Add Rule
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Active Rules</BbTypographyMuted>
+                            <BbTypographyH3>@_rules.Count(x => x.IsActive)</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Low Stock</BbTypographyMuted>
+                            <BbTypographyH3>@_lowStock.Count</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+                <BbCard>
+                    <BbCardContent>
+                        <div class="space-y-1 pt-4">
+                            <BbTypographyMuted>Suggested Quantity</BbTypographyMuted>
+                            <BbTypographyH3>@_suggestions.Sum(x => x.SuggestedQuantity).ToString("N2")</BbTypographyH3>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Reorder Suggestions</BbCardTitle>
+                    <BbCardDescription>@_suggestions.Count suggestion(s) generated from active rules</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_suggestions" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.WarehouseName)" Title="Warehouse" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LocationName)" Title="Location" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.SuggestedQuantity)" Title="Suggested Qty" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Preferred Supplier" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Reorder Rules</BbCardTitle>
+                    <BbCardDescription>@_rules.Count rule(s) configured</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_rules" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Scope">
+                                <ChildContent Context="item">@GetScopeLabel(item)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.MinimumQuantity)" Title="Min" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MaximumQuantity)" Title="Max" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Point" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReorderQuantity)" Title="Qty" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Supplier" />
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsActive ? "Active" : "Inactive")" Status="@(item.IsActive ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_ruleDialogOpen" OpenChanged="@(v => _ruleDialogOpen = v)">
+    <BbDialogContent TrapFocus="false">
+        <BbDialogHeader>
+            <BbDialogTitle>Add Reorder Rule</BbDialogTitle>
+            <BbDialogDescription>Rules can apply tenant-wide for a product or be scoped to a warehouse/location.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-2">
+                <div class="xf-form-field">
+                    <BbLabel>Product</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_form.ProductId"
+                                 Options="@ProductOptions"
+                                 Placeholder="Select product"
+                                 SearchPlaceholder="Search products..."
+                                 EmptyMessage="No products found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <div class="xf-form-field">
+                    <BbLabel>Warehouse</BbLabel>
+                    <BbCombobox TValue="string"
+                                 Value="@_form.WarehouseId"
+                                 ValueChanged="@OnWarehouseChanged"
+                                 Options="@WarehouseOptions"
+                                 Placeholder="Any warehouse"
+                                 SearchPlaceholder="Search warehouses..."
+                                 EmptyMessage="No warehouses found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <div class="xf-form-field">
+                    <BbLabel>Location</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_form.LocationId"
+                                 Options="@LocationOptions"
+                                 Placeholder="Any location"
+                                 SearchPlaceholder="Search locations..."
+                                 EmptyMessage="No locations found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <BbFormFieldInput TValue="string" @bind-Value="_form.PreferredSupplier" Label="Preferred Supplier" />
+            </div>
+            <div class="grid gap-3 md:grid-cols-4">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.MinimumQuantity" Label="Minimum" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.MaximumQuantity" Label="Maximum" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ReorderPoint" Label="Reorder Point" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ReorderQuantity" Label="Reorder Qty" />
+            </div>
+            <BbFormFieldSwitch Checked="@_form.IsActive"
+                               CheckedChanged="@((bool value) => _form.IsActive = value)"
+                               Label="Rule active" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _ruleDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@CreateRule" Disabled="@_savingRule">Create Rule</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private readonly RuleForm _form = new();
+    private List<Product> _products = [];
+    private List<Warehouse> _warehouses = [];
+    private List<InventoryLocation> _locations = [];
+    private List<StockBalance> _balances = [];
+    private List<InventoryReorderRule> _rules = [];
+    private List<PlanningRow> _lowStock = [];
+    private List<PlanningRow> _suggestions = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _planningEnabled;
+    private bool _ruleDialogOpen;
+    private bool _savingRule;
+
+    private List<SelectOption<string>> ProductOptions =>
+        _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
+    private List<SelectOption<string>> WarehouseOptions
+    {
+        get
+        {
+            var options = new List<SelectOption<string>> { new("", "Any warehouse") };
+            options.AddRange(_warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))));
+            return options;
+        }
+    }
+    private List<SelectOption<string>> LocationOptions
+    {
+        get
+        {
+            var options = new List<SelectOption<string>> { new("", "Any location") };
+            options.AddRange(LocationsForSelectedWarehouse().Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))));
+            return options;
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _planningEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "planning");
+            _products = [];
+            _warehouses = [];
+            _locations = [];
+            _balances = [];
+            _rules = [];
+            _lowStock = [];
+            _suggestions = [];
+
+            if (!_hasTenant || !_planningEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _products = await DataContext.Query<Product>().IgnoreQueryFilters().NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.Name).Take(500).ToListAsync();
+            _warehouses = await DataContext.Query<Warehouse>().IgnoreQueryFilters().NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.Code).Take(500).ToListAsync();
+            _locations = await DataContext.Query<InventoryLocation>().IgnoreQueryFilters().NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.Code).Take(500).ToListAsync();
+            _balances = await DataContext.Query<StockBalance>().IgnoreQueryFilters().NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(1000).ToListAsync();
+            _rules = await DataContext.Query<InventoryReorderRule>().IgnoreQueryFilters().NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.CreatedAt).Take(500).ToListAsync();
+
+            BuildSuggestions();
+            ApplyDefaults();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load planning: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void BuildSuggestions()
+    {
+        _lowStock = [];
+        _suggestions = [];
+        foreach (var rule in _rules.Where(x => x.IsActive))
+        {
+            var available = _balances
+                .Where(x =>
+                    x.ProductId == rule.ProductId &&
+                    (rule.WarehouseId is null || x.WarehouseId == rule.WarehouseId) &&
+                    (rule.LocationId is null || x.LocationId == rule.LocationId))
+                .Sum(x => x.AvailableQuantity);
+            var reorderPoint = rule.ReorderPoint > 0 ? rule.ReorderPoint : rule.MinimumQuantity;
+            if (available > reorderPoint) continue;
+
+            var row = new PlanningRow(
+                GetProductName(rule.ProductId),
+                GetWarehouseName(rule.WarehouseId),
+                GetLocationName(rule.LocationId),
+                available,
+                reorderPoint,
+                Math.Max(rule.ReorderQuantity, Math.Max(0, (rule.MaximumQuantity ?? reorderPoint + rule.ReorderQuantity) - available)),
+                rule.PreferredSupplier);
+            _lowStock.Add(row);
+            _suggestions.Add(row);
+        }
+    }
+
+    private async Task CreateRule()
+    {
+        if (!_hasTenant || !Guid.TryParse(_form.ProductId, out var productId))
+        {
+            ToastService.Show("Select a product.");
+            return;
+        }
+
+        if (!decimal.TryParse(_form.MinimumQuantity, out var min) ||
+            !decimal.TryParse(_form.ReorderPoint, out var point) ||
+            !decimal.TryParse(_form.ReorderQuantity, out var qty) ||
+            min < 0 || point < 0 || qty <= 0)
+        {
+            ToastService.Show("Quantities must be valid.");
+            return;
+        }
+
+        decimal? max = null;
+        if (!string.IsNullOrWhiteSpace(_form.MaximumQuantity))
+        {
+            if (!decimal.TryParse(_form.MaximumQuantity, out var parsedMax) || parsedMax < min)
+            {
+                ToastService.Show("Maximum must be greater than or equal to minimum.");
+                return;
+            }
+            max = parsedMax;
+        }
+
+        _savingRule = true;
+        try
+        {
+            var now = DateTime.UtcNow;
+            DataContext.Add(new InventoryReorderRule
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TenantFilter.SelectedTenantId!.Value,
+                ProductId = productId,
+                WarehouseId = Guid.TryParse(_form.WarehouseId, out var warehouseId) ? warehouseId : null,
+                LocationId = Guid.TryParse(_form.LocationId, out var locationId) ? locationId : null,
+                MinimumQuantity = min,
+                MaximumQuantity = max,
+                ReorderPoint = point,
+                ReorderQuantity = qty,
+                PreferredSupplier = NullIfEmpty(_form.PreferredSupplier),
+                IsActive = _form.IsActive,
+                IsEnabled = true,
+                CreatedAt = now,
+                ConcurrencyStamp = Guid.NewGuid()
+            });
+            var save = await DataContext.SaveChangesAsync();
+            ToastService.Show(save.IsSuccess ? "Reorder rule created." : $"Failed: {save.Message}");
+            if (save.IsSuccess)
+            {
+                _ruleDialogOpen = false;
+                ResetForm();
+                await Reload();
+            }
+        }
+        finally
+        {
+            _savingRule = false;
+        }
+    }
+
+    private void OpenRuleDialog()
+    {
+        ApplyDefaults();
+        _ruleDialogOpen = true;
+    }
+
+    private void OnWarehouseChanged(string? value)
+    {
+        _form.WarehouseId = value ?? "";
+        _form.LocationId = "";
+    }
+
+    private IEnumerable<InventoryLocation> LocationsForSelectedWarehouse()
+    {
+        if (!Guid.TryParse(_form.WarehouseId, out var warehouseId))
+            return _locations;
+        return _locations.Where(x => x.WarehouseId == warehouseId);
+    }
+
+    private void ApplyDefaults() =>
+        _form.ProductId = _form.ProductId.Length > 0 ? _form.ProductId : _products.FirstOrDefault()?.Id.ToString() ?? "";
+
+    private void ResetForm()
+    {
+        _form.ProductId = "";
+        _form.WarehouseId = "";
+        _form.LocationId = "";
+        _form.MinimumQuantity = "0";
+        _form.MaximumQuantity = "";
+        _form.ReorderPoint = "0";
+        _form.ReorderQuantity = "1";
+        _form.PreferredSupplier = "";
+        _form.IsActive = true;
+    }
+
+    private string GetProductName(Guid productId) =>
+        _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
+
+    private string GetProductLabel(Product product) =>
+        string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
+
+    private string GetWarehouseName(Guid? warehouseId) =>
+        warehouseId is { } id ? _warehouses.FirstOrDefault(x => x.Id == id) is { } warehouse ? GetWarehouseLabel(warehouse) : id.ToString()[..8] : "Any warehouse";
+
+    private string GetLocationName(Guid? locationId) =>
+        locationId is { } id ? _locations.FirstOrDefault(x => x.Id == id) is { } location ? GetLocationLabel(location) : id.ToString()[..8] : "Any location";
+
+    private string GetScopeLabel(InventoryReorderRule rule) =>
+        $"{GetWarehouseName(rule.WarehouseId)} / {GetLocationName(rule.LocationId)}";
+
+    private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+    private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
+    private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed record PlanningRow(
+        string ProductName,
+        string WarehouseName,
+        string LocationName,
+        decimal AvailableQuantity,
+        decimal ReorderPoint,
+        decimal SuggestedQuantity,
+        string? PreferredSupplier);
+
+    private sealed class RuleForm
+    {
+        public string ProductId { get; set; } = "";
+        public string WarehouseId { get; set; } = "";
+        public string LocationId { get; set; } = "";
+        public string MinimumQuantity { get; set; } = "0";
+        public string MaximumQuantity { get; set; } = "";
+        public string ReorderPoint { get; set; } = "0";
+        public string ReorderQuantity { get; set; } = "1";
+        public string PreferredSupplier { get; set; } = "";
+        public bool IsActive { get; set; } = true;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reports.razor
@@ -1,0 +1,331 @@
+@page "/inventario/reports"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Reports - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_reportingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Reporting" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Inventory Reports</BbTypographyH3>
+                    <BbTypographyMuted>Focused inventory views for stock, expiry, movement, and allocation status.</BbTypographyMuted>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+                <ReportMetric Title="Low Stock" Value="@_lowStock.Count.ToString()" />
+                <ReportMetric Title="Near Expiry" Value="@_nearExpiry.Count.ToString()" />
+                <ReportMetric Title="Expired Lots" Value="@_expired.Count.ToString()" />
+                <ReportMetric Title="Stock Positions" Value="@_balances.Count.ToString()" />
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Low Stock</BbCardTitle>
+                    <BbCardDescription>@_lowStock.Count scoped rule(s) at or below reorder point</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_lowStock" ShowPagination="true" InitialPageSize="10">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Scope" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Near Expiry</BbCardTitle>
+                    <BbCardDescription>Lots expiring in the next 30 days with on-hand stock</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_nearExpiry" ShowPagination="true" InitialPageSize="10">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Expired Stock</BbCardTitle>
+                    <BbCardDescription>Expired or expired-status lots that still have on-hand stock</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_expired" ShowPagination="true" InitialPageSize="10">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expired" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Stock By Product / Location / Lot</BbCardTitle>
+                    <BbCardDescription>@_stockPositions.Count balance row(s)</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_stockPositions" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" />
+                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Recent Movement Ledger</BbCardTitle>
+                    <BbCardDescription>@_movements.Count latest movement(s)</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Reference)" Title="Reference" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Date" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Reservation Allocation Status</BbCardTitle>
+                    <BbCardDescription>@_allocations.Count allocation row(s)</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_allocations" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private List<Product> _products = [];
+    private List<Warehouse> _warehouses = [];
+    private List<InventoryLocation> _locations = [];
+    private List<InventoryLot> _lots = [];
+    private List<StockBalance> _balances = [];
+    private List<InventoryReorderRule> _rules = [];
+    private List<InventoryMovement> _rawMovements = [];
+    private List<ReservationAllocation> _rawAllocations = [];
+    private List<LowStockRow> _lowStock = [];
+    private List<ExpiryRow> _nearExpiry = [];
+    private List<ExpiryRow> _expired = [];
+    private List<StockRow> _stockPositions = [];
+    private List<MovementRow> _movements = [];
+    private List<AllocationRow> _allocations = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _reportingEnabled;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _reportingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "reporting");
+            ClearRows();
+            if (!_hasTenant || !_reportingEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _products = await DataContext.Query<Product>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(1000).ToListAsync();
+            _warehouses = await DataContext.Query<Warehouse>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(1000).ToListAsync();
+            _locations = await DataContext.Query<InventoryLocation>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(1000).ToListAsync();
+            _lots = await DataContext.Query<InventoryLot>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(1000).ToListAsync();
+            _balances = await DataContext.Query<StockBalance>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(2000).ToListAsync();
+            _rules = await DataContext.Query<InventoryReorderRule>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && x.IsActive && !x.IsDeleted).Take(1000).ToListAsync();
+            _rawMovements = await DataContext.Query<InventoryMovement>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderByDescending(x => x.MovementDate).Take(500).ToListAsync();
+            _rawAllocations = await DataContext.Query<ReservationAllocation>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderByDescending(x => x.ReservedAt).Take(500).ToListAsync();
+
+            BuildRows();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load inventory reports: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void ClearRows()
+    {
+        _products = [];
+        _warehouses = [];
+        _locations = [];
+        _lots = [];
+        _balances = [];
+        _rules = [];
+        _rawMovements = [];
+        _rawAllocations = [];
+        _lowStock = [];
+        _nearExpiry = [];
+        _expired = [];
+        _stockPositions = [];
+        _movements = [];
+        _allocations = [];
+    }
+
+    private void BuildRows()
+    {
+        _lowStock = _rules.Select(rule =>
+            {
+                var available = _balances.Where(x =>
+                        x.ProductId == rule.ProductId &&
+                        (rule.WarehouseId is null || x.WarehouseId == rule.WarehouseId) &&
+                        (rule.LocationId is null || x.LocationId == rule.LocationId))
+                    .Sum(x => x.AvailableQuantity);
+                var reorderPoint = rule.ReorderPoint > 0 ? rule.ReorderPoint : rule.MinimumQuantity;
+                return new LowStockRow(GetProductName(rule.ProductId), GetScope(rule.WarehouseId, rule.LocationId), available, reorderPoint);
+            })
+            .Where(x => x.AvailableQuantity <= x.ReorderPoint)
+            .ToList();
+
+        var now = DateTime.UtcNow;
+        _nearExpiry = BuildExpiryRows(lot => lot.ExpiresAt is not null && lot.ExpiresAt > now && lot.ExpiresAt <= now.AddDays(30));
+        _expired = BuildExpiryRows(lot => lot.Status == InventoryLotStatus.Expired || lot.ExpiresAt is not null && lot.ExpiresAt <= now);
+        _stockPositions = _balances.Select(balance => new StockRow(
+                GetProductName(balance.ProductId),
+                GetScope(balance.WarehouseId, balance.LocationId),
+                GetLotNumber(balance.LotId),
+                balance.OnHandQuantity,
+                balance.ReservedQuantity,
+                balance.AvailableQuantity))
+            .ToList();
+        _movements = _rawMovements.Select(movement => new MovementRow(
+                GetProductName(movement.ProductId),
+                movement.MovementType,
+                movement.QuantityDelta,
+                FormatReference(movement.ReferenceType, movement.ReferenceId),
+                movement.MovementDate))
+            .ToList();
+        _allocations = _rawAllocations.Select(allocation => new AllocationRow(
+                GetProductName(allocation.ProductId),
+                GetLotNumber(allocation.LotId),
+                allocation.Quantity,
+                allocation.Status,
+                allocation.ReservedAt))
+            .ToList();
+    }
+
+    private List<ExpiryRow> BuildExpiryRows(Func<InventoryLot, bool> lotFilter)
+    {
+        var lots = _lots.Where(lotFilter).ToDictionary(x => x.Id);
+        if (lots.Count == 0) return [];
+
+        return _balances
+            .Where(x => x.LotId is { } lotId && lots.ContainsKey(lotId) && x.OnHandQuantity > 0)
+            .Select(balance =>
+            {
+                var lot = lots[balance.LotId!.Value];
+                return new ExpiryRow(
+                    GetProductName(lot.ProductId),
+                    lot.LotNumber ?? lot.Id.ToString()[..8],
+                    GetScope(balance.WarehouseId, balance.LocationId),
+                    balance.AvailableQuantity,
+                    lot.ExpiresAt);
+            })
+            .OrderBy(x => x.ExpiresAt)
+            .ToList();
+    }
+
+    private string GetProductName(Guid productId) =>
+        _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
+
+    private string GetScope(Guid? warehouseId, Guid? locationId) =>
+        $"{GetWarehouseName(warehouseId)} / {GetLocationName(locationId)}";
+
+    private string GetWarehouseName(Guid? id) =>
+        id is { } value ? _warehouses.FirstOrDefault(x => x.Id == value) is { } warehouse ? $"{warehouse.Code} - {warehouse.Name}" : value.ToString()[..8] : "Any warehouse";
+
+    private string GetLocationName(Guid? id) =>
+        id is { } value ? _locations.FirstOrDefault(x => x.Id == value) is { } location ? $"{location.Code} - {location.Name}" : value.ToString()[..8] : "Any location";
+
+    private string GetLotNumber(Guid? id) =>
+        id is { } value ? _lots.FirstOrDefault(x => x.Id == value)?.LotNumber ?? value.ToString()[..8] : "Untracked";
+
+    private static string FormatReference(string? type, Guid? id) =>
+        string.IsNullOrWhiteSpace(type) ? "N/A" : id is { } value ? $"{type} / {value.ToString()[..8]}" : type;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed record LowStockRow(string ProductName, string Scope, decimal AvailableQuantity, decimal ReorderPoint);
+    private sealed record ExpiryRow(string ProductName, string LotNumber, string Scope, decimal AvailableQuantity, DateTime? ExpiresAt);
+    private sealed record StockRow(string ProductName, string Scope, string LotNumber, decimal OnHandQuantity, decimal ReservedQuantity, decimal AvailableQuantity);
+    private sealed record MovementRow(string ProductName, InventoryMovementType MovementType, decimal QuantityDelta, string Reference, DateTime MovementDate);
+    private sealed record AllocationRow(string ProductName, string LotNumber, decimal Quantity, ReservationAllocationStatus Status, DateTime ReservedAt);
+}

--- a/src/Presentation/ControlPanel.Server/Components/Shared/ReportMetric.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/ReportMetric.razor
@@ -1,0 +1,13 @@
+<BbCard>
+    <BbCardContent>
+        <div class="space-y-1 pt-4">
+            <BbTypographyMuted>@Title</BbTypographyMuted>
+            <BbTypographyH3>@Value</BbTypographyH3>
+        </div>
+    </BbCardContent>
+</BbCard>
+
+@code {
+    [Parameter] public string Title { get; set; } = "";
+    [Parameter] public string Value { get; set; } = "";
+}

--- a/src/Tests/Inventario.Api.Tests/InventoryPlanningReportingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/InventoryPlanningReportingServiceTests.cs
@@ -1,0 +1,301 @@
+using System.Collections;
+using System.Linq.Expressions;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace Inventario.Api.Tests;
+
+[TestFixture]
+public sealed class InventoryPlanningReportingServiceTests
+{
+    [Test]
+    public async Task GetReorderSuggestionsAsync_AvailableBelowReorderPoint_ReturnsSuggestedQuantity()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedPlanningData(tenantId, ids, availableQuantity: 3);
+        var service = CreatePlanningService(dataContext, tenantId);
+
+        var result = await service.GetReorderSuggestionsAsync(new GetReorderSuggestionsRequest());
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.Data.Should().ContainSingle();
+        var suggestion = result.Data![0];
+        suggestion.ProductId.Should().Be(ids.ProductId);
+        suggestion.AvailableQuantity.Should().Be(3);
+        suggestion.ReorderPoint.Should().Be(5);
+        suggestion.SuggestedQuantity.Should().Be(17);
+        suggestion.PreferredSupplier.Should().Be("Acme Supply");
+    }
+
+    [Test]
+    public async Task GetReorderSuggestionsAsync_AvailableAboveReorderPoint_ReturnsEmpty()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedPlanningData(tenantId, ids, availableQuantity: 6);
+        var service = CreatePlanningService(dataContext, tenantId);
+
+        var result = await service.GetReorderSuggestionsAsync(new GetReorderSuggestionsRequest());
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.Data.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task CreateRuleAsync_DuplicateProductScope_ReturnsConflict()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedPlanningData(tenantId, ids, availableQuantity: 3);
+        var service = CreatePlanningService(dataContext, tenantId);
+
+        var result = await service.CreateRuleAsync(new CreateInventoryReorderRuleRequest
+        {
+            ProductId = ids.ProductId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            MinimumQuantity = 2,
+            ReorderPoint = 4,
+            ReorderQuantity = 8,
+            IsActive = true
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        dataContext.Added.OfType<InventoryReorderRule>().Should().BeEmpty();
+        dataContext.SaveCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task GetNearExpiryAsync_ExpiringLotWithStock_ReturnsReportRow()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var lotId = Guid.NewGuid();
+        var dataContext = SeedPlanningData(tenantId, ids, availableQuantity: 3);
+        dataContext.Set<InventoryLot>().Add(new InventoryLot
+        {
+            Id = lotId,
+            TenantId = tenantId,
+            ProductId = ids.ProductId,
+            LotNumber = "LOT-EXP-1",
+            ReceivedAt = DateTime.UtcNow.AddDays(-5),
+            ExpiresAt = DateTime.UtcNow.AddDays(10),
+            Status = InventoryLotStatus.Available,
+            IsEnabled = true
+        });
+        dataContext.Set<StockBalance>().Add(new StockBalance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = ids.ProductId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            LotId = lotId,
+            OnHandQuantity = 4,
+            ReservedQuantity = 1,
+            AvailableQuantity = 3,
+            IsEnabled = true
+        });
+        var planningService = CreatePlanningService(dataContext, tenantId);
+        var reportingService = CreateReportingService(dataContext, tenantId, planningService);
+
+        var result = await reportingService.GetNearExpiryAsync(new GetNearExpiryStockReportRequest
+        {
+            DaysAhead = 30
+        });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.Data.Should().ContainSingle();
+        var row = result.Data![0];
+        row.LotId.Should().Be(lotId);
+        row.LotNumber.Should().Be("LOT-EXP-1");
+        row.OnHandQuantity.Should().Be(4);
+        row.AvailableQuantity.Should().Be(3);
+        row.ProductName.Should().Be("Widget");
+    }
+
+    private static FakeDataContext SeedPlanningData(Guid tenantId, TestIds ids, decimal availableQuantity)
+    {
+        var dataContext = new FakeDataContext();
+        dataContext.Set<Product>().Add(new Product
+        {
+            Id = ids.ProductId,
+            TenantId = tenantId,
+            Name = "Widget",
+            CategoryId = Guid.NewGuid(),
+            IsEnabled = true
+        });
+        dataContext.Set<Warehouse>().Add(new Warehouse
+        {
+            Id = ids.WarehouseId,
+            TenantId = tenantId,
+            Code = "MAIN",
+            Name = "Main Warehouse",
+            IsEnabled = true
+        });
+        dataContext.Set<InventoryLocation>().Add(new InventoryLocation
+        {
+            Id = ids.LocationId,
+            TenantId = tenantId,
+            WarehouseId = ids.WarehouseId,
+            Code = "BIN-01",
+            Name = "Bin 01",
+            IsEnabled = true
+        });
+        dataContext.Set<StockBalance>().Add(new StockBalance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = ids.ProductId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            OnHandQuantity = availableQuantity,
+            ReservedQuantity = 0,
+            AvailableQuantity = availableQuantity,
+            IsEnabled = true
+        });
+        dataContext.Set<InventoryReorderRule>().Add(new InventoryReorderRule
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = ids.ProductId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            MinimumQuantity = 2,
+            MaximumQuantity = 20,
+            ReorderPoint = 5,
+            ReorderQuantity = 6,
+            PreferredSupplier = "Acme Supply",
+            IsActive = true,
+            IsEnabled = true
+        });
+
+        return dataContext;
+    }
+
+    private static InventoryPlanningService CreatePlanningService(FakeDataContext dataContext, Guid tenantId) =>
+        new(dataContext, CreateHttpContextAccessor(tenantId));
+
+    private static InventoryReportingService CreateReportingService(
+        FakeDataContext dataContext,
+        Guid tenantId,
+        InventoryPlanningService planningService) =>
+        new(dataContext, CreateHttpContextAccessor(tenantId), planningService);
+
+    private static HttpContextAccessor CreateHttpContextAccessor(Guid tenantId) =>
+        new()
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim("tenantId", tenantId.ToString())],
+                    authenticationType: "Test"))
+            }
+        };
+
+    private sealed record TestIds(Guid ProductId, Guid WarehouseId, Guid LocationId)
+    {
+        public static TestIds Create() => new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+    }
+
+    private sealed class FakeDataContext : IDataContext
+    {
+        private readonly Dictionary<Type, IList> sets = [];
+
+        public List<object> Added { get; } = [];
+        public List<object> Updated { get; } = [];
+        public int SaveCount { get; private set; }
+
+        public List<T> Set<T>() where T : class
+        {
+            if (!sets.TryGetValue(typeof(T), out var set))
+            {
+                set = new List<T>();
+                sets[typeof(T)] = set;
+            }
+
+            return (List<T>)set;
+        }
+
+        public IRemoteQuery<T> Query<T>() where T : class =>
+            new InMemoryRemoteQuery<T>(Set<T>().AsQueryable());
+
+        public void Add<T>(T entity) where T : class
+        {
+            Added.Add(entity);
+            Set<T>().Add(entity);
+        }
+
+        public void Update<T>(T entity) where T : class =>
+            Updated.Add(entity);
+
+        public void Remove<T>(T entity) where T : class =>
+            Set<T>().Remove(entity);
+
+        public Task<DataContextResult> SaveChangesAsync(CancellationToken ct = default)
+        {
+            SaveCount++;
+            return Task.FromResult(DataContextResult.Success());
+        }
+    }
+
+    private sealed class InMemoryRemoteQuery<T>(IQueryable<T> queryable) : IRemoteQuery<T>
+        where T : class
+    {
+        private IQueryable<T> query = queryable;
+
+        public IRemoteQuery<T> Where(Expression<Func<T, bool>> predicate) { query = query.Where(predicate); return this; }
+        public IRemoteQuery<T> OrderBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.OrderBy(keySelector); return this; }
+        public IRemoteQuery<T> OrderByDescending<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.OrderByDescending(keySelector); return this; }
+        public IRemoteQuery<T> ThenBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = ((IOrderedQueryable<T>)query).ThenBy(keySelector); return this; }
+        public IRemoteQuery<T> ThenByDescending<TKey>(Expression<Func<T, TKey>> keySelector) { query = ((IOrderedQueryable<T>)query).ThenByDescending(keySelector); return this; }
+        public IRemoteQuery<T> Skip(int count) { query = query.Skip(count); return this; }
+        public IRemoteQuery<T> Take(int count) { query = query.Take(count); return this; }
+        public IRemoteQuery<T> Include<TProperty>(Expression<Func<T, TProperty>> navigationSelector) => this;
+        public IRemoteQuery<T> Distinct() { query = query.Distinct(); return this; }
+        public IRemoteQuery<T> DistinctBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.AsEnumerable().DistinctBy(keySelector.Compile()).AsQueryable(); return this; }
+        public IRemoteQuery<T> NoCache() => this;
+        public IRemoteQuery<T> IgnoreQueryFilters() => this;
+        public Task<List<T>> ToListAsync(CancellationToken ct = default) => Task.FromResult(query.ToList());
+        public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) => Task.FromResult(query.FirstOrDefault());
+        public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default) => Task.FromResult(query.SingleOrDefault());
+        public async IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in query)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+        public Task<int> CountAsync(CancellationToken ct = default) => Task.FromResult(query.Count());
+        public Task<bool> AnyAsync(CancellationToken ct = default) => Task.FromResult(query.Any());
+        public Task<bool> AnyAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) => Task.FromResult(query.Any(predicate));
+        public Task<bool> AllAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) => Task.FromResult(query.All(predicate));
+        public Task<TResult?> MinAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) => Task.FromResult(query.Select(selector).Min());
+        public Task<TResult?> MaxAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) => Task.FromResult(query.Select(selector).Max());
+        public Task<T?> MinByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) => Task.FromResult(query.AsEnumerable().MinBy(keySelector.Compile()));
+        public Task<T?> MaxByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) => Task.FromResult(query.AsEnumerable().MaxBy(keySelector.Compile()));
+        public Task<decimal> SumAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) => Task.FromResult(query.Sum(selector));
+        public Task<double> AverageAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) => Task.FromResult((double)query.Average(selector));
+        public Task<List<GroupResult<TKey, T>>> GroupByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default)
+        {
+            var compiled = keySelector.Compile();
+            return Task.FromResult(query.AsEnumerable()
+                .GroupBy(compiled)
+                .Select(g => new GroupResult<TKey, T> { Key = g.Key, Items = g.ToList() })
+                .ToList());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- adds tenant-scoped `InventoryReorderRule` support with planning endpoints for low stock and reorder suggestions
- adds reporting endpoints for low stock, near expiry, expired stock, stock position, movement ledger, and reservation allocation status
- adds ControlPanel Planning and Reports pages behind Inventario planning/reporting subfeature navigation
- adds EF migration for the reorder-rule table and focused Inventario service tests

## Stacking
This PR is stacked on #265 (`codex/inventario-fefo-allocation`), which is stacked on #264. After #264 and #265 merge, this branch should be rebased/retargeted to `develop` before merge.

## Verification
- `dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false`
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --no-restore`
- `dotnet restore XFramework.slnx`
- `dotnet build XFramework.slnx -m:1 /nr:false --no-restore`