### PR TITLE
Improve Inventario ControlPanel layouts

### DIFF
--- a/docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md
+++ b/docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md
@@ -116,6 +116,18 @@ ControlPanel forms should use framework controls that match the data type:
 
 For `BbCombobox`, prefer typed `SelectOption<TValue>` options when the selection is simple. Use compositional `BbComboboxItem` only when the option rows need rich custom markup.
 
+## Operational Page Layout
+
+For module admin surfaces such as Inventario, keep list and detail workflows distinct:
+
+- List pages are for scanning, filtering, creating small records, and navigating to detail pages.
+- Viewing and editing existing records should happen on the detail page with a clear edit mode, not in list-page edit modals.
+- Detail pages should show the operational context users need for that entity. For example, product detail should include catalog fields, replenishment rules, stock balances by warehouse/location/lot, and traceability records when those features are enabled.
+- Header actions belong on the far right of the page header. Use the shared `xf-page-header` and `xf-page-actions` classes instead of hand-assembling inconsistent flex utility combinations.
+- Card headers that combine a title with search/filter controls should use `xf-page-header` plus `xf-filter-actions`; do not assume arbitrary responsive width utilities such as `md:w-[28rem]` are available in the compiled app CSS.
+- Summary metrics should use the shared `xf-summary-grid` classes. Do not rely on new responsive Tailwind utility class names until the compiled `wwwroot/css/app.css` is verified to include them on xeon-dev.
+- Avoid card-in-card summary layouts unless the surrounding component is a true detail surface. Dense operational pages should use stable grids and tables that do not collapse to one full-width row on desktop.
+
 ## Visual Verification Workflow
 
 Use the Codex built-in browser for BlazorBlueprint work that touches interactive UI:

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
@@ -20,15 +20,17 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex items-center justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Product Categories</BbTypographyH3>
                     <BbTypographyMuted>Manage catalog categories for the selected tenant.</BbTypographyMuted>
                 </div>
-                <BbButton OnClick="@OpenCreateDialog">
-                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
-                    Create Category
-                </BbButton>
+                <div class="xf-page-actions">
+                    <BbButton OnClick="@OpenCreateDialog">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Create Category
+                    </BbButton>
+                </div>
             </div>
 
             <BbCard>
@@ -54,10 +56,6 @@ else
                                                   OnClick="@(() => Navigation.NavigateTo($"/inventario/categories/{item.Id}"))">
                                             <LucideIcon Name="eye" class="h-4 w-4" />
                                         </BbButton>
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Edit category"
-                                                  OnClick="@(() => OpenEditDialog(item))">
-                                            <LucideIcon Name="pencil" class="h-4 w-4" />
-                                        </BbButton>
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Delete category"
                                                   OnClick="@(() => OpenDeleteDialog(item))">
                                             <LucideIcon Name="trash-2" class="h-4 w-4" />
@@ -76,7 +74,7 @@ else
 <BbDialog Open="@_dialogOpen" OpenChanged="@(v => _dialogOpen = v)">
     <BbDialogContent>
         <BbDialogHeader>
-            <BbDialogTitle>@(_editingCategory is null ? "Create Category" : "Edit Category")</BbDialogTitle>
+            <BbDialogTitle>Create Category</BbDialogTitle>
             <BbDialogDescription>Categories organize products in this tenant.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
@@ -85,7 +83,7 @@ else
         </div>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _dialogOpen = false)">Cancel</BbButton>
-            <BbButton OnClick="@SaveCategory" Disabled="@_saving">@(_editingCategory is null ? "Create" : "Save")</BbButton>
+            <BbButton OnClick="@SaveCategory" Disabled="@_saving">Create</BbButton>
         </BbDialogFooter>
     </BbDialogContent>
 </BbDialog>
@@ -110,7 +108,6 @@ else
     private bool _moduleEnabled;
     private bool _dialogOpen;
     private bool _deleteDialogOpen;
-    private ProductCategory? _editingCategory;
     private ProductCategory? _deletingCategory;
     private string _name = "";
     private string _description = "";
@@ -170,17 +167,8 @@ else
 
     private void OpenCreateDialog()
     {
-        _editingCategory = null;
         _name = "";
         _description = "";
-        _dialogOpen = true;
-    }
-
-    private void OpenEditDialog(ProductCategory category)
-    {
-        _editingCategory = category;
-        _name = category.Name ?? "";
-        _description = category.Description ?? "";
         _dialogOpen = true;
     }
 
@@ -202,41 +190,20 @@ else
         _saving = true;
         try
         {
-            if (_editingCategory is null)
+            DataContext.Add(new ProductCategory
             {
-                DataContext.Add(new ProductCategory
-                {
-                    Id = Guid.NewGuid(),
-                    TenantId = tenantId,
-                    Name = _name.Trim(),
-                    Description = string.IsNullOrWhiteSpace(_description) ? null : _description.Trim(),
-                    CreatedAt = DateTime.UtcNow,
-                    IsEnabled = true
-                });
-            }
-            else
-            {
-                var fresh = await DataContext.Query<ProductCategory>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.Id == _editingCategory.Id && x.TenantId == tenantId)
-                    .FirstOrDefaultAsync();
-                if (fresh is null)
-                {
-                    ToastService.Show("Category not found.");
-                    return;
-                }
-
-                fresh.Name = _name.Trim();
-                fresh.Description = string.IsNullOrWhiteSpace(_description) ? null : _description.Trim();
-                fresh.ModifiedAt = DateTime.UtcNow;
-                DataContext.Update(fresh);
-            }
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                Name = _name.Trim(),
+                Description = string.IsNullOrWhiteSpace(_description) ? null : _description.Trim(),
+                CreatedAt = DateTime.UtcNow,
+                IsEnabled = true
+            });
 
             var result = await DataContext.SaveChangesAsync();
             if (result.IsSuccess)
             {
-                ToastService.Show(_editingCategory is null ? "Category created." : "Category updated.");
+                ToastService.Show("Category created.");
                 _dialogOpen = false;
                 await Reload();
             }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/CategoryDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/CategoryDetail.razor
