### PR TITLE
Fix xeon-dev service deploy concurrency gate

### DIFF
--- a/.github/actions/detect-shared-deploy-changes/action.yml
+++ b/.github/actions/detect-shared-deploy-changes/action.yml
@@ -1,0 +1,50 @@
+name: Detect Shared Deploy Changes
+description: Detects whether a xeon-dev push is owned by the all-services deploy workflow.
+
+outputs:
+  has_shared:
+    description: Whether this run includes shared deployment paths.
+    value: ${{ steps.detect.outputs.has_shared }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect shared deploy paths
+      id: detect
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BEFORE_SHA: ${{ github.event.before }}
+        HEAD_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        has_shared=false
+
+        if [ "$EVENT_NAME" = "push" ]; then
+          base_sha="$BEFORE_SHA"
+
+          if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git rev-list --max-parents=0 "$HEAD_SHA")"
+          fi
+
+          changed_files="$(mktemp)"
+          git diff --name-only "$base_sha" "$HEAD_SHA" > "$changed_files"
+
+          while IFS= read -r path; do
+            case "$path" in
+              Dockerfile|docker-compose.yml|Directory.Build.props|Directory.Build.targets|Directory.Packages.props|Version.props|XFramework.slnx|global.json|NuGet.config|src/Kernel/*|src/Infrastructure/*|src/Shared/*|src/SourceGenerators/*|src/Libraries/*|src/Tools/XFramework.MigrationRunner/*|src/Modules/*/Migrations/*|src/Modules/XFramework.Bolt/Bolt.Domain.Shared/*)
+                has_shared=true
+                echo "Shared deployment path changed: $path"
+                ;;
+            esac
+          done < "$changed_files"
+        fi
+
+        if [ "$has_shared" = "true" ]; then
+          echo "::notice::Shared deployment paths changed; skipping service-specific deploy so Deploy Xeon Dev - All Services owns this commit."
+        else
+          echo "No shared deployment paths detected for this service workflow."
+        fi
+
+        echo "has_shared=$has_shared" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-xeon-dev-bolt-hub.yml
+++ b/.github/workflows/deploy-xeon-dev-bolt-hub.yml
@@ -12,7 +12,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: bolt-hub

--- a/.github/workflows/deploy-xeon-dev-controlpanel.yml
+++ b/.github/workflows/deploy-xeon-dev-controlpanel.yml
@@ -21,7 +21,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: controlpanel

--- a/.github/workflows/deploy-xeon-dev-identityserver.yml
+++ b/.github/workflows/deploy-xeon-dev-identityserver.yml
@@ -14,7 +14,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: identityserver

--- a/.github/workflows/deploy-xeon-dev-inventario.yml
+++ b/.github/workflows/deploy-xeon-dev-inventario.yml
@@ -14,7 +14,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: inventario

--- a/.github/workflows/deploy-xeon-dev-messaging.yml
+++ b/.github/workflows/deploy-xeon-dev-messaging.yml
@@ -14,7 +14,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: messaging

--- a/.github/workflows/deploy-xeon-dev-notifications.yml
+++ b/.github/workflows/deploy-xeon-dev-notifications.yml
@@ -12,7 +12,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: notifications

--- a/.github/workflows/deploy-xeon-dev-operations-dashboard.yml
+++ b/.github/workflows/deploy-xeon-dev-operations-dashboard.yml
@@ -14,7 +14,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: operations-dashboard

--- a/.github/workflows/deploy-xeon-dev-service.yml
+++ b/.github/workflows/deploy-xeon-dev-service.yml
@@ -54,43 +54,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect shared changes
-        id: shared
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          has_shared=false
-
-          if [ "${{ github.event_name }}" = "push" ]; then
-            base_sha="${{ github.event.before }}"
-
-            if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
-              base_sha="$(git rev-list --max-parents=0 HEAD)"
-            fi
-
-            git diff --name-only "$base_sha" "$GITHUB_SHA" > /tmp/xframework-changed-files.txt
-
-            while IFS= read -r path; do
-              case "$path" in
-                Dockerfile|docker-compose.yml|Directory.Build.props|Directory.Build.targets|Directory.Packages.props|Version.props|XFramework.slnx|global.json|NuGet.config|src/Kernel/*|src/Infrastructure/*|src/Shared/*|src/SourceGenerators/*|src/Libraries/*|src/Tools/XFramework.MigrationRunner/*|src/Modules/*/Migrations/*|src/Modules/XFramework.Bolt/Bolt.Domain.Shared/*)
-                  has_shared=true
-                  echo "Shared deployment path changed: $path"
-                  ;;
-              esac
-            done < /tmp/xframework-changed-files.txt
-          fi
-
-          echo "has_shared=$has_shared" >> "$GITHUB_OUTPUT"
-
-      - name: Skip service deploy for shared changes
-        if: steps.shared.outputs.has_shared == 'true'
-        shell: bash
-        run: |
-          echo "Shared paths changed in this push; the all-services deploy workflow owns this deployment."
-
       - name: Verify build runner, Docker, registry, and deploy host
-        if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -117,14 +81,12 @@ jobs:
             "test -r '$XFRAMEWORK_ENV_FILE' && docker --version && docker compose version && curl -sSI 'https://${REGISTRY_HOST}/v2/' | sed -n '1,8p'"
 
       - name: Validate compose
-        if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
           set -euo pipefail
           docker compose -f "$COMPOSE_FILE_PATH" config >/tmp/xframework-compose.yml
 
       - name: Login to dev registry
-        if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         env:
           XSYSTEMS_DEV_REGISTRY_USERNAME: ${{ secrets.XSYSTEMS_DEV_REGISTRY_USERNAME }}
@@ -142,14 +104,12 @@ jobs:
                 "docker login '$REGISTRY_HOST' --username '$XSYSTEMS_DEV_REGISTRY_USERNAME' --password-stdin"
 
       - name: Build image on buildserver
-        if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
           set -euo pipefail
           docker compose -f "$COMPOSE_FILE_PATH" build "$SERVICE_NAME"
 
       - name: Push image to dev registry
-        if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -161,7 +121,6 @@ jobs:
           docker push "$channel_image"
 
       - name: Deploy service on xeon-dev
-        if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -180,7 +139,6 @@ jobs:
             "$remote_env docker compose --env-file '$XFRAMEWORK_ENV_FILE' -f '$REMOTE_COMPOSE_FILE' ps '$SERVICE_NAME'"
 
       - name: Wait for readiness
-        if: steps.shared.outputs.has_shared != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -210,7 +168,7 @@ jobs:
           fi
 
       - name: Deployment diagnostics
-        if: failure() && steps.shared.outputs.has_shared != 'true'
+        if: failure()
         shell: bash
         run: |
           remote_env="COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' REGISTRY_HOST='$REGISTRY_HOST' REGISTRY_NAMESPACE='$REGISTRY_NAMESPACE' IMAGE_TAG='$IMAGE_TAG'"

--- a/.github/workflows/deploy-xeon-dev-smsgateway.yml
+++ b/.github/workflows/deploy-xeon-dev-smsgateway.yml
@@ -12,7 +12,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: smsgateway

--- a/.github/workflows/deploy-xeon-dev-wallets.yml
+++ b/.github/workflows/deploy-xeon-dev-wallets.yml
@@ -12,7 +12,24 @@ permissions:
   contents: read
 
 jobs:
+  detect-shared-changes:
+    name: Detect shared deploy ownership
+    runs-on: ubuntu-latest
+    outputs:
+      has_shared: ${{ steps.shared.outputs.has_shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect shared changes
+        id: shared
+        uses: ./.github/actions/detect-shared-deploy-changes
+
   deploy:
+    needs: detect-shared-changes
+    if: needs.detect-shared-changes.outputs.has_shared != 'true'
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: wallets


### PR DESCRIPTION
## Summary
- Move shared-change detection out of the reusable service deploy workflow and into each visible service wrapper workflow.
- Keep the service deploy reusable workflow focused on build/push/deploy once the wrapper has confirmed the commit is service-owned.
- Prevent skip-only service workflows from entering the shared `xeon-dev-deploy` concurrency group and cancelling the real all-services deploy run.

## Root Cause
A shared-path push can trigger the all-services deploy plus multiple service deploy wrappers. The reusable service deploy workflow previously acquired the `xeon-dev-deploy` concurrency group before detecting shared changes and skipping. GitHub Actions keeps only one running and one pending run per concurrency group, so skip-only service runs could cancel the pending all-services deploy before jobs were scheduled.

## Validation
- Parsed all `.github/**/*.yml` files with PyYAML.
- Ran `git diff --check` / `git diff --cached --check`.
- Simulated the shared-path detector against shared and service-local paths with Git Bash.