### PR TITLE
Avoid dev Seq host port conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -283,7 +283,7 @@ services:
       ACCEPT_EULA: "Y"
       SEQ_FIRSTRUN_NOAUTHENTICATION: "true"
     ports:
-      - "${SEQ_EXPOSE_PORT:-5341}:80"
+      - "${SEQ_EXPOSE_PORT:-5342}:80"
     volumes:
       - seqdata:/data
 


### PR DESCRIPTION
## Summary
- Changes the xframework Seq host port default from 5341 to 5342.

## Why
- xeon-dev already has a separate running container named `seq` bound to host port 5341.
- The xframework compose service still uses internal `seq:80`; this only avoids the host-port conflict.

## Validation
- `docker-compose -f docker-compose.yml config` passes locally with placeholder required env vars.