@@ -37,23 +37,40 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex items-center gap-4">
+            <div class="xf-detail-header">
                 <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to categories"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/categories"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>
-                <div class="flex-1">
-                    <div class="flex items-center gap-2">
+                <div class="xf-detail-header-main">
+                    <div class="xf-detail-header-title">
                         <BbTypographyH3>@(_category.Name ?? "Unnamed Category")</BbTypographyH3>
                         <StatusBadge Text="@(_category.IsEnabled ? "Enabled" : "Disabled")"
                                      Status="@(_category.IsEnabled ? "active" : "inactive")" />
                     </div>
                     <BbTypographyMuted>ID: @_category.Id</BbTypographyMuted>
                 </div>
-                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
-                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-                    Refresh
-                </BbButton>
+                <div class="xf-page-actions">
+                    @if (_editMode)
+                    {
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@CancelEdit" Disabled="@_saving">Discard</BbButton>
+                        <BbButton OnClick="@SaveCategory" Disabled="@_saving">
+                            <LucideIcon Name="save" class="mr-2 h-4 w-4" />
+                            Save
+                        </BbButton>
+                    }
+                    else
+                    {
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                            Refresh
+                        </BbButton>
+                        <BbButton OnClick="@StartEdit">
+                            <LucideIcon Name="pencil" class="mr-2 h-4 w-4" />
+                            Edit
+                        </BbButton>
+                    }
+                </div>
             </div>
 
             <BbCard>
@@ -62,28 +79,41 @@ else
                     <BbCardDescription>Catalog category details for the selected tenant.</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <div class="grid gap-4 md:grid-cols-2">
-                        <div>
-                            <BbTypographyMuted>Name</BbTypographyMuted>
-                            <div>@(_category.Name ?? "Unnamed Category")</div>
+                    @if (_editMode)
+                    {
+                        <div class="grid gap-4">
+                            <BbFormFieldInput TValue="string" @bind-Value="_name" Label="Name" Required="true" />
+                            <BbFormFieldInput TValue="string" @bind-Value="_description" Label="Description" />
+                            <BbFormFieldSwitch Checked="@_isEnabled"
+                                               CheckedChanged="@((bool value) => _isEnabled = value)"
+                                               Label="Enabled" />
                         </div>
-                        <div>
-                            <BbTypographyMuted>Products</BbTypographyMuted>
-                            <div>@_products.Count</div>
+                    }
+                    else
+                    {
+                        <div class="xf-detail-field-grid">
+                            <div>
+                                <BbTypographyMuted>Name</BbTypographyMuted>
+                                <div>@(_category.Name ?? "Unnamed Category")</div>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Products</BbTypographyMuted>
+                                <div>@_products.Count</div>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Created</BbTypographyMuted>
+                                <div>@_category.CreatedAt.ToLocalTime().ToString("g")</div>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Last Modified</BbTypographyMuted>
+                                <div>@(_category.ModifiedAt?.ToLocalTime().ToString("g") ?? "Never")</div>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Description</BbTypographyMuted>
+                                <div>@(_category.Description ?? "No description")</div>
+                            </div>
                         </div>
-                        <div>
-                            <BbTypographyMuted>Created</BbTypographyMuted>
-                            <div>@_category.CreatedAt.ToLocalTime().ToString("g")</div>
-                        </div>
-                        <div>
-                            <BbTypographyMuted>Last Modified</BbTypographyMuted>
-                            <div>@(_category.ModifiedAt?.ToLocalTime().ToString("g") ?? "Never")</div>
-                        </div>
-                        <div class="md:col-span-2">
-                            <BbTypographyMuted>Description</BbTypographyMuted>
-                            <div>@(_category.Description ?? "No description")</div>
-                        </div>
-                    </div>
+                    }
                 </BbCardContent>
             </BbCard>
 
@@ -139,6 +169,11 @@ else
     private bool _hasTenant;
     private bool _moduleEnabled;
     private bool _outsideTenantContext;
+    private bool _editMode;
+    private bool _saving;
+    private bool _isEnabled = true;
+    private string _name = "";
+    private string _description = "";
     private Guid? _loadedId;
 
     protected override void OnInitialized()
@@ -186,6 +221,9 @@ else
                 .OrderBy(x => x.Name)
                 .Take(250)
                 .ToListAsync();
