### PR TITLE
Add Inventario purchasing and receiving

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260619105428_AddInventarioPurchasingReceiving.Designer.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619105428_AddInventarioPurchasingReceiving.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XFramework.Domain.Contexts;
@@ -11,9 +12,11 @@ using XFramework.Domain.Contexts;
 namespace XFramework.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619105428_AddInventarioPurchasingReceiving")]
+    partial class AddInventarioPurchasingReceiving
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kernel/XFramework.Domain/Migrations/20260619105428_AddInventarioPurchasingReceiving.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260619105428_AddInventarioPurchasingReceiving.cs
@@ -1,0 +1,483 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInventarioPurchasingReceiving : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Supplier",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    Code = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    ContactName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Email = table.Column<string>(type: "character varying(320)", maxLength: 320, nullable: true),
+                    Phone = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_Supplier", x => x.ID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PurchaseOrder",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    OrderNumber = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    SupplierId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    OrderDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ExpectedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Notes = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_PurchaseOrder", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_PurchaseOrder_Supplier",
+                        column: x => x.SupplierId,
+                        principalSchema: "Inventario",
+                        principalTable: "Supplier",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PurchaseOrderLine",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    PurchaseOrderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrderedQuantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    ReceivedQuantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    UnitCost = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: true),
+                    UnitOfMeasure = table.Column<string>(type: "character varying(25)", maxLength: 25, nullable: true),
+                    Notes = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_PurchaseOrderLine", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_PurchaseOrderLine_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_PurchaseOrderLine_PurchaseOrder_PurchaseOrderId",
+                        column: x => x.PurchaseOrderId,
+                        principalSchema: "Inventario",
+                        principalTable: "PurchaseOrder",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ReceivingDocument",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ReceiptNumber = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    PurchaseOrderId = table.Column<Guid>(type: "uuid", nullable: true),
+                    WarehouseId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LocationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SupplierId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    ReceivedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ReferenceNumber = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Notes = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IdempotencyKey = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    RequestHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_ReceivingDocument", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingDocument_Location",
+                        column: x => x.LocationId,
+                        principalSchema: "Inventario",
+                        principalTable: "InventoryLocation",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingDocument_PurchaseOrder",
+                        column: x => x.PurchaseOrderId,
+                        principalSchema: "Inventario",
+                        principalTable: "PurchaseOrder",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingDocument_Supplier",
+                        column: x => x.SupplierId,
+                        principalSchema: "Inventario",
+                        principalTable: "Supplier",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingDocument_Warehouse",
+                        column: x => x.WarehouseId,
+                        principalSchema: "Inventario",
+                        principalTable: "Warehouse",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ReceivingLine",
+                schema: "Inventario",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    ReceivingDocumentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PurchaseOrderLineId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LotId = table.Column<Guid>(type: "uuid", nullable: true),
+                    StockBalanceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InventoryMovementId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Quantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    UnitCost = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: true),
+                    UnitOfMeasure = table.Column<string>(type: "character varying(25)", maxLength: 25, nullable: true),
+                    LotNumber = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inventario_ReceivingLine", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingLine_InventoryMovement",
+                        column: x => x.InventoryMovementId,
+                        principalSchema: "Inventario",
+                        principalTable: "InventoryMovement",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingLine_Lot",
+                        column: x => x.LotId,
+                        principalSchema: "Inventario",
+                        principalTable: "InventoryLot",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingLine_Product",
+                        column: x => x.ProductId,
+                        principalSchema: "Inventario",
+                        principalTable: "Product",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingLine_PurchaseOrderLine",
+                        column: x => x.PurchaseOrderLineId,
+                        principalSchema: "Inventario",
+                        principalTable: "PurchaseOrderLine",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Inventario_ReceivingLine_StockBalance",
+                        column: x => x.StockBalanceId,
+                        principalSchema: "Inventario",
+                        principalTable: "StockBalance",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ReceivingLine_ReceivingDocument_ReceivingDocumentId",
+                        column: x => x.ReceivingDocumentId,
+                        principalSchema: "Inventario",
+                        principalTable: "ReceivingDocument",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrder_SupplierId",
+                schema: "Inventario",
+                table: "PurchaseOrder",
+                column: "SupplierId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrder_TenantId",
+                schema: "Inventario",
+                table: "PurchaseOrder",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrder_TenantId_IsDeleted",
+                schema: "Inventario",
+                table: "PurchaseOrder",
+                columns: new[] { "TenantId", "IsDeleted" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrder_TenantId_OrderNumber",
+                schema: "Inventario",
+                table: "PurchaseOrder",
+                columns: new[] { "TenantId", "OrderNumber" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrder_TenantId_Status",
+                schema: "Inventario",
+                table: "PurchaseOrder",
+                columns: new[] { "TenantId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrderLine_ProductId",
+                schema: "Inventario",
+                table: "PurchaseOrderLine",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrderLine_PurchaseOrderId",
+                schema: "Inventario",
+                table: "PurchaseOrderLine",
+                column: "PurchaseOrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrderLine_TenantId",
+                schema: "Inventario",
+                table: "PurchaseOrderLine",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrderLine_TenantId_IsDeleted",
+                schema: "Inventario",
+                table: "PurchaseOrderLine",
+                columns: new[] { "TenantId", "IsDeleted" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrderLine_TenantId_ProductId",
+                schema: "Inventario",
+                table: "PurchaseOrderLine",
+                columns: new[] { "TenantId", "ProductId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PurchaseOrderLine_TenantId_PurchaseOrderId",
+                schema: "Inventario",
+                table: "PurchaseOrderLine",
+                columns: new[] { "TenantId", "PurchaseOrderId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_LocationId",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                column: "LocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_PurchaseOrderId",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                column: "PurchaseOrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_SupplierId",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                column: "SupplierId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_TenantId",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_TenantId_IdempotencyKey",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                columns: new[] { "TenantId", "IdempotencyKey" },
+                unique: true,
+                filter: "\"IdempotencyKey\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_TenantId_IsDeleted",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                columns: new[] { "TenantId", "IsDeleted" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_TenantId_PurchaseOrderId",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                columns: new[] { "TenantId", "PurchaseOrderId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_TenantId_ReceiptNumber",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                columns: new[] { "TenantId", "ReceiptNumber" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingDocument_WarehouseId",
+                schema: "Inventario",
+                table: "ReceivingDocument",
+                column: "WarehouseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_InventoryMovementId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                column: "InventoryMovementId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_LotId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                column: "LotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_ProductId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_PurchaseOrderLineId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                column: "PurchaseOrderLineId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_ReceivingDocumentId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                column: "ReceivingDocumentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_StockBalanceId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                column: "StockBalanceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_TenantId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_TenantId_IsDeleted",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                columns: new[] { "TenantId", "IsDeleted" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_TenantId_ProductId_LotId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                columns: new[] { "TenantId", "ProductId", "LotId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_TenantId_PurchaseOrderLineId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                columns: new[] { "TenantId", "PurchaseOrderLineId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceivingLine_TenantId_ReceivingDocumentId",
+                schema: "Inventario",
+                table: "ReceivingLine",
+                columns: new[] { "TenantId", "ReceivingDocumentId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Supplier_TenantId",
+                schema: "Inventario",
+                table: "Supplier",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Supplier_TenantId_Code",
+                schema: "Inventario",
+                table: "Supplier",
+                columns: new[] { "TenantId", "Code" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Supplier_TenantId_IsDeleted",
+                schema: "Inventario",
+                table: "Supplier",
+                columns: new[] { "TenantId", "IsDeleted" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Supplier_TenantId_Name",
+                schema: "Inventario",
+                table: "Supplier",
+                columns: new[] { "TenantId", "Name" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReceivingLine",
+                schema: "Inventario");
+
+            migrationBuilder.DropTable(
+                name: "PurchaseOrderLine",
+                schema: "Inventario");
+
+            migrationBuilder.DropTable(
+                name: "ReceivingDocument",
+                schema: "Inventario");
+
+            migrationBuilder.DropTable(
+                name: "PurchaseOrder",
+                schema: "Inventario");
+
+            migrationBuilder.DropTable(
+                name: "Supplier",
+                schema: "Inventario");
+        }
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/CreateEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/CreateEndpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.PurchaseOrders;
+
+public static class CreatePurchaseOrderEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/purchase-orders", Tags = ["Inventario Purchasing"],
+        Summary = "Create purchase order",
+        Description = "Creates a purchase order with line items.")]
+    public static async Task<Result<PurchaseOrder>> Handle(
+        CreatePurchaseOrderRequest request,
+        PurchasingService purchasingService,
+        CancellationToken ct)
+    {
+        return await purchasingService.CreatePurchaseOrderAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/CreatePurchaseOrderValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/CreatePurchaseOrderValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace Inventario.Api.Features.Purchasing.PurchaseOrders;
+
+public sealed class CreatePurchaseOrderValidator : AbstractValidator<CreatePurchaseOrderRequest>
+{
+    public CreatePurchaseOrderValidator()
+    {
+        RuleFor(x => x.OrderNumber).MaximumLength(100);
+        RuleFor(x => x.Notes).MaximumLength(1000);
+        RuleFor(x => x.Status)
+            .Must(x => x is PurchaseOrderStatus.Draft or PurchaseOrderStatus.Open)
+            .WithMessage("New purchase orders can only start as draft or open.");
+        RuleFor(x => x.Lines).NotEmpty();
+        RuleForEach(x => x.Lines).ChildRules(line =>
+        {
+            line.RuleFor(x => x.ProductId).NotEmpty();
+            line.RuleFor(x => x.OrderedQuantity).GreaterThan(0);
+            line.RuleFor(x => x.UnitCost).GreaterThanOrEqualTo(0).When(x => x.UnitCost is not null);
+            line.RuleFor(x => x.UnitOfMeasure).MaximumLength(25);
+            line.RuleFor(x => x.Notes).MaximumLength(1000);
+        });
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/GetEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/GetEndpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.PurchaseOrders;
+
+public static class GetPurchaseOrderEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/purchase-orders/{id:guid}", Tags = ["Inventario Purchasing"],
+        Summary = "Get purchase order",
+        Description = "Gets a purchase order with line items.")]
+    public static async Task<Result<PurchaseOrder>> Handle(
+        Guid id,
+        PurchasingService purchasingService,
+        CancellationToken ct)
+    {
+        return await purchasingService.GetPurchaseOrderAsync(new GetPurchaseOrderRequest { Id = id }, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/GetListEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/GetListEndpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.PurchaseOrders;
+
+public static class GetPurchaseOrdersEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/purchase-orders", Tags = ["Inventario Purchasing"],
+        Summary = "List purchase orders",
+        Description = "Lists purchase orders for the current tenant.")]
+    public static async Task<Result<List<PurchaseOrder>>> Handle(
+        [AsParameters] GetPurchaseOrdersRequest request,
+        PurchasingService purchasingService,
+        CancellationToken ct)
+    {
+        return await purchasingService.GetPurchaseOrdersAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/SetStatusEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/SetStatusEndpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.PurchaseOrders;
+
+public static class SetPurchaseOrderStatusEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/purchase-orders/status", Tags = ["Inventario Purchasing"],
+        Summary = "Set purchase order status",
+        Description = "Opens or cancels a purchase order. Receiving controls partially received and received statuses.")]
+    public static async Task<Result<PurchaseOrder>> Handle(
+        SetPurchaseOrderStatusRequest request,
+        PurchasingService purchasingService,
+        CancellationToken ct)
+    {
+        return await purchasingService.SetPurchaseOrderStatusAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Receiving/GetListEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Receiving/GetListEndpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.Receiving;
+
+public static class GetReceivingDocumentsEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/receiving", Tags = ["Inventario Purchasing"],
+        Summary = "List receiving documents",
+        Description = "Lists posted receiving documents for the current tenant.")]
+    public static async Task<Result<List<ReceivingDocument>>> Handle(
+        [AsParameters] GetReceivingDocumentsRequest request,
+        PurchasingService purchasingService,
+        CancellationToken ct)
+    {
+        return await purchasingService.GetReceivingDocumentsAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Receiving/ReceiveEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Receiving/ReceiveEndpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.Receiving;
+
+public static class ReceiveInventoryEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/receiving", Tags = ["Inventario Purchasing"],
+        Summary = "Receive inventory",
+        Description = "Posts received stock into a warehouse/location, optionally creating/selecting lots and updating a purchase order.")]
+    public static async Task<Result<ReceivingDocument>> Handle(
+        ReceiveInventoryRequest request,
+        PurchasingService purchasingService,
+        CancellationToken ct)
+    {
+        return await purchasingService.ReceiveAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Receiving/ReceiveInventoryValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Receiving/ReceiveInventoryValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.Receiving;
+
+public sealed class ReceiveInventoryValidator : AbstractValidator<ReceiveInventoryRequest>
+{
+    public ReceiveInventoryValidator()
+    {
+        RuleFor(x => x.ReceiptNumber).MaximumLength(100);
+        RuleFor(x => x.WarehouseId).NotEmpty();
+        RuleFor(x => x.LocationId).NotEmpty();
+        RuleFor(x => x.ReferenceNumber).MaximumLength(100);
+        RuleFor(x => x.Notes).MaximumLength(1000);
+        RuleFor(x => x.IdempotencyKey).MaximumLength(200);
+        RuleFor(x => x.Lines).NotEmpty();
+        RuleForEach(x => x.Lines).ChildRules(line =>
+        {
+            line.RuleFor(x => x.ProductId).NotEmpty();
+            line.RuleFor(x => x.Quantity).GreaterThan(0);
+            line.RuleFor(x => x.UnitCost).GreaterThanOrEqualTo(0).When(x => x.UnitCost is not null);
+            line.RuleFor(x => x.UnitOfMeasure).MaximumLength(25);
+            line.RuleFor(x => x.LotNumber).MaximumLength(100);
+            line.RuleFor(x => x.SupplierReference).MaximumLength(200);
+            line.RuleFor(x => x.ExpiresAt)
+                .GreaterThanOrEqualTo(x => x.ManufacturedAt)
+                .When(x => x.ExpiresAt is not null && x.ManufacturedAt is not null);
+        });
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Suppliers/CreateEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Suppliers/CreateEndpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.Suppliers;
+
+public static class CreateSupplierEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/inventario/suppliers", Tags = ["Inventario Purchasing"],
+        Summary = "Create supplier",
+        Description = "Creates a tenant-scoped inventory supplier.")]
+    public static async Task<Result<Supplier>> Handle(
+        CreateSupplierRequest request,
+        PurchasingService purchasingService,
+        CancellationToken ct)
+    {
+        return await purchasingService.CreateSupplierAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Suppliers/CreateSupplierValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Suppliers/CreateSupplierValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.Suppliers;
+
+public sealed class CreateSupplierValidator : AbstractValidator<CreateSupplierRequest>
+{
+    public CreateSupplierValidator()
+    {
+        RuleFor(x => x.Code).NotEmpty().MaximumLength(50);
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.ContactName).MaximumLength(200);
+        RuleFor(x => x.Email).EmailAddress().MaximumLength(320).When(x => !string.IsNullOrWhiteSpace(x.Email));
+        RuleFor(x => x.Phone).MaximumLength(50);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Suppliers/GetListEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Suppliers/GetListEndpoint.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+namespace Inventario.Api.Features.Purchasing.Suppliers;
+
+public static class GetSuppliersEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/suppliers", Tags = ["Inventario Purchasing"],
+        Summary = "List suppliers",
+        Description = "Lists tenant-scoped inventory suppliers.")]
+    public static async Task<Result<List<Supplier>>> Handle(
+        [AsParameters] GetSuppliersRequest request,
+        PurchasingService purchasingService,
+        CancellationToken ct)
+    {
+        return await purchasingService.GetSuppliersAsync(request, ct);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Installers/ServicesInstaller.cs
@@ -22,6 +22,7 @@ public class ServicesInstaller : IInstaller
         services.AddScoped<InventoryAllocationService>();
         services.AddScoped<InventoryPlanningService>();
         services.AddScoped<InventoryReportingService>();
+        services.AddScoped<PurchasingService>();
 
         // Register FluentValidation validators
         services.AddValidatorsFromAssemblyContaining<Program>();

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
@@ -50,6 +50,9 @@ app.UseTenantModuleFeatureGate(options =>
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reorder-rules", "planning");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/planning", "planning");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports", "reporting");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/suppliers", "purchasing");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/purchase-orders", "purchasing");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/receiving", "purchasing");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api");
 });
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/PurchasingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/PurchasingService.cs
@@ -1,0 +1,647 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Api.Services;
+
+public sealed class PurchasingService(
+    IDataContext dataContext,
+    IHttpContextAccessor httpContextAccessor,
+    StockPostingService stockPostingService)
+{
+    private static readonly JsonSerializerOptions HashJsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<Result<List<Supplier>>> GetSuppliersAsync(
+        GetSuppliersRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<Supplier>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var query = dataContext.Query<Supplier>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
+
+        if (!request.IncludeInactive)
+            query = query.Where(x => x.IsActive);
+
+        var suppliers = await query
+            .OrderBy(x => x.Name)
+            .Take(500)
+            .ToListAsync(ct);
+
+        return Result<List<Supplier>>.Success(suppliers);
+    }
+
+    public async Task<Result<Supplier>> CreateSupplierAsync(
+        CreateSupplierRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<Supplier>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        var code = NormalizeRequired(request.Code);
+        var name = NormalizeRequired(request.Name);
+        if (code is null || name is null)
+            return Result<Supplier>.Failure("Supplier code and name are required.", 400);
+
+        var duplicate = await dataContext.Query<Supplier>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x => x.TenantId == tenantId && x.Code == code && !x.IsDeleted, ct);
+        if (duplicate)
+            return Result<Supplier>.Conflict("A supplier with the same code already exists.");
+
+        var supplier = new Supplier
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Code = code,
+            Name = name,
+            ContactName = NormalizeOptional(request.ContactName),
+            Email = NormalizeOptional(request.Email),
+            Phone = NormalizeOptional(request.Phone),
+            IsActive = request.IsActive,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        dataContext.Add(supplier);
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<Supplier>.Failure(saveResult.Message ?? "Supplier save failed.", saveResult.StatusCode);
+
+        return Result<Supplier>.Success(supplier, 201, "Supplier created.");
+    }
+
+    public async Task<Result<List<PurchaseOrder>>> GetPurchaseOrdersAsync(
+        GetPurchaseOrdersRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<PurchaseOrder>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var query = dataContext.Query<PurchaseOrder>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
+
+        if (request.Status is { } status)
+            query = query.Where(x => x.Status == status);
+        if (request.SupplierId is { } supplierId)
+            query = query.Where(x => x.SupplierId == supplierId);
+
+        var orders = await query
+            .OrderByDescending(x => x.OrderDate)
+            .Take(500)
+            .ToListAsync(ct);
+
+        return Result<List<PurchaseOrder>>.Success(orders);
+    }
+
+    public async Task<Result<PurchaseOrder>> GetPurchaseOrderAsync(
+        GetPurchaseOrderRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<PurchaseOrder>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var order = await LoadPurchaseOrder(tenantResult.Data, request.Id, ct);
+        return order is null
+            ? Result<PurchaseOrder>.NotFound("Purchase order not found.")
+            : Result<PurchaseOrder>.Success(order);
+    }
+
+    public async Task<Result<PurchaseOrder>> CreatePurchaseOrderAsync(
+        CreatePurchaseOrderRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<PurchaseOrder>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        if (request.Lines.Count == 0)
+            return Result<PurchaseOrder>.Failure("At least one purchase order line is required.", 400);
+
+        if (request.Status is PurchaseOrderStatus.Received or PurchaseOrderStatus.PartiallyReceived or PurchaseOrderStatus.Cancelled)
+            return Result<PurchaseOrder>.Failure("New purchase orders can only start as draft or open.", 400);
+
+        var tenantId = tenantResult.Data;
+        if (request.SupplierId is { } supplierId)
+        {
+            var supplierExists = await dataContext.Query<Supplier>()
+                .IgnoreQueryFilters()
+                .AnyAsync(x => x.TenantId == tenantId && x.Id == supplierId && !x.IsDeleted && x.IsActive, ct);
+            if (!supplierExists)
+                return Result<PurchaseOrder>.NotFound("Supplier not found.");
+        }
+
+        foreach (var line in request.Lines)
+        {
+            if (line.OrderedQuantity <= 0)
+                return Result<PurchaseOrder>.Failure("Purchase order line quantities must be greater than zero.", 400);
+
+            var productExists = await dataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .AnyAsync(x => x.TenantId == tenantId && x.Id == line.ProductId && !x.IsDeleted, ct);
+            if (!productExists)
+                return Result<PurchaseOrder>.NotFound("Product not found.");
+        }
+
+        var orderNumber = NormalizeOptional(request.OrderNumber) ?? GenerateDocumentNumber("PO");
+        var duplicate = await dataContext.Query<PurchaseOrder>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x => x.TenantId == tenantId && x.OrderNumber == orderNumber && !x.IsDeleted, ct);
+        if (duplicate)
+            return Result<PurchaseOrder>.Conflict("A purchase order with the same number already exists.");
+
+        var now = DateTime.UtcNow;
+        var order = new PurchaseOrder
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            OrderNumber = orderNumber,
+            SupplierId = request.SupplierId,
+            Status = request.Status,
+            OrderDate = request.OrderDate ?? now,
+            ExpectedDate = request.ExpectedDate,
+            Notes = NormalizeOptional(request.Notes),
+            IsEnabled = true,
+            CreatedAt = now,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+        dataContext.Add(order);
+
+        foreach (var lineRequest in request.Lines)
+        {
+            var line = new PurchaseOrderLine
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                PurchaseOrderId = order.Id,
+                ProductId = lineRequest.ProductId,
+                OrderedQuantity = lineRequest.OrderedQuantity,
+                ReceivedQuantity = 0,
+                UnitCost = lineRequest.UnitCost,
+                UnitOfMeasure = NormalizeOptional(lineRequest.UnitOfMeasure),
+                Notes = NormalizeOptional(lineRequest.Notes),
+                IsEnabled = true,
+                CreatedAt = now,
+                ConcurrencyStamp = Guid.NewGuid()
+            };
+            order.Lines.Add(line);
+            dataContext.Add(line);
+        }
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<PurchaseOrder>.Failure(saveResult.Message ?? "Purchase order save failed.", saveResult.StatusCode);
+
+        return Result<PurchaseOrder>.Success(order, 201, "Purchase order created.");
+    }
+
+    public async Task<Result<PurchaseOrder>> SetPurchaseOrderStatusAsync(
+        SetPurchaseOrderStatusRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<PurchaseOrder>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var order = await LoadPurchaseOrder(tenantResult.Data, request.PurchaseOrderId, ct);
+        if (order is null)
+            return Result<PurchaseOrder>.NotFound("Purchase order not found.");
+
+        if (order.Status is PurchaseOrderStatus.Received && request.Status != PurchaseOrderStatus.Received)
+            return Result<PurchaseOrder>.Conflict("Received purchase orders cannot be reopened.");
+
+        if (request.Status is PurchaseOrderStatus.PartiallyReceived or PurchaseOrderStatus.Received)
+            return Result<PurchaseOrder>.Failure("Receiving controls received purchase order statuses.", 400);
+
+        order.Status = request.Status;
+        order.ModifiedAt = DateTime.UtcNow;
+        dataContext.Update(order);
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<PurchaseOrder>.Failure(saveResult.Message ?? "Purchase order status update failed.", saveResult.StatusCode);
+
+        return Result<PurchaseOrder>.Success(order);
+    }
+
+    public async Task<Result<List<ReceivingDocument>>> GetReceivingDocumentsAsync(
+        GetReceivingDocumentsRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<ReceivingDocument>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var query = dataContext.Query<ReceivingDocument>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
+
+        if (request.PurchaseOrderId is { } purchaseOrderId)
+            query = query.Where(x => x.PurchaseOrderId == purchaseOrderId);
+        if (request.Status is { } status)
+            query = query.Where(x => x.Status == status);
+
+        var documents = await query
+            .OrderByDescending(x => x.ReceivedAt)
+            .Take(500)
+            .ToListAsync(ct);
+
+        return Result<List<ReceivingDocument>>.Success(documents);
+    }
+
+    public async Task<Result<ReceivingDocument>> ReceiveAsync(
+        ReceiveInventoryRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<ReceivingDocument>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        if (request.Lines.Count == 0)
+            return Result<ReceivingDocument>.Failure("At least one receiving line is required.", 400);
+
+        var tenantId = tenantResult.Data;
+        var idempotencyKey = NormalizeOptional(request.IdempotencyKey);
+        var requestHash = ComputeRequestHash(tenantId, request);
+        var replay = await FindReceivingReplay(tenantId, idempotencyKey, requestHash, ct);
+        if (replay is not null)
+            return replay;
+
+        var warehouseExists = await dataContext.Query<Warehouse>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x => x.TenantId == tenantId && x.Id == request.WarehouseId && !x.IsDeleted, ct);
+        if (!warehouseExists)
+            return Result<ReceivingDocument>.NotFound("Warehouse not found.");
+
+        var locationExists = await dataContext.Query<InventoryLocation>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x => x.TenantId == tenantId && x.Id == request.LocationId && x.WarehouseId == request.WarehouseId && !x.IsDeleted, ct);
+        if (!locationExists)
+            return Result<ReceivingDocument>.NotFound("Location not found.");
+
+        PurchaseOrder? purchaseOrder = null;
+        var purchaseOrderLines = new List<PurchaseOrderLine>();
+        if (request.PurchaseOrderId is { } purchaseOrderId)
+        {
+            purchaseOrder = await LoadPurchaseOrder(tenantId, purchaseOrderId, ct);
+            if (purchaseOrder is null)
+                return Result<ReceivingDocument>.NotFound("Purchase order not found.");
+            if (purchaseOrder.Status is PurchaseOrderStatus.Draft or PurchaseOrderStatus.Cancelled or PurchaseOrderStatus.Received)
+                return Result<ReceivingDocument>.Conflict("Purchase order is not open for receiving.");
+
+            purchaseOrderLines = purchaseOrder.Lines;
+        }
+
+        if (request.SupplierId is { } supplierId)
+        {
+            var supplierExists = await dataContext.Query<Supplier>()
+                .IgnoreQueryFilters()
+                .AnyAsync(x => x.TenantId == tenantId && x.Id == supplierId && !x.IsDeleted && x.IsActive, ct);
+            if (!supplierExists)
+                return Result<ReceivingDocument>.NotFound("Supplier not found.");
+        }
+
+        var receiptNumber = NormalizeOptional(request.ReceiptNumber) ?? GenerateDocumentNumber("RCV");
+        var duplicateReceipt = await dataContext.Query<ReceivingDocument>()
+            .IgnoreQueryFilters()
+            .AnyAsync(x => x.TenantId == tenantId && x.ReceiptNumber == receiptNumber && !x.IsDeleted, ct);
+        if (duplicateReceipt)
+            return Result<ReceivingDocument>.Conflict("A receiving document with the same receipt number already exists.");
+
+        var now = DateTime.UtcNow;
+        var document = new ReceivingDocument
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ReceiptNumber = receiptNumber,
+            PurchaseOrderId = request.PurchaseOrderId,
+            WarehouseId = request.WarehouseId,
+            LocationId = request.LocationId,
+            SupplierId = request.SupplierId ?? purchaseOrder?.SupplierId,
+            Status = ReceivingDocumentStatus.Posted,
+            ReceivedAt = request.ReceivedAt ?? now,
+            ReferenceNumber = NormalizeOptional(request.ReferenceNumber),
+            Notes = NormalizeOptional(request.Notes),
+            IdempotencyKey = idempotencyKey,
+            RequestHash = idempotencyKey is null ? null : requestHash,
+            IsEnabled = true,
+            CreatedAt = now,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+        dataContext.Add(document);
+
+        for (var i = 0; i < request.Lines.Count; i++)
+        {
+            var lineRequest = request.Lines[i];
+            var lineResult = await StageReceivingLine(
+                tenantId,
+                document,
+                lineRequest,
+                purchaseOrderLines,
+                idempotencyKey,
+                i,
+                ct);
+            if (!lineResult.IsSuccess)
+                return Result<ReceivingDocument>.Failure(lineResult.Message!, lineResult.StatusCode);
+
+            document.Lines.Add(lineResult.Data!);
+        }
+
+        if (purchaseOrder is not null)
+        {
+            ApplyPurchaseOrderStatus(purchaseOrder, purchaseOrderLines);
+            purchaseOrder.ModifiedAt = now;
+            dataContext.Update(purchaseOrder);
+        }
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<ReceivingDocument>.Failure(saveResult.Message ?? "Receiving save failed.", saveResult.StatusCode);
+
+        return Result<ReceivingDocument>.Success(document, 201, "Receiving document posted.");
+    }
+
+    private async Task<Result<ReceivingLine>> StageReceivingLine(
+        Guid tenantId,
+        ReceivingDocument document,
+        ReceivingLineRequest lineRequest,
+        List<PurchaseOrderLine> purchaseOrderLines,
+        string? receivingIdempotencyKey,
+        int lineIndex,
+        CancellationToken ct)
+    {
+        if (lineRequest.Quantity <= 0)
+            return Result<ReceivingLine>.Failure("Receiving quantity must be greater than zero.", 400);
+
+        var product = await dataContext.Query<Product>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && x.Id == lineRequest.ProductId && !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+        if (product is null)
+            return Result<ReceivingLine>.NotFound("Product not found.");
+
+        PurchaseOrderLine? purchaseOrderLine = null;
+        if (document.PurchaseOrderId is not null)
+        {
+            if (lineRequest.PurchaseOrderLineId is not { } purchaseOrderLineId)
+                return Result<ReceivingLine>.Failure("Receiving against a purchase order requires purchase order line id.", 400);
+
+            purchaseOrderLine = purchaseOrderLines.FirstOrDefault(x => x.Id == purchaseOrderLineId);
+            if (purchaseOrderLine is null)
+                return Result<ReceivingLine>.NotFound("Purchase order line not found.");
+            if (purchaseOrderLine.ProductId != lineRequest.ProductId)
+                return Result<ReceivingLine>.Failure("Receiving line product does not match the purchase order line.", 400);
+
+            var remaining = purchaseOrderLine.OrderedQuantity - purchaseOrderLine.ReceivedQuantity;
+            if (lineRequest.Quantity > remaining)
+                return Result<ReceivingLine>.Conflict("Receiving quantity exceeds the remaining purchase order quantity.");
+        }
+
+        var lotResult = await ResolveLot(tenantId, document, lineRequest, ct);
+        if (!lotResult.IsSuccess)
+            return Result<ReceivingLine>.Failure(lotResult.Message!, lotResult.StatusCode);
+
+        var stockResult = await stockPostingService.StageAsync(new PostStockMovementRequest
+        {
+            Metadata = new() { TenantId = tenantId },
+            ProductId = lineRequest.ProductId,
+            WarehouseId = document.WarehouseId,
+            LocationId = document.LocationId,
+            LotId = lotResult.Data?.Id,
+            MovementType = InventoryMovementType.Receipt,
+            Quantity = lineRequest.Quantity,
+            UnitOfMeasure = NormalizeOptional(lineRequest.UnitOfMeasure),
+            ReferenceType = "receiving",
+            ReferenceId = document.Id,
+            Reason = $"Receiving {document.ReceiptNumber}",
+            IdempotencyKey = receivingIdempotencyKey is null ? null : $"{receivingIdempotencyKey}:line:{lineIndex}"
+        }, ct);
+        if (!stockResult.IsSuccess)
+            return Result<ReceivingLine>.Failure(stockResult.Message!, stockResult.StatusCode);
+
+        if (purchaseOrderLine is not null)
+        {
+            purchaseOrderLine.ReceivedQuantity += lineRequest.Quantity;
+            purchaseOrderLine.ModifiedAt = DateTime.UtcNow;
+            dataContext.Update(purchaseOrderLine);
+        }
+
+        var line = new ReceivingLine
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ReceivingDocumentId = document.Id,
+            PurchaseOrderLineId = lineRequest.PurchaseOrderLineId,
+            ProductId = lineRequest.ProductId,
+            LotId = lotResult.Data?.Id,
+            StockBalanceId = stockResult.Data!.StockBalanceId,
+            Quantity = lineRequest.Quantity,
+            UnitCost = lineRequest.UnitCost,
+            UnitOfMeasure = NormalizeOptional(lineRequest.UnitOfMeasure),
+            LotNumber = lotResult.Data?.LotNumber ?? NormalizeOptional(lineRequest.LotNumber),
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+        dataContext.Add(line);
+        return Result<ReceivingLine>.Success(line);
+    }
+
+    private async Task<Result<InventoryLot?>> ResolveLot(
+        Guid tenantId,
+        ReceivingDocument document,
+        ReceivingLineRequest lineRequest,
+        CancellationToken ct)
+    {
+        if (lineRequest.LotId is { } lotId)
+        {
+            var existing = await dataContext.Query<InventoryLot>()
+                .IgnoreQueryFilters()
+                .Where(x => x.TenantId == tenantId && x.Id == lotId && !x.IsDeleted)
+                .FirstOrDefaultAsync(ct);
+            if (existing is null)
+                return Result<InventoryLot?>.NotFound("Lot not found.");
+            if (existing.ProductId != lineRequest.ProductId)
+                return Result<InventoryLot?>.Failure("Lot does not belong to the receiving product.", 400);
+
+            return Result<InventoryLot?>.Success(existing);
+        }
+
+        var lotNumber = NormalizeOptional(lineRequest.LotNumber);
+        if (lotNumber is null)
+            return Result<InventoryLot?>.Success(null);
+
+        var existingLot = await dataContext.Query<InventoryLot>()
+            .IgnoreQueryFilters()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                x.ProductId == lineRequest.ProductId &&
+                x.LotNumber == lotNumber &&
+                !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+        if (existingLot is not null)
+            return Result<InventoryLot?>.Success(existingLot);
+
+        if (lineRequest.ManufacturedAt is { } manufacturedAt &&
+            lineRequest.ExpiresAt is { } expiresAt &&
+            manufacturedAt > expiresAt)
+        {
+            return Result<InventoryLot?>.Failure("Lot manufacture date must be before expiration date.", 400);
+        }
+
+        var lot = new InventoryLot
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = lineRequest.ProductId,
+            LotNumber = lotNumber,
+            SupplierReference = NormalizeOptional(lineRequest.SupplierReference) ?? document.ReferenceNumber,
+            SourceReferenceType = "receiving",
+            SourceReferenceId = document.Id,
+            ReceivedAt = document.ReceivedAt,
+            ManufacturedAt = lineRequest.ManufacturedAt,
+            ExpiresAt = lineRequest.ExpiresAt,
+            UnitCost = lineRequest.UnitCost,
+            Status = InventoryLotStatus.Available,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+        dataContext.Add(lot);
+        return Result<InventoryLot?>.Success(lot);
+    }
+
+    private async Task<Result<ReceivingDocument>?> FindReceivingReplay(
+        Guid tenantId,
+        string? idempotencyKey,
+        string requestHash,
+        CancellationToken ct)
+    {
+        if (idempotencyKey is null)
+            return null;
+
+        var existing = await dataContext.Query<ReceivingDocument>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && x.IdempotencyKey == idempotencyKey && !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+        if (existing is null)
+            return null;
+
+        if (!string.Equals(existing.RequestHash, requestHash, StringComparison.Ordinal))
+            return Result<ReceivingDocument>.Conflict("Idempotency key was already used with a different receiving request.");
+
+        existing.Lines = await dataContext.Query<ReceivingLine>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && x.ReceivingDocumentId == existing.Id && !x.IsDeleted)
+            .ToListAsync(ct);
+        return Result<ReceivingDocument>.Success(existing, "Receiving document already processed.");
+    }
+
+    private async Task<PurchaseOrder?> LoadPurchaseOrder(Guid tenantId, Guid purchaseOrderId, CancellationToken ct)
+    {
+        var order = await dataContext.Query<PurchaseOrder>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && x.Id == purchaseOrderId && !x.IsDeleted)
+            .FirstOrDefaultAsync(ct);
+        if (order is null)
+            return null;
+
+        order.Lines = await dataContext.Query<PurchaseOrderLine>()
+            .IgnoreQueryFilters()
+            .Where(x => x.TenantId == tenantId && x.PurchaseOrderId == purchaseOrderId && !x.IsDeleted)
+            .OrderBy(x => x.CreatedAt)
+            .ToListAsync(ct);
+        return order;
+    }
+
+    private static void ApplyPurchaseOrderStatus(PurchaseOrder order, List<PurchaseOrderLine> lines)
+    {
+        if (lines.All(x => x.ReceivedQuantity >= x.OrderedQuantity))
+        {
+            order.Status = PurchaseOrderStatus.Received;
+            return;
+        }
+
+        order.Status = lines.Any(x => x.ReceivedQuantity > 0)
+            ? PurchaseOrderStatus.PartiallyReceived
+            : PurchaseOrderStatus.Open;
+    }
+
+    private Result<Guid> GetCurrentTenantId(RequestBase? request)
+    {
+        if (request?.Metadata?.TenantId is { } metadataTenantId && metadataTenantId != Guid.Empty)
+            return Result<Guid>.Success(metadataTenantId);
+
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return Result<Guid>.Unauthorized("Authentication is required for purchasing operations.");
+
+        var tenantIdClaim = user.FindFirst("tenantId")?.Value
+            ?? user.FindFirst("TenantId")?.Value
+            ?? user.FindFirst("tid")?.Value;
+
+        if (Guid.TryParse(tenantIdClaim, out var tenantId) && tenantId != Guid.Empty)
+            return Result<Guid>.Success(tenantId);
+
+        return Result<Guid>.Forbidden("Authenticated user does not have a valid tenant context.");
+    }
+
+    private static string GenerateDocumentNumber(string prefix) =>
+        $"{prefix}-{DateTime.UtcNow:yyyyMMddHHmmssfff}";
+
+    private static string? NormalizeRequired(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string ComputeRequestHash(Guid tenantId, ReceiveInventoryRequest request)
+    {
+        var hashPayload = new
+        {
+            tenantId,
+            request.ReceiptNumber,
+            request.PurchaseOrderId,
+            request.WarehouseId,
+            request.LocationId,
+            request.SupplierId,
+            request.ReceivedAt,
+            request.ReferenceNumber,
+            request.Notes,
+            lines = request.Lines.Select(x => new
+            {
+                x.PurchaseOrderLineId,
+                x.ProductId,
+                x.Quantity,
+                x.UnitCost,
+                x.UnitOfMeasure,
+                x.LotId,
+                x.LotNumber,
+                x.SupplierReference,
+                x.ManufacturedAt,
+                x.ExpiresAt
+            }).ToList()
+        };
+
+        var json = JsonSerializer.Serialize(hashPayload, HashJsonOptions);
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+        return Convert.ToHexString(bytes);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/PurchaseOrderConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/PurchaseOrderConfiguration.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class PurchaseOrderConfiguration : IEntityTypeConfiguration<PurchaseOrder>
+{
+    public void Configure(EntityTypeBuilder<PurchaseOrder> entity)
+    {
+        entity.ToTable("PurchaseOrder", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_PurchaseOrder");
+
+        entity.Property(e => e.OrderNumber).HasMaxLength(100).IsRequired();
+        entity.Property(e => e.Status).HasDefaultValue(PurchaseOrderStatus.Draft);
+        entity.Property(e => e.OrderDate).HasDefaultValueSql("now()");
+        entity.Property(e => e.Notes).HasMaxLength(1000);
+
+        entity.HasIndex(e => new { e.TenantId, e.OrderNumber })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+        entity.HasIndex(e => new { e.TenantId, e.Status });
+
+        entity.HasOne(e => e.Supplier)
+            .WithMany()
+            .HasForeignKey(e => e.SupplierId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_PurchaseOrder_Supplier");
+
+        entity.HasMany(e => e.Lines)
+            .WithOne(e => e.PurchaseOrder)
+            .HasForeignKey(e => e.PurchaseOrderId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/PurchaseOrderLineConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/PurchaseOrderLineConfiguration.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class PurchaseOrderLineConfiguration : IEntityTypeConfiguration<PurchaseOrderLine>
+{
+    public void Configure(EntityTypeBuilder<PurchaseOrderLine> entity)
+    {
+        entity.ToTable("PurchaseOrderLine", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_PurchaseOrderLine");
+
+        entity.Property(e => e.OrderedQuantity).HasPrecision(18, 4);
+        entity.Property(e => e.ReceivedQuantity).HasPrecision(18, 4);
+        entity.Property(e => e.UnitCost).HasPrecision(18, 4);
+        entity.Property(e => e.UnitOfMeasure).HasMaxLength(25);
+        entity.Property(e => e.Notes).HasMaxLength(1000);
+
+        entity.HasIndex(e => new { e.TenantId, e.PurchaseOrderId });
+        entity.HasIndex(e => new { e.TenantId, e.ProductId });
+
+        entity.HasOne(e => e.Product)
+            .WithMany()
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_PurchaseOrderLine_Product");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ReceivingDocumentConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ReceivingDocumentConfiguration.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class ReceivingDocumentConfiguration : IEntityTypeConfiguration<ReceivingDocument>
+{
+    public void Configure(EntityTypeBuilder<ReceivingDocument> entity)
+    {
+        entity.ToTable("ReceivingDocument", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_ReceivingDocument");
+
+        entity.Property(e => e.ReceiptNumber).HasMaxLength(100).IsRequired();
+        entity.Property(e => e.Status).HasDefaultValue(ReceivingDocumentStatus.Posted);
+        entity.Property(e => e.ReceivedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ReferenceNumber).HasMaxLength(100);
+        entity.Property(e => e.Notes).HasMaxLength(1000);
+        entity.Property(e => e.IdempotencyKey).HasMaxLength(200);
+        entity.Property(e => e.RequestHash).HasMaxLength(128);
+
+        entity.HasIndex(e => new { e.TenantId, e.ReceiptNumber })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+        entity.HasIndex(e => new { e.TenantId, e.PurchaseOrderId });
+        entity.HasIndex(e => new { e.TenantId, e.IdempotencyKey })
+            .IsUnique()
+            .HasFilter("\"IdempotencyKey\" IS NOT NULL");
+
+        entity.HasOne(e => e.PurchaseOrder)
+            .WithMany()
+            .HasForeignKey(e => e.PurchaseOrderId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingDocument_PurchaseOrder");
+
+        entity.HasOne(e => e.Warehouse)
+            .WithMany()
+            .HasForeignKey(e => e.WarehouseId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingDocument_Warehouse");
+
+        entity.HasOne(e => e.Location)
+            .WithMany()
+            .HasForeignKey(e => e.LocationId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingDocument_Location");
+
+        entity.HasOne(e => e.Supplier)
+            .WithMany()
+            .HasForeignKey(e => e.SupplierId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingDocument_Supplier");
+
+        entity.HasMany(e => e.Lines)
+            .WithOne(e => e.ReceivingDocument)
+            .HasForeignKey(e => e.ReceivingDocumentId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ReceivingLineConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ReceivingLineConfiguration.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class ReceivingLineConfiguration : IEntityTypeConfiguration<ReceivingLine>
+{
+    public void Configure(EntityTypeBuilder<ReceivingLine> entity)
+    {
+        entity.ToTable("ReceivingLine", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_ReceivingLine");
+
+        entity.Property(e => e.Quantity).HasPrecision(18, 4);
+        entity.Property(e => e.UnitCost).HasPrecision(18, 4);
+        entity.Property(e => e.UnitOfMeasure).HasMaxLength(25);
+        entity.Property(e => e.LotNumber).HasMaxLength(100);
+
+        entity.HasIndex(e => new { e.TenantId, e.ReceivingDocumentId });
+        entity.HasIndex(e => new { e.TenantId, e.PurchaseOrderLineId });
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.LotId });
+
+        entity.HasOne(e => e.PurchaseOrderLine)
+            .WithMany()
+            .HasForeignKey(e => e.PurchaseOrderLineId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingLine_PurchaseOrderLine");
+
+        entity.HasOne(e => e.Product)
+            .WithMany()
+            .HasForeignKey(e => e.ProductId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingLine_Product");
+
+        entity.HasOne(e => e.Lot)
+            .WithMany()
+            .HasForeignKey(e => e.LotId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingLine_Lot");
+
+        entity.HasOne(e => e.StockBalance)
+            .WithMany()
+            .HasForeignKey(e => e.StockBalanceId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingLine_StockBalance");
+
+        entity.HasOne(e => e.InventoryMovement)
+            .WithMany()
+            .HasForeignKey(e => e.InventoryMovementId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("FK_Inventario_ReceivingLine_InventoryMovement");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/SupplierConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/SupplierConfiguration.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using XFramework.Inventario.Domain.Shared.Contracts;
+
+namespace XFramework.Inventario.Domain.Shared.Configurations;
+
+public class SupplierConfiguration : IEntityTypeConfiguration<Supplier>
+{
+    public void Configure(EntityTypeBuilder<Supplier> entity)
+    {
+        entity.ToTable("Supplier", "Inventario");
+        entity.ConfigureBaseModel("PK_Inventario_Supplier");
+
+        entity.Property(e => e.Code).HasMaxLength(50).IsRequired();
+        entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+        entity.Property(e => e.ContactName).HasMaxLength(200);
+        entity.Property(e => e.Email).HasMaxLength(320);
+        entity.Property(e => e.Phone).HasMaxLength(50);
+        entity.Property(e => e.IsActive).HasDefaultValue(true);
+
+        entity.HasIndex(e => new { e.TenantId, e.Code })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+        entity.HasIndex(e => new { e.TenantId, e.Name });
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/PurchaseOrder.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/PurchaseOrder.cs
@@ -1,0 +1,34 @@
+using XFramework.Domain.Shared.Attributes;
+using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/purchase-orders",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-purchase-orders"
+)]
+public partial class PurchaseOrder : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public string OrderNumber { get; set; } = string.Empty;
+    [MemoryPackOrder(1)]
+    public Guid? SupplierId { get; set; }
+    [MemoryPackIgnore]
+    public Supplier? Supplier { get; set; }
+    [MemoryPackOrder(2)]
+    public PurchaseOrderStatus Status { get; set; } = PurchaseOrderStatus.Draft;
+    [MemoryPackOrder(3)]
+    public DateTime OrderDate { get; set; }
+    [MemoryPackOrder(4)]
+    public DateTime? ExpectedDate { get; set; }
+    [MemoryPackOrder(5)]
+    public string? Notes { get; set; }
+    [MemoryPackIgnore]
+    public List<PurchaseOrderLine> Lines { get; set; } = [];
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/PurchaseOrderLine.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/PurchaseOrderLine.cs
@@ -1,0 +1,35 @@
+using XFramework.Domain.Shared.Attributes;
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/purchase-order-lines",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-purchase-order-lines"
+)]
+public partial class PurchaseOrderLine : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid PurchaseOrderId { get; set; }
+    [MemoryPackIgnore]
+    public PurchaseOrder? PurchaseOrder { get; set; }
+    [MemoryPackOrder(1)]
+    public Guid ProductId { get; set; }
+    [MemoryPackIgnore]
+    public Product? Product { get; set; }
+    [MemoryPackOrder(2)]
+    public decimal OrderedQuantity { get; set; }
+    [MemoryPackOrder(3)]
+    public decimal ReceivedQuantity { get; set; }
+    [MemoryPackOrder(4)]
+    public decimal? UnitCost { get; set; }
+    [MemoryPackOrder(5)]
+    public string? UnitOfMeasure { get; set; }
+    [MemoryPackOrder(6)]
+    public string? Notes { get; set; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ReceivingDocument.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ReceivingDocument.cs
@@ -1,0 +1,50 @@
+using XFramework.Domain.Shared.Attributes;
+using XFramework.Domain.Shared.Contracts.Base;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/receiving",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-receiving"
+)]
+public partial class ReceivingDocument : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public string ReceiptNumber { get; set; } = string.Empty;
+    [MemoryPackOrder(1)]
+    public Guid? PurchaseOrderId { get; set; }
+    [MemoryPackIgnore]
+    public PurchaseOrder? PurchaseOrder { get; set; }
+    [MemoryPackOrder(2)]
+    public Guid WarehouseId { get; set; }
+    [MemoryPackIgnore]
+    public Warehouse? Warehouse { get; set; }
+    [MemoryPackOrder(3)]
+    public Guid LocationId { get; set; }
+    [MemoryPackIgnore]
+    public InventoryLocation? Location { get; set; }
+    [MemoryPackOrder(4)]
+    public Guid? SupplierId { get; set; }
+    [MemoryPackIgnore]
+    public Supplier? Supplier { get; set; }
+    [MemoryPackOrder(5)]
+    public ReceivingDocumentStatus Status { get; set; } = ReceivingDocumentStatus.Posted;
+    [MemoryPackOrder(6)]
+    public DateTime ReceivedAt { get; set; }
+    [MemoryPackOrder(7)]
+    public string? ReferenceNumber { get; set; }
+    [MemoryPackOrder(8)]
+    public string? Notes { get; set; }
+    [MemoryPackOrder(9)]
+    public string? IdempotencyKey { get; set; }
+    [MemoryPackOrder(10)]
+    public string? RequestHash { get; set; }
+    [MemoryPackIgnore]
+    public List<ReceivingLine> Lines { get; set; } = [];
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ReceivingLine.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ReceivingLine.cs
@@ -1,0 +1,49 @@
+using XFramework.Domain.Shared.Attributes;
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/receiving-lines",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-receiving-lines"
+)]
+public partial class ReceivingLine : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid ReceivingDocumentId { get; set; }
+    [MemoryPackIgnore]
+    public ReceivingDocument? ReceivingDocument { get; set; }
+    [MemoryPackOrder(1)]
+    public Guid? PurchaseOrderLineId { get; set; }
+    [MemoryPackIgnore]
+    public PurchaseOrderLine? PurchaseOrderLine { get; set; }
+    [MemoryPackOrder(2)]
+    public Guid ProductId { get; set; }
+    [MemoryPackIgnore]
+    public Product? Product { get; set; }
+    [MemoryPackOrder(3)]
+    public Guid? LotId { get; set; }
+    [MemoryPackIgnore]
+    public InventoryLot? Lot { get; set; }
+    [MemoryPackOrder(4)]
+    public Guid? StockBalanceId { get; set; }
+    [MemoryPackIgnore]
+    public StockBalance? StockBalance { get; set; }
+    [MemoryPackOrder(5)]
+    public Guid? InventoryMovementId { get; set; }
+    [MemoryPackIgnore]
+    public InventoryMovement? InventoryMovement { get; set; }
+    [MemoryPackOrder(6)]
+    public decimal Quantity { get; set; }
+    [MemoryPackOrder(7)]
+    public decimal? UnitCost { get; set; }
+    [MemoryPackOrder(8)]
+    public string? UnitOfMeasure { get; set; }
+    [MemoryPackOrder(9)]
+    public string? LotNumber { get; set; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/CreatePurchaseOrderRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/CreatePurchaseOrderRequest.cs
@@ -1,0 +1,23 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+using TRequest = CreatePurchaseOrderRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreatePurchaseOrderRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public string? OrderNumber { get; init; }
+    public Guid? SupplierId { get; init; }
+    public PurchaseOrderStatus Status { get; init; } = PurchaseOrderStatus.Open;
+    public DateTime? OrderDate { get; init; }
+    public DateTime? ExpectedDate { get; init; }
+    public string? Notes { get; init; }
+    public List<PurchaseOrderLineRequest> Lines { get; init; } = [];
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/CreateSupplierRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/CreateSupplierRequest.cs
@@ -1,0 +1,21 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+using TRequest = CreateSupplierRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreateSupplierRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public string? Code { get; init; }
+    public string? Name { get; init; }
+    public string? ContactName { get; init; }
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public bool IsActive { get; init; } = true;
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/GetPurchaseOrderRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/GetPurchaseOrderRequest.cs
@@ -1,0 +1,16 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+using TRequest = GetPurchaseOrderRequest;
+using TResponse = QueryResponse<PurchaseOrder>;
+
+[MemoryPackable]
+public partial record GetPurchaseOrderRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid Id { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/GetPurchaseOrdersRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/GetPurchaseOrdersRequest.cs
@@ -1,0 +1,18 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+using TRequest = GetPurchaseOrdersRequest;
+using TResponse = QueryResponse<List<PurchaseOrder>>;
+
+[MemoryPackable]
+public partial record GetPurchaseOrdersRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public PurchaseOrderStatus? Status { get; init; }
+    public Guid? SupplierId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/GetReceivingDocumentsRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/GetReceivingDocumentsRequest.cs
@@ -1,0 +1,18 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+using TRequest = GetReceivingDocumentsRequest;
+using TResponse = QueryResponse<List<ReceivingDocument>>;
+
+[MemoryPackable]
+public partial record GetReceivingDocumentsRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid? PurchaseOrderId { get; init; }
+    public ReceivingDocumentStatus? Status { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/GetSuppliersRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/GetSuppliersRequest.cs
@@ -1,0 +1,16 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+using TRequest = GetSuppliersRequest;
+using TResponse = QueryResponse<List<Supplier>>;
+
+[MemoryPackable]
+public partial record GetSuppliersRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public bool IncludeInactive { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/PurchaseOrderLineRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/PurchaseOrderLineRequest.cs
@@ -1,0 +1,11 @@
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+[MemoryPackable]
+public partial record PurchaseOrderLineRequest
+{
+    public Guid ProductId { get; init; }
+    public decimal OrderedQuantity { get; init; }
+    public decimal? UnitCost { get; init; }
+    public string? UnitOfMeasure { get; init; }
+    public string? Notes { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/ReceiveInventoryRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/ReceiveInventoryRequest.cs
@@ -1,0 +1,25 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+using TRequest = ReceiveInventoryRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record ReceiveInventoryRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public string? ReceiptNumber { get; init; }
+    public Guid? PurchaseOrderId { get; init; }
+    public Guid WarehouseId { get; init; }
+    public Guid LocationId { get; init; }
+    public Guid? SupplierId { get; init; }
+    public DateTime? ReceivedAt { get; init; }
+    public string? ReferenceNumber { get; init; }
+    public string? Notes { get; init; }
+    public string? IdempotencyKey { get; init; }
+    public List<ReceivingLineRequest> Lines { get; init; } = [];
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/ReceivingLineRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/ReceivingLineRequest.cs
@@ -1,0 +1,16 @@
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+[MemoryPackable]
+public partial record ReceivingLineRequest
+{
+    public Guid? PurchaseOrderLineId { get; init; }
+    public Guid ProductId { get; init; }
+    public decimal Quantity { get; init; }
+    public decimal? UnitCost { get; init; }
+    public string? UnitOfMeasure { get; init; }
+    public Guid? LotId { get; init; }
+    public string? LotNumber { get; init; }
+    public string? SupplierReference { get; init; }
+    public DateTime? ManufacturedAt { get; init; }
+    public DateTime? ExpiresAt { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/SetPurchaseOrderStatusRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Purchasing/SetPurchaseOrderStatusRequest.cs
@@ -1,0 +1,18 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+
+using TRequest = SetPurchaseOrderStatusRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record SetPurchaseOrderStatusRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid PurchaseOrderId { get; init; }
+    public PurchaseOrderStatus Status { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Supplier.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Supplier.cs
@@ -1,0 +1,29 @@
+using XFramework.Domain.Shared.Attributes;
+using XFramework.Domain.Shared.Contracts.Base;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+[GenerateEndpoints(
+    Type = EndpointType.Rest,
+    Actions = EndpointActions.None,
+    RoutePrefix = "api/inventario/suppliers",
+    RequireAuthorization = true,
+    CacheDurationSeconds = 60,
+    CacheKeyPrefix = "inventario-suppliers"
+)]
+public partial class Supplier : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public string Code { get; set; } = string.Empty;
+    [MemoryPackOrder(1)]
+    public string Name { get; set; } = string.Empty;
+    [MemoryPackOrder(2)]
+    public string? ContactName { get; set; }
+    [MemoryPackOrder(3)]
+    public string? Email { get; set; }
+    [MemoryPackOrder(4)]
+    public string? Phone { get; set; }
+    [MemoryPackOrder(5)]
+    public bool IsActive { get; set; } = true;
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/PurchaseOrderStatus.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/PurchaseOrderStatus.cs
@@ -1,0 +1,10 @@
+namespace XFramework.Inventario.Domain.Shared.Enums;
+
+public enum PurchaseOrderStatus
+{
+    Draft = 0,
+    Open = 1,
+    PartiallyReceived = 2,
+    Received = 3,
+    Cancelled = 4
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/ReceivingDocumentStatus.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Enums/ReceivingDocumentStatus.cs
@@ -1,0 +1,7 @@
+namespace XFramework.Inventario.Domain.Shared.Enums;
+
+public enum ReceivingDocumentStatus
+{
+    Posted = 0,
+    Cancelled = 1
+}

--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -70,6 +70,18 @@
                     <LucideIcon Name="chart-no-axes-combined" class="h-4 w-4" /> Planning
                 </NavLink>
             }
+            @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "purchasing"))
+            {
+                <NavLink href="/inventario/suppliers" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="truck" class="h-4 w-4" /> Suppliers
+                </NavLink>
+                <NavLink href="/inventario/purchase-orders" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="clipboard-list" class="h-4 w-4" /> Purchase Orders
+                </NavLink>
+                <NavLink href="/inventario/receiving" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">
+                    <LucideIcon Name="package-check" class="h-4 w-4" /> Receiving
+                </NavLink>
+            }
             @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "reporting"))
             {
                 <NavLink href="/inventario/reports" class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent" ActiveClass="bg-sidebar-accent text-sidebar-accent-foreground">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrderDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrderDetail.razor
@@ -1,0 +1,223 @@
+@page "/inventario/purchase-orders/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Purchase Order - Inventario</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_purchasingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Purchasing" />
+}
+else if (_order is null)
+{
+    <BbCard>
+        <BbCardHeader>
+            <BbCardTitle>Purchase order not found</BbCardTitle>
+            <BbCardDescription>This purchase order is not available in the selected tenant.</BbCardDescription>
+        </BbCardHeader>
+    </BbCard>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div class="flex items-center gap-3">
+                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" OnClick="@GoBack">
+                        <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                    </BbButton>
+                    <div>
+                        <div class="flex flex-wrap items-center gap-2">
+                            <BbTypographyH3>@_order.OrderNumber</BbTypographyH3>
+                            <StatusBadge Text="@_order.Status.ToString()" Status="@GetStatusBadge(_order.Status)" />
+                        </div>
+                        <BbTypographyMuted>Supplier: @GetSupplierName(_order.SupplierId) — ID: @_order.Id</BbTypographyMuted>
+                    </div>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Order Summary</BbCardTitle>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-3">
+                        <div>
+                            <BbTypographyMuted>Order Date</BbTypographyMuted>
+                            <p>@_order.OrderDate.ToString("g")</p>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Expected Date</BbTypographyMuted>
+                            <p>@(_order.ExpectedDate?.ToString("g") ?? "N/A")</p>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Notes</BbTypographyMuted>
+                            <p>@(_order.Notes ?? "N/A")</p>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Lines</BbCardTitle>
+                    <BbCardDescription>@_lines.Count line(s) on this purchase order</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_lines" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.OrderedQuantity)" Title="Ordered" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedQuantity)" Title="Received" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Remaining">
+                                <ChildContent Context="item">@Math.Max(0, item.OrderedQuantity - item.ReceivedQuantity).ToString("N2")</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.UnitCost)" Title="Unit Cost" />
+                            <BbDataGridPropertyColumn Property="@(x => x.UnitOfMeasure)" Title="Unit" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Receiving Documents</BbCardTitle>
+                    <BbCardDescription>@_receipts.Count receipt(s) posted against this order</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_receipts" ShowPagination="true" InitialPageSize="10"
+                                OnRowClick="@((ReceivingDocument item) => Navigation.NavigateTo($"/inventario/receiving/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceiptNumber)" Title="Receipt" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private PurchaseOrder? _order;
+    private List<PurchaseOrderLine> _lines = [];
+    private List<ReceivingDocument> _receipts = [];
+    private List<Product> _products = [];
+    private List<Supplier> _suppliers = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _purchasingEnabled;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _purchasingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "purchasing");
+            _order = null;
+            _lines = [];
+            _receipts = [];
+            _products = [];
+            _suppliers = [];
+
+            if (!_hasTenant || !_purchasingEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _order = await DataContext.Query<PurchaseOrder>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.Id == Id && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+            if (_order is null) return;
+
+            _lines = await DataContext.Query<PurchaseOrderLine>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.PurchaseOrderId == Id && !x.IsDeleted)
+                .OrderBy(x => x.CreatedAt)
+                .ToListAsync();
+            _receipts = await DataContext.Query<ReceivingDocument>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.PurchaseOrderId == Id && !x.IsDeleted)
+                .OrderByDescending(x => x.ReceivedAt)
+                .ToListAsync();
+            _products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(500)
+                .ToListAsync();
+            _suppliers = await DataContext.Query<Supplier>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(500)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load purchase order: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void GoBack() => Navigation.NavigateTo("/inventario/purchase-orders");
+    private string GetProductName(Guid productId) => _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
+    private string GetSupplierName(Guid? supplierId) => supplierId is { } id ? _suppliers.FirstOrDefault(x => x.Id == id)?.Name ?? id.ToString()[..8] : "No supplier";
+    private static string GetStatusBadge(PurchaseOrderStatus status) =>
+        status switch
+        {
+            PurchaseOrderStatus.Received => "active",
+            PurchaseOrderStatus.Cancelled => "danger",
+            PurchaseOrderStatus.PartiallyReceived => "warning",
+            _ => "info"
+        };
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
@@ -1,0 +1,348 @@
+@page "/inventario/purchase-orders"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Purchase Orders - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_purchasingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Purchasing" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Purchase Orders</BbTypographyH3>
+                    <BbTypographyMuted>Track supplier orders, partial receiving, and completion state.</BbTypographyMuted>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <BbButton OnClick="@OpenCreateDialog" Disabled="@(_products.Count == 0)">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Create PO
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                </div>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Purchase Order List</BbCardTitle>
+                    <BbCardDescription>@_orders.Count purchase order(s) loaded</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_orders" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((PurchaseOrder item) => Navigation.NavigateTo($"/inventario/purchase-orders/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.OrderNumber)" Title="Order" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Supplier">
+                                <ChildContent Context="item">@GetSupplierName(item.SupplierId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@item.Status.ToString()" Status="@GetStatusBadge(item.Status)" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.OrderDate)" Title="Order Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpectedDate)" Title="Expected" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Lines">
+                                <ChildContent Context="item">@_lines.Count(x => x.PurchaseOrderId == item.Id)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              OnClick="@(() => Navigation.NavigateTo($"/inventario/purchase-orders/{item.Id}"))">
+                                        <LucideIcon Name="eye" class="h-4 w-4" />
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_createDialogOpen" OpenChanged="@(v => _createDialogOpen = v)">
+    <BbDialogContent TrapFocus="false" class="max-w-4xl">
+        <BbDialogHeader>
+            <BbDialogTitle>Create Purchase Order</BbDialogTitle>
+            <BbDialogDescription>Add one or more product lines. Receiving will update line quantities later.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-3">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.OrderNumber" Label="Order Number" />
+                <div class="xf-form-field">
+                    <BbLabel>Supplier</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_form.SupplierId"
+                                 Options="@SupplierOptions"
+                                 Placeholder="No supplier"
+                                 SearchPlaceholder="Search suppliers..."
+                                 EmptyMessage="No suppliers found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <BbFormFieldSelect TValue="string" @bind-Value="_form.Status" Label="Status">
+                    <BbSelectItem Value="@PurchaseOrderStatus.Open.ToString()">Open</BbSelectItem>
+                    <BbSelectItem Value="@PurchaseOrderStatus.Draft.ToString()">Draft</BbSelectItem>
+                </BbFormFieldSelect>
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ExpectedDate" Label="Expected Date" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Notes" Label="Notes" />
+            </div>
+
+            <div class="rounded-md border p-3">
+                <div class="mb-3 flex items-center justify-between">
+                    <BbTypographyH4>Lines</BbTypographyH4>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@AddLine">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Add Line
+                    </BbButton>
+                </div>
+                <div class="grid gap-3">
+                    @for (var i = 0; i < _form.Lines.Count; i++)
+                    {
+                        var index = i;
+                        var line = _form.Lines[index];
+                        <div class="grid gap-3 rounded-md border p-3 md:grid-cols-[2fr_1fr_1fr_auto]">
+                            <div class="xf-form-field">
+                                <BbLabel>Product</BbLabel>
+                                <BbCombobox TValue="string"
+                                             @bind-Value="line.ProductId"
+                                             Options="@ProductOptions"
+                                             Placeholder="Select product"
+                                             SearchPlaceholder="Search products..."
+                                             EmptyMessage="No products found."
+                                             Class="xf-entity-combobox"
+                                             MatchTriggerWidth="true" />
+                            </div>
+                            <BbFormFieldInput TValue="string" @bind-Value="line.Quantity" Label="Quantity" />
+                            <BbFormFieldInput TValue="string" @bind-Value="line.UnitCost" Label="Unit Cost" />
+                            <div class="flex items-end">
+                                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                          Disabled="@(_form.Lines.Count == 1)"
+                                          OnClick="@(() => RemoveLine(index))">
+                                    <LucideIcon Name="trash-2" class="h-4 w-4" />
+                                </BbButton>
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _createDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@CreatePurchaseOrder" Disabled="@IsCreateDisabled">Create</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private readonly PurchaseOrderForm _form = new();
+    private List<PurchaseOrder> _orders = [];
+    private List<PurchaseOrderLine> _lines = [];
+    private List<Supplier> _suppliers = [];
+    private List<Product> _products = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _purchasingEnabled;
+    private bool _saving;
+    private bool _createDialogOpen;
+    private bool IsCreateDisabled => _saving || _products.Count == 0 || _form.Lines.Any(x => string.IsNullOrWhiteSpace(x.ProductId) || !decimal.TryParse(x.Quantity, out var quantity) || quantity <= 0);
+
+    private List<SelectOption<string>> SupplierOptions => [new("", "No supplier"), .. _suppliers.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Code} - {x.Name}"))];
+    private List<SelectOption<string>> ProductOptions => _products.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Name} ({x.SKU ?? x.Id.ToString()[..8]})")).ToList();
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _purchasingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "purchasing");
+            _orders = [];
+            _lines = [];
+            _suppliers = [];
+            _products = [];
+
+            if (!_hasTenant || !_purchasingEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _suppliers = await DataContext.Query<Supplier>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(500)
+                .ToListAsync();
+            _products = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(500)
+                .ToListAsync();
+            _orders = await DataContext.Query<PurchaseOrder>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.OrderDate)
+                .Take(500)
+                .ToListAsync();
+            _lines = await DataContext.Query<PurchaseOrderLine>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .Take(1000)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load purchase orders: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OpenCreateDialog()
+    {
+        _form.Reset(_products.FirstOrDefault()?.Id.ToString() ?? "");
+        _createDialogOpen = true;
+    }
+
+    private void AddLine() => _form.Lines.Add(new PurchaseOrderLineForm { ProductId = _products.FirstOrDefault()?.Id.ToString() ?? "", Quantity = "1" });
+
+    private void RemoveLine(int index)
+    {
+        if (_form.Lines.Count > 1 && index >= 0 && index < _form.Lines.Count)
+            _form.Lines.RemoveAt(index);
+    }
+
+    private async Task CreatePurchaseOrder()
+    {
+        _saving = true;
+        try
+        {
+            var result = await Inventario.CreatePurchaseOrder(new CreatePurchaseOrderRequest
+            {
+                Metadata = BuildMetadata(),
+                OrderNumber = NullIfEmpty(_form.OrderNumber),
+                SupplierId = Guid.TryParse(_form.SupplierId, out var supplierId) ? supplierId : null,
+                Status = Enum.TryParse<PurchaseOrderStatus>(_form.Status, out var status) ? status : PurchaseOrderStatus.Open,
+                ExpectedDate = ParseDate(_form.ExpectedDate),
+                Notes = NullIfEmpty(_form.Notes),
+                Lines = _form.Lines
+                    .Where(x => Guid.TryParse(x.ProductId, out _) && decimal.TryParse(x.Quantity, out var quantity) && quantity > 0)
+                    .Select(x => new PurchaseOrderLineRequest
+                    {
+                        ProductId = Guid.Parse(x.ProductId),
+                        OrderedQuantity = decimal.Parse(x.Quantity),
+                        UnitCost = decimal.TryParse(x.UnitCost, out var unitCost) ? unitCost : null,
+                        UnitOfMeasure = NullIfEmpty(x.UnitOfMeasure)
+                    })
+                    .ToList()
+            });
+
+            ToastService.Show(result.IsSuccess ? "Purchase order created." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _createDialogOpen = false;
+                await Reload();
+            }
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private string GetSupplierName(Guid? supplierId) =>
+        supplierId is { } id ? _suppliers.FirstOrDefault(x => x.Id == id)?.Name ?? id.ToString()[..8] : "No supplier";
+
+    private static string GetStatusBadge(PurchaseOrderStatus status) =>
+        status switch
+        {
+            PurchaseOrderStatus.Received => "active",
+            PurchaseOrderStatus.Cancelled => "danger",
+            PurchaseOrderStatus.PartiallyReceived => "warning",
+            _ => "info"
+        };
+
+    private RequestMetadata BuildMetadata() => new() { TenantId = TenantFilter.SelectedTenantId };
+    private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    private static DateTime? ParseDate(string? value) => DateTime.TryParse(value, out var date) ? date : null;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class PurchaseOrderForm
+    {
+        public string OrderNumber { get; set; } = "";
+        public string SupplierId { get; set; } = "";
+        public string Status { get; set; } = PurchaseOrderStatus.Open.ToString();
+        public string ExpectedDate { get; set; } = "";
+        public string Notes { get; set; } = "";
+        public List<PurchaseOrderLineForm> Lines { get; } = [];
+
+        public void Reset(string productId)
+        {
+            OrderNumber = "";
+            SupplierId = "";
+            Status = PurchaseOrderStatus.Open.ToString();
+            ExpectedDate = "";
+            Notes = "";
+            Lines.Clear();
+            Lines.Add(new PurchaseOrderLineForm { ProductId = productId, Quantity = "1" });
+        }
+    }
+
+    private sealed class PurchaseOrderLineForm
+    {
+        public string ProductId { get; set; } = "";
+        public string Quantity { get; set; } = "1";
+        public string UnitCost { get; set; } = "";
+        public string UnitOfMeasure { get; set; } = "";
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
@@ -1,0 +1,421 @@
+@page "/inventario/receiving"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing
+@using XFramework.Inventario.Domain.Shared.Enums
+@implements IDisposable
+
+<PageTitle>Inventario Receiving - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_purchasingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Purchasing" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Receiving</BbTypographyH3>
+                    <BbTypographyMuted>Post received stock into warehouses and locations with optional lot tracking.</BbTypographyMuted>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <BbButton OnClick="@OpenReceiveDialog" Disabled="@(_products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0)">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Receive Stock
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                </div>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Receiving Documents</BbCardTitle>
+                    <BbCardDescription>@_documents.Count receipt(s) loaded</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_documents" ShowPagination="true" InitialPageSize="20"
+                                OnRowClick="@((ReceivingDocument item) => Navigation.NavigateTo($"/inventario/receiving/{item.Id}"))"
+                                Class="cursor-pointer">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceiptNumber)" Title="Receipt" Sortable="true" />
+                            <BbDataGridTemplateColumn Title="Purchase Order">
+                                <ChildContent Context="item">@GetPurchaseOrderNumber(item.PurchaseOrderId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Supplier">
+                                <ChildContent Context="item">@GetSupplierName(item.SupplierId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Warehouse">
+                                <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
+                            <BbDataGridTemplateColumn Title="Lines">
+                                <ChildContent Context="item">@_lines.Count(x => x.ReceivingDocumentId == item.Id)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Actions">
+                                <ChildContent Context="item">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              OnClick="@(() => Navigation.NavigateTo($"/inventario/receiving/{item.Id}"))">
+                                        <LucideIcon Name="eye" class="h-4 w-4" />
+                                    </BbButton>
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_receiveDialogOpen" OpenChanged="@(v => _receiveDialogOpen = v)">
+    <BbDialogContent TrapFocus="false" class="max-w-5xl">
+        <BbDialogHeader>
+            <BbDialogTitle>Receive Stock</BbDialogTitle>
+            <BbDialogDescription>Receiving posts receipt movements and updates balances in one save.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-3">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ReceiptNumber" Label="Receipt Number" />
+                <div class="xf-form-field">
+                    <BbLabel>Purchase Order</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_form.PurchaseOrderId"
+                                 Options="@PurchaseOrderOptions"
+                                 Placeholder="No purchase order"
+                                 SearchPlaceholder="Search purchase orders..."
+                                 EmptyMessage="No purchase orders found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <div class="xf-form-field">
+                    <BbLabel>Supplier</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_form.SupplierId"
+                                 Options="@SupplierOptions"
+                                 Placeholder="No supplier"
+                                 SearchPlaceholder="Search suppliers..."
+                                 EmptyMessage="No suppliers found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+            </div>
+            <div class="grid gap-3 md:grid-cols-3">
+                <div class="xf-form-field">
+                    <BbLabel>Warehouse</BbLabel>
+                    <BbCombobox TValue="string"
+                                 Value="@_form.WarehouseId"
+                                 ValueChanged="@OnWarehouseChanged"
+                                 Options="@WarehouseOptions"
+                                 Placeholder="Select warehouse"
+                                 SearchPlaceholder="Search warehouses..."
+                                 EmptyMessage="No warehouses found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <div class="xf-form-field">
+                    <BbLabel>Location</BbLabel>
+                    <BbCombobox TValue="string"
+                                 @bind-Value="_form.LocationId"
+                                 Options="@LocationOptions"
+                                 Placeholder="Select location"
+                                 SearchPlaceholder="Search locations..."
+                                 EmptyMessage="No locations found."
+                                 Class="xf-entity-combobox"
+                                 MatchTriggerWidth="true" />
+                </div>
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ReferenceNumber" Label="Reference" />
+            </div>
+
+            <div class="rounded-md border p-3">
+                <div class="mb-3 flex items-center justify-between">
+                    <BbTypographyH4>Lines</BbTypographyH4>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@AddLine">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Add Line
+                    </BbButton>
+                </div>
+                <div class="grid gap-3">
+                    @for (var i = 0; i < _form.Lines.Count; i++)
+                    {
+                        var index = i;
+                        var line = _form.Lines[index];
+                        <div class="grid gap-3 rounded-md border p-3">
+                            <div class="grid gap-3 md:grid-cols-[1.2fr_1.4fr_0.8fr_0.8fr_auto]">
+                                <div class="xf-form-field">
+                                    <BbLabel>PO Line</BbLabel>
+                                    <BbCombobox TValue="string"
+                                                 @bind-Value="line.PurchaseOrderLineId"
+                                                 Options="@PurchaseOrderLineOptions"
+                                                 Placeholder="No PO line"
+                                                 SearchPlaceholder="Search PO lines..."
+                                                 EmptyMessage="No open PO lines."
+                                                 Class="xf-entity-combobox"
+                                                 MatchTriggerWidth="true" />
+                                </div>
+                                <div class="xf-form-field">
+                                    <BbLabel>Product</BbLabel>
+                                    <BbCombobox TValue="string"
+                                                 @bind-Value="line.ProductId"
+                                                 Options="@ProductOptions"
+                                                 Placeholder="Select product"
+                                                 SearchPlaceholder="Search products..."
+                                                 EmptyMessage="No products found."
+                                                 Class="xf-entity-combobox"
+                                                 MatchTriggerWidth="true" />
+                                </div>
+                                <BbFormFieldInput TValue="string" @bind-Value="line.Quantity" Label="Quantity" />
+                                <BbFormFieldInput TValue="string" @bind-Value="line.UnitCost" Label="Unit Cost" />
+                                <div class="flex items-end">
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              Disabled="@(_form.Lines.Count == 1)"
+                                              OnClick="@(() => RemoveLine(index))">
+                                        <LucideIcon Name="trash-2" class="h-4 w-4" />
+                                    </BbButton>
+                                </div>
+                            </div>
+                            <div class="grid gap-3 md:grid-cols-4">
+                                <div class="xf-form-field">
+                                    <BbLabel>Existing Lot</BbLabel>
+                                    <BbCombobox TValue="string"
+                                                 @bind-Value="line.LotId"
+                                                 Options="@LotOptions"
+                                                 Placeholder="Create/no lot"
+                                                 SearchPlaceholder="Search lots..."
+                                                 EmptyMessage="No lots found."
+                                                 Class="xf-entity-combobox"
+                                                 MatchTriggerWidth="true" />
+                                </div>
+                                <BbFormFieldInput TValue="string" @bind-Value="line.LotNumber" Label="New Lot Number" />
+                                <BbFormFieldInput TValue="string" @bind-Value="line.ManufacturedAt" Label="Manufacture Date" />
+                                <BbFormFieldInput TValue="string" @bind-Value="line.ExpiresAt" Label="Expiration Date" />
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _receiveDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@ReceiveStock" Disabled="@IsReceiveDisabled">Post Receiving</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private readonly ReceivingForm _form = new();
+    private List<ReceivingDocument> _documents = [];
+    private List<ReceivingLine> _lines = [];
+    private List<PurchaseOrder> _orders = [];
+    private List<PurchaseOrderLine> _orderLines = [];
+    private List<Supplier> _suppliers = [];
+    private List<Product> _products = [];
+    private List<Warehouse> _warehouses = [];
+    private List<InventoryLocation> _locations = [];
+    private List<InventoryLot> _lots = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _purchasingEnabled;
+    private bool _saving;
+    private bool _receiveDialogOpen;
+    private bool IsReceiveDisabled =>
+        _saving ||
+        string.IsNullOrWhiteSpace(_form.WarehouseId) ||
+        string.IsNullOrWhiteSpace(_form.LocationId) ||
+        _form.Lines.Any(x => string.IsNullOrWhiteSpace(x.ProductId) || !decimal.TryParse(x.Quantity, out var quantity) || quantity <= 0);
+
+    private List<SelectOption<string>> PurchaseOrderOptions => [new("", "No purchase order"), .. _orders.Where(x => x.Status is PurchaseOrderStatus.Open or PurchaseOrderStatus.PartiallyReceived).Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.OrderNumber} ({x.Status})"))];
+    private List<SelectOption<string>> PurchaseOrderLineOptions => [new("", "No PO line"), .. _orderLines.Where(x => x.ReceivedQuantity < x.OrderedQuantity).Select(x => new SelectOption<string>(x.Id.ToString(), $"{GetPurchaseOrderNumber(x.PurchaseOrderId)} - {GetProductName(x.ProductId)} ({x.OrderedQuantity - x.ReceivedQuantity:N2} remaining)"))];
+    private List<SelectOption<string>> SupplierOptions => [new("", "No supplier"), .. _suppliers.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Code} - {x.Name}"))];
+    private List<SelectOption<string>> ProductOptions => _products.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Name} ({x.SKU ?? x.Id.ToString()[..8]})")).ToList();
+    private List<SelectOption<string>> WarehouseOptions => _warehouses.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Code} - {x.Name}")).ToList();
+    private List<SelectOption<string>> LocationOptions => _locations.Where(x => x.WarehouseId.ToString() == _form.WarehouseId).Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Code} - {x.Name}")).ToList();
+    private List<SelectOption<string>> LotOptions => [new("", "Create/no lot"), .. _lots.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.LotNumber} - {GetProductName(x.ProductId)}"))];
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _purchasingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "purchasing");
+            _documents = [];
+            _lines = [];
+            _orders = [];
+            _orderLines = [];
+            _suppliers = [];
+            _products = [];
+            _warehouses = [];
+            _locations = [];
+            _lots = [];
+
+            if (!_hasTenant || !_purchasingEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _documents = await DataContext.Query<ReceivingDocument>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderByDescending(x => x.ReceivedAt).Take(500).ToListAsync();
+            _lines = await DataContext.Query<ReceivingLine>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(1000).ToListAsync();
+            _orders = await DataContext.Query<PurchaseOrder>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(500).ToListAsync();
+            _orderLines = await DataContext.Query<PurchaseOrderLine>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(1000).ToListAsync();
+            _suppliers = await DataContext.Query<Supplier>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.Name).Take(500).ToListAsync();
+            _products = await DataContext.Query<Product>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.Name).Take(500).ToListAsync();
+            _warehouses = await DataContext.Query<Warehouse>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.Code).Take(200).ToListAsync();
+            _locations = await DataContext.Query<InventoryLocation>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.Code).Take(500).ToListAsync();
+            _lots = await DataContext.Query<InventoryLot>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.LotNumber).Take(500).ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load receiving: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OpenReceiveDialog()
+    {
+        _form.Reset(_warehouses.FirstOrDefault()?.Id.ToString() ?? "", _locations.FirstOrDefault()?.Id.ToString() ?? "", _products.FirstOrDefault()?.Id.ToString() ?? "");
+        _receiveDialogOpen = true;
+    }
+
+    private void OnWarehouseChanged(string? warehouseId)
+    {
+        _form.WarehouseId = warehouseId ?? "";
+        _form.LocationId = _locations.FirstOrDefault(x => x.WarehouseId.ToString() == _form.WarehouseId)?.Id.ToString() ?? "";
+    }
+
+    private void AddLine() => _form.Lines.Add(new ReceivingLineForm { ProductId = _products.FirstOrDefault()?.Id.ToString() ?? "", Quantity = "1" });
+
+    private void RemoveLine(int index)
+    {
+        if (_form.Lines.Count > 1 && index >= 0 && index < _form.Lines.Count)
+            _form.Lines.RemoveAt(index);
+    }
+
+    private async Task ReceiveStock()
+    {
+        _saving = true;
+        try
+        {
+            var result = await Inventario.ReceiveInventory(new ReceiveInventoryRequest
+            {
+                Metadata = BuildMetadata(),
+                ReceiptNumber = NullIfEmpty(_form.ReceiptNumber),
+                PurchaseOrderId = Guid.TryParse(_form.PurchaseOrderId, out var poId) ? poId : null,
+                WarehouseId = Guid.Parse(_form.WarehouseId),
+                LocationId = Guid.Parse(_form.LocationId),
+                SupplierId = Guid.TryParse(_form.SupplierId, out var supplierId) ? supplierId : null,
+                ReferenceNumber = NullIfEmpty(_form.ReferenceNumber),
+                IdempotencyKey = NullIfEmpty(_form.IdempotencyKey),
+                Lines = _form.Lines
+                    .Where(x => Guid.TryParse(x.ProductId, out _) && decimal.TryParse(x.Quantity, out var quantity) && quantity > 0)
+                    .Select(x => new ReceivingLineRequest
+                    {
+                        PurchaseOrderLineId = Guid.TryParse(x.PurchaseOrderLineId, out var poLineId) ? poLineId : null,
+                        ProductId = Guid.Parse(x.ProductId),
+                        Quantity = decimal.Parse(x.Quantity),
+                        UnitCost = decimal.TryParse(x.UnitCost, out var unitCost) ? unitCost : null,
+                        LotId = Guid.TryParse(x.LotId, out var lotId) ? lotId : null,
+                        LotNumber = NullIfEmpty(x.LotNumber),
+                        ManufacturedAt = ParseDate(x.ManufacturedAt),
+                        ExpiresAt = ParseDate(x.ExpiresAt)
+                    })
+                    .ToList()
+            });
+
+            ToastService.Show(result.IsSuccess ? "Receiving posted." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _receiveDialogOpen = false;
+                await Reload();
+            }
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private string GetPurchaseOrderNumber(Guid? orderId) => orderId is { } id ? _orders.FirstOrDefault(x => x.Id == id)?.OrderNumber ?? id.ToString()[..8] : "No PO";
+    private string GetProductName(Guid productId) => _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
+    private string GetSupplierName(Guid? supplierId) => supplierId is { } id ? _suppliers.FirstOrDefault(x => x.Id == id)?.Name ?? id.ToString()[..8] : "No supplier";
+    private string GetWarehouseName(Guid warehouseId) => _warehouses.FirstOrDefault(x => x.Id == warehouseId)?.Name ?? warehouseId.ToString()[..8];
+
+    private RequestMetadata BuildMetadata() => new() { TenantId = TenantFilter.SelectedTenantId };
+    private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    private static DateTime? ParseDate(string? value) => DateTime.TryParse(value, out var date) ? date : null;
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class ReceivingForm
+    {
+        public string ReceiptNumber { get; set; } = "";
+        public string PurchaseOrderId { get; set; } = "";
+        public string SupplierId { get; set; } = "";
+        public string WarehouseId { get; set; } = "";
+        public string LocationId { get; set; } = "";
+        public string ReferenceNumber { get; set; } = "";
+        public string IdempotencyKey { get; set; } = "";
+        public List<ReceivingLineForm> Lines { get; } = [];
+
+        public void Reset(string warehouseId, string locationId, string productId)
+        {
+            ReceiptNumber = "";
+            PurchaseOrderId = "";
+            SupplierId = "";
+            WarehouseId = warehouseId;
+            LocationId = locationId;
+            ReferenceNumber = "";
+            IdempotencyKey = "";
+            Lines.Clear();
+            Lines.Add(new ReceivingLineForm { ProductId = productId, Quantity = "1" });
+        }
+    }
+
+    private sealed class ReceivingLineForm
+    {
+        public string PurchaseOrderLineId { get; set; } = "";
+        public string ProductId { get; set; } = "";
+        public string Quantity { get; set; } = "1";
+        public string UnitCost { get; set; } = "";
+        public string LotId { get; set; } = "";
+        public string LotNumber { get; set; } = "";
+        public string ManufacturedAt { get; set; } = "";
+        public string ExpiresAt { get; set; } = "";
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReceivingDocumentDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReceivingDocumentDetail.razor
@@ -1,0 +1,208 @@
+@page "/inventario/receiving/{Id:guid}"
+@using XFramework.Domain.Shared.DataContext
+@implements IDisposable
+
+<PageTitle>Receiving Document - Inventario</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_purchasingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Purchasing" />
+}
+else if (_document is null)
+{
+    <BbCard>
+        <BbCardHeader>
+            <BbCardTitle>Receiving document not found</BbCardTitle>
+            <BbCardDescription>This receiving document is not available in the selected tenant.</BbCardDescription>
+        </BbCardHeader>
+    </BbCard>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div class="flex items-center gap-3">
+                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" OnClick="@GoBack">
+                        <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                    </BbButton>
+                    <div>
+                        <div class="flex flex-wrap items-center gap-2">
+                            <BbTypographyH3>@_document.ReceiptNumber</BbTypographyH3>
+                            <StatusBadge Text="@_document.Status.ToString()" Status="active" />
+                        </div>
+                        <BbTypographyMuted>Purchase Order: @GetPurchaseOrderNumber(_document.PurchaseOrderId) — ID: @_document.Id</BbTypographyMuted>
+                    </div>
+                </div>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Receipt Summary</BbCardTitle>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-3">
+                        <div>
+                            <BbTypographyMuted>Supplier</BbTypographyMuted>
+                            <p>@GetSupplierName(_document.SupplierId)</p>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Warehouse</BbTypographyMuted>
+                            <p>@GetWarehouseName(_document.WarehouseId)</p>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Location</BbTypographyMuted>
+                            <p>@GetLocationName(_document.LocationId)</p>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Received</BbTypographyMuted>
+                            <p>@_document.ReceivedAt.ToString("g")</p>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Reference</BbTypographyMuted>
+                            <p>@(_document.ReferenceNumber ?? "N/A")</p>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Idempotency</BbTypographyMuted>
+                            <p>@(_document.IdempotencyKey ?? "N/A")</p>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Received Lines</BbCardTitle>
+                    <BbCardDescription>@_lines.Count line(s) posted</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_lines" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridTemplateColumn Title="Product">
+                                <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridTemplateColumn Title="Lot">
+                                <ChildContent Context="item">@GetLotLabel(item.LotId, item.LotNumber)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Quantity" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.UnitCost)" Title="Unit Cost" />
+                            <BbDataGridTemplateColumn Title="Stock Balance">
+                                <ChildContent Context="item">
+                                    @if (item.StockBalanceId is { } balanceId)
+                                    {
+                                        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo($"/inventario/stock/balances/{balanceId}"))">
+                                            @balanceId.ToString()[..8]
+                                        </BbButton>
+                                    }
+                                    else
+                                    {
+                                        <span>N/A</span>
+                                    }
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private ReceivingDocument? _document;
+    private List<ReceivingLine> _lines = [];
+    private List<PurchaseOrder> _orders = [];
+    private List<Supplier> _suppliers = [];
+    private List<Product> _products = [];
+    private List<Warehouse> _warehouses = [];
+    private List<InventoryLocation> _locations = [];
+    private List<InventoryLot> _lots = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _purchasingEnabled;
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _purchasingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "purchasing");
+            _document = null;
+            _lines = [];
+            _orders = [];
+            _suppliers = [];
+            _products = [];
+            _warehouses = [];
+            _locations = [];
+            _lots = [];
+
+            if (!_hasTenant || !_purchasingEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _document = await DataContext.Query<ReceivingDocument>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && x.Id == Id && !x.IsDeleted).FirstOrDefaultAsync();
+            if (_document is null) return;
+
+            _lines = await DataContext.Query<ReceivingLine>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && x.ReceivingDocumentId == Id && !x.IsDeleted).ToListAsync();
+            _orders = await DataContext.Query<PurchaseOrder>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(500).ToListAsync();
+            _suppliers = await DataContext.Query<Supplier>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(500).ToListAsync();
+            _products = await DataContext.Query<Product>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(500).ToListAsync();
+            _warehouses = await DataContext.Query<Warehouse>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(200).ToListAsync();
+            _locations = await DataContext.Query<InventoryLocation>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(500).ToListAsync();
+            _lots = await DataContext.Query<InventoryLot>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(500).ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load receiving document: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void GoBack() => Navigation.NavigateTo("/inventario/receiving");
+    private string GetPurchaseOrderNumber(Guid? orderId) => orderId is { } id ? _orders.FirstOrDefault(x => x.Id == id)?.OrderNumber ?? id.ToString()[..8] : "No PO";
+    private string GetSupplierName(Guid? supplierId) => supplierId is { } id ? _suppliers.FirstOrDefault(x => x.Id == id)?.Name ?? id.ToString()[..8] : "No supplier";
+    private string GetProductName(Guid productId) => _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
+    private string GetWarehouseName(Guid warehouseId) => _warehouses.FirstOrDefault(x => x.Id == warehouseId)?.Name ?? warehouseId.ToString()[..8];
+    private string GetLocationName(Guid locationId) => _locations.FirstOrDefault(x => x.Id == locationId)?.Name ?? locationId.ToString()[..8];
+    private string GetLotLabel(Guid? lotId, string? fallback) => lotId is { } id ? _lots.FirstOrDefault(x => x.Id == id)?.LotNumber ?? id.ToString()[..8] : fallback ?? "Untracked";
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Suppliers.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Suppliers.razor
@@ -1,0 +1,214 @@
+@page "/inventario/suppliers"
+@using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing
+@implements IDisposable
+
+<PageTitle>Inventario Suppliers - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (!_hasTenant)
+{
+    <ModuleUnavailable ModuleName="Inventario" RequiresTenant="true" />
+}
+else if (!_purchasingEnabled)
+{
+    <ModuleUnavailable ModuleName="Inventario Purchasing" />
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <BbTypographyH3>Suppliers</BbTypographyH3>
+                    <BbTypographyMuted>Maintain suppliers for purchase orders and receiving.</BbTypographyMuted>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <BbButton OnClick="@OpenCreateDialog">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Create Supplier
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                </div>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Supplier List</BbCardTitle>
+                    <BbCardDescription>@_suppliers.Count supplier(s) loaded</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <BbDataGrid Items="@_suppliers" ShowPagination="true" InitialPageSize="20">
+                        <Columns>
+                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ContactName)" Title="Contact" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Email)" Title="Email" />
+                            <BbDataGridTemplateColumn Title="Status">
+                                <ChildContent Context="item">
+                                    <StatusBadge Text="@(item.IsActive ? "Active" : "Inactive")" Status="@(item.IsActive ? "active" : "inactive")" />
+                                </ChildContent>
+                            </BbDataGridTemplateColumn>
+                        </Columns>
+                    </BbDataGrid>
+                </BbCardContent>
+            </BbCard>
+        </div>
+    </FadeInContent>
+}
+
+<BbDialog Open="@_createDialogOpen" OpenChanged="@(v => _createDialogOpen = v)">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>Create Supplier</BbDialogTitle>
+            <BbDialogDescription>Supplier codes are unique inside the selected tenant.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Code" Label="Code" Required="true" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Name" Label="Name" Required="true" />
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <BbFormFieldInput TValue="string" @bind-Value="_form.ContactName" Label="Contact Name" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Email" Label="Email" />
+            </div>
+            <BbFormFieldInput TValue="string" @bind-Value="_form.Phone" Label="Phone" />
+            <BbFormFieldSwitch Checked="@_form.IsActive"
+                               CheckedChanged="@((bool value) => _form.IsActive = value)"
+                               Label="Active supplier" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _createDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@CreateSupplier" Disabled="@IsCreateDisabled">Create</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+
+    private readonly SupplierForm _form = new();
+    private List<Supplier> _suppliers = [];
+    private bool _loading = true;
+    private bool _hasTenant;
+    private bool _purchasingEnabled;
+    private bool _saving;
+    private bool _createDialogOpen;
+    private bool IsCreateDisabled => _saving || string.IsNullOrWhiteSpace(_form.Code) || string.IsNullOrWhiteSpace(_form.Name);
+
+    protected override void OnInitialized()
+    {
+        TenantFilter.OnChanged += OnTenantChanged;
+        ModuleNavigation.OnChanged += OnTenantChanged;
+    }
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
+
+    private async Task Reload()
+    {
+        _loading = true;
+        try
+        {
+            await ModuleNavigation.EnsureLoadedAsync();
+            _hasTenant = TenantFilter.SelectedTenantId is Guid;
+            _purchasingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "purchasing");
+            _suppliers = [];
+
+            if (!_hasTenant || !_purchasingEnabled) return;
+
+            var tenantId = TenantFilter.SelectedTenantId!.Value;
+            _suppliers = await DataContext.Query<Supplier>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(500)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to load suppliers: {ex.Message}");
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OpenCreateDialog()
+    {
+        _form.Reset();
+        _createDialogOpen = true;
+    }
+
+    private async Task CreateSupplier()
+    {
+        _saving = true;
+        try
+        {
+            var result = await Inventario.CreateSupplier(new CreateSupplierRequest
+            {
+                Metadata = BuildMetadata(),
+                Code = NullIfEmpty(_form.Code),
+                Name = NullIfEmpty(_form.Name),
+                ContactName = NullIfEmpty(_form.ContactName),
+                Email = NullIfEmpty(_form.Email),
+                Phone = NullIfEmpty(_form.Phone),
+                IsActive = _form.IsActive
+            });
+
+            ToastService.Show(result.IsSuccess ? "Supplier created." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _createDialogOpen = false;
+                await Reload();
+            }
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private RequestMetadata BuildMetadata() => new() { TenantId = TenantFilter.SelectedTenantId };
+    private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantChanged;
+        ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class SupplierForm
+    {
+        public string Code { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string ContactName { get; set; } = "";
+        public string Email { get; set; } = "";
+        public string Phone { get; set; } = "";
+        public bool IsActive { get; set; } = true;
+
+        public void Reset()
+        {
+            Code = "";
+            Name = "";
+            ContactName = "";
+            Email = "";
+            Phone = "";
+            IsActive = true;
+        }
+    }
+}

--- a/src/Tests/Inventario.Api.Tests/PurchasingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/PurchasingServiceTests.cs
@@ -1,0 +1,335 @@
+using System.Collections;
+using System.Linq.Expressions;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace Inventario.Api.Tests;
+
+[TestFixture]
+public sealed class PurchasingServiceTests
+{
+    [Test]
+    public async Task ReceiveAsync_OpenPurchaseOrderLine_PostsReceiptAndMarksOrderPartiallyReceived()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedPurchasingData(tenantId, ids, orderedQuantity: 10);
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.ReceiveAsync(new ReceiveInventoryRequest
+        {
+            PurchaseOrderId = ids.PurchaseOrderId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            IdempotencyKey = "receive-po-1",
+            Lines =
+            [
+                new()
+                {
+                    PurchaseOrderLineId = ids.PurchaseOrderLineId,
+                    ProductId = ids.ProductId,
+                    Quantity = 4,
+                    UnitCost = 2.50m,
+                    LotNumber = "LOT-RCV-1"
+                }
+            ]
+        });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.StatusCode.Should().Be(201);
+        result.Data!.Lines.Should().ContainSingle();
+
+        dataContext.Set<PurchaseOrder>().Single().Status.Should().Be(PurchaseOrderStatus.PartiallyReceived);
+        dataContext.Set<PurchaseOrderLine>().Single().ReceivedQuantity.Should().Be(4);
+        dataContext.Set<InventoryLot>().Should().ContainSingle(x => x.LotNumber == "LOT-RCV-1");
+        dataContext.Set<StockBalance>().Should().ContainSingle(x => x.LotId != null && x.OnHandQuantity == 4 && x.AvailableQuantity == 4);
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x =>
+            x.MovementType == InventoryMovementType.Receipt &&
+            x.QuantityDelta == 4 &&
+            x.IdempotencyKey == "receive-po-1:line:0");
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task ReceiveAsync_OverRemainingPurchaseOrderQuantity_ReturnsConflictWithoutSaving()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedPurchasingData(tenantId, ids, orderedQuantity: 10, receivedQuantity: 8);
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.ReceiveAsync(new ReceiveInventoryRequest
+        {
+            PurchaseOrderId = ids.PurchaseOrderId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            Lines =
+            [
+                new()
+                {
+                    PurchaseOrderLineId = ids.PurchaseOrderLineId,
+                    ProductId = ids.ProductId,
+                    Quantity = 3
+                }
+            ]
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        dataContext.Set<PurchaseOrderLine>().Single().ReceivedQuantity.Should().Be(8);
+        dataContext.Added.OfType<ReceivingDocument>().Should().ContainSingle();
+        dataContext.Added.OfType<InventoryMovement>().Should().BeEmpty();
+        dataContext.SaveCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task ReceiveAsync_SameIdempotencyKeyAndPayload_ReplaysWithoutDoublePosting()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedPurchasingData(tenantId, ids, orderedQuantity: 10);
+        var service = CreateService(dataContext, tenantId);
+        var request = new ReceiveInventoryRequest
+        {
+            ReceiptNumber = "RCV-100",
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            IdempotencyKey = "direct-receive-1",
+            Lines =
+            [
+                new()
+                {
+                    ProductId = ids.ProductId,
+                    Quantity = 5
+                }
+            ]
+        };
+
+        var first = await service.ReceiveAsync(request);
+        var replay = await service.ReceiveAsync(request);
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        replay.IsSuccess.Should().BeTrue(replay.Message);
+        replay.Message.Should().Be("Receiving document already processed.");
+        dataContext.Added.OfType<ReceivingDocument>().Should().ContainSingle(x => x.IdempotencyKey == "direct-receive-1");
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x => x.IdempotencyKey == "direct-receive-1:line:0");
+        dataContext.Set<StockBalance>().Should().ContainSingle(x => x.OnHandQuantity == 5);
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task ReceiveAsync_SameIdempotencyKeyWithDifferentPayload_ReturnsConflict()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedPurchasingData(tenantId, ids, orderedQuantity: 10);
+        var service = CreateService(dataContext, tenantId);
+
+        var first = await service.ReceiveAsync(new ReceiveInventoryRequest
+        {
+            ReceiptNumber = "RCV-100",
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            IdempotencyKey = "direct-receive-1",
+            Lines = [new() { ProductId = ids.ProductId, Quantity = 5 }]
+        });
+        var conflict = await service.ReceiveAsync(new ReceiveInventoryRequest
+        {
+            ReceiptNumber = "RCV-100",
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            IdempotencyKey = "direct-receive-1",
+            Lines = [new() { ProductId = ids.ProductId, Quantity = 6 }]
+        });
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        conflict.IsSuccess.Should().BeFalse();
+        conflict.StatusCode.Should().Be(409);
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    private static FakeDataContext SeedPurchasingData(
+        Guid tenantId,
+        TestIds ids,
+        decimal orderedQuantity,
+        decimal receivedQuantity = 0)
+    {
+        var dataContext = new FakeDataContext();
+        dataContext.Set<Product>().Add(new Product
+        {
+            Id = ids.ProductId,
+            TenantId = tenantId,
+            Name = "Widget",
+            CategoryId = Guid.NewGuid(),
+            IsEnabled = true
+        });
+        dataContext.Set<Warehouse>().Add(new Warehouse
+        {
+            Id = ids.WarehouseId,
+            TenantId = tenantId,
+            Code = "MAIN",
+            Name = "Main Warehouse",
+            IsEnabled = true
+        });
+        dataContext.Set<InventoryLocation>().Add(new InventoryLocation
+        {
+            Id = ids.LocationId,
+            TenantId = tenantId,
+            WarehouseId = ids.WarehouseId,
+            Code = "BIN-01",
+            Name = "Bin 01",
+            IsEnabled = true
+        });
+        dataContext.Set<PurchaseOrder>().Add(new PurchaseOrder
+        {
+            Id = ids.PurchaseOrderId,
+            TenantId = tenantId,
+            OrderNumber = "PO-100",
+            Status = PurchaseOrderStatus.Open,
+            OrderDate = DateTime.UtcNow.AddDays(-1),
+            IsEnabled = true
+        });
+        dataContext.Set<PurchaseOrderLine>().Add(new PurchaseOrderLine
+        {
+            Id = ids.PurchaseOrderLineId,
+            TenantId = tenantId,
+            PurchaseOrderId = ids.PurchaseOrderId,
+            ProductId = ids.ProductId,
+            OrderedQuantity = orderedQuantity,
+            ReceivedQuantity = receivedQuantity,
+            UnitCost = 2.50m,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-1)
+        });
+
+        return dataContext;
+    }
+
+    private static PurchasingService CreateService(FakeDataContext dataContext, Guid tenantId)
+    {
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim("tenantId", tenantId.ToString())],
+                    authenticationType: "Test"))
+            }
+        };
+        var stockPostingService = new StockPostingService(dataContext, httpContextAccessor);
+        return new PurchasingService(dataContext, httpContextAccessor, stockPostingService);
+    }
+
+    private sealed record TestIds(
+        Guid ProductId,
+        Guid WarehouseId,
+        Guid LocationId,
+        Guid PurchaseOrderId,
+        Guid PurchaseOrderLineId)
+    {
+        public static TestIds Create() => new(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid());
+    }
+
+    private sealed class FakeDataContext : IDataContext
+    {
+        private readonly Dictionary<Type, IList> sets = [];
+
+        public List<object> Added { get; } = [];
+        public List<object> Updated { get; } = [];
+        public int SaveCount { get; private set; }
+
+        public List<T> Set<T>() where T : class
+        {
+            if (!sets.TryGetValue(typeof(T), out var set))
+            {
+                set = new List<T>();
+                sets[typeof(T)] = set;
+            }
+
+            return (List<T>)set;
+        }
+
+        public IRemoteQuery<T> Query<T>() where T : class =>
+            new InMemoryRemoteQuery<T>(Set<T>().AsQueryable());
+
+        public void Add<T>(T entity) where T : class
+        {
+            Added.Add(entity);
+            Set<T>().Add(entity);
+        }
+
+        public void Update<T>(T entity) where T : class =>
+            Updated.Add(entity);
+
+        public void Remove<T>(T entity) where T : class =>
+            Set<T>().Remove(entity);
+
+        public Task<DataContextResult> SaveChangesAsync(CancellationToken ct = default)
+        {
+            SaveCount++;
+            return Task.FromResult(DataContextResult.Success());
+        }
+    }
+
+    private sealed class InMemoryRemoteQuery<T>(IQueryable<T> queryable) : IRemoteQuery<T>
+        where T : class
+    {
+        private IQueryable<T> query = queryable;
+
+        public IRemoteQuery<T> Where(Expression<Func<T, bool>> predicate) { query = query.Where(predicate); return this; }
+        public IRemoteQuery<T> OrderBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.OrderBy(keySelector); return this; }
+        public IRemoteQuery<T> OrderByDescending<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.OrderByDescending(keySelector); return this; }
+        public IRemoteQuery<T> ThenBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = ((IOrderedQueryable<T>)query).ThenBy(keySelector); return this; }
+        public IRemoteQuery<T> ThenByDescending<TKey>(Expression<Func<T, TKey>> keySelector) { query = ((IOrderedQueryable<T>)query).ThenByDescending(keySelector); return this; }
+        public IRemoteQuery<T> Skip(int count) { query = query.Skip(count); return this; }
+        public IRemoteQuery<T> Take(int count) { query = query.Take(count); return this; }
+        public IRemoteQuery<T> Include<TProperty>(Expression<Func<T, TProperty>> navigationSelector) => this;
+        public IRemoteQuery<T> Distinct() { query = query.Distinct(); return this; }
+        public IRemoteQuery<T> DistinctBy<TKey>(Expression<Func<T, TKey>> keySelector) { query = query.AsEnumerable().DistinctBy(keySelector.Compile()).AsQueryable(); return this; }
+        public IRemoteQuery<T> NoCache() => this;
+        public IRemoteQuery<T> IgnoreQueryFilters() => this;
+        public Task<List<T>> ToListAsync(CancellationToken ct = default) => Task.FromResult(query.ToList());
+        public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) => Task.FromResult(query.FirstOrDefault());
+        public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default) => Task.FromResult(query.SingleOrDefault());
+        public async IAsyncEnumerable<T> ToAsyncEnumerable(int chunkSize = 100, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in query)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+        public Task<int> CountAsync(CancellationToken ct = default) => Task.FromResult(query.Count());
+        public Task<bool> AnyAsync(CancellationToken ct = default) => Task.FromResult(query.Any());
+        public Task<bool> AnyAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) => Task.FromResult(query.Any(predicate));
+        public Task<bool> AllAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default) => Task.FromResult(query.All(predicate));
+        public Task<TResult?> MinAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) => Task.FromResult(query.Select(selector).Min());
+        public Task<TResult?> MaxAsync<TResult>(Expression<Func<T, TResult>> selector, CancellationToken ct = default) => Task.FromResult(query.Select(selector).Max());
+        public Task<T?> MinByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) => Task.FromResult(query.AsEnumerable().MinBy(keySelector.Compile()));
+        public Task<T?> MaxByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default) => Task.FromResult(query.AsEnumerable().MaxBy(keySelector.Compile()));
+        public Task<decimal> SumAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) => Task.FromResult(query.Sum(selector));
+        public Task<double> AverageAsync(Expression<Func<T, decimal>> selector, CancellationToken ct = default) => Task.FromResult((double)query.Average(selector));
+        public Task<List<GroupResult<TKey, T>>> GroupByAsync<TKey>(Expression<Func<T, TKey>> keySelector, CancellationToken ct = default)
+        {
+            var compiled = keySelector.Compile();
+            return Task.FromResult(query.AsEnumerable()
+                .GroupBy(compiled)
+                .Select(g => new GroupResult<TKey, T> { Key = g.Key, Items = g.ToList() })
+                .ToList());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Inventario suppliers, purchase orders, receiving documents, and receiving lines
- post receiving through the stock posting service, including optional lot creation/selection and partial PO receiving
- add purchasing ControlPanel pages and navigation behind the inventario.purchasing sub-feature
- add receiving idempotency coverage so retries do not double-post stock

## Stack
- Stacked on #266 (`codex/inventario-planning-reporting`), which is stacked on #265 and #264.
- After earlier PRs merge, this branch should be rebased/retargeted to `develop` before final merge.

## Tests
- `dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false`
- `dotnet build src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj -m:1 /nr:false --no-restore`
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --no-restore`
- `dotnet restore XFramework.slnx`
- `dotnet build XFramework.slnx -m:1 /nr:false --no-restore`