### PR TITLE
Deploy develop via buildserver and dev registry

### DIFF
--- a/.github/workflows/deploy-xeon-dev-bolt-hub.yml
+++ b/.github/workflows/deploy-xeon-dev-bolt-hub.yml
@@ -18,3 +18,4 @@ jobs:
       service: bolt-hub
       health_url: http://localhost:7000/health/ready
       diagnostics_services: migrate bolt-hub
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-controlpanel.yml
+++ b/.github/workflows/deploy-xeon-dev-controlpanel.yml
@@ -27,3 +27,4 @@ jobs:
       service: controlpanel
       health_url: http://localhost:5000/health/ready
       diagnostics_services: bolt-hub identityserver messaging wallets inventario controlpanel
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-identityserver.yml
+++ b/.github/workflows/deploy-xeon-dev-identityserver.yml
@@ -20,3 +20,4 @@ jobs:
       service: identityserver
       health_url: http://localhost:8261/health/ready
       diagnostics_services: bolt-hub identityserver
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-inventario.yml
+++ b/.github/workflows/deploy-xeon-dev-inventario.yml
@@ -20,3 +20,4 @@ jobs:
       service: inventario
       health_url: http://localhost:8105/health/ready
       diagnostics_services: bolt-hub messaging inventario
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-messaging.yml
+++ b/.github/workflows/deploy-xeon-dev-messaging.yml
@@ -20,3 +20,4 @@ jobs:
       service: messaging
       health_url: http://localhost:5148/health/ready
       diagnostics_services: bolt-hub smsgateway messaging
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-notifications.yml
+++ b/.github/workflows/deploy-xeon-dev-notifications.yml
@@ -18,3 +18,4 @@ jobs:
       service: notifications
       health_url: http://localhost:5166/health/ready
       diagnostics_services: bolt-hub notifications
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-operations-dashboard.yml
+++ b/.github/workflows/deploy-xeon-dev-operations-dashboard.yml
@@ -20,3 +20,4 @@ jobs:
       service: operations-dashboard
       health_url: http://localhost:5050/health/ready
       diagnostics_services: bolt-hub seq jaeger operations-dashboard
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-service.yml
+++ b/.github/workflows/deploy-xeon-dev-service.yml
@@ -12,6 +12,11 @@ on:
       diagnostics_services:
         required: true
         type: string
+    secrets:
+      XSYSTEMS_DEV_REGISTRY_USERNAME:
+        required: true
+      XSYSTEMS_DEV_REGISTRY_PASSWORD:
+        required: true
 
 permissions:
   contents: read
@@ -24,10 +29,21 @@ jobs:
   deploy:
     name: Deploy ${{ inputs.service }} to xeon-dev
     runs-on: [self-hosted, Linux, xeon-dev-deploy]
-    timeout-minutes: 45
+    timeout-minutes: 50
     env:
       COMPOSE_FILE_PATH: docker-compose.yml
+      COMPOSE_PROJECT_NAME: xframework
+      REGISTRY_HOST: xsystems-registry-dev.tailed40e.ts.net
+      REGISTRY_NAMESPACE: xframework
+      IMAGE_TAG: ${{ github.sha }}
+      CHANNEL_TAG: develop
+      DEPLOY_HOST: github-runner@xeon-dev
+      DEPLOY_SSH_KEY: /home/xeon/.ssh/xframework_xeon_dev_ed25519
+      REMOTE_DEPLOY_DIR: /home/github-runner/xframework-deploy
+      REMOTE_COMPOSE_FILE: /home/github-runner/xframework-deploy/docker-compose.yml
       XFRAMEWORK_ENV_FILE: /opt/xframework/xeon-dev.env
+      DB_PASSWORD: compose-validation-placeholder
+      JWT_SECRET: compose-validation-placeholder
       SERVICE_NAME: ${{ inputs.service }}
       HEALTH_URL: ${{ inputs.health_url }}
       DIAGNOSTICS_SERVICES: ${{ inputs.diagnostics_services }}
@@ -57,7 +73,7 @@ jobs:
 
             while IFS= read -r path; do
               case "$path" in