+
+            if (!_editMode)
+                LoadForm();
         }
         catch (Exception ex)
         {
@@ -195,6 +233,77 @@ else
         {
             _loading = false;
             StateHasChanged();
+        }
+    }
+
+    private void StartEdit()
+    {
+        LoadForm();
+        _editMode = true;
+    }
+
+    private void CancelEdit()
+    {
+        LoadForm();
+        _editMode = false;
+    }
+
+    private void LoadForm()
+    {
+        if (_category is null) return;
+        _name = _category.Name ?? "";
+        _description = _category.Description ?? "";
+        _isEnabled = _category.IsEnabled;
+    }
+
+    private async Task SaveCategory()
+    {
+        if (_category is null || TenantFilter.SelectedTenantId is not Guid tenantId) return;
+        if (string.IsNullOrWhiteSpace(_name))
+        {
+            ToastService.Show("Category name is required.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var fresh = await DataContext.Query<ProductCategory>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == _category.Id && x.TenantId == tenantId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+            if (fresh is null)
+            {
+                ToastService.Show("Category not found.");
+                return;
+            }
+
+            fresh.Name = _name.Trim();
+            fresh.Description = string.IsNullOrWhiteSpace(_description) ? null : _description.Trim();
+            fresh.IsEnabled = _isEnabled;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show("Category updated.");
+                _editMode = false;
+                await Reload();
+            }
+            else
+            {
+                ToastService.Show($"Failed to save category: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving category: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
         }
     }
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/InventoryMovementDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/InventoryMovementDetail.razor
@@ -55,7 +55,7 @@ else
                 </BbButton>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div class="xf-summary-grid xf-summary-grid-3">
                 <BbCard>
                     <BbCardContent>
                         <div class="space-y-1 pt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LocationDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LocationDetail.razor
@@ -96,7 +96,7 @@ else
                 </BbCardContent>
             </BbCard>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div class="xf-summary-grid xf-summary-grid-3">
                 <BbCard>
                     <BbCardContent>
                         <div class="space-y-1 pt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LotDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LotDetail.razor
@@ -56,7 +56,7 @@ else
                 </BbButton>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div class="xf-summary-grid xf-summary-grid-3">
                 <BbCard>
                     <BbCardContent>
                         <div class="space-y-1 pt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
@@ -22,12 +22,12 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Lots and Batches</BbTypographyH3>
                     <BbTypographyMuted>Track inventory by product, source, received date, and expiry.</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     <BbButton OnClick="@OpenCreateDialog" Disabled="@(_products.Count == 0)">
                         <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
                         Create Lot

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
@@ -20,12 +20,12 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Replenishment Planning</BbTypographyH3>
                     <BbTypographyMuted>Maintain reorder rules and review suggested replenishment quantities.</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     <BbButton OnClick="@OpenRuleDialog">
                         <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
                         Add Rule
@@ -37,7 +37,7 @@ else
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div class="xf-summary-grid xf-summary-grid-3">
                 <BbCard>
                     <BbCardContent>
                         <div class="space-y-1 pt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -37,49 +37,205 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex items-center gap-4">
+            <div class="xf-detail-header">
                 <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to products"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>
-                <div class="flex-1">
-                    <div class="flex items-center gap-2">
+                <div class="xf-detail-header-main">
+                    <div class="xf-detail-header-title">
                         <BbTypographyH3>@(_product.Name ?? "Unnamed Product")</BbTypographyH3>
                         <StatusBadge Text="@(_product.IsAvailable ? "Available" : "Unavailable")"
                                      Status="@(_product.IsAvailable ? "active" : "inactive")" />
                     </div>
-                    <BbTypographyMuted>SKU: @(_product.SKU ?? "N/A") — Category: @(_product.Category?.Name ?? "Uncategorized")</BbTypographyMuted>
+                    <BbTypographyMuted>SKU: @(_product.SKU ?? "N/A") - Category: @GetCategoryName(_product.CategoryId)</BbTypographyMuted>
                 </div>
+                <div class="xf-page-actions">
+                    @if (_editMode)
+                    {
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@CancelEdit" Disabled="@_saving">
+                            Discard
+                        </BbButton>
+                        <BbButton OnClick="@SaveProduct" Disabled="@_saving">
+                            <LucideIcon Name="save" class="mr-2 h-4 w-4" />
+                            Save
+                        </BbButton>
+                    }
+                    else
+                    {
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                            Refresh
+                        </BbButton>
+                        <BbButton OnClick="@StartEdit">
+                            <LucideIcon Name="pencil" class="mr-2 h-4 w-4" />
+                            Edit
+                        </BbButton>
+                    }
+                </div>
+            </div>
+
+            <div class="xf-summary-grid xf-summary-grid-4">
+                <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Price</BbTypographyMuted><BbTypographyH3>@_product.Price.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
+                <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Available Stock</BbTypographyMuted><BbTypographyH3>@TotalAvailable.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
+                <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Locations</BbTypographyMuted><BbTypographyH3>@ActiveLocationCount</BbTypographyH3></div></BbCardContent></BbCard>
+                <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Reorder Rules</BbTypographyMuted><BbTypographyH3>@_reorderRules.Count</BbTypographyH3></div></BbCardContent></BbCard>
             </div>
 
             <BbCard>
                 <BbCardHeader>
                     <BbCardTitle>Product Summary</BbCardTitle>
-                    <BbCardDescription>Catalog and stock snapshot for this tenant.</BbCardDescription>
+                    <BbCardDescription>Catalog fields, availability, and lifecycle metadata.</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
-                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Price</BbTypographyMuted><BbTypographyH3>@_product.Price.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
-                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Stock</BbTypographyMuted><BbTypographyH3>@_product.StockQuantity</BbTypographyH3></div></BbCardContent></BbCard>
-                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Variations</BbTypographyMuted><BbTypographyH3>@_variations.Count</BbTypographyH3></div></BbCardContent></BbCard>
-                        <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Transactions</BbTypographyMuted><BbTypographyH3>@_transactions.Count</BbTypographyH3></div></BbCardContent></BbCard>
-                    </div>
-                    <div class="mt-4 grid gap-4 md:grid-cols-2">
-                        <div>
-                            <BbTypographyMuted>Description</BbTypographyMuted>
-                            <div>@(_product.Description ?? "No description")</div>
+                    @if (_editMode)
+                    {
+                        <div class="grid gap-4">
+                            <div class="xf-detail-field-grid">
+                                <BbFormFieldInput TValue="string" @bind-Value="_productForm.Name" Label="Name" Required="true" />
+                                <BbFormFieldInput TValue="string" @bind-Value="_productForm.Sku" Label="SKU" />
+                            </div>
+                            <BbFormFieldCombobox TValue="string"
+                                                  @bind-Value="_productForm.CategoryId"
+                                                  Options="@CategoryOptions"
+                                                  Label="Category"
+                                                  Placeholder="Select category"
+                                                  SearchPlaceholder="Search categories..."
+                                                  EmptyMessage="No categories found."
+                                                  MatchTriggerWidth="true"
+                                                  Required="true" />
+                            <div class="xf-detail-field-grid">
+                                <BbFormFieldInput TValue="string" @bind-Value="_productForm.Price" Label="Price" />
+                                <BbFormFieldInput TValue="string" @bind-Value="_productForm.Brand" Label="Brand" />
+                            </div>
+                            <BbFormFieldInput TValue="string" @bind-Value="_productForm.Description" Label="Description" />
+                            <BbFormFieldSwitch Checked="@_productForm.IsAvailable"
+                                               CheckedChanged="@((bool value) => _productForm.IsAvailable = value)"
+                                               Label="Available" />
                         </div>
-                        <div>
-                            <BbTypographyMuted>Brand</BbTypographyMuted>
-                            <div>@(_product.Brand ?? "N/A")</div>
+                    }
+                    else
+                    {
+                        <div class="xf-detail-field-grid">
+                            <div>
+                                <BbTypographyMuted>Description</BbTypographyMuted>
+                                <div>@(_product.Description ?? "No description")</div>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Brand</BbTypographyMuted>
+                                <div>@(_product.Brand ?? "N/A")</div>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Created</BbTypographyMuted>
+                                <div>@_product.CreatedAt.ToLocalTime().ToString("g")</div>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Last Modified</BbTypographyMuted>
+                                <div>@(_product.ModifiedAt?.ToLocalTime().ToString("g") ?? "Never")</div>
+                            </div>
                         </div>
-                    </div>
+                    }
                 </BbCardContent>
             </BbCard>
 
+            @if (_planningEnabled)
+            {
+                <BbCard>
+                    <BbCardHeader>
+                        <div class="xf-page-header">
+                            <div>
+                                <BbCardTitle>Replenishment Rules</BbCardTitle>
+                                <BbCardDescription>Min, max, reorder point, and scoped warehouse/location rules for this product.</BbCardDescription>
+                            </div>
+                            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => Navigation.NavigateTo("/inventario/planning"))">
+                                <LucideIcon Name="external-link" class="mr-2 h-4 w-4" />
+                                Manage Rules
+                            </BbButton>
+                        </div>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_reorderRules" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridTemplateColumn Title="Scope">
+                                    <ChildContent Context="item">@GetRuleScope(item)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.MinimumQuantity)" Title="Min" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MaximumQuantity)" Title="Max" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReorderQuantity)" Title="Reorder Qty" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Preferred Supplier" />
+                                <BbDataGridTemplateColumn Title="Status">
+                                    <ChildContent Context="item">
+                                        <StatusBadge Text="@(item.IsActive ? "Active" : "Inactive")" Status="@(item.IsActive ? "active" : "inactive")" />
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            }
+
+            @if (_stockEnabled)
+            {
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Warehouse and Location Stock</BbCardTitle>
+                        <BbCardDescription>Current stock balances for this product.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="10"
+                                    OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
+                                    Class="cursor-pointer">
+                            <Columns>
+                                <BbDataGridTemplateColumn Title="Warehouse">
+                                    <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Location">
+                                    <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                @if (_traceabilityEnabled)
+                                {
+                                    <BbDataGridTemplateColumn Title="Lot">
+                                        <ChildContent Context="item">@GetLotNumber(item.LotId)</ChildContent>
+                                    </BbDataGridTemplateColumn>
+                                }
+                                <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            }
+
+            @if (_traceabilityEnabled)
+            {
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Lots and Batches</BbCardTitle>
+                        <BbCardDescription>Traceability records connected to this product.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_lots" ShowPagination="true" InitialPageSize="10"
+                                    OnRowClick="@((InventoryLot item) => Navigation.NavigateTo($"/inventario/lots/{item.Id}"))"
+                                    Class="cursor-pointer">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot / Batch" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="On Hand">
+                                    <ChildContent Context="item">@GetLotOnHand(item.Id).ToString("N2")</ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            }
+
             <BbCard>
                 <BbCardHeader>
