### PR TITLE
Label Inventario ControlPanel icon actions

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
@@ -50,15 +50,15 @@ else
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
                                     <div class="flex items-center gap-1" @onclick:stopPropagation="true">
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View category"
                                                   OnClick="@(() => Navigation.NavigateTo($"/inventario/categories/{item.Id}"))">
                                             <LucideIcon Name="eye" class="h-4 w-4" />
                                         </BbButton>
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Edit category"
                                                   OnClick="@(() => OpenEditDialog(item))">
                                             <LucideIcon Name="pencil" class="h-4 w-4" />
                                         </BbButton>
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Delete category"
                                                   OnClick="@(() => OpenDeleteDialog(item))">
                                             <LucideIcon Name="trash-2" class="h-4 w-4" />
                                         </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/CategoryDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/CategoryDetail.razor
@@ -38,7 +38,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex items-center gap-4">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to categories"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/categories"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/InventoryMovementDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/InventoryMovementDetail.razor
@@ -38,7 +38,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex items-center gap-4">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to stock"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/stock"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LocationDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LocationDetail.razor
@@ -39,7 +39,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex items-center gap-4">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to warehouses"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/warehouses"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LotDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LotDetail.razor
@@ -39,7 +39,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex items-center gap-4">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to lots"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/lots"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
@@ -65,7 +65,7 @@ else
                             <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
-                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View lot"
                                               OnClick="@(() => Navigation.NavigateTo($"/inventario/lots/{item.Id}"))">
                                         <LucideIcon Name="eye" class="h-4 w-4" />
                                     </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -38,7 +38,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex items-center gap-4">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to products"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductTransactionDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductTransactionDetail.razor
@@ -38,7 +38,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex items-center gap-4">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to transactions"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/transactions"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
@@ -100,11 +100,11 @@ else
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
                                     <div class="flex items-center gap-1">
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View product"
                                                   OnClick="@(() => Navigation.NavigateTo($"/inventario/products/{item.Id}"))">
                                             <LucideIcon Name="eye" class="h-4 w-4" />
                                         </BbButton>
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Edit product"
                                                   OnClick="@(() => OpenEditDialog(item))">
                                             <LucideIcon Name="pencil" class="h-4 w-4" />
                                         </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrderDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrderDetail.razor
@@ -32,7 +32,7 @@ else
         <div class="space-y-6">
             <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div class="flex items-center gap-3">
-                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" OnClick="@GoBack">
+                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" AriaLabel="Back to purchase orders" OnClick="@GoBack">
                         <LucideIcon Name="arrow-left" class="h-4 w-4" />
                     </BbButton>
                     <div>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
@@ -65,7 +65,7 @@ else
                             </BbDataGridTemplateColumn>
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
-                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View purchase order"
                                               OnClick="@(() => Navigation.NavigateTo($"/inventario/purchase-orders/{item.Id}"))">
                                         <LucideIcon Name="eye" class="h-4 w-4" />
                                     </BbButton>
@@ -137,7 +137,7 @@ else
                             <BbFormFieldInput TValue="string" @bind-Value="line.Quantity" Label="Quantity" />
                             <BbFormFieldInput TValue="string" @bind-Value="line.UnitCost" Label="Unit Cost" />
                             <div class="flex items-end">
-                                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Remove line"
                                           Disabled="@(_form.Lines.Count == 1)"
                                           OnClick="@(() => RemoveLine(index))">
                                     <LucideIcon Name="trash-2" class="h-4 w-4" />

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
@@ -66,7 +66,7 @@ else
                             </BbDataGridTemplateColumn>
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
-                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View receiving document"
                                               OnClick="@(() => Navigation.NavigateTo($"/inventario/receiving/{item.Id}"))">
                                         <LucideIcon Name="eye" class="h-4 w-4" />
                                     </BbButton>
@@ -179,7 +179,7 @@ else
                                 <BbFormFieldInput TValue="string" @bind-Value="line.Quantity" Label="Quantity" />
                                 <BbFormFieldInput TValue="string" @bind-Value="line.UnitCost" Label="Unit Cost" />
                                 <div class="flex items-end">
-                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Remove line"
                                               Disabled="@(_form.Lines.Count == 1)"
                                               OnClick="@(() => RemoveLine(index))">
                                         <LucideIcon Name="trash-2" class="h-4 w-4" />

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReceivingDocumentDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReceivingDocumentDetail.razor
@@ -31,7 +31,7 @@ else
         <div class="space-y-6">
             <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div class="flex items-center gap-3">
-                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" OnClick="@GoBack">
+                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" AriaLabel="Back to receiving" OnClick="@GoBack">
                         <LucideIcon Name="arrow-left" class="h-4 w-4" />
                     </BbButton>
                     <div>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReservationDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReservationDetail.razor
@@ -41,7 +41,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex flex-col gap-3 md:flex-row md:items-center">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to reservations"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/reservations"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
@@ -84,7 +84,7 @@ else
                                     else
                                     {
                                         <div @onclick:stopPropagation="true">
-                                            <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                            <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View reservation"
                                                       OnClick="@(() => Navigation.NavigateTo($"/inventario/reservations/{item.Id}"))">
                                                 <LucideIcon Name="eye" class="h-4 w-4" />
                                             </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -78,7 +78,7 @@ else
                                 <BbDataGridPropertyColumn Property="@(x => x.LastMovementAt)" Title="Last Movement" Sortable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View stock balance"
                                                   OnClick="@(() => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))">
                                             <LucideIcon Name="eye" class="h-4 w-4" />
                                         </BbButton>
@@ -119,7 +119,7 @@ else
                                 <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View movement"
                                                   OnClick="@(() => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))">
                                             <LucideIcon Name="eye" class="h-4 w-4" />
                                         </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/StockBalanceDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/StockBalanceDetail.razor
@@ -38,7 +38,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex items-center gap-4">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to stock"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/stock"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
@@ -52,7 +52,7 @@ else
                             <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
-                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View transaction"
                                               OnClick="@(() => Navigation.NavigateTo($"/inventario/transactions/{item.Id}"))">
                                         <LucideIcon Name="eye" class="h-4 w-4" />
                                     </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/WarehouseDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/WarehouseDetail.razor
@@ -38,7 +38,7 @@ else
     <FadeInContent>
         <div class="space-y-6">
             <div class="flex items-center gap-4">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to warehouses"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/warehouses"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
@@ -67,7 +67,7 @@ else
                             </BbDataGridTemplateColumn>
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
-                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View warehouse"
                                               OnClick="@(() => Navigation.NavigateTo($"/inventario/warehouses/{item.Id}"))">
                                         <LucideIcon Name="eye" class="h-4 w-4" />
                                     </BbButton>
@@ -101,7 +101,7 @@ else
                             </BbDataGridTemplateColumn>
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
-                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View location"
                                               OnClick="@(() => Navigation.NavigateTo($"/inventario/locations/{item.Id}"))">
                                         <LucideIcon Name="eye" class="h-4 w-4" />
                                     </BbButton>


### PR DESCRIPTION
## Summary
- Add accessible labels to Inventario icon-only list/detail action buttons.
- Covers view/edit/delete actions, back buttons, and dynamic form remove-line buttons.

## Test Plan
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj --no-restore -m:1 /nr:false`
- Browser smoke on xeon-dev before patch identified the issue and confirmed Inventario routes render after a fresh Blazor circuit.