-                Dockerfile|docker-compose.yml|Directory.Build.props|Directory.Build.targets|Directory.Packages.props|Version.props|XFramework.slnx|global.json|NuGet.config|src/Kernel/*|src/Infrastructure/*|src/Shared/*|src/SourceGenerators/*|src/Libraries/*|src/Tools/XFramework.MigrationRunner/*|src/Modules/XFramework.Bolt/Bolt.Domain.Shared/*)
+                Dockerfile|docker-compose.yml|Directory.Build.props|Directory.Build.targets|Directory.Packages.props|Version.props|XFramework.slnx|global.json|NuGet.config|src/Kernel/*|src/Infrastructure/*|src/Shared/*|src/SourceGenerators/*|src/Libraries/*|src/Tools/XFramework.MigrationRunner/*|src/Modules/*/Migrations/*|src/Modules/XFramework.Bolt/Bolt.Domain.Shared/*)
                   has_shared=true
                   echo "Shared deployment path changed: $path"
                   ;;
@@ -73,7 +89,7 @@ jobs:
         run: |
           echo "Shared paths changed in this push; the all-services deploy workflow owns this deployment."
 
-      - name: Verify runner and Docker
+      - name: Verify build runner, Docker, registry, and deploy host
         if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
@@ -84,25 +100,84 @@ jobs:
           docker --version
           docker compose version
           curl --version
-
-          test -r "$XFRAMEWORK_ENV_FILE"
           test -S /var/run/docker.sock
           docker info --format 'Docker daemon: {{.Name}} {{.ServerVersion}}'
+
+          test -r "$DEPLOY_SSH_KEY"
+          mkdir -p ~/.ssh
+          ssh-keyscan -H xeon-dev >> ~/.ssh/known_hosts 2>/dev/null || true
+
+          registry_headers="$(mktemp)"
+          registry_status="$(curl -sS -o "$registry_headers" -w "%{http_code}" -I "https://${REGISTRY_HOST}/v2/" || true)"
+          cat "$registry_headers"
+          test "$registry_status" = "401"
+          grep -qi '^Docker-Distribution-Api-Version: registry/2.0' "$registry_headers"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "test -r '$XFRAMEWORK_ENV_FILE' && docker --version && docker compose version && curl -sSI 'https://${REGISTRY_HOST}/v2/' | sed -n '1,8p'"
 
       - name: Validate compose
         if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" config
+          docker compose -f "$COMPOSE_FILE_PATH" config >/tmp/xframework-compose.yml
 
-      - name: Deploy service
+      - name: Login to dev registry
+        if: steps.shared.outputs.has_shared != 'true'
+        shell: bash
+        env:
+          XSYSTEMS_DEV_REGISTRY_USERNAME: ${{ secrets.XSYSTEMS_DEV_REGISTRY_USERNAME }}
+          XSYSTEMS_DEV_REGISTRY_PASSWORD: ${{ secrets.XSYSTEMS_DEV_REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$XSYSTEMS_DEV_REGISTRY_USERNAME"
+          test -n "$XSYSTEMS_DEV_REGISTRY_PASSWORD"
+
+          printf '%s' "$XSYSTEMS_DEV_REGISTRY_PASSWORD" \
+            | docker login "$REGISTRY_HOST" --username "$XSYSTEMS_DEV_REGISTRY_USERNAME" --password-stdin
+
+          printf '%s' "$XSYSTEMS_DEV_REGISTRY_PASSWORD" \
+            | ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+                "docker login '$REGISTRY_HOST' --username '$XSYSTEMS_DEV_REGISTRY_USERNAME' --password-stdin"
+
+      - name: Build image on buildserver
         if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" up --build -d --no-deps "$SERVICE_NAME"
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps "$SERVICE_NAME"
+          docker compose -f "$COMPOSE_FILE_PATH" build "$SERVICE_NAME"
+
+      - name: Push image to dev registry
+        if: steps.shared.outputs.has_shared != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${REGISTRY_HOST}/${REGISTRY_NAMESPACE}/${SERVICE_NAME}:${IMAGE_TAG}"
+          channel_image="${REGISTRY_HOST}/${REGISTRY_NAMESPACE}/${SERVICE_NAME}:${CHANNEL_TAG}"
+
+          docker tag "$image" "$channel_image"
+          docker push "$image"
+          docker push "$channel_image"
+
+      - name: Deploy service on xeon-dev
+        if: steps.shared.outputs.has_shared != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" "mkdir -p '$REMOTE_DEPLOY_DIR'"
+          scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$COMPOSE_FILE_PATH" "$DEPLOY_HOST:$REMOTE_COMPOSE_FILE"
+
+          remote_env="COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' REGISTRY_HOST='$REGISTRY_HOST' REGISTRY_NAMESPACE='$REGISTRY_NAMESPACE' IMAGE_TAG='$IMAGE_TAG'"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' pull '$SERVICE_NAME'"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' up -d --no-build --no-deps '$SERVICE_NAME'"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' ps '$SERVICE_NAME'"
 
       - name: Wait for readiness
         if: steps.shared.outputs.has_shared != 'true'
@@ -115,7 +190,10 @@ jobs:
 
           ready=0
           for attempt in {1..60}; do
-            status="$(curl -fsS -o "$body" -w "%{http_code}" "$HEALTH_URL" || true)"
+            status="$(
+              ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+                "curl -sS -o '$body' -w '%{http_code}' '$HEALTH_URL' || true"
+            )"
             if [ "$status" = "200" ]; then
               ready=1
               break
@@ -127,7 +205,7 @@ jobs:
 
           if [ "$ready" -ne 1 ]; then
             echo "::error::${SERVICE_NAME} failed readiness check at ${HEALTH_URL}"
-            cat "$body" || true
+            ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" "cat '$body' || true"
             exit 1
           fi
 
@@ -135,5 +213,8 @@ jobs:
         if: failure() && steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps || true
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 $DIAGNOSTICS_SERVICES || true
+          remote_env="COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' REGISTRY_HOST='$REGISTRY_HOST' REGISTRY_NAMESPACE='$REGISTRY_NAMESPACE' IMAGE_TAG='$IMAGE_TAG'"
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' ps" || true
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' logs --tail=200 $DIAGNOSTICS_SERVICES" || true

--- a/.github/workflows/deploy-xeon-dev-smsgateway.yml
+++ b/.github/workflows/deploy-xeon-dev-smsgateway.yml
@@ -18,3 +18,4 @@ jobs:
       service: smsgateway
       health_url: http://localhost:5274/health/ready
       diagnostics_services: bolt-hub smsgateway
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-wallets.yml
+++ b/.github/workflows/deploy-xeon-dev-wallets.yml
@@ -18,3 +18,4 @@ jobs:
       service: wallets
       health_url: http://localhost:9696/health/ready
       diagnostics_services: bolt-hub wallets
+    secrets: inherit

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -19,6 +19,7 @@ on:
       - src/SourceGenerators/**
       - src/Libraries/**
       - src/Tools/XFramework.MigrationRunner/**
+      - src/Modules/**/Migrations/**
       - src/Modules/XFramework.Bolt/Bolt.Domain.Shared/**
   workflow_dispatch:
 
@@ -33,10 +34,21 @@ jobs:
   deploy:
     name: Deploy all services to xeon-dev
     runs-on: [self-hosted, Linux, xeon-dev-deploy]
-    timeout-minutes: 60
+    timeout-minutes: 75
     env:
       COMPOSE_FILE_PATH: docker-compose.yml
+      COMPOSE_PROJECT_NAME: xframework
+      REGISTRY_HOST: xsystems-registry-dev.tailed40e.ts.net
+      REGISTRY_NAMESPACE: xframework
+      IMAGE_TAG: ${{ github.sha }}
+      CHANNEL_TAG: develop
+      DEPLOY_HOST: github-runner@xeon-dev
+      DEPLOY_SSH_KEY: /home/xeon/.ssh/xframework_xeon_dev_ed25519
+      REMOTE_DEPLOY_DIR: /home/github-runner/xframework-deploy
+      REMOTE_COMPOSE_FILE: /home/github-runner/xframework-deploy/docker-compose.yml
       XFRAMEWORK_ENV_FILE: /opt/xframework/xeon-dev.env
+      DB_PASSWORD: compose-validation-placeholder
+      JWT_SECRET: compose-validation-placeholder
 
     steps:
       - name: Checkout
@@ -44,7 +56,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Verify runner and Docker
+      - name: Verify build runner, Docker, registry, and deploy host
         shell: bash
         run: |
           set -euo pipefail
@@ -54,23 +66,122 @@ jobs:
           docker --version
           docker compose version
           curl --version
-
-          test -r "$XFRAMEWORK_ENV_FILE"
           test -S /var/run/docker.sock
           docker info --format 'Docker daemon: {{.Name}} {{.ServerVersion}}'
+
+          test -r "$DEPLOY_SSH_KEY"
+          mkdir -p ~/.ssh
+          ssh-keyscan -H xeon-dev >> ~/.ssh/known_hosts 2>/dev/null || true
+
+          registry_headers="$(mktemp)"
+          registry_status="$(curl -sS -o "$registry_headers" -w "%{http_code}" -I "https://${REGISTRY_HOST}/v2/" || true)"
+          cat "$registry_headers"
+          test "$registry_status" = "401"
+          grep -qi '^Docker-Distribution-Api-Version: registry/2.0' "$registry_headers"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "test -r '$XFRAMEWORK_ENV_FILE' && docker --version && docker compose version && curl -sSI 'https://${REGISTRY_HOST}/v2/' | sed -n '1,8p'"
 
       - name: Validate compose
         shell: bash
         run: |
           set -euo pipefail
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" config
+          docker compose -f "$COMPOSE_FILE_PATH" config >/tmp/xframework-compose.yml
 
-      - name: Deploy stack
+      - name: Login to dev registry
+        shell: bash
+        env:
+          XSYSTEMS_DEV_REGISTRY_USERNAME: ${{ secrets.XSYSTEMS_DEV_REGISTRY_USERNAME }}
+          XSYSTEMS_DEV_REGISTRY_PASSWORD: ${{ secrets.XSYSTEMS_DEV_REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$XSYSTEMS_DEV_REGISTRY_USERNAME"
+          test -n "$XSYSTEMS_DEV_REGISTRY_PASSWORD"
+
+          printf '%s' "$XSYSTEMS_DEV_REGISTRY_PASSWORD" \
+            | docker login "$REGISTRY_HOST" --username "$XSYSTEMS_DEV_REGISTRY_USERNAME" --password-stdin
+
+          printf '%s' "$XSYSTEMS_DEV_REGISTRY_PASSWORD" \
+            | ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+                "docker login '$REGISTRY_HOST' --username '$XSYSTEMS_DEV_REGISTRY_USERNAME' --password-stdin"
+
+      - name: Build images on buildserver
         shell: bash
         run: |
           set -euo pipefail
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" up --build -d
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps
+          services=(
+            migrate
+            bolt-hub
+            identityserver
+            messaging
+            notifications
+            smsgateway
+            wallets
+            inventario
+            controlpanel
+            operations-dashboard
+          )
+
+          docker compose -f "$COMPOSE_FILE_PATH" build "${services[@]}"
+
+      - name: Push images to dev registry
+        shell: bash
+        run: |
+          set -euo pipefail
+          services=(
+            migrate
+            bolt-hub
+            identityserver
+            messaging
+            notifications
+            smsgateway
+            wallets
+            inventario
+            controlpanel
+            operations-dashboard
+          )
+
+          for service in "${services[@]}"; do
+            image="${REGISTRY_HOST}/${REGISTRY_NAMESPACE}/${service}:${IMAGE_TAG}"
+            channel_image="${REGISTRY_HOST}/${REGISTRY_NAMESPACE}/${service}:${CHANNEL_TAG}"
+            docker tag "$image" "$channel_image"
+            docker push "$image"
+            docker push "$channel_image"
+          done
+
+      - name: Deploy stack on xeon-dev
+        shell: bash
+        run: |
+          set -euo pipefail
+          pull_services=(
+            postgres
+            seq
+            jaeger
+            migrate
+            bolt-hub
+            identityserver
+            messaging
+            notifications
+            smsgateway
+            wallets
+            inventario
+            controlpanel
+            operations-dashboard
+          )
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" "mkdir -p '$REMOTE_DEPLOY_DIR'"
+          scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$COMPOSE_FILE_PATH" "$DEPLOY_HOST:$REMOTE_COMPOSE_FILE"
+
+          remote_env="COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' REGISTRY_HOST='$REGISTRY_HOST' REGISTRY_NAMESPACE='$REGISTRY_NAMESPACE' IMAGE_TAG='$IMAGE_TAG'"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' pull ${pull_services[*]}"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' up -d --no-build"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' ps"
 
       - name: Wait for readiness
         shell: bash
@@ -97,7 +208,10 @@ jobs:
 
             ready=0
             for attempt in {1..60}; do
-              status="$(curl -fsS -o "$body" -w "%{http_code}" "$url" || true)"
+              status="$(
+                ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+                  "curl -sS -o '$body' -w '%{http_code}' '$url' || true"
+              )"
               if [ "$status" = "200" ]; then
                 ready=1
                 break
@@ -109,7 +223,7 @@ jobs:
 
             if [ "$ready" -ne 1 ]; then
               echo "::error::${name} failed readiness check at ${url}"
-              cat "$body" || true
+              ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" "cat '$body' || true"
               exit 1
             fi
           done
@@ -118,5 +232,8 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" ps || true
-          docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$COMPOSE_FILE_PATH" logs --tail=200 migrate bolt-hub identityserver messaging notifications smsgateway wallets inventario controlpanel operations-dashboard seq jaeger || true
+          remote_env="COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' REGISTRY_HOST='$REGISTRY_HOST' REGISTRY_NAMESPACE='$REGISTRY_NAMESPACE' IMAGE_TAG='$IMAGE_TAG'"
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' ps" || true
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' logs --tail=200 migrate bolt-hub identityserver messaging notifications smsgateway wallets inventario controlpanel operations-dashboard seq jaeger" || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
 
   # ── Database Migration Runner (runs once, then exits) ───────
   migrate:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/migrate:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -53,6 +54,7 @@ services:
 
   # ── Bolt Hub (must be healthy before services start) ─────────
   bolt-hub:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/bolt-hub:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -77,6 +79,7 @@ services:
 
   # ── Identity Server ─────────────────────────────────────────
   identityserver:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/identityserver:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -98,6 +101,7 @@ services:
 
   # ── Messaging Server ────────────────────────────────────────
   messaging:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/messaging:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -119,6 +123,7 @@ services:
 
   # ── Notifications Server ────────────────────────────────────
   notifications:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/notifications:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -140,6 +145,7 @@ services:
 
   # ── SMS Gateway ─────────────────────────────────────────────
   smsgateway:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/smsgateway:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -161,6 +167,7 @@ services:
 
   # ── Wallets Server ──────────────────────────────────────────
   wallets:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/wallets:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -182,6 +189,7 @@ services:
 
   # ── Inventario Server ───────────────────────────────────────
   inventario:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/inventario:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -203,6 +211,7 @@ services:
 
   # ── Control Panel ───────────────────────────────────────────
   controlpanel:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/controlpanel:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile
@@ -234,6 +243,7 @@ services:
   # ── Seq (structured log aggregator) ──────────────────────────
   # Operations Dashboard
   operations-dashboard:
+    image: ${REGISTRY_HOST:-xsystems-registry-dev.tailed40e.ts.net}/${REGISTRY_NAMESPACE:-xframework}/operations-dashboard:${IMAGE_TAG:-develop}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- Builds develop deploy images on `xeon-buildserver01` and pushes to the private dev registry.
- Deploys xeon-dev by SSHing to `github-runner@xeon-dev`, pulling registry images, and running `docker compose up -d --no-build`.
- Adds registry-backed image names for buildable compose services while keeping service-specific and all-services workflow separation.
- Pins `COMPOSE_PROJECT_NAME=xframework` so remote deploys update the existing xeon-dev compose project.

## Validation
- Parsed all workflow YAML files with PyYAML.
- Ran local compose config with placeholder required env vars.
- Validated compose config on `xeon-buildserver01`.
- Copied compose to xeon-dev deploy dir and validated against `/opt/xframework/xeon-dev.env` without restarting containers.
- Verified registry `/v2/` returns expected 401 + `Docker-Distribution-Api-Version: registry/2.0` from both buildserver and xeon-dev.
- Verified buildserver runner is online and old xeon-dev runner service is disabled.
- Reset dev registry htpasswd file to the intended `docker` credential, removed the misleading comment line, and restarted only the dev registry container.
- GitHub secrets `XSYSTEMS_DEV_REGISTRY_USERNAME` and `XSYSTEMS_DEV_REGISTRY_PASSWORD` are configured.
- Wallets service workflow passed from PR branch: https://github.com/kaizendevsio/XFramework/actions/runs/27828320731
- Full-stack workflow passed from PR branch: https://github.com/kaizendevsio/XFramework/actions/runs/27828526668