-                    <div class="flex items-center justify-between">
+                    <div class="xf-page-header">
                         <div>
                             <BbCardTitle>Variations</BbCardTitle>
                             <BbCardDescription>Optional product options and price adjustments.</BbCardDescription>
@@ -153,18 +309,34 @@ else
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
 
+    private readonly ProductForm _productForm = new();
     private Product? _product;
+    private List<ProductCategory> _categories = [];
     private List<ProductVariation> _variations = [];
     private List<ProductTransaction> _transactions = [];
+    private List<InventoryReorderRule> _reorderRules = [];
+    private List<StockBalance> _balances = [];
+    private List<InventoryLot> _lots = [];
+    private List<Warehouse> _warehouses = [];
+    private List<InventoryLocation> _locations = [];
     private bool _loading = true;
     private bool _saving;
     private bool _hasTenant;
     private bool _moduleEnabled;
+    private bool _planningEnabled;
+    private bool _stockEnabled;
+    private bool _traceabilityEnabled;
     private bool _outsideTenantContext;
+    private bool _editMode;
     private bool _variationDialogOpen;
     private string _variationName = "";
     private string _variationAdditionalPrice = "0";
     private Guid? _loadedId;
+
+    private decimal TotalAvailable => _balances.Sum(x => x.AvailableQuantity);
+    private int ActiveLocationCount => _balances.Select(x => x.LocationId).Distinct().Count();
+    private List<SelectOption<string>> CategoryOptions =>
+        _categories.Select(category => new SelectOption<string>(category.Id.ToString(), category.Name ?? category.Id.ToString()[..8])).ToList();
 
     protected override void OnInitialized()
     {
@@ -192,27 +364,44 @@ else
             await ModuleNavigation.EnsureLoadedAsync();
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
             _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+            _planningEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "planning");
