### PR TITLE
Fix Inventario startup service registration

### DIFF
--- a/src/Modules/XFramework.Inventario/Inventario.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Installers/ServicesInstaller.cs
@@ -20,6 +20,7 @@ public class ServicesInstaller : IInstaller
         services.AddScoped<WarehouseService>();
         services.AddScoped<ReservationService>();
         services.AddScoped<InventoryAllocationService>();
+        services.AddScoped<InventoryLotService>();
         services.AddScoped<InventoryPlanningService>();
         services.AddScoped<InventoryReportingService>();
         services.AddScoped<PurchasingService>();


### PR DESCRIPTION
## Summary
- Register InventoryLotService in the Inventario service installer.
- Fix the Docker startup crash where Minimal API could not resolve the lotService endpoint parameter.

## Tests
- dotnet build src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj --no-restore -m:1 /nr:false
- dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj --no-restore -m:1 /nr:false