### PR TITLE
Harden Inventario validation and feature gates

### DIFF
--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Locations/Create/CreateInventoryLocationValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Locations/Create/CreateInventoryLocationValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace Inventario.Api.Features.Locations.Create;
+
+public sealed class CreateInventoryLocationValidator : AbstractValidator<CreateInventoryLocationRequest>
+{
+    public CreateInventoryLocationValidator()
+    {
+        RuleFor(x => x.WarehouseId)
+            .NotEmpty();
+
+        RuleFor(x => x.Code)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(1000);
+
+        RuleFor(x => x.LocationType)
+            .Must(value => Enum.IsDefined(typeof(InventoryLocationType), value))
+            .WithMessage("Location type is invalid.");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/Create/CreateInventoryLotValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Lots/Create/CreateInventoryLotValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace Inventario.Api.Features.Lots.Create;
 
@@ -9,6 +10,10 @@ public sealed class CreateInventoryLotValidator : AbstractValidator<CreateInvent
     {
         RuleFor(x => x.ProductId)
             .NotEmpty().WithMessage("Product is required.");
+
+        RuleFor(x => x.Status)
+            .Must(value => Enum.IsDefined(typeof(InventoryLotStatus), value))
+            .WithMessage("Lot status is invalid.");
 
         RuleFor(x => x.LotNumber)
             .NotEmpty().WithMessage("Lot number is required.")

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/CreatePurchaseOrderValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/CreatePurchaseOrderValidator.cs
@@ -11,6 +11,9 @@ public sealed class CreatePurchaseOrderValidator : AbstractValidator<CreatePurch
         RuleFor(x => x.OrderNumber).MaximumLength(100);
         RuleFor(x => x.Notes).MaximumLength(1000);
         RuleFor(x => x.Status)
+            .Must(value => Enum.IsDefined(typeof(PurchaseOrderStatus), value))
+            .WithMessage("Purchase order status is invalid.");
+        RuleFor(x => x.Status)
             .Must(x => x is PurchaseOrderStatus.Draft or PurchaseOrderStatus.Open)
             .WithMessage("New purchase orders can only start as draft or open.");
         RuleFor(x => x.Lines).NotEmpty();

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/SetPurchaseOrderStatusValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/SetPurchaseOrderStatusValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace Inventario.Api.Features.Purchasing.PurchaseOrders;
+
+public sealed class SetPurchaseOrderStatusValidator : AbstractValidator<SetPurchaseOrderStatusRequest>
+{
+    public SetPurchaseOrderStatusValidator()
+    {
+        RuleFor(x => x.PurchaseOrderId)
+            .NotEmpty();
+
+        RuleFor(x => x.Status)
+            .Must(value => Enum.IsDefined(typeof(PurchaseOrderStatus), value))
+            .WithMessage("Purchase order status is invalid.");
+
+        RuleFor(x => x.Status)
+            .Must(status => status is PurchaseOrderStatus.Draft or PurchaseOrderStatus.Open or PurchaseOrderStatus.Cancelled)
+            .WithMessage("Purchase orders can only be set to draft, open, or cancelled directly.");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Receiving/ReceiveInventoryValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/Receiving/ReceiveInventoryValidator.cs
@@ -13,6 +13,10 @@ public sealed class ReceiveInventoryValidator : AbstractValidator<ReceiveInvento
         RuleFor(x => x.ReferenceNumber).MaximumLength(100);
         RuleFor(x => x.Notes).MaximumLength(1000);
         RuleFor(x => x.IdempotencyKey).MaximumLength(200);
+        RuleFor(x => x.ReceivedAt)
+            .Must(value => value is null || value <= DateTime.UtcNow.AddMinutes(5))
+            .When(x => x.ReceivedAt is not null)
+            .WithMessage("Received date cannot be in the future.");
         RuleFor(x => x.Lines).NotEmpty();
         RuleForEach(x => x.Lines).ChildRules(line =>
         {
@@ -22,6 +26,9 @@ public sealed class ReceiveInventoryValidator : AbstractValidator<ReceiveInvento
             line.RuleFor(x => x.UnitOfMeasure).MaximumLength(25);
             line.RuleFor(x => x.LotNumber).MaximumLength(100);
             line.RuleFor(x => x.SupplierReference).MaximumLength(200);
+            line.RuleFor(x => x)
+                .Must(x => x.LotId is null || string.IsNullOrWhiteSpace(x.LotNumber))
+                .WithMessage("Use either an existing lot or a new lot number, not both.");
             line.RuleFor(x => x.ExpiresAt)
                 .GreaterThanOrEqualTo(x => x.ManufacturedAt)
                 .When(x => x.ExpiresAt is not null && x.ManufacturedAt is not null);

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reservations/Cancel/CancelReservationValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reservations/Cancel/CancelReservationValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations;
+
+namespace Inventario.Api.Features.Reservations.Cancel;
+
+public sealed class CancelReservationValidator : AbstractValidator<CancelReservationRequest>
+{
+    public CancelReservationValidator()
+    {
+        RuleFor(x => x.ReservationId)
+            .NotEmpty();
+
+        RuleFor(x => x.Reason)
+            .MaximumLength(500);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reservations/Expire/ExpireReservationsValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reservations/Expire/ExpireReservationsValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations;
+
+namespace Inventario.Api.Features.Reservations.Expire;
+
+public sealed class ExpireReservationsValidator : AbstractValidator<ExpireReservationsRequest>
+{
+    public ExpireReservationsValidator()
+    {
+        RuleFor(x => x.MaxCount)
+            .InclusiveBetween(1, 500);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reservations/Fulfill/FulfillReservationValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reservations/Fulfill/FulfillReservationValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations;
+
+namespace Inventario.Api.Features.Reservations.Fulfill;
+
+public sealed class FulfillReservationValidator : AbstractValidator<FulfillReservationRequest>
+{
+    public FulfillReservationValidator()
+    {
+        RuleFor(x => x.ReservationId)
+            .NotEmpty();
+
+        RuleFor(x => x.Reason)
+            .MaximumLength(500);
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/Post/PostStockMovementValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/Post/PostStockMovementValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace Inventario.Api.Features.Stock.Post;
 
@@ -10,7 +11,22 @@ public sealed class PostStockMovementValidator : AbstractValidator<PostStockMove
         RuleFor(x => x.ProductId).NotEmpty().WithMessage("Product is required.");
         RuleFor(x => x.WarehouseId).NotEmpty().WithMessage("Warehouse is required.");
         RuleFor(x => x.LocationId).NotEmpty().WithMessage("Location is required.");
+        RuleFor(x => x.MovementType)
+            .Must(value => Enum.IsDefined(typeof(InventoryMovementType), value))
+            .WithMessage("Movement type is invalid.");
         RuleFor(x => x.Quantity).NotEqual(0).WithMessage("Quantity must not be zero.");
+        RuleFor(x => x.Quantity)
+            .GreaterThan(0)
+            .When(x => x.MovementType != InventoryMovementType.Adjustment)
+            .WithMessage("Quantity must be positive for this movement type.");
+        RuleFor(x => x.DestinationWarehouseId)
+            .NotEmpty()
+            .When(x => x.MovementType == InventoryMovementType.Transfer)
+            .WithMessage("Transfer destination warehouse is required.");
+        RuleFor(x => x.DestinationLocationId)
+            .NotEmpty()
+            .When(x => x.MovementType == InventoryMovementType.Transfer)
+            .WithMessage("Transfer destination location is required.");
         RuleFor(x => x.UnitOfMeasure).MaximumLength(25).When(x => !string.IsNullOrWhiteSpace(x.UnitOfMeasure));
         RuleFor(x => x.ReferenceType).MaximumLength(100).When(x => !string.IsNullOrWhiteSpace(x.ReferenceType));
         RuleFor(x => x.Reason).MaximumLength(1000).When(x => !string.IsNullOrWhiteSpace(x.Reason));

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Warehouses/Create/CreateWarehouseValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Warehouses/Create/CreateWarehouseValidator.cs
@@ -1,0 +1,38 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+
+namespace Inventario.Api.Features.Warehouses.Create;
+
+public sealed class CreateWarehouseValidator : AbstractValidator<CreateWarehouseRequest>
+{
+    public CreateWarehouseValidator()
+    {
+        RuleFor(x => x.Code)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(1000);
+
+        RuleFor(x => x.AddressLine)
+            .MaximumLength(500);
+
+        RuleFor(x => x.City)
+            .MaximumLength(100);
+
+        RuleFor(x => x.Region)
+            .MaximumLength(100);
+
+        RuleFor(x => x.PostalCode)
+            .MaximumLength(30);
+
+        RuleFor(x => x.CountryCode)
+            .Length(2)
+            .When(x => !string.IsNullOrWhiteSpace(x.CountryCode))
+            .WithMessage("Country code must use the two-character ISO code.");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
@@ -49,6 +49,8 @@ app.UseTenantModuleFeatureGate(options =>
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/lots", "traceability");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reorder-rules", "planning");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/planning", "planning");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports/near-expiry", "traceability");
+    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports/expired-stock", "traceability");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports", "reporting");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/suppliers", "purchasing");
     options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/purchase-orders", "purchasing");

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryLotService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryLotService.cs
@@ -1,5 +1,7 @@
+using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.Contracts.Requests;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -9,7 +11,8 @@ namespace XFramework.Inventario.Api.Services;
 
 public sealed class InventoryLotService(
     IDataContext dataContext,
-    IHttpContextAccessor httpContextAccessor)
+    IHttpContextAccessor httpContextAccessor,
+    ITenantModuleFeatureService featureService)
 {
     public async Task<Result<List<InventoryLot>>> GetLotsAsync(
         GetInventoryLotsRequest request,
@@ -18,6 +21,10 @@ public sealed class InventoryLotService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<List<InventoryLot>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureTraceabilityEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<InventoryLot>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var query = dataContext.Query<InventoryLot>()
             .IgnoreQueryFilters()
@@ -50,6 +57,10 @@ public sealed class InventoryLotService(
         if (!tenantResult.IsSuccess)
             return Result<InventoryLot>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
+        var featureResult = await EnsureTraceabilityEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<InventoryLot>.Failure(featureResult.Message!, featureResult.StatusCode);
+
         var lot = await dataContext.Query<InventoryLot>()
             .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && x.Id == request.Id && !x.IsDeleted)
@@ -67,6 +78,10 @@ public sealed class InventoryLotService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<InventoryLot>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureTraceabilityEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<InventoryLot>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
         var lotNumber = NormalizeRequired(request.LotNumber);
@@ -141,4 +156,11 @@ public sealed class InventoryLotService(
 
     private static string? NormalizeOptional(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private async Task<Result> EnsureTraceabilityEnabledAsync(Guid tenantId, CancellationToken ct) =>
+        await featureService.EnsureEnabledAsync(
+            tenantId,
+            TenantModuleFeatureKeys.Inventario,
+            TenantModuleFeatureKeys.TraceabilitySubFeature,
+            ct);
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryPlanningService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryPlanningService.cs
@@ -1,5 +1,7 @@
+using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.Contracts.Requests;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -11,7 +13,8 @@ namespace XFramework.Inventario.Api.Services;
 
 public sealed class InventoryPlanningService(
     IDataContext dataContext,
-    IHttpContextAccessor httpContextAccessor)
+    IHttpContextAccessor httpContextAccessor,
+    ITenantModuleFeatureService featureService)
 {
     public async Task<Result<List<InventoryReorderRule>>> GetRulesAsync(
         GetInventoryReorderRulesRequest request,
@@ -20,6 +23,10 @@ public sealed class InventoryPlanningService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<List<InventoryReorderRule>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsurePlanningEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<InventoryReorderRule>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<InventoryReorderRule>()
@@ -47,6 +54,10 @@ public sealed class InventoryPlanningService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<InventoryReorderRule>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsurePlanningEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<InventoryReorderRule>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         if (request.MinimumQuantity < 0 || request.ReorderPoint < 0 || request.ReorderQuantity <= 0)
             return Result<InventoryReorderRule>.Failure("Reorder quantities must be valid positive values.", 400);
@@ -129,7 +140,11 @@ public sealed class InventoryPlanningService(
         if (!tenantResult.IsSuccess)
             return Result<List<LowStockReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
-        var rows = await BuildLowStockRows(tenantResult.Data, request.ProductId, request.WarehouseId, request.LocationId, ct);
+        var featureResult = await EnsurePlanningEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<LowStockReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
+
+        var rows = await BuildLowStockRowsAsync(tenantResult.Data, request.ProductId, request.WarehouseId, request.LocationId, ct);
         return Result<List<LowStockReportRow>>.Success(rows);
     }
 
@@ -141,7 +156,11 @@ public sealed class InventoryPlanningService(
         if (!tenantResult.IsSuccess)
             return Result<List<ReorderSuggestionRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
-        var lowStock = await BuildLowStockRows(tenantResult.Data, request.ProductId, request.WarehouseId, request.LocationId, ct);
+        var featureResult = await EnsurePlanningEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<ReorderSuggestionRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
+
+        var lowStock = await BuildLowStockRowsAsync(tenantResult.Data, request.ProductId, request.WarehouseId, request.LocationId, ct);
         var rules = await LoadRules(tenantResult.Data, request.ProductId, request.WarehouseId, request.LocationId, ct);
 
         var suggestions = lowStock.Select(row =>
@@ -169,7 +188,7 @@ public sealed class InventoryPlanningService(
         return Result<List<ReorderSuggestionRow>>.Success(suggestions);
     }
 
-    private async Task<List<LowStockReportRow>> BuildLowStockRows(
+    internal async Task<List<LowStockReportRow>> BuildLowStockRowsAsync(
         Guid tenantId,
         Guid? productId,
         Guid? warehouseId,
@@ -276,4 +295,11 @@ public sealed class InventoryPlanningService(
 
     private static string? NormalizeOptional(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private async Task<Result> EnsurePlanningEnabledAsync(Guid tenantId, CancellationToken ct) =>
+        await featureService.EnsureEnabledAsync(
+            tenantId,
+            TenantModuleFeatureKeys.Inventario,
+            TenantModuleFeatureKeys.PlanningSubFeature,
+            ct);
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryReportingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryReportingService.cs
@@ -1,5 +1,7 @@
+using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.Contracts.Requests;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -12,12 +14,30 @@ namespace XFramework.Inventario.Api.Services;
 public sealed class InventoryReportingService(
     IDataContext dataContext,
     IHttpContextAccessor httpContextAccessor,
-    InventoryPlanningService planningService)
+    InventoryPlanningService planningService,
+    ITenantModuleFeatureService featureService)
 {
     public async Task<Result<List<LowStockReportRow>>> GetLowStockAsync(
         GetLowStockReportRequest request,
-        CancellationToken ct = default) =>
-        await planningService.GetLowStockAsync(request, ct);
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<LowStockReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureReportingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<LowStockReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
+
+        var rows = await planningService.BuildLowStockRowsAsync(
+            tenantResult.Data,
+            request.ProductId,
+            request.WarehouseId,
+            request.LocationId,
+            ct);
+
+        return Result<List<LowStockReportRow>>.Success(rows);
+    }
 
     public async Task<Result<List<NearExpiryStockReportRow>>> GetNearExpiryAsync(
         GetNearExpiryStockReportRequest request,
@@ -26,6 +46,14 @@ public sealed class InventoryReportingService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<List<NearExpiryStockReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureReportingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<NearExpiryStockReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
+
+        var traceabilityResult = await EnsureTraceabilityEnabledAsync(tenantResult.Data, ct);
+        if (!traceabilityResult.IsSuccess)
+            return Result<List<NearExpiryStockReportRow>>.Failure(traceabilityResult.Message!, traceabilityResult.StatusCode);
 
         var now = DateTime.UtcNow;
         var cutoff = now.AddDays(Math.Clamp(request.DaysAhead, 1, 365));
@@ -43,6 +71,14 @@ public sealed class InventoryReportingService(
         if (!tenantResult.IsSuccess)
             return Result<List<NearExpiryStockReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
+        var featureResult = await EnsureReportingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<NearExpiryStockReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
+
+        var traceabilityResult = await EnsureTraceabilityEnabledAsync(tenantResult.Data, ct);
+        if (!traceabilityResult.IsSuccess)
+            return Result<List<NearExpiryStockReportRow>>.Failure(traceabilityResult.Message!, traceabilityResult.StatusCode);
+
         var now = DateTime.UtcNow;
         var rows = await BuildExpiryRows(tenantResult.Data, request.ProductId, lot =>
             lot.Status == InventoryLotStatus.Expired || lot.ExpiresAt is not null && lot.ExpiresAt <= now, ct);
@@ -57,6 +93,10 @@ public sealed class InventoryReportingService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<List<StockPositionReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureReportingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<StockPositionReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
         var balances = await dataContext.Query<StockBalance>()
@@ -102,6 +142,10 @@ public sealed class InventoryReportingService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<List<MovementLedgerReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureReportingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<MovementLedgerReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
         var movements = await dataContext.Query<InventoryMovement>()
@@ -161,6 +205,10 @@ public sealed class InventoryReportingService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<List<ReservationAllocationStatusReportRow>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureReportingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<ReservationAllocationStatusReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
         var allocations = await dataContext.Query<ReservationAllocation>()
@@ -295,4 +343,18 @@ public sealed class InventoryReportingService(
         Dictionary<Guid, string> WarehouseNames,
         Dictionary<Guid, string> LocationNames,
         Dictionary<Guid, string> LotNumbers);
+
+    private async Task<Result> EnsureReportingEnabledAsync(Guid tenantId, CancellationToken ct) =>
+        await featureService.EnsureEnabledAsync(
+            tenantId,
+            TenantModuleFeatureKeys.Inventario,
+            TenantModuleFeatureKeys.ReportingSubFeature,
+            ct);
+
+    private async Task<Result> EnsureTraceabilityEnabledAsync(Guid tenantId, CancellationToken ct) =>
+        await featureService.EnsureEnabledAsync(
+            tenantId,
+            TenantModuleFeatureKeys.Inventario,
+            TenantModuleFeatureKeys.TraceabilitySubFeature,
+            ct);
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/PurchasingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/PurchasingService.cs
@@ -1,8 +1,10 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.Contracts.Requests;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -15,7 +17,8 @@ namespace XFramework.Inventario.Api.Services;
 public sealed class PurchasingService(
     IDataContext dataContext,
     IHttpContextAccessor httpContextAccessor,
-    StockPostingService stockPostingService)
+    StockPostingService stockPostingService,
+    ITenantModuleFeatureService featureService)
 {
     private static readonly JsonSerializerOptions HashJsonOptions = new(JsonSerializerDefaults.Web);
 
@@ -26,6 +29,10 @@ public sealed class PurchasingService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<List<Supplier>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsurePurchasingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<Supplier>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var query = dataContext.Query<Supplier>()
             .IgnoreQueryFilters()
@@ -49,6 +56,10 @@ public sealed class PurchasingService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<Supplier>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsurePurchasingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<Supplier>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
         var code = NormalizeRequired(request.Code);
@@ -93,6 +104,10 @@ public sealed class PurchasingService(
         if (!tenantResult.IsSuccess)
             return Result<List<PurchaseOrder>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
+        var featureResult = await EnsurePurchasingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<PurchaseOrder>>.Failure(featureResult.Message!, featureResult.StatusCode);
+
         var query = dataContext.Query<PurchaseOrder>()
             .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
@@ -118,6 +133,10 @@ public sealed class PurchasingService(
         if (!tenantResult.IsSuccess)
             return Result<PurchaseOrder>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
+        var featureResult = await EnsurePurchasingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<PurchaseOrder>.Failure(featureResult.Message!, featureResult.StatusCode);
+
         var order = await LoadPurchaseOrder(tenantResult.Data, request.Id, ct);
         return order is null
             ? Result<PurchaseOrder>.NotFound("Purchase order not found.")
@@ -131,6 +150,10 @@ public sealed class PurchasingService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<PurchaseOrder>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsurePurchasingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<PurchaseOrder>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         if (request.Lines.Count == 0)
             return Result<PurchaseOrder>.Failure("At least one purchase order line is required.", 400);
@@ -220,6 +243,10 @@ public sealed class PurchasingService(
         if (!tenantResult.IsSuccess)
             return Result<PurchaseOrder>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
+        var featureResult = await EnsurePurchasingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<PurchaseOrder>.Failure(featureResult.Message!, featureResult.StatusCode);
+
         var order = await LoadPurchaseOrder(tenantResult.Data, request.PurchaseOrderId, ct);
         if (order is null)
             return Result<PurchaseOrder>.NotFound("Purchase order not found.");
@@ -249,6 +276,10 @@ public sealed class PurchasingService(
         if (!tenantResult.IsSuccess)
             return Result<List<ReceivingDocument>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
+        var featureResult = await EnsurePurchasingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<ReceivingDocument>>.Failure(featureResult.Message!, featureResult.StatusCode);
+
         var query = dataContext.Query<ReceivingDocument>()
             .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
@@ -273,6 +304,10 @@ public sealed class PurchasingService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<ReceivingDocument>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsurePurchasingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<ReceivingDocument>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         if (request.Lines.Count == 0)
             return Result<ReceivingDocument>.Failure("At least one receiving line is required.", 400);
@@ -611,6 +646,13 @@ public sealed class PurchasingService(
 
     private static string? NormalizeOptional(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private async Task<Result> EnsurePurchasingEnabledAsync(Guid tenantId, CancellationToken ct) =>
+        await featureService.EnsureEnabledAsync(
+            tenantId,
+            TenantModuleFeatureKeys.Inventario,
+            TenantModuleFeatureKeys.PurchasingSubFeature,
+            ct);
 
     private static string ComputeRequestHash(Guid tenantId, ReceiveInventoryRequest request)
     {

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
@@ -2,8 +2,10 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.Contracts.Requests;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -15,7 +17,8 @@ namespace XFramework.Inventario.Api.Services;
 
 public sealed class StockPostingService(
     IDataContext dataContext,
-    IHttpContextAccessor httpContextAccessor)
+    IHttpContextAccessor httpContextAccessor,
+    ITenantModuleFeatureService featureService)
 {
     private static readonly JsonSerializerOptions HashJsonOptions = new(JsonSerializerDefaults.Web);
 
@@ -79,8 +82,12 @@ public sealed class StockPostingService(
         var afterOnHand = before + delta;
         var afterReserved = balance.ReservedQuantity + reservedDelta;
 
-        if (!request.AllowNegativeStock && (afterOnHand < 0 || afterReserved < 0 || afterOnHand - afterReserved < 0))
-            return Result<StockPostingResponse>.Failure("Stock movement would create a negative stock position.", 409);
+        if (CreatesNegativeStock(afterOnHand, afterReserved))
+        {
+            var negativeStockResult = await EnsureNegativeStockAllowedAsync(tenantId, request, ct);
+            if (!negativeStockResult.IsSuccess)
+                return Result<StockPostingResponse>.Failure(negativeStockResult.Message!, negativeStockResult.StatusCode);
+        }
 
         if (!balanceState.IsNew)
             dataContext.Update(balance);
@@ -233,8 +240,12 @@ public sealed class StockPostingService(
         var source = sourceState.Balance;
         var destination = destinationState.Balance;
         var sourceAfter = source.OnHandQuantity - request.Quantity;
-        if (!request.AllowNegativeStock && sourceAfter < source.ReservedQuantity)
-            return Result<StockPostingResponse>.Failure("Transfer would create a negative source stock position.", 409);
+        if (CreatesNegativeStock(sourceAfter, source.ReservedQuantity))
+        {
+            var negativeStockResult = await EnsureNegativeStockAllowedAsync(tenantId, request, ct);
+            if (!negativeStockResult.IsSuccess)
+                return Result<StockPostingResponse>.Failure(negativeStockResult.Message!, negativeStockResult.StatusCode);
+        }
 
         var now = DateTime.UtcNow;
         var sourceBefore = source.OnHandQuantity;
@@ -382,6 +393,29 @@ public sealed class StockPostingService(
             InventoryMovementType.Release => -quantity,
             _ => 0
         };
+
+    private async Task<Result> EnsureNegativeStockAllowedAsync(
+        Guid tenantId,
+        PostStockMovementRequest request,
+        CancellationToken ct)
+    {
+        if (!request.AllowNegativeStock)
+            return Result.Failure("Stock movement would create a negative stock position.", 409);
+
+        var featureResult = await featureService.EnsureEnabledAsync(
+            tenantId,
+            TenantModuleFeatureKeys.Inventario,
+            TenantModuleFeatureKeys.NegativeStockSubFeature,
+            ct);
+
+        if (!featureResult.IsSuccess)
+            return featureResult;
+
+        return Result.Success();
+    }
+
+    private static bool CreatesNegativeStock(decimal onHandQuantity, decimal reservedQuantity) =>
+        onHandQuantity < 0 || reservedQuantity < 0 || onHandQuantity - reservedQuantity < 0;
 
     private static void ApplyBalance(
         StockBalance balance,

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -204,9 +204,12 @@ else
                 <BbFormFieldInput TValue="string" @bind-Value="_movementForm.ReferenceType" Label="Reference Type" />
             </div>
             <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Reason" Label="Reason" />
-            <BbFormFieldSwitch Checked="@_movementForm.AllowNegativeStock"
-                               CheckedChanged="@((bool value) => _movementForm.AllowNegativeStock = value)"
-                               Label="Allow negative stock for this posting" />
+            @if (_negativeStockEnabled)
+            {
+                <BbFormFieldSwitch Checked="@_movementForm.AllowNegativeStock"
+                                   CheckedChanged="@((bool value) => _movementForm.AllowNegativeStock = value)"
+                                   Label="Allow negative stock for this posting" />
+            }
         </div>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _movementDialogOpen = false)">Cancel</BbButton>
@@ -237,6 +240,7 @@ else
     private bool _stockEnabled;
     private bool _movementsEnabled;
     private bool _traceabilityEnabled;
+    private bool _negativeStockEnabled;
     private bool _postingMovement;
     private bool _movementDialogOpen;
     private bool IsPostMovementDisabled => _postingMovement || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
@@ -280,6 +284,9 @@ else
             _stockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances");
             _movementsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "movements");
             _traceabilityEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability");
+            _negativeStockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "negative_stock");
+            if (!_negativeStockEnabled)
+                _movementForm.AllowNegativeStock = false;
             _products = [];
             _warehouses = [];
             _locations = [];
@@ -385,7 +392,7 @@ else
                 UnitOfMeasure = NullIfEmpty(_movementForm.UnitOfMeasure),
                 ReferenceType = NullIfEmpty(_movementForm.ReferenceType),
                 Reason = NullIfEmpty(_movementForm.Reason),
-                AllowNegativeStock = _movementForm.AllowNegativeStock
+                AllowNegativeStock = _negativeStockEnabled && _movementForm.AllowNegativeStock
             });
 
             ToastService.Show(result.IsSuccess ? "Stock movement posted." : $"Failed: {result.Message}");

--- a/src/Tests/Inventario.Api.Tests/InventoryPlanningReportingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/InventoryPlanningReportingServiceTests.cs
@@ -1,10 +1,12 @@
 using System.Collections;
 using System.Linq.Expressions;
 using System.Security.Claims;
+using IdentityServer.Domain.Shared.Contracts;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Api.Services;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -185,13 +187,13 @@ public sealed class InventoryPlanningReportingServiceTests
     }
 
     private static InventoryPlanningService CreatePlanningService(FakeDataContext dataContext, Guid tenantId) =>
-        new(dataContext, CreateHttpContextAccessor(tenantId));
+        new(dataContext, CreateHttpContextAccessor(tenantId), new FakeTenantModuleFeatureService());
 
     private static InventoryReportingService CreateReportingService(
         FakeDataContext dataContext,
         Guid tenantId,
         InventoryPlanningService planningService) =>
-        new(dataContext, CreateHttpContextAccessor(tenantId), planningService);
+        new(dataContext, CreateHttpContextAccessor(tenantId), planningService, new FakeTenantModuleFeatureService());
 
     private static HttpContextAccessor CreateHttpContextAccessor(Guid tenantId) =>
         new()
@@ -203,6 +205,37 @@ public sealed class InventoryPlanningReportingServiceTests
                     authenticationType: "Test"))
             }
         };
+
+    private sealed class FakeTenantModuleFeatureService : ITenantModuleFeatureService
+    {
+        public Task<Result<bool>> IsEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<bool>.Success(IsEnabled(moduleKey, subFeatureKey)));
+
+        public Task<Result> EnsureEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(IsEnabled(moduleKey, subFeatureKey)
+                ? Result.Success()
+                : Result.Forbidden($"Feature disabled: '{TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey)}' is not enabled for this tenant."));
+
+        public void Invalidate(Guid tenantId, string moduleKey, string? subFeatureKey = null)
+        {
+        }
+
+        private static bool IsEnabled(string moduleKey, string? subFeatureKey)
+        {
+            var key = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+            return string.Equals(key, TenantModuleFeatureKeys.InventarioPlanning, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(key, TenantModuleFeatureKeys.InventarioReporting, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(key, TenantModuleFeatureKeys.InventarioTraceability, StringComparison.OrdinalIgnoreCase);
+        }
+    }
 
     private sealed record TestIds(Guid ProductId, Guid WarehouseId, Guid LocationId)
     {

--- a/src/Tests/Inventario.Api.Tests/PurchasingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/PurchasingServiceTests.cs
@@ -1,10 +1,12 @@
 using System.Collections;
 using System.Linq.Expressions;
 using System.Security.Claims;
+using IdentityServer.Domain.Shared.Contracts;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Api.Services;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -224,8 +226,38 @@ public sealed class PurchasingServiceTests
                     authenticationType: "Test"))
             }
         };
-        var stockPostingService = new StockPostingService(dataContext, httpContextAccessor);
-        return new PurchasingService(dataContext, httpContextAccessor, stockPostingService);
+        var featureService = new FakeTenantModuleFeatureService();
+        var stockPostingService = new StockPostingService(
+            dataContext,
+            httpContextAccessor,
+            featureService);
+        return new PurchasingService(dataContext, httpContextAccessor, stockPostingService, featureService);
+    }
+
+    private sealed class FakeTenantModuleFeatureService : ITenantModuleFeatureService
+    {
+        public Task<Result<bool>> IsEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<bool>.Success(IsEnabled(moduleKey, subFeatureKey)));
+
+        public Task<Result> EnsureEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(IsEnabled(moduleKey, subFeatureKey)
+                ? Result.Success()
+                : Result.Forbidden($"Feature disabled: '{TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey)}' is not enabled for this tenant."));
+
+        public void Invalidate(Guid tenantId, string moduleKey, string? subFeatureKey = null)
+        {
+        }
+
+        private static bool IsEnabled(string moduleKey, string? subFeatureKey) =>
+            string.Equals(TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey), TenantModuleFeatureKeys.InventarioPurchasing, StringComparison.OrdinalIgnoreCase);
     }
 
     private sealed record TestIds(

--- a/src/Tests/Inventario.Api.Tests/ReservationServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ReservationServiceTests.cs
@@ -1,10 +1,12 @@
 using System.Collections;
 using System.Linq.Expressions;
 using System.Security.Claims;
+using IdentityServer.Domain.Shared.Contracts;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Api.Services;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -363,9 +365,33 @@ public sealed class ReservationServiceTests
             }
         };
 
-        var stockPostingService = new StockPostingService(dataContext, httpContextAccessor);
+        var stockPostingService = new StockPostingService(
+            dataContext,
+            httpContextAccessor,
+            new FakeTenantModuleFeatureService());
         var allocationService = new InventoryAllocationService(dataContext, httpContextAccessor, stockPostingService);
         return new ReservationService(dataContext, httpContextAccessor, allocationService);
+    }
+
+    private sealed class FakeTenantModuleFeatureService : ITenantModuleFeatureService
+    {
+        public Task<Result<bool>> IsEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<bool>.Success(false));
+
+        public Task<Result> EnsureEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result.Forbidden($"Feature disabled: '{TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey)}' is not enabled for this tenant."));
+
+        public void Invalidate(Guid tenantId, string moduleKey, string? subFeatureKey = null)
+        {
+        }
     }
 
     private sealed record TestIds(Guid ProductId, Guid WarehouseId, Guid LocationId, Guid BalanceId)

--- a/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
@@ -1,10 +1,12 @@
 using System.Collections;
 using System.Linq.Expressions;
 using System.Security.Claims;
+using IdentityServer.Domain.Shared.Contracts;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Api.Services;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -87,6 +89,83 @@ public sealed class StockPostingServiceTests
         result.StatusCode.Should().Be(409);
         dataContext.Added.OfType<InventoryMovement>().Should().BeEmpty();
         dataContext.SaveCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task PostAsync_NegativeStockFlagWithoutTenantFeature_ReturnsForbiddenWithoutSaving()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        dataContext.Set<StockBalance>().Add(new StockBalance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            OnHandQuantity = 3,
+            ReservedQuantity = 0,
+            AvailableQuantity = 3
+        });
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            MovementType = InventoryMovementType.Shipment,
+            Quantity = 5,
+            AllowNegativeStock = true
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+        dataContext.Added.OfType<InventoryMovement>().Should().BeEmpty();
+        dataContext.SaveCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task PostAsync_NegativeStockFlagWithTenantFeature_AllowsNegativeBalance()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        dataContext.Set<StockBalance>().Add(new StockBalance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            OnHandQuantity = 3,
+            ReservedQuantity = 0,
+            AvailableQuantity = 3
+        });
+        var service = CreateService(dataContext, tenantId, negativeStockEnabled: true);
+
+        var result = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            MovementType = InventoryMovementType.Shipment,
+            Quantity = 5,
+            AllowNegativeStock = true
+        });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.Data!.OnHandQuantity.Should().Be(-2);
+        result.Data.AvailableQuantity.Should().Be(-2);
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x =>
+            x.MovementType == InventoryMovementType.Shipment &&
+            x.QuantityDelta == -5);
+        dataContext.SaveCount.Should().Be(1);
     }
 
     [Test]
@@ -277,7 +356,10 @@ public sealed class StockPostingServiceTests
             IsEnabled = true
         };
 
-    private static StockPostingService CreateService(FakeDataContext dataContext, Guid tenantId)
+    private static StockPostingService CreateService(
+        FakeDataContext dataContext,
+        Guid tenantId,
+        bool negativeStockEnabled = false)
     {
         var httpContextAccessor = new HttpContextAccessor
         {
@@ -289,7 +371,37 @@ public sealed class StockPostingServiceTests
             }
         };
 
-        return new StockPostingService(dataContext, httpContextAccessor);
+        return new StockPostingService(
+            dataContext,
+            httpContextAccessor,
+            new FakeTenantModuleFeatureService(negativeStockEnabled));
+    }
+
+    private sealed class FakeTenantModuleFeatureService(bool negativeStockEnabled) : ITenantModuleFeatureService
+    {
+        public Task<Result<bool>> IsEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<bool>.Success(IsEnabled(moduleKey, subFeatureKey)));
+
+        public Task<Result> EnsureEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(IsEnabled(moduleKey, subFeatureKey)
+                ? Result.Success()
+                : Result.Forbidden($"Feature disabled: '{TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey)}' is not enabled for this tenant."));
+
+        public void Invalidate(Guid tenantId, string moduleKey, string? subFeatureKey = null)
+        {
+        }
+
+        private bool IsEnabled(string moduleKey, string? subFeatureKey) =>
+            negativeStockEnabled &&
+            string.Equals(TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey), TenantModuleFeatureKeys.InventarioNegativeStock, StringComparison.OrdinalIgnoreCase);
     }
 
     private sealed class FakeDataContext : IDataContext


### PR DESCRIPTION
## Summary
- enforce Inventario subfeature gates inside lots, planning, reporting, purchasing, and negative-stock stock posting services so direct Bolt/RPC execution is protected too
- require `inventario.negative_stock` before honoring per-movement negative stock overrides
- add missing FluentValidation coverage for warehouses, locations, reservation terminal actions, PO status updates, lot status, transfer destination fields, receiving dates, and purchase status values
- hide the ControlPanel negative-stock posting switch unless the tenant has the negative-stock subfeature enabled

## Stack
- Stacked on #267 (`codex/inventario-purchasing-receiving`), which is stacked on #266, #265, and #264.
- After earlier PRs merge, this branch should be rebased/retargeted to `develop` before final merge.

## Tests
- `dotnet restore XFramework.slnx`
- `dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false --no-restore`
- `dotnet build src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj -m:1 /nr:false --no-restore`
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --no-restore`
- `dotnet build XFramework.slnx -m:1 /nr:false --no-restore`