+            _stockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances");
+            _traceabilityEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability");
             _outsideTenantContext = false;
             _product = null;
+            _categories = [];
             _variations = [];
             _transactions = [];
+            _reorderRules = [];
+            _balances = [];
+            _lots = [];
+            _warehouses = [];
+            _locations = [];
 
             if (!_hasTenant || !_moduleEnabled) return;
 
             _product = await DataContext.Query<Product>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Include(x => x.Category)
                 .Where(x => x.Id == Id && !x.IsDeleted)
                 .FirstOrDefaultAsync();
 
             _outsideTenantContext = _product is not null && _product.TenantId != TenantFilter.SelectedTenantId;
             if (_product is null || _outsideTenantContext) return;
 
+            var tenantId = _product.TenantId;
+            _categories = await DataContext.Query<ProductCategory>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(200)
+                .ToListAsync();
+
             _variations = await DataContext.Query<ProductVariation>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.ProductId == Id && x.TenantId == _product.TenantId && !x.IsDeleted)
+                .Where(x => x.ProductId == Id && x.TenantId == tenantId && !x.IsDeleted)
                 .OrderBy(x => x.Name)
                 .Take(100)
                 .ToListAsync();
@@ -220,10 +409,67 @@ else
             _transactions = await DataContext.Query<ProductTransaction>()
                 .IgnoreQueryFilters()
                 .NoCache()
-                .Where(x => x.ProductId == Id && x.TenantId == _product.TenantId && !x.IsDeleted)
+                .Where(x => x.ProductId == Id && x.TenantId == tenantId && !x.IsDeleted)
                 .OrderByDescending(x => x.TransactionDate)
                 .Take(100)
                 .ToListAsync();
+
+            if (_planningEnabled)
+                _reorderRules = await DataContext.Query<InventoryReorderRule>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
+                    .OrderBy(x => x.WarehouseId)
+                    .ThenBy(x => x.LocationId)
+                    .Take(100)
+                    .ToListAsync();
+
+            if (_stockEnabled || _traceabilityEnabled)
+                _balances = await DataContext.Query<StockBalance>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
+                    .OrderBy(x => x.WarehouseId)
+                    .ThenBy(x => x.LocationId)
+                    .Take(500)
+                    .ToListAsync();
+
+            if (_traceabilityEnabled)
+                _lots = await DataContext.Query<InventoryLot>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
+                    .OrderBy(x => x.ExpiresAt)
+                    .ThenBy(x => x.LotNumber)
+                    .Take(500)
+                    .ToListAsync();
+
+            var warehouseIds = _balances.Select(x => x.WarehouseId)
+                .Concat(_reorderRules.Where(x => x.WarehouseId is not null).Select(x => x.WarehouseId!.Value))
+                .Distinct()
+                .ToList();
+            if (warehouseIds.Count > 0)
+                _warehouses = await DataContext.Query<Warehouse>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && warehouseIds.Contains(x.Id) && !x.IsDeleted)
+                    .Take(200)
+                    .ToListAsync();
+
+            var locationIds = _balances.Select(x => x.LocationId)
+                .Concat(_reorderRules.Where(x => x.LocationId is not null).Select(x => x.LocationId!.Value))
+                .Distinct()
+                .ToList();
+            if (locationIds.Count > 0)
+                _locations = await DataContext.Query<InventoryLocation>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => x.TenantId == tenantId && locationIds.Contains(x.Id) && !x.IsDeleted)
+                    .Take(500)
+                    .ToListAsync();
+
+            if (!_editMode)
+                LoadProductForm();
         }
         catch (Exception ex)
         {
@@ -233,6 +479,95 @@ else
         {
             _loading = false;
             StateHasChanged();
+        }
+    }
+
+    private void StartEdit()
+    {
+        LoadProductForm();
+        _editMode = true;
+    }
+
+    private void CancelEdit()
+    {
+        LoadProductForm();
+        _editMode = false;
+    }
+
+    private void LoadProductForm()
+    {
+        if (_product is null) return;
+        _productForm.Name = _product.Name ?? "";
+        _productForm.Sku = _product.SKU ?? "";
+        _productForm.CategoryId = _product.CategoryId.ToString();
+        _productForm.Price = _product.Price.ToString("0.##");
+        _productForm.Brand = _product.Brand ?? "";
+        _productForm.Description = _product.Description ?? "";
+        _productForm.IsAvailable = _product.IsAvailable;
+    }
+
+    private async Task SaveProduct()
+    {
+        if (_product is null || TenantFilter.SelectedTenantId is not Guid tenantId) return;
+        if (string.IsNullOrWhiteSpace(_productForm.Name))
+        {
+            ToastService.Show("Product name is required.");
+            return;
+        }
+        if (!Guid.TryParse(_productForm.CategoryId, out var categoryId))
+        {
+            ToastService.Show("Select a category.");
+            return;
+        }
+        if (!decimal.TryParse(_productForm.Price, out var price) || price < 0)
+        {
+            ToastService.Show("Price must be a non-negative number.");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var fresh = await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == _product.Id && x.TenantId == tenantId && !x.IsDeleted)
+                .FirstOrDefaultAsync();
+            if (fresh is null)
+            {
+                ToastService.Show("Product not found.");
+                return;
+            }
+
+            fresh.Name = _productForm.Name.Trim();
+            fresh.SKU = NullIfEmpty(_productForm.Sku);
+            fresh.CategoryId = categoryId;
+            fresh.Price = price;
+            fresh.Brand = NullIfEmpty(_productForm.Brand);
+            fresh.Description = NullIfEmpty(_productForm.Description);
+            fresh.IsAvailable = _productForm.IsAvailable;
+            fresh.ModifiedAt = DateTime.UtcNow;
+            DataContext.Update(fresh);
+
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Show("Product updated.");
+                _editMode = false;
+                await Reload();
+            }
+            else
+            {
+                ToastService.Show($"Failed to save product: {result.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Error saving product: {ex.Message}");
+        }
+        finally
+        {
+            _saving = false;
         }
     }
 
