### PR TITLE
Allow unauthenticated Seq in dev compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,6 +281,7 @@ services:
     image: datalust/seq:2025
     environment:
       ACCEPT_EULA: "Y"
+      SEQ_FIRSTRUN_NOAUTHENTICATION: "true"
     ports:
       - "${SEQ_EXPOSE_PORT:-5341}:80"
     volumes:


### PR DESCRIPTION
## Summary
- Adds `SEQ_FIRSTRUN_NOAUTHENTICATION=true` for the dev Seq container.

## Why
- After the buildserver registry deploy, Seq restarted from `datalust/seq:2025` and exited because first-run auth was not configured.
- The xeon-dev stack is a private dev environment and existing app configs point at Seq without credentials.

## Validation
- `docker-compose -f docker-compose.yml config` passes locally with placeholder required env vars.