@@ -294,9 +629,41 @@ else
         }
     }
 
+    private string GetCategoryName(Guid categoryId) =>
+        _categories.FirstOrDefault(x => x.Id == categoryId)?.Name ?? "Uncategorized";
+
+    private string GetRuleScope(InventoryReorderRule rule) =>
+        $"{GetWarehouseName(rule.WarehouseId)} / {GetLocationName(rule.LocationId)}";
+
+    private string GetWarehouseName(Guid? warehouseId) =>
+        warehouseId is { } id ? _warehouses.FirstOrDefault(x => x.Id == id) is { } warehouse ? $"{warehouse.Code} - {warehouse.Name}" : id.ToString()[..8] : "Any warehouse";
+
+    private string GetLocationName(Guid? locationId) =>
+        locationId is { } id ? _locations.FirstOrDefault(x => x.Id == id) is { } location ? $"{location.Code} - {location.Name}" : id.ToString()[..8] : "Any location";
+
+    private string GetLotNumber(Guid? lotId) =>
+        lotId is { } id ? _lots.FirstOrDefault(x => x.Id == id)?.LotNumber ?? id.ToString()[..8] : "Untracked";
+
+    private decimal GetLotOnHand(Guid lotId) =>
+        _balances.Where(x => x.LotId == lotId).Sum(x => x.OnHandQuantity);
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
     public void Dispose()
     {
         TenantFilter.OnChanged -= OnTenantChanged;
         ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private sealed class ProductForm
+    {
+        public string Name { get; set; } = "";
+        public string Sku { get; set; } = "";
+        public string CategoryId { get; set; } = "";
+        public string Price { get; set; } = "0";
+        public string Brand { get; set; } = "";
+        public string Description { get; set; } = "";
+        public bool IsAvailable { get; set; } = true;
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductTransactionDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductTransactionDetail.razor
@@ -52,7 +52,7 @@ else
                 </BbButton>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div class="xf-summary-grid xf-summary-grid-3">
                 <BbCard>
                     <BbCardContent>
                         <div class="space-y-1 pt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
@@ -20,18 +20,20 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Products</BbTypographyH3>
                     <BbTypographyMuted>Manage the selected tenant's product catalog.</BbTypographyMuted>
                 </div>
-                <BbButton OnClick="@OpenCreateDialog">
-                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
-                    Create Product
-                </BbButton>
+                <div class="xf-page-actions">
+                    <BbButton OnClick="@OpenCreateDialog">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Create Product
+                    </BbButton>
+                </div>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+            <div class="xf-summary-grid xf-summary-grid-4">
                 <BbCard>
                     <BbCardHeader><BbCardTitle>Total Products</BbCardTitle></BbCardHeader>
                     <BbCardContent><BbTypographyH2>@_products.Count</BbTypographyH2></BbCardContent>
@@ -52,12 +54,12 @@ else
 
             <BbCard>
                 <BbCardHeader>
-                    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                    <div class="xf-page-header">
                         <div>
                             <BbCardTitle>Product Catalog</BbCardTitle>
                             <BbCardDescription>@_filteredProducts.Count product(s) shown</BbCardDescription>
                         </div>
-                        <div class="flex flex-col gap-2 md:w-[28rem] md:flex-row">
+                        <div class="xf-filter-actions">
                             <BbInput @bind-Value="_search" Placeholder="Search products..." @oninput="OnSearchChanged" />
                             <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
                                 <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
@@ -104,10 +106,6 @@ else
                                                   OnClick="@(() => Navigation.NavigateTo($"/inventario/products/{item.Id}"))">
                                             <LucideIcon Name="eye" class="h-4 w-4" />
                                         </BbButton>
-                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Edit product"
-                                                  OnClick="@(() => OpenEditDialog(item))">
-                                            <LucideIcon Name="pencil" class="h-4 w-4" />
-                                        </BbButton>
                                     </div>
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
@@ -122,7 +120,7 @@ else
 <BbDialog Open="@_productDialogOpen" OpenChanged="@(v => _productDialogOpen = v)">
     <BbDialogContent>
         <BbDialogHeader>
-            <BbDialogTitle>@(_editingProduct is null ? "Create Product" : "Edit Product")</BbDialogTitle>
+            <BbDialogTitle>Create Product</BbDialogTitle>
             <BbDialogDescription>Catalog data belongs to the selected tenant.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
@@ -149,7 +147,7 @@ else
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _productDialogOpen = false)">Cancel</BbButton>
             <BbButton OnClick="@SaveProduct" Disabled="@_saving">
-                @(_editingProduct is null ? "Create" : "Save")
+                Create
             </BbButton>
         </BbDialogFooter>
     </BbDialogContent>
@@ -171,7 +169,6 @@ else
     private bool _hasTenant;
     private bool _moduleEnabled;
     private bool _productDialogOpen;
-    private Product? _editingProduct;
     private string _search = "";
     private int _lowStockThreshold = 5;
 
@@ -283,23 +280,9 @@ else
 
     private void OpenCreateDialog()
     {
-        _editingProduct = null;
         _form.Reset();
         _form.IsAvailable = true;
         _form.CategoryId = _categories.FirstOrDefault()?.Id.ToString() ?? "";
-        _productDialogOpen = true;
-    }
-
-    private void OpenEditDialog(Product product)
-    {
-        _editingProduct = product;
-        _form.Name = product.Name ?? "";
-        _form.Sku = product.SKU ?? "";
-        _form.CategoryId = product.CategoryId.ToString();
-        _form.Price = product.Price.ToString("0.##");
-        _form.Brand = product.Brand ?? "";
-        _form.Description = product.Description ?? "";
-        _form.IsAvailable = product.IsAvailable;
         _productDialogOpen = true;
     }
 
@@ -332,52 +315,26 @@ else
         _saving = true;
         try
         {
-            if (_editingProduct is null)
+            DataContext.Add(new Product
             {
-                DataContext.Add(new Product
-                {
-                    Id = Guid.NewGuid(),
-                    TenantId = tenantId,
-                    Name = _form.Name.Trim(),
-                    SKU = NullIfEmpty(_form.Sku),
-                    CategoryId = categoryId,
-                    Price = price,
-                    StockQuantity = 0,
-                    Brand = NullIfEmpty(_form.Brand),
-                    Description = NullIfEmpty(_form.Description),
-                    IsAvailable = _form.IsAvailable,
-                    CreatedAt = DateTime.UtcNow,
-                    IsEnabled = true
-                });
-            }
-            else
-            {
-                var fresh = await DataContext.Query<Product>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.Id == _editingProduct.Id && x.TenantId == tenantId)
-                    .FirstOrDefaultAsync();
-                if (fresh is null)
-                {
-                    ToastService.Show("Product not found.");
-                    return;
-                }
-
-                fresh.Name = _form.Name.Trim();
-                fresh.SKU = NullIfEmpty(_form.Sku);
-                fresh.CategoryId = categoryId;
-                fresh.Price = price;
-                fresh.Brand = NullIfEmpty(_form.Brand);
-                fresh.Description = NullIfEmpty(_form.Description);
-                fresh.IsAvailable = _form.IsAvailable;
-                fresh.ModifiedAt = DateTime.UtcNow;
-                DataContext.Update(fresh);
-            }
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                Name = _form.Name.Trim(),
+                SKU = NullIfEmpty(_form.Sku),
+                CategoryId = categoryId,
+                Price = price,
+                StockQuantity = 0,
+                Brand = NullIfEmpty(_form.Brand),
+                Description = NullIfEmpty(_form.Description),
+                IsAvailable = _form.IsAvailable,
+                CreatedAt = DateTime.UtcNow,
+                IsEnabled = true
+            });
 
             var result = await DataContext.SaveChangesAsync();
             if (result.IsSuccess)
             {
-                ToastService.Show(_editingProduct is null ? "Product created." : "Product updated.");
+                ToastService.Show("Product created.");
                 _productDialogOpen = false;
                 await Reload();
             }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
@@ -128,12 +128,15 @@ else
         <div class="grid gap-4 py-4">
             <BbFormFieldInput TValue="string" @bind-Value="_form.Name" Label="Name" Required="true" />
             <BbFormFieldInput TValue="string" @bind-Value="_form.Sku" Label="SKU" />
-            <BbFormFieldSelect TValue="string" @bind-Value="_form.CategoryId" Label="Category" Placeholder="Select category">
-                @foreach (var category in _categories)
-                {
-                    <BbSelectItem Value="@category.Id.ToString()">@(category.Name ?? category.Id.ToString()[..8])</BbSelectItem>
-                }
-            </BbFormFieldSelect>
+            <BbFormFieldCombobox TValue="string"
+                                  @bind-Value="_form.CategoryId"
+                                  Options="@CategoryOptions"
+                                  Label="Category"
+                                  Placeholder="Select category"
+                                  SearchPlaceholder="Search categories..."
+                                  EmptyMessage="No categories found."
+                                  MatchTriggerWidth="true"
+                                  Required="true" />
             <div class="grid gap-4 md:grid-cols-2">
                 <BbFormFieldInput TValue="string" @bind-Value="_form.Price" Label="Price" />
                 <BbFormFieldInput TValue="string" @bind-Value="_form.Brand" Label="Brand" />
@@ -272,6 +275,11 @@ else
 
     private string GetCategoryName(Guid categoryId) =>
         _categories.FirstOrDefault(x => x.Id == categoryId)?.Name ?? "Uncategorized";
+
+    private List<SelectOption<string>> CategoryOptions =>
+        _categories
+            .Select(category => new SelectOption<string>(category.Id.ToString(), category.Name ?? category.Id.ToString()[..8]))
+            .ToList();
 
     private void OpenCreateDialog()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrderDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrderDetail.razor
@@ -30,7 +30,7 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div class="flex items-center gap-3">
                     <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" AriaLabel="Back to purchase orders" OnClick="@GoBack">
                         <LucideIcon Name="arrow-left" class="h-4 w-4" />

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
@@ -22,12 +22,12 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Purchase Orders</BbTypographyH3>
                     <BbTypographyMuted>Track supplier orders, partial receiving, and completion state.</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     <BbButton OnClick="@OpenCreateDialog" Disabled="@(_products.Count == 0)">
                         <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
                         Create PO

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
@@ -22,12 +22,12 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Receiving</BbTypographyH3>
                     <BbTypographyMuted>Post received stock into warehouses and locations with optional lot tracking.</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     <BbButton OnClick="@OpenReceiveDialog" Disabled="@(_products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0)">
                         <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
                         Receive Stock

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReceivingDocumentDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReceivingDocumentDetail.razor
@@ -29,7 +29,7 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div class="flex items-center gap-3">
                     <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" AriaLabel="Back to receiving" OnClick="@GoBack">
                         <LucideIcon Name="arrow-left" class="h-4 w-4" />

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reports.razor
@@ -21,7 +21,7 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Inventory Reports</BbTypographyH3>
                     <BbTypographyMuted>Focused inventory views for stock, expiry, movement, and allocation status.</BbTypographyMuted>
@@ -32,7 +32,7 @@ else
                 </BbButton>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+            <div class="xf-summary-grid xf-summary-grid-4">
                 <ReportMetric Title="Low Stock" Value="@_lowStock.Count.ToString()" />
                 <ReportMetric Title="Near Expiry" Value="@_nearExpiry.Count.ToString()" />
                 <ReportMetric Title="Expired Lots" Value="@_expired.Count.ToString()" />

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReservationDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReservationDetail.razor
@@ -40,19 +40,19 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center">
+            <div class="xf-detail-header">
                 <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to reservations"
                           OnClick="@(() => Navigation.NavigateTo("/inventario/reservations"))">
                     <LucideIcon Name="arrow-left" class="h-4 w-4" />
                 </BbButton>
-                <div class="flex-1">
-                    <div class="flex items-center gap-2">
+                <div class="xf-detail-header-main">
+                    <div class="xf-detail-header-title">
                         <BbTypographyH3>Reservation</BbTypographyH3>
                         <StatusBadge Text="@_reservation.Status.ToString()" Status="@GetStatusBadge(_reservation.Status)" />
                     </div>
                     <BbTypographyMuted>@GetProductLabel() - Qty @_reservation.Quantity.ToString("N2")</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     @if (_reservation.Status == ReservationStatus.Active)
                     {
                         <BbButton Variant="ButtonVariant.Outline" OnClick="@ReleaseReservation" Disabled="@_runningAction">
@@ -72,7 +72,7 @@ else
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div class="xf-summary-grid xf-summary-grid-3">
                 <BbCard>
                     <BbCardContent>
                         <div class="space-y-1 pt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
@@ -25,12 +25,12 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Reservations</BbTypographyH3>
                     <BbTypographyMuted>Reserve, release, fulfill, and expire allocated inventory.</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     <BbButton OnClick="@OpenReservationDialog">
                         <LucideIcon Name="clipboard-plus" class="mr-2 h-4 w-4" />
                         Reserve Inventory

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -25,12 +25,12 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Stock Control</BbTypographyH3>
                     <BbTypographyMuted>Post stock movements and inspect balances for the selected tenant.</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     @if (_movementsEnabled)
                     {
                         <BbButton OnClick="@OpenMovementDialog">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/StockBalanceDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/StockBalanceDetail.razor
@@ -52,7 +52,7 @@ else
                 </BbButton>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div class="xf-summary-grid xf-summary-grid-3">
                 <BbCard>
                     <BbCardContent>
                         <div class="space-y-1 pt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Suppliers.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Suppliers.razor
@@ -21,12 +21,12 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Suppliers</BbTypographyH3>
                     <BbTypographyMuted>Maintain suppliers for purchase orders and receiving.</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     <BbButton OnClick="@OpenCreateDialog">
                         <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
                         Create Supplier

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/WarehouseDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/WarehouseDetail.razor
@@ -87,7 +87,7 @@ else
                 </BbCardContent>
             </BbCard>
 
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div class="xf-summary-grid xf-summary-grid-3">
                 <BbCard>
                     <BbCardContent>
                         <div class="space-y-1 pt-4">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
@@ -23,12 +23,12 @@ else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div class="xf-page-header">
                 <div>
                     <BbTypographyH3>Warehouses</BbTypographyH3>
                     <BbTypographyMuted>Set up stock storage warehouses and internal locations.</BbTypographyMuted>
                 </div>
-                <div class="flex flex-wrap gap-2">
+                <div class="xf-page-actions">
                     <BbButton OnClick="@OpenWarehouseDialog">
                         <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
                         Create Warehouse

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -165,6 +165,100 @@
     opacity: 0.75;
 }
 
+.xf-page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.xf-page-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.xf-filter-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.xf-summary-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+}
+
+.xf-detail-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.xf-detail-header-main {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.xf-detail-header-title {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.xf-detail-field-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.xf-detail-field-grid-wide {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 768px) {
+    .xf-page-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .xf-page-actions {
+        justify-content: flex-end;
+        margin-left: auto;
+    }
+
+    .xf-filter-actions {
+        width: 28rem;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-end;
+    }
+
+    .xf-summary-grid-2 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .xf-summary-grid-3 {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .xf-summary-grid-4 {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .xf-detail-field-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .xf-detail-field-grid-wide {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
 .login-shell {
     display: grid;
     min-height: 100vh;


### PR DESCRIPTION
## Summary
- add explicit ControlPanel layout helpers for page headers, filter actions, summary grids, and detail fields
- move product/category existing-record edits onto detail pages with inline edit modes
- expand product detail with replenishment rules, warehouse/location stock, lots, variations, and transaction context
- document the BlazorBlueprint/ControlPanel layout learnings for future agents

## Test Plan
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false
- browser smoke on localhost:5012 for Inventario planning, products, product detail edit mode, categories, and category detail edit mode