### PR TITLE
Add standardized integration test infrastructure

### DIFF
--- a/XFramework.slnx
+++ b/XFramework.slnx
@@ -79,6 +79,7 @@
   <Folder Name="/Tests/">
     <Project Path="src\Tests\ControlPanel.E2ETests\ControlPanel.E2ETests.csproj" />
     <Project Path="src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj" />
+    <Project Path="src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj" />
     <Project Path="src\Tests\OperationsDashboard.Tests\OperationsDashboard.Tests.csproj" />
     <Project Path="src\Tests\XFramework.Core.Tests\XFramework.Core.Tests.csproj" />
     <Project Path="src\Tests\XFramework.SourceGenerators.Tests\XFramework.SourceGenerators.Tests.csproj" />

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/TenantModuleFeatureConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/TenantModuleFeatureConfiguration.cs
@@ -43,7 +43,8 @@ public sealed class TenantModuleFeatureConfiguration : IEntityTypeConfiguration<
         entity.Property(e => e.IsDeleted).HasDefaultValueSql("false");
         entity.Property(e => e.IsEnabled)
             .IsRequired()
-            .HasDefaultValueSql("true");
+            .HasDefaultValueSql("true")
+            .HasSentinel(true);
 
         entity.HasOne(d => d.Tenant).WithMany(p => p.TenantModuleFeatures)
             .HasForeignKey(d => d.TenantId)

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Infrastructure/InventarioFeatureGateRoutes.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Infrastructure/InventarioFeatureGateRoutes.cs
@@ -1,0 +1,28 @@
+using IdentityServer.Domain.Shared.Contracts;
+using XFramework.Core.Services.FeatureGates;
+
+namespace Inventario.Api.Infrastructure;
+
+public static class InventarioFeatureGateRoutes
+{
+    public static void Configure(TenantModuleFeatureGateOptions options)
+    {
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/warehouses", "warehousing");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/locations", "warehousing");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/balances", "stock_balances");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/movements", "movements");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/post", "movements");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reservations", "reservations");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/allocations", "reservations");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/lots", "traceability");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reorder-rules", "planning");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/planning", "planning");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports/near-expiry", "traceability");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports/expired-stock", "traceability");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports", "reporting");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/suppliers", "purchasing");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/purchase-orders", "purchasing");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/receiving", "purchasing");
+        options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Program.cs
@@ -1,6 +1,6 @@
 using FluentValidation;
-using IdentityServer.Domain.Shared.Contracts;
 using Inventario.Api.Features.Products.Update;
+using Inventario.Api.Infrastructure;
 using Microsoft.Extensions.Caching.Distributed;
 using StackExchange.Redis;
 using XFramework.Core.DataContext;
@@ -37,26 +37,7 @@ var app = (WebApplication)builder.Build();
 
 // Add correlation ID middleware early in the pipeline for request tracing
 app.UseCorrelationId();
-app.UseTenantModuleFeatureGate(options =>
-{
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/warehouses", "warehousing");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/locations", "warehousing");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/balances", "stock_balances");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/movements", "movements");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/stock/post", "movements");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reservations", "reservations");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/allocations", "reservations");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/lots", "traceability");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reorder-rules", "planning");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/planning", "planning");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports/near-expiry", "traceability");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports/expired-stock", "traceability");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/reports", "reporting");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/suppliers", "purchasing");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/purchase-orders", "purchasing");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api/inventario/receiving", "purchasing");
-    options.RequireFeature(TenantModuleFeatureKeys.Inventario, "/api");
-});
+app.UseTenantModuleFeatureGate(InventarioFeatureGateRoutes.Configure);
 
 app.EnsureDatabase<DbContext>();
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryAllocationService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryAllocationService.cs
@@ -320,11 +320,13 @@ public sealed class InventoryAllocationService(
         return Result<List<ReservationAllocation>>.Success([allocation]);
     }
 
-    private static void CompleteAllocation(
+    private void CompleteAllocation(
         ReservationAllocation allocation,
         ReservationAllocationStatus terminalStatus,
         DateTime completedAt)
     {
+        dataContext.Update(allocation);
+
         allocation.Status = terminalStatus;
         allocation.ReleasedAt = completedAt;
         allocation.FulfilledAt = terminalStatus == ReservationAllocationStatus.Fulfilled ? completedAt : null;

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/PurchasingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/PurchasingService.cs
@@ -453,21 +453,24 @@ public sealed class PurchasingService(
         if (!lotResult.IsSuccess)
             return Result<ReceivingLine>.Failure(lotResult.Message!, lotResult.StatusCode);
 
-        var stockResult = await stockPostingService.StageAsync(new PostStockMovementRequest
-        {
-            Metadata = new() { TenantId = tenantId },
-            ProductId = lineRequest.ProductId,
-            WarehouseId = document.WarehouseId,
-            LocationId = document.LocationId,
-            LotId = lotResult.Data?.Id,
-            MovementType = InventoryMovementType.Receipt,
-            Quantity = lineRequest.Quantity,
-            UnitOfMeasure = NormalizeOptional(lineRequest.UnitOfMeasure),
-            ReferenceType = "receiving",
-            ReferenceId = document.Id,
-            Reason = $"Receiving {document.ReceiptNumber}",
-            IdempotencyKey = receivingIdempotencyKey is null ? null : $"{receivingIdempotencyKey}:line:{lineIndex}"
-        }, ct);
+        var stockResult = await stockPostingService.StageAsync(
+            new PostStockMovementRequest
+            {
+                Metadata = new() { TenantId = tenantId },
+                ProductId = lineRequest.ProductId,
+                WarehouseId = document.WarehouseId,
+                LocationId = document.LocationId,
+                LotId = lotResult.Data?.Id,
+                MovementType = InventoryMovementType.Receipt,
+                Quantity = lineRequest.Quantity,
+                UnitOfMeasure = NormalizeOptional(lineRequest.UnitOfMeasure),
+                ReferenceType = "receiving",
+                ReferenceId = document.Id,
+                Reason = $"Receiving {document.ReceiptNumber}",
+                IdempotencyKey = receivingIdempotencyKey is null ? null : $"{receivingIdempotencyKey}:line:{lineIndex}"
+            },
+            lotResult.Data,
+            ct);
         if (!stockResult.IsSuccess)
             return Result<ReceivingLine>.Failure(stockResult.Message!, stockResult.StatusCode);
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
@@ -252,12 +252,13 @@ public sealed class ReservationService(
         DateTime? releasedAt = null,
         DateTime? fulfilledAt = null)
     {
+        dataContext.Update(reservation);
+
         reservation.Status = status;
         reservation.ReleasedAt = releasedAt;
         reservation.FulfilledAt = fulfilledAt;
         reservation.ModifiedAt = DateTime.UtcNow;
         reservation.ConcurrencyStamp = Guid.NewGuid();
-        dataContext.Update(reservation);
     }
 
     private Result<Guid> GetCurrentTenantId(RequestBase? request)

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using XFramework.Core.Patterns;
 using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.Contracts.Requests;
@@ -18,7 +19,8 @@ namespace XFramework.Inventario.Api.Services;
 public sealed class StockPostingService(
     IDataContext dataContext,
     IHttpContextAccessor httpContextAccessor,
-    ITenantModuleFeatureService featureService)
+    ITenantModuleFeatureService featureService,
+    DbContext? dbContext = null)
 {
     private static readonly JsonSerializerOptions HashJsonOptions = new(JsonSerializerDefaults.Web);
 
@@ -32,10 +34,17 @@ public sealed class StockPostingService(
         CancellationToken ct = default) =>
         await PostCoreAsync(request, saveChanges: false, ct);
 
+    internal async Task<Result<StockPostingResponse>> StageAsync(
+        PostStockMovementRequest request,
+        InventoryLot? stagedLot,
+        CancellationToken ct = default) =>
+        await PostCoreAsync(request, saveChanges: false, ct, stagedLot);
+
     private async Task<Result<StockPostingResponse>> PostCoreAsync(
         PostStockMovementRequest request,
         bool saveChanges,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        InventoryLot? stagedLot = null)
     {
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
@@ -60,7 +69,7 @@ public sealed class StockPostingService(
         if (product is null)
             return Result<StockPostingResponse>.NotFound("Product not found.");
 
-        var lotResult = await ValidateLotAsync(tenantId, request.ProductId, request.LotId, ct);
+        var lotResult = await ValidateLotAsync(tenantId, request.ProductId, request.LotId, stagedLot, ct);
         if (!lotResult.IsSuccess)
             return Result<StockPostingResponse>.Failure(lotResult.Message!, lotResult.StatusCode);
 
@@ -211,7 +220,7 @@ public sealed class StockPostingService(
         if (product is null)
             return Result<StockPostingResponse>.NotFound("Product not found.");
 
-        var lotResult = await ValidateLotAsync(tenantId, request.ProductId, request.LotId, ct);
+        var lotResult = await ValidateLotAsync(tenantId, request.ProductId, request.LotId, stagedLot: null, ct);
         if (!lotResult.IsSuccess)
             return Result<StockPostingResponse>.Failure(lotResult.Message!, lotResult.StatusCode);
 
@@ -295,20 +304,41 @@ public sealed class StockPostingService(
             isReplay: false));
     }
 
-    private async Task<Product?> GetProduct(Guid tenantId, Guid productId, CancellationToken ct) =>
-        await dataContext.Query<Product>()
+    private async Task<Product?> GetProduct(Guid tenantId, Guid productId, CancellationToken ct)
+    {
+        var tracked = dbContext?.Set<Product>().Local.FirstOrDefault(x =>
+            x.TenantId == tenantId &&
+            x.Id == productId &&
+            !x.IsDeleted);
+
+        if (tracked is not null)
+            return tracked;
+
+        return await dataContext.Query<Product>()
             .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.Id == productId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
+    }
 
     private async Task<Result<InventoryLot?>> ValidateLotAsync(
         Guid tenantId,
         Guid productId,
         Guid? lotId,
+        InventoryLot? stagedLot,
         CancellationToken ct)
     {
         if (lotId is null)
             return Result<InventoryLot?>.Success(null);
+
+        if (stagedLot is not null && stagedLot.Id == lotId.Value)
+        {
+            if (stagedLot.TenantId != tenantId)
+                return Result<InventoryLot?>.NotFound("Lot not found.");
+            if (stagedLot.ProductId != productId)
+                return Result<InventoryLot?>.Failure("Lot does not belong to the requested product.", 400);
+
+            return Result<InventoryLot?>.Success(stagedLot);
+        }
 
         var lot = await dataContext.Query<InventoryLot>()
             .IgnoreQueryFilters()
@@ -335,6 +365,17 @@ public sealed class StockPostingService(
         Guid? lotId,
         CancellationToken ct)
     {
+        var trackedBalance = dbContext?.Set<StockBalance>().Local.FirstOrDefault(x =>
+            x.TenantId == tenantId &&
+            x.ProductId == productId &&
+            x.WarehouseId == warehouseId &&
+            x.LocationId == locationId &&
+            x.LotId == lotId &&
+            !x.IsDeleted);
+
+        if (trackedBalance is not null)
+            return Result<StockBalanceLookup>.Success(new StockBalanceLookup(trackedBalance, IsNew: false));
+
         var warehouseExists = await dataContext.Query<Warehouse>()
             .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == warehouseId && !x.IsDeleted, ct);

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/WarehouseService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/WarehouseService.cs
@@ -1,5 +1,7 @@
+using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
 using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.Contracts.Requests;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
@@ -11,7 +13,8 @@ namespace XFramework.Inventario.Api.Services;
 
 public sealed class WarehouseService(
     IDataContext dataContext,
-    IHttpContextAccessor httpContextAccessor)
+    IHttpContextAccessor httpContextAccessor,
+    ITenantModuleFeatureService featureService)
 {
     public async Task<Result<List<Warehouse>>> GetWarehousesAsync(
         GetWarehousesRequest request,
@@ -20,6 +23,10 @@ public sealed class WarehouseService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<List<Warehouse>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureWarehousingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<Warehouse>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var warehouses = await dataContext.Query<Warehouse>()
             .IgnoreQueryFilters()
@@ -36,6 +43,10 @@ public sealed class WarehouseService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<Warehouse>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureWarehousingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<Warehouse>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
         var code = NormalizeRequired(request.Code);
@@ -83,6 +94,10 @@ public sealed class WarehouseService(
         if (!tenantResult.IsSuccess)
             return Result<List<InventoryLocation>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
+        var featureResult = await EnsureWarehousingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<List<InventoryLocation>>.Failure(featureResult.Message!, featureResult.StatusCode);
+
         var query = dataContext.Query<InventoryLocation>()
             .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
@@ -103,6 +118,10 @@ public sealed class WarehouseService(
         var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<InventoryLocation>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var featureResult = await EnsureWarehousingEnabledAsync(tenantResult.Data, ct);
+        if (!featureResult.IsSuccess)
+            return Result<InventoryLocation>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
         var code = NormalizeRequired(request.Code);
@@ -175,4 +194,11 @@ public sealed class WarehouseService(
 
     private static string? NormalizeOptional(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private async Task<Result> EnsureWarehousingEnabledAsync(Guid tenantId, CancellationToken ct) =>
+        await featureService.EnsureEnabledAsync(
+            tenantId,
+            TenantModuleFeatureKeys.Inventario,
+            TenantModuleFeatureKeys.WarehousingSubFeature,
+            ct);
 }

--- a/src/Tests/Inventario.IntegrationTests/GlobalUsings.cs
+++ b/src/Tests/Inventario.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using NUnit.Framework;
+global using FluentAssertions;
+global using Inventario.IntegrationTests;
+global using Inventario.IntegrationTests.Infrastructure;

--- a/src/Tests/Inventario.IntegrationTests/Infrastructure/InventarioIntegrationTestFixture.cs
+++ b/src/Tests/Inventario.IntegrationTests/Infrastructure/InventarioIntegrationTestFixture.cs
@@ -1,0 +1,284 @@
+using Bolt.Client;
+using Bolt.Hub.Extensions;
+using FluentValidation;
+using Inventario.Api.Features.Products.Update;
+using Inventario.Api.Infrastructure;
+using Inventario.Integration.Drivers;
+using Messaging.Integration.Drivers;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using StackExchange.Redis;
+using Testcontainers.PostgreSql;
+using XFramework.Core.DataContext;
+using XFramework.Core.Extensions;
+using XFramework.Core.Middlewares;
+using XFramework.Domain.Contexts;
+using XFramework.Domain.Interceptors;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Extensions;
+using XFramework.Integration.Extensions;
+using XFramework.Inventario.Api.Services;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests;
+
+[SetUpFixture]
+public sealed class InventarioIntegrationTestFixture
+{
+    private static PostgreSqlContainer _postgres = null!;
+    private static WebApplication _boltApp = null!;
+    private static WebApplication _inventarioApp = null!;
+    private static WebApplication _testClientApp = null!;
+    private static Task? _boltTask;
+    private static Task? _inventarioTask;
+    private static Task? _testClientTask;
+
+    public static string ConnectionString { get; private set; } = null!;
+    public static string BoltUrl => TestConstants.Ports.InventarioBolt;
+    public static string InventarioUrl => TestConstants.Ports.InventarioServer;
+    public static string TestClientUrl => TestConstants.Ports.InventarioTestClient;
+    public static Guid TestTenantId => TestConstants.TenantId;
+
+    public static IServiceProvider Services => _inventarioApp.Services;
+    public static IInventarioServiceWrapper ServiceWrapper =>
+        _testClientApp.Services.GetRequiredService<IInventarioServiceWrapper>();
+    public static IDataContext DataContext =>
+        _testClientApp.Services.CreateScope().ServiceProvider.GetRequiredService<IDataContext>();
+
+    [OneTimeSetUp]
+    public async Task GlobalSetup()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithDatabase("XFramework_Inventario_Test")
+            .WithUsername("test_user")
+            .WithPassword("test_password")
+            .Build();
+
+        await _postgres.StartAsync();
+        ConnectionString = _postgres.GetConnectionString();
+
+        await MigrateAndSeed();
+
+        _boltApp = StartBolt();
+        await TestHostWaiter.WaitForHealth($"{BoltUrl}/health/live", _boltTask);
+
+        _inventarioApp = StartInventario();
+        await TestHostWaiter.WaitForHealth($"{InventarioUrl}/health/live", _inventarioTask);
+
+        _testClientApp = StartTestClient();
+        await TestHostWaiter.WaitForHealth($"{TestClientUrl}/health/live", _testClientTask);
+
+        await WaitForBoltClients();
+    }
+
+    [OneTimeTearDown]
+    public async Task GlobalTeardown()
+    {
+        try { if (_testClientApp != null) await _testClientApp.StopAsync(); } catch { }
+        try { if (_inventarioApp != null) await _inventarioApp.StopAsync(); } catch { }
+        try { if (_boltApp != null) await _boltApp.StopAsync(); } catch { }
+        if (_postgres != null) await _postgres.DisposeAsync();
+    }
+
+    private static WebApplication StartBolt()
+    {
+        var builder = XApplication.Configure<Bolt.Hub.Installers.BoltInstaller>();
+        builder.WebHost.UseUrls(BoltUrl);
+        OverrideConfig(builder, "Bolt.InventarioTest", "00000000-0000-0000-0000-000000000020");
+
+        var app = (WebApplication)builder.Build();
+        app.UseCorrelationId();
+        app.UseAppServices();
+        app.MapGet("/health/live", () => Results.Ok("healthy"));
+
+        _boltTask = Task.Run(() => app.RunAsync());
+        return app;
+    }
+
+    private static WebApplication StartInventario()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls(InventarioUrl);
+        OverrideConfig(builder, "Inventario", "f9f79c2d-79f3-4a8e-85f6-90aef15bf184");
+        builder.Configuration["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/bolt/ws";
+
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddScoped<AuditInterceptor>();
+        builder.Services.AddDbContext<DbContext, AppDbContext>((sp, options) => options
+            .UseNpgsql(ConnectionString,
+                npgsql => npgsql.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery))
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.BoolWithDefaultWarning,
+                Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning))
+            .AddInterceptors(sp.GetRequiredService<AuditInterceptor>()));
+        builder.Services.AddServerDataContext<AppDbContext>();
+        builder.Services.InstallStandardServices<ProductService>(builder.Configuration);
+        builder.Services.AddMemoryCaching();
+        builder.Services.AddSingleton<IDistributedCache>(_ => null!);
+        builder.Services.AddSingleton<IConnectionMultiplexer>(_ => null!);
+        builder.Services.AddMessagingWrapperServices();
+        builder.Services.AddTenantResolver();
+        builder.Services.AddTenantModuleFeatures();
+        builder.Services.AddScoped<ProductService>();
+        builder.Services.AddScoped<StockPostingService>();
+        builder.Services.AddScoped<WarehouseService>();
+        builder.Services.AddScoped<ReservationService>();
+        builder.Services.AddScoped<InventoryAllocationService>();
+        builder.Services.AddScoped<InventoryLotService>();
+        builder.Services.AddScoped<InventoryPlanningService>();
+        builder.Services.AddScoped<InventoryReportingService>();
+        builder.Services.AddScoped<PurchasingService>();
+        builder.Services.AddValidatorsFromAssemblyContaining<ProductService>();
+        builder.Services.AddAuthentication("InventarioTest")
+            .AddScheme<AuthenticationSchemeOptions, InventarioTestAuthHandler>("InventarioTest", _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddXFrameworkBoltClient(builder.Configuration, autoConnect: false);
+        builder.Services.AddDataContextHandler(typeof(ProductService).Assembly);
+
+        var app = (WebApplication)builder.Build();
+        RegisterInventarioBoltHandlers(app);
+        app.UseCorrelationId();
+        app.UseAuthentication();
+        app.UseTenantModuleFeatureGate(InventarioFeatureGateRoutes.Configure);
+        app.UseAuthorization();
+
+        var authorizedRoutes = app.MapGroup("").RequireAuthorization();
+        Inventario.Api.Generated.GeneratedEndpointRoutes.MapGeneratedEndpoints(authorizedRoutes);
+        UpdateProductEndpoint.Map(authorizedRoutes);
+        app.MapGet("/health/live", () => Results.Ok("healthy"));
+
+        _inventarioTask = Task.Run(() => app.RunAsync());
+        return app;
+    }
+
+    private static void RegisterInventarioBoltHandlers(WebApplication app)
+    {
+        var client = app.Services.GetRequiredService<BoltClient>();
+        var logger = app.Services.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Inventario.GeneratedBoltHandlers");
+        var scopeFactory = app.Services.GetRequiredService<IServiceScopeFactory>();
+
+        Inventario.Api.Generated.BoltHandlerRegistry.RegisterAll(client, logger, scopeFactory);
+    }
+
+    private static WebApplication StartTestClient()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls(TestClientUrl);
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["BoltConfiguration:ClientName"] = "InventarioTestClient",
+            ["BoltConfiguration:ClientGuid"] = Guid.NewGuid().ToString(),
+            ["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/bolt/ws",
+            ["Tenant:DefaultId"] = TestTenantId.ToString(),
+            ["Logging:LogLevel:Default"] = "Warning"
+        });
+
+        builder.Services.InstallStandardServices<InventarioIntegrationTestFixture>(builder.Configuration);
+        builder.Services.AddSingleton(new DeviceAgentProvider("InventarioTest"));
+        builder.Services.AddXFrameworkBoltClient(builder.Configuration, autoConnect: false);
+        builder.Services.AddInventarioWrapperServices();
+        builder.Services.AddRemoteDataContext();
+        builder.Services.AddScoped(_ => new RequestMetadata
+        {
+            TenantId = TestTenantId,
+            RequestId = Guid.NewGuid()
+        });
+
+        var app = builder.Build();
+        app.MapGet("/health/live", () => Results.Ok("healthy"));
+
+        _testClientTask = Task.Run(() => app.RunAsync());
+        return app;
+    }
+
+    private static async Task WaitForBoltClients()
+    {
+        var inventarioClient = _inventarioApp.Services.GetRequiredService<BoltClient>();
+        var testClient = _testClientApp.Services.GetRequiredService<BoltClient>();
+
+        await ConnectBoltClient(inventarioClient, "Inventario service");
+        await ConnectBoltClient(testClient, "Inventario test client");
+        await Task.Delay(1000);
+
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (inventarioClient.IsConnected && testClient.IsConnected)
+            {
+                await Task.Delay(1000);
+                return;
+            }
+
+            await Task.Delay(250);
+        }
+
+        throw new TimeoutException("Inventario Bolt clients failed to connect within 15s");
+    }
+
+    private static async Task ConnectBoltClient(BoltClient client, string clientName)
+    {
+        if (client.IsConnected)
+            return;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        try
+        {
+            await client.ConnectWithRetryAsync(cts.Token);
+        }
+        catch (OperationCanceledException ex)
+        {
+            throw new TimeoutException($"{clientName} Bolt client failed to connect within 15s", ex);
+        }
+    }
+
+    private static void OverrideConfig(WebApplicationBuilder builder, string clientName, string clientGuid)
+    {
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DefaultDatabaseConnection"] = ConnectionString,
+            ["BoltConfiguration:ClientGuid"] = clientGuid,
+            ["BoltConfiguration:ClientName"] = clientName,
+            ["Tenant:DefaultId"] = TestTenantId.ToString(),
+            ["Logging:LogLevel:Default"] = "Warning"
+        });
+    }
+
+    private static async Task MigrateAndSeed()
+    {
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(IdentityServer.Domain.Shared.Contracts.IdentityCredential).TypeHandle);
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(Wallets.Domain.Shared.Contracts.WalletType).TypeHandle);
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(XFramework.Inventario.Domain.Shared.Contracts.Product).TypeHandle);
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(ConnectionString)
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        await using var db = new AppDbContext(options);
+        await db.Database.MigrateAsync();
+        await TestSeedData.SeedAll(db);
+        await EnableInventarioFeatures(db);
+    }
+
+    private static async Task EnableInventarioFeatures(AppDbContext db)
+    {
+        await TestInventarioSeed.SetInventarioFeature(db, string.Empty, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.CatalogSubFeature, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.WarehousingSubFeature, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.StockBalancesSubFeature, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.MovementsSubFeature, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.ReservationsSubFeature, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.TraceabilitySubFeature, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.PlanningSubFeature, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.InventarioReportingSubFeature, true);
+        await TestInventarioSeed.SetInventarioFeature(db, IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.PurchasingSubFeature, true);
+    }
+}

--- a/src/Tests/Inventario.IntegrationTests/Infrastructure/InventarioTestAuthHandler.cs
+++ b/src/Tests/Inventario.IntegrationTests/Infrastructure/InventarioTestAuthHandler.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Infrastructure;
+
+public sealed class InventarioTestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (Request.Headers.TryGetValue(TestAuthHeaders.Unauthenticated, out var unauthenticatedHeader) &&
+            bool.TryParse(unauthenticatedHeader.FirstOrDefault(), out var unauthenticated) &&
+            unauthenticated)
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var tenantId = TryGetGuidHeader(TestAuthHeaders.TenantId, out var suppliedTenantId)
+            ? suppliedTenantId
+            : InventarioIntegrationTestFixture.TestTenantId;
+        var identityId = TryGetGuidHeader(TestAuthHeaders.IdentityId, out var suppliedIdentityId)
+            ? suppliedIdentityId
+            : Guid.Parse("00000000-0000-0000-0000-000000000184");
+        var username = Request.Headers.TryGetValue(TestAuthHeaders.Username, out var usernameHeader)
+            ? usernameHeader.FirstOrDefault() ?? "inventario-test"
+            : "inventario-test";
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, identityId.ToString()),
+            new(ClaimTypes.Name, username),
+            new("identity_id", identityId.ToString()),
+            new("tenantId", tenantId.ToString()),
+            new("TenantId", tenantId.ToString()),
+            new("tid", tenantId.ToString())
+        };
+
+        if (TryGetGuidHeader(TestAuthHeaders.CredentialId, out var credentialId))
+            claims.Add(new Claim("credential_id", credentialId.ToString()));
+
+        if (Request.Headers.TryGetValue(TestAuthHeaders.Roles, out var roleHeader))
+        {
+            foreach (var role in roleHeader.SelectMany(static value =>
+                         value?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? []))
+            {
+                claims.Add(new Claim(ClaimTypes.Role, role));
+            }
+        }
+        else
+        {
+            claims.Add(new Claim(ClaimTypes.Role, "Admin"));
+        }
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+
+    private bool TryGetGuidHeader(string headerName, out Guid value)
+    {
+        value = Guid.Empty;
+        return Request.Headers.TryGetValue(headerName, out var header) &&
+               Guid.TryParse(header.FirstOrDefault(), out value);
+    }
+}

--- a/src/Tests/Inventario.IntegrationTests/Infrastructure/InventarioTestBase.cs
+++ b/src/Tests/Inventario.IntegrationTests/Infrastructure/InventarioTestBase.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using XFramework.Domain.Contexts;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Infrastructure;
+
+public abstract class InventarioTestBase
+{
+    protected HttpClient HttpClient { get; private set; } = null!;
+
+    [SetUp]
+    public void BaseSetUp()
+    {
+        HttpClient = new HttpClient
+        {
+            BaseAddress = new Uri(InventarioIntegrationTestFixture.InventarioUrl)
+        };
+    }
+
+    [TearDown]
+    public void BaseTearDown() => HttpClient.Dispose();
+
+    protected AppDbContext CreateDbContext()
+    {
+        var connectionString = InventarioIntegrationTestFixture.ConnectionString;
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException("Inventario integration test database connection string was not initialized.");
+        }
+
+        var connection = new NpgsqlConnection(connectionString);
+        var options = new DbContextOptionsBuilder()
+            .UseNpgsql(connection)
+            .Options;
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tenant:DefaultId"] = InventarioIntegrationTestFixture.TestTenantId.ToString()
+            })
+            .Build();
+
+        return new AppDbContext(options, new HttpContextAccessor(), config);
+    }
+
+    protected static RequestMetadata CreateMetadata() => new()
+    {
+        TenantId = InventarioIntegrationTestFixture.TestTenantId,
+        RequestId = Guid.NewGuid(),
+        IpAddress = "127.0.0.1",
+        Name = "InventarioIntegrationTest",
+        DeviceName = "TestDevice",
+        DeviceAgent = "TestAgent"
+    };
+
+    protected static string UniqueCode(string prefix) => $"{prefix}-{Guid.NewGuid():N}"[..Math.Min(prefix.Length + 13, prefix.Length + 33)];
+}

--- a/src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj
+++ b/src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>Inventario.IntegrationTests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Integration\Inventario.Integration.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Bolt\Bolt.Hub\Bolt.Hub.csproj" />
+        <ProjectReference Include="..\XFramework.TestInfrastructure\XFramework.TestInfrastructure.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.Inventario)]
+[Category(TestCategories.Catalog)]
+public sealed class CatalogTests : InventarioTestBase
+{
+    [Test]
+    public async Task SaveChangesAsync_RemoteProductCategoryCreate_PersistsThroughInventarioDataContext()
+    {
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+        var category = new ProductCategory
+        {
+            Id = Guid.NewGuid(),
+            TenantId = InventarioIntegrationTestFixture.TestTenantId,
+            Name = $"Category {Guid.NewGuid():N}",
+            Description = "Remote DataContext category",
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        ctx.Add(category);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        await using var db = CreateDbContext();
+        var persisted = await db.Set<ProductCategory>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.Id == category.Id);
+        persisted.Should().NotBeNull();
+        persisted!.TenantId.Should().Be(InventarioIntegrationTestFixture.TestTenantId);
+    }
+
+    [Test]
+    public async Task SaveChangesAsync_RemoteProductCreate_PersistsWithCategory()
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+        var product = new Product
+        {
+            Id = Guid.NewGuid(),
+            TenantId = InventarioIntegrationTestFixture.TestTenantId,
+            CategoryId = category.Id,
+            Name = $"Product {Guid.NewGuid():N}",
+            SKU = $"SKU-{Guid.NewGuid():N}"[..18],
+            Price = 25m,
+            IsAvailable = true,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        ctx.Add(product);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        var persisted = await db.Set<Product>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.Id == product.Id);
+        persisted.Should().NotBeNull();
+        persisted!.CategoryId.Should().Be(category.Id);
+    }
+}

--- a/src/Tests/Inventario.IntegrationTests/Tests/PlanningPurchasingReportingTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/PlanningPurchasingReportingTests.cs
@@ -1,0 +1,372 @@
+using Microsoft.EntityFrameworkCore;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reports;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Enums;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.Inventario)]
+public sealed class PlanningPurchasingReportingTests : InventarioTestBase
+{
+    [Test]
+    [Category(TestCategories.Planning)]
+    [Category(TestCategories.Reporting)]
+    public async Task GetReorderSuggestions_LowStockProduct_ReturnsSuggestedQuantity()
+    {
+        var seed = await SeedInventoryScope();
+        var rule = await InventarioIntegrationTestFixture.ServiceWrapper.CreateInventoryReorderRule(
+            new CreateInventoryReorderRuleRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                MinimumQuantity = 5,
+                MaximumQuantity = 50,
+                ReorderPoint = 10,
+                ReorderQuantity = 25,
+                PreferredSupplier = "preferred-supplier",
+                IsActive = true
+            });
+        rule.IsSuccess.Should().BeTrue(rule.Message);
+
+        await PostOpeningBalance(seed.Product.Id, seed.Warehouse.Id, seed.Location.Id, quantity: 4);
+
+        var suggestions = await InventarioIntegrationTestFixture.ServiceWrapper.GetReorderSuggestions(
+            new GetReorderSuggestionsRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id
+            });
+
+        suggestions.IsSuccess.Should().BeTrue(suggestions.Message);
+        suggestions.Response.Should().ContainSingle(x =>
+            x.ProductId == seed.Product.Id &&
+            x.SuggestedQuantity == 46);
+
+        var lowStock = await InventarioIntegrationTestFixture.ServiceWrapper.GetLowStockReport(
+            new GetLowStockReportRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id
+            });
+
+        lowStock.IsSuccess.Should().BeTrue(lowStock.Message);
+        lowStock.Response.Should().ContainSingle(x =>
+            x.ProductId == seed.Product.Id &&
+            x.AvailableQuantity == 4 &&
+            x.ReorderPoint == 10);
+    }
+
+    [Test]
+    [Category(TestCategories.Reporting)]
+    public async Task GetStockPositionReport_PostedStock_ReturnsProductLocationLotRow()
+    {
+        var seed = await SeedInventoryScope(withLot: true);
+        await PostOpeningBalance(seed.Product.Id, seed.Warehouse.Id, seed.Location.Id, seed.Lot?.Id, 12);
+
+        var report = await InventarioIntegrationTestFixture.ServiceWrapper.GetStockPositionReport(
+            new GetStockPositionReportRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                LotId = seed.Lot?.Id
+            });
+
+        report.IsSuccess.Should().BeTrue(report.Message);
+        report.Response.Should().ContainSingle(x =>
+            x.ProductId == seed.Product.Id &&
+            x.LotId == seed.Lot!.Id &&
+            x.OnHandQuantity == 12);
+    }
+
+    [Test]
+    [Category(TestCategories.Reporting)]
+    public async Task ExpiryAndMovementReports_PostedLots_ReturnFilteredRows()
+    {
+        var nearExpirySeed = await SeedInventoryScope(withLot: true, expiresAt: DateTime.UtcNow.AddDays(7));
+        var expiredSeed = await SeedInventoryScope(withLot: true, expiresAt: DateTime.UtcNow.AddDays(-2));
+
+        await PostOpeningBalance(
+            nearExpirySeed.Product.Id,
+            nearExpirySeed.Warehouse.Id,
+            nearExpirySeed.Location.Id,
+            nearExpirySeed.Lot!.Id,
+            8,
+            referenceType: "near-expiry-report");
+        await PostOpeningBalance(
+            expiredSeed.Product.Id,
+            expiredSeed.Warehouse.Id,
+            expiredSeed.Location.Id,
+            expiredSeed.Lot!.Id,
+            6,
+            referenceType: "expired-report");
+
+        var nearExpiry = await InventarioIntegrationTestFixture.ServiceWrapper.GetNearExpiryStockReport(
+            new GetNearExpiryStockReportRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = nearExpirySeed.Product.Id,
+                DaysAhead = 30
+            });
+        var expired = await InventarioIntegrationTestFixture.ServiceWrapper.GetExpiredStockReport(
+            new GetExpiredStockReportRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = expiredSeed.Product.Id
+            });
+        var movementLedger = await InventarioIntegrationTestFixture.ServiceWrapper.GetMovementLedgerReport(
+            new GetMovementLedgerReportRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = nearExpirySeed.Product.Id,
+                LotId = nearExpirySeed.Lot.Id,
+                ReferenceType = "near-expiry-report"
+            });
+
+        nearExpiry.IsSuccess.Should().BeTrue(nearExpiry.Message);
+        nearExpiry.Response.Should().ContainSingle(x => x.LotId == nearExpirySeed.Lot.Id);
+
+        expired.IsSuccess.Should().BeTrue(expired.Message);
+        expired.Response.Should().ContainSingle(x => x.LotId == expiredSeed.Lot.Id);
+
+        movementLedger.IsSuccess.Should().BeTrue(movementLedger.Message);
+        movementLedger.Response.Should().ContainSingle(x =>
+            x.LotId == nearExpirySeed.Lot.Id &&
+            x.ReferenceType == "near-expiry-report");
+    }
+
+    [Test]
+    [Category(TestCategories.Reporting)]
+    [Category(TestCategories.Reservations)]
+    public async Task GetReservationAllocationStatusReport_ReservedStock_ReturnsAllocationRow()
+    {
+        var seed = await SeedInventoryScope(withLot: true);
+        await PostOpeningBalance(seed.Product.Id, seed.Warehouse.Id, seed.Location.Id, seed.Lot!.Id, 9);
+        var referenceId = Guid.NewGuid();
+
+        var reservation = await InventarioIntegrationTestFixture.ServiceWrapper.ReserveInventory(
+            new ReserveInventoryRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                LotId = seed.Lot.Id,
+                Quantity = 3,
+                ReferenceType = "allocation-report",
+                ReferenceId = referenceId
+            });
+        reservation.IsSuccess.Should().BeTrue(reservation.Message);
+
+        var report = await InventarioIntegrationTestFixture.ServiceWrapper.GetReservationAllocationStatusReport(
+            new GetReservationAllocationStatusReportRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                LotId = seed.Lot.Id,
+                Status = ReservationAllocationStatus.Reserved
+            });
+
+        report.IsSuccess.Should().BeTrue(report.Message);
+        report.Response.Should().ContainSingle(x =>
+            x.ProductId == seed.Product.Id &&
+            x.LotId == seed.Lot.Id &&
+            x.Quantity == 3 &&
+            x.Status == ReservationAllocationStatus.Reserved);
+    }
+
+    [Test]
+    [Category(TestCategories.Purchasing)]
+    public async Task ReceiveInventory_AgainstPurchaseOrder_PostsReceiptAndUpdatesOrderStatus()
+    {
+        var seed = await SeedInventoryScope();
+        var supplierCode = UniqueCode("SUP");
+        var supplier = await InventarioIntegrationTestFixture.ServiceWrapper.CreateSupplier(
+            new CreateSupplierRequest
+            {
+                Metadata = CreateMetadata(),
+                Code = supplierCode,
+                Name = "Integration Supplier",
+                IsActive = true
+            });
+        supplier.IsSuccess.Should().BeTrue(supplier.Message);
+
+        await using var setupDb = CreateDbContext();
+        var persistedSupplier = await setupDb.Set<Supplier>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Code == supplierCode);
+
+        var orderNumber = UniqueCode("PO");
+        var order = await InventarioIntegrationTestFixture.ServiceWrapper.CreatePurchaseOrder(
+            new CreatePurchaseOrderRequest
+            {
+                Metadata = CreateMetadata(),
+                OrderNumber = orderNumber,
+                SupplierId = persistedSupplier.Id,
+                Status = PurchaseOrderStatus.Open,
+                Lines =
+                [
+                    new PurchaseOrderLineRequest
+                    {
+                        ProductId = seed.Product.Id,
+                        OrderedQuantity = 10,
+                        UnitCost = 7m,
+                        UnitOfMeasure = "ea"
+                    }
+                ]
+            });
+        order.IsSuccess.Should().BeTrue(order.Message);
+
+        var persistedOrder = await setupDb.Set<PurchaseOrder>()
+            .IgnoreQueryFilters()
+            .Include(x => x.Lines)
+            .FirstAsync(x => x.OrderNumber == orderNumber);
+        persistedOrder.Lines.Should().ContainSingle();
+        var line = persistedOrder.Lines[0];
+
+        var receiptNumber = UniqueCode("RCV");
+        var receipt = await InventarioIntegrationTestFixture.ServiceWrapper.ReceiveInventory(
+            new ReceiveInventoryRequest
+            {
+                Metadata = CreateMetadata(),
+                ReceiptNumber = receiptNumber,
+                PurchaseOrderId = persistedOrder.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                SupplierId = persistedSupplier.Id,
+                ReceivedAt = DateTime.UtcNow,
+                IdempotencyKey = $"receive-{Guid.NewGuid():N}",
+                Lines =
+                [
+                    new ReceivingLineRequest
+                    {
+                        PurchaseOrderLineId = line.Id,
+                        ProductId = seed.Product.Id,
+                        Quantity = 5,
+                        UnitCost = 7m,
+                        UnitOfMeasure = "ea",
+                        LotNumber = UniqueCode("LOT"),
+                        ExpiresAt = DateTime.UtcNow.AddDays(180)
+                    }
+                ]
+            });
+
+        receipt.IsSuccess.Should().BeTrue(receipt.Message);
+
+        await using var db = CreateDbContext();
+        var persistedReceipt = await db.Set<ReceivingDocument>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ReceiptNumber == receiptNumber);
+        persistedReceipt.Status.Should().Be(ReceivingDocumentStatus.Posted);
+
+        var updatedOrder = await db.Set<PurchaseOrder>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Id == persistedOrder.Id);
+        updatedOrder.Status.Should().Be(PurchaseOrderStatus.PartiallyReceived);
+
+        var movement = await db.Set<InventoryMovement>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.ReferenceId == persistedReceipt.Id && x.MovementType == InventoryMovementType.Receipt);
+        movement.Should().NotBeNull();
+    }
+
+    [Test]
+    [Category(TestCategories.Purchasing)]
+    public async Task ReceiveInventory_SameIdempotencyKeyAndPayload_ReplaysWithoutDuplicateDocument()
+    {
+        var seed = await SeedInventoryScope();
+        var key = $"receive-idem-{Guid.NewGuid():N}";
+        var receivedAt = DateTime.UtcNow;
+        var receiptNumber = UniqueCode("RCV");
+        var request = new ReceiveInventoryRequest
+        {
+            Metadata = CreateMetadata(),
+            ReceiptNumber = receiptNumber,
+            WarehouseId = seed.Warehouse.Id,
+            LocationId = seed.Location.Id,
+            ReceivedAt = receivedAt,
+            IdempotencyKey = key,
+            Lines =
+            [
+                new ReceivingLineRequest
+                {
+                    ProductId = seed.Product.Id,
+                    Quantity = 3,
+                    UnitCost = 5m,
+                    UnitOfMeasure = "ea"
+                }
+            ]
+        };
+
+        var first = await InventarioIntegrationTestFixture.ServiceWrapper.ReceiveInventory(request);
+        var replay = await InventarioIntegrationTestFixture.ServiceWrapper.ReceiveInventory(request);
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        replay.IsSuccess.Should().BeTrue(replay.Message);
+
+        await using var db = CreateDbContext();
+        var documentCount = await db.Set<ReceivingDocument>()
+            .IgnoreQueryFilters()
+            .CountAsync(x => x.IdempotencyKey == key);
+        documentCount.Should().Be(1);
+    }
+
+    private async Task<InventoryScope> SeedInventoryScope(
+        bool withLot = false,
+        DateTime? expiresAt = null)
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var product = await TestInventarioSeed.SeedProduct(db, categoryId: category.Id);
+        var warehouse = await TestInventarioSeed.SeedWarehouse(db);
+        var location = await TestInventarioSeed.SeedLocation(db, warehouse.Id);
+        var lot = withLot
+            ? await TestInventarioSeed.SeedLot(db, product.Id, expiresAt: expiresAt ?? DateTime.UtcNow.AddDays(120))
+            : null;
+        return new InventoryScope(product, warehouse, location, lot);
+    }
+
+    private static async Task PostOpeningBalance(
+        Guid productId,
+        Guid warehouseId,
+        Guid locationId,
+        Guid? lotId = null,
+        decimal quantity = 1,
+        string? referenceType = null)
+    {
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.PostStockMovement(
+            new PostStockMovementRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = productId,
+                WarehouseId = warehouseId,
+                LocationId = locationId,
+                LotId = lotId,
+                MovementType = InventoryMovementType.OpeningBalance,
+                Quantity = quantity,
+                ReferenceType = referenceType,
+                IdempotencyKey = $"planning-stock-{Guid.NewGuid():N}"
+            });
+        result.IsSuccess.Should().BeTrue(result.Message);
+    }
+
+    private sealed record InventoryScope(
+        Product Product,
+        Warehouse Warehouse,
+        InventoryLocation Location,
+        InventoryLot? Lot);
+}

--- a/src/Tests/Inventario.IntegrationTests/Tests/SmokeTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/SmokeTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using XFramework.Core.Services.FeatureGates;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.Inventario)]
+public sealed class SmokeTests : InventarioTestBase
+{
+    [Test]
+    [Category(TestCategories.Auth)]
+    public async Task GetWarehouses_UnauthenticatedRequest_ReturnsUnauthorizedOrForbidden()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/inventario/warehouses");
+        request.Headers.Add(TestAuthHeaders.Unauthenticated, "true");
+
+        using var response = await HttpClient.SendAsync(request);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    [Category(TestCategories.FeatureGates)]
+    public async Task CreateWarehouse_WarehousingFeatureDisabled_ReturnsForbidden()
+    {
+        var tenantId = Guid.NewGuid();
+        await using (var db = CreateDbContext())
+        {
+            db.Set<Tenant>().Add(new Tenant
+            {
+                Id = tenantId,
+                TenantId = tenantId,
+                Name = "Inventario Disabled Tenant",
+                Description = "Feature gate test tenant",
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+            await TestInventarioSeed.SetInventarioFeature(db, string.Empty, true, tenantId);
+            await TestInventarioSeed.SetInventarioFeature(db, TenantModuleFeatureKeys.WarehousingSubFeature, false, tenantId);
+
+            var seededFeature = await db.Set<TenantModuleFeature>()
+                .IgnoreQueryFilters()
+                .SingleAsync(x =>
+                    x.TenantId == tenantId &&
+                    x.ModuleKey == TenantModuleFeatureKeys.Inventario &&
+                    x.SubFeatureKey == TenantModuleFeatureKeys.WarehousingSubFeature);
+            seededFeature.IsEnabled.Should().BeFalse();
+        }
+
+        using (var scope = InventarioIntegrationTestFixture.Services.CreateScope())
+        {
+            var featureService = scope.ServiceProvider.GetRequiredService<ITenantModuleFeatureService>();
+            var featureResult = await featureService.IsEnabledAsync(
+                tenantId,
+                TenantModuleFeatureKeys.Inventario,
+                TenantModuleFeatureKeys.WarehousingSubFeature);
+            featureResult.IsSuccess.Should().BeTrue();
+            featureResult.Data.Should().BeFalse();
+        }
+
+        var metadata = CreateMetadata();
+        metadata.TenantId = tenantId;
+
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.CreateWarehouse(
+            new CreateWarehouseRequest
+            {
+                Metadata = metadata,
+                Code = UniqueCode("WH"),
+                Name = "Disabled Warehouse"
+            });
+
+        result.IsSuccess.Should().BeFalse();
+        result.HttpStatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    [Category(TestCategories.DataContext)]
+    public async Task RemoteQuery_ToListAsync_ReturnsProductsFromInventarioService()
+    {
+        await using var db = CreateDbContext();
+        var product = await TestInventarioSeed.SeedProduct(db);
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+
+        var products = await ctx.Query<Product>()
+            .Where(x => x.Id == product.Id)
+            .ToListAsync();
+
+        products.Should().ContainSingle(x => x.Id == product.Id);
+    }
+}

--- a/src/Tests/Inventario.IntegrationTests/Tests/StockReservationTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/StockReservationTests.cs
@@ -1,0 +1,380 @@
+using Microsoft.EntityFrameworkCore;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Enums;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.Inventario)]
+public sealed class StockReservationTests : InventarioTestBase
+{
+    [Test]
+    [Category(TestCategories.Stock)]
+    public async Task PostStockMovement_OpeningBalance_CreatesMovementAndBalance()
+    {
+        var seed = await SeedInventoryScope();
+
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.PostStockMovement(
+            new PostStockMovementRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                LotId = seed.Lot.Id,
+                MovementType = InventoryMovementType.OpeningBalance,
+                Quantity = 25,
+                IdempotencyKey = $"stock-{Guid.NewGuid():N}"
+            });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+
+        await using var db = CreateDbContext();
+        var balance = await db.Set<StockBalance>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x =>
+                x.ProductId == seed.Product.Id &&
+                x.WarehouseId == seed.Warehouse.Id &&
+                x.LocationId == seed.Location.Id &&
+                x.LotId == seed.Lot.Id);
+        balance.Should().NotBeNull();
+        balance!.OnHandQuantity.Should().Be(25);
+        balance.AvailableQuantity.Should().Be(25);
+
+        var movement = await db.Set<InventoryMovement>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.StockBalanceId == balance.Id);
+        movement.Should().NotBeNull();
+        movement!.LotId.Should().Be(seed.Lot.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.Stock)]
+    public async Task PostStockMovement_SameIdempotencyKeyAndPayload_ReplaysWithoutDoublePosting()
+    {
+        var seed = await SeedInventoryScope();
+        var key = $"stock-idem-{Guid.NewGuid():N}";
+        var request = new PostStockMovementRequest
+        {
+            Metadata = CreateMetadata(),
+            ProductId = seed.Product.Id,
+            WarehouseId = seed.Warehouse.Id,
+            LocationId = seed.Location.Id,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 10,
+            IdempotencyKey = key
+        };
+
+        var first = await InventarioIntegrationTestFixture.ServiceWrapper.PostStockMovement(request);
+        var replay = await InventarioIntegrationTestFixture.ServiceWrapper.PostStockMovement(request);
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        replay.IsSuccess.Should().BeTrue(replay.Message);
+
+        await using var db = CreateDbContext();
+        var movementCount = await db.Set<InventoryMovement>()
+            .IgnoreQueryFilters()
+            .CountAsync(x => x.IdempotencyKey == key);
+        movementCount.Should().Be(1);
+    }
+
+    [Test]
+    [Category(TestCategories.Stock)]
+    public async Task PostStockMovement_SameIdempotencyKeyDifferentPayload_ReturnsConflict()
+    {
+        var seed = await SeedInventoryScope();
+        var key = $"stock-conflict-{Guid.NewGuid():N}";
+        var request = new PostStockMovementRequest
+        {
+            Metadata = CreateMetadata(),
+            ProductId = seed.Product.Id,
+            WarehouseId = seed.Warehouse.Id,
+            LocationId = seed.Location.Id,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 10,
+            IdempotencyKey = key
+        };
+
+        var first = await InventarioIntegrationTestFixture.ServiceWrapper.PostStockMovement(request);
+        var conflict = await InventarioIntegrationTestFixture.ServiceWrapper.PostStockMovement(request with { Quantity = 11 });
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        conflict.IsSuccess.Should().BeFalse();
+        conflict.HttpStatusCode.Should().Be(System.Net.HttpStatusCode.Conflict);
+    }
+
+    [Test]
+    [Category(TestCategories.Reservations)]
+    public async Task ReserveInventory_LotOmitted_AllocatesEarliestExpiryFirst()
+    {
+        await using var setupDb = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(setupDb);
+        var product = await TestInventarioSeed.SeedProduct(setupDb, categoryId: category.Id);
+        var warehouse = await TestInventarioSeed.SeedWarehouse(setupDb);
+        var location = await TestInventarioSeed.SeedLocation(setupDb, warehouse.Id);
+        var laterLot = await TestInventarioSeed.SeedLot(setupDb, product.Id, expiresAt: DateTime.UtcNow.AddDays(60));
+        var earlierLot = await TestInventarioSeed.SeedLot(setupDb, product.Id, expiresAt: DateTime.UtcNow.AddDays(15));
+
+        await PostOpeningBalance(product.Id, warehouse.Id, location.Id, laterLot.Id, 10);
+        await PostOpeningBalance(product.Id, warehouse.Id, location.Id, earlierLot.Id, 10);
+
+        var referenceId = Guid.NewGuid();
+        var reservation = await InventarioIntegrationTestFixture.ServiceWrapper.ReserveInventory(
+            new ReserveInventoryRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = product.Id,
+                WarehouseId = warehouse.Id,
+                LocationId = location.Id,
+                Quantity = 6,
+                ReferenceType = "integration-test",
+                ReferenceId = referenceId
+            });
+
+        reservation.IsSuccess.Should().BeTrue(reservation.Message);
+
+        await using var assertDb = CreateDbContext();
+        var persistedReservation = await assertDb.Set<Reservation>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.ReferenceId == referenceId);
+        persistedReservation.Should().NotBeNull();
+
+        var allocations = await assertDb.Set<ReservationAllocation>()
+            .IgnoreQueryFilters()
+            .Where(x => x.ReservationId == persistedReservation!.Id)
+            .ToListAsync();
+
+        allocations.Should().ContainSingle();
+        allocations[0].LotId.Should().Be(earlierLot.Id);
+        allocations[0].Quantity.Should().Be(6);
+    }
+
+    [Test]
+    [Category(TestCategories.Reservations)]
+    public async Task ReserveInventory_OnlyExpiredLotWithoutOverride_ReturnsConflict()
+    {
+        await using var setupDb = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(setupDb);
+        var product = await TestInventarioSeed.SeedProduct(setupDb, categoryId: category.Id);
+        var warehouse = await TestInventarioSeed.SeedWarehouse(setupDb);
+        var location = await TestInventarioSeed.SeedLocation(setupDb, warehouse.Id);
+        var expiredLot = await TestInventarioSeed.SeedLot(setupDb, product.Id, expiresAt: DateTime.UtcNow.AddDays(-1));
+
+        await PostOpeningBalance(product.Id, warehouse.Id, location.Id, expiredLot.Id, 10);
+
+        var reservation = await InventarioIntegrationTestFixture.ServiceWrapper.ReserveInventory(
+            new ReserveInventoryRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = product.Id,
+                WarehouseId = warehouse.Id,
+                LocationId = location.Id,
+                Quantity = 3,
+                ReferenceType = "expired-lot-test",
+                ReferenceId = Guid.NewGuid()
+            });
+
+        reservation.IsSuccess.Should().BeFalse();
+        reservation.HttpStatusCode.Should().Be(System.Net.HttpStatusCode.Conflict);
+
+        await using var assertDb = CreateDbContext();
+        var allocationCount = await assertDb.Set<ReservationAllocation>()
+            .IgnoreQueryFilters()
+            .CountAsync(x => x.ProductId == product.Id);
+        allocationCount.Should().Be(0);
+    }
+
+    [Test]
+    [Category(TestCategories.Reservations)]
+    public async Task ReleaseReservation_ActiveReservation_ReleasesAllocationAndAvailability()
+    {
+        var seed = await SeedInventoryScope();
+        await PostOpeningBalance(seed.Product.Id, seed.Warehouse.Id, seed.Location.Id, seed.Lot.Id, 10);
+        var reservationId = await ReserveAndGetId(seed, quantity: 4);
+
+        var release = await InventarioIntegrationTestFixture.ServiceWrapper.ReleaseReservation(
+            new ReleaseReservationRequest
+            {
+                Metadata = CreateMetadata(),
+                ReservationId = reservationId,
+                Reason = "integration release"
+            });
+
+        release.IsSuccess.Should().BeTrue(release.Message);
+
+        await using var db = CreateDbContext();
+        var reservation = await db.Set<Reservation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Id == reservationId);
+        reservation.Status.Should().Be(ReservationStatus.Released);
+
+        var allocation = await db.Set<ReservationAllocation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ReservationId == reservationId);
+        allocation.Status.Should().Be(ReservationAllocationStatus.Released);
+
+        var balance = await db.Set<StockBalance>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x =>
+                x.ProductId == seed.Product.Id &&
+                x.WarehouseId == seed.Warehouse.Id &&
+                x.LocationId == seed.Location.Id &&
+                x.LotId == seed.Lot.Id);
+        balance.ReservedQuantity.Should().Be(0);
+        balance.AvailableQuantity.Should().Be(10);
+    }
+
+    [Test]
+    [Category(TestCategories.Reservations)]
+    public async Task FulfillReservation_ActiveReservation_PostsShipmentAndCompletesAllocation()
+    {
+        var seed = await SeedInventoryScope();
+        await PostOpeningBalance(seed.Product.Id, seed.Warehouse.Id, seed.Location.Id, seed.Lot.Id, 10);
+        var reservationId = await ReserveAndGetId(seed, quantity: 4);
+
+        var fulfill = await InventarioIntegrationTestFixture.ServiceWrapper.FulfillReservation(
+            new FulfillReservationRequest
+            {
+                Metadata = CreateMetadata(),
+                ReservationId = reservationId,
+                Reason = "integration fulfill"
+            });
+
+        fulfill.IsSuccess.Should().BeTrue(fulfill.Message);
+
+        await using var db = CreateDbContext();
+        var reservation = await db.Set<Reservation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Id == reservationId);
+        reservation.Status.Should().Be(ReservationStatus.Fulfilled);
+
+        var allocation = await db.Set<ReservationAllocation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ReservationId == reservationId);
+        allocation.Status.Should().Be(ReservationAllocationStatus.Fulfilled);
+        allocation.FulfilledAt.Should().NotBeNull();
+
+        var shipment = await db.Set<InventoryMovement>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x =>
+                x.ReferenceId == reservationId &&
+                x.MovementType == InventoryMovementType.Shipment);
+        shipment.Should().NotBeNull();
+
+        var balance = await db.Set<StockBalance>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x =>
+                x.ProductId == seed.Product.Id &&
+                x.WarehouseId == seed.Warehouse.Id &&
+                x.LocationId == seed.Location.Id &&
+                x.LotId == seed.Lot.Id);
+        balance.OnHandQuantity.Should().Be(6);
+        balance.AvailableQuantity.Should().Be(6);
+    }
+
+    [Test]
+    [Category(TestCategories.Reservations)]
+    public async Task ExpireReservations_ExpiredActiveReservation_ExpiresAllocation()
+    {
+        var seed = await SeedInventoryScope();
+        await PostOpeningBalance(seed.Product.Id, seed.Warehouse.Id, seed.Location.Id, seed.Lot.Id, 10);
+        var reservationId = await ReserveAndGetId(
+            seed,
+            quantity: 2,
+            expiresAt: DateTime.UtcNow.AddMinutes(-5));
+
+        var expired = await InventarioIntegrationTestFixture.ServiceWrapper.ExpireReservations(
+            new ExpireReservationsRequest
+            {
+                Metadata = CreateMetadata(),
+                ExpiresBefore = DateTime.UtcNow,
+                MaxCount = 10
+            });
+
+        expired.IsSuccess.Should().BeTrue(expired.Message);
+
+        await using var db = CreateDbContext();
+        var reservation = await db.Set<Reservation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Id == reservationId);
+        reservation.Status.Should().Be(ReservationStatus.Expired);
+
+        var allocation = await db.Set<ReservationAllocation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ReservationId == reservationId);
+        allocation.Status.Should().Be(ReservationAllocationStatus.Expired);
+    }
+
+    private async Task<InventoryScope> SeedInventoryScope()
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var product = await TestInventarioSeed.SeedProduct(db, categoryId: category.Id);
+        var warehouse = await TestInventarioSeed.SeedWarehouse(db);
+        var location = await TestInventarioSeed.SeedLocation(db, warehouse.Id);
+        var lot = await TestInventarioSeed.SeedLot(db, product.Id, expiresAt: DateTime.UtcNow.AddDays(90));
+        return new InventoryScope(product, warehouse, location, lot);
+    }
+
+    private static async Task PostOpeningBalance(
+        Guid productId,
+        Guid warehouseId,
+        Guid locationId,
+        Guid lotId,
+        decimal quantity)
+    {
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.PostStockMovement(
+            new PostStockMovementRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = productId,
+                WarehouseId = warehouseId,
+                LocationId = locationId,
+                LotId = lotId,
+                MovementType = InventoryMovementType.OpeningBalance,
+                Quantity = quantity,
+                IdempotencyKey = $"seed-stock-{Guid.NewGuid():N}"
+            });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+    }
+
+    private async Task<Guid> ReserveAndGetId(
+        InventoryScope seed,
+        decimal quantity,
+        DateTime? expiresAt = null)
+    {
+        var referenceId = Guid.NewGuid();
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.ReserveInventory(
+            new ReserveInventoryRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                LotId = seed.Lot.Id,
+                Quantity = quantity,
+                ExpiresAt = expiresAt,
+                ReferenceType = "reservation-lifecycle-test",
+                ReferenceId = referenceId
+            });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+
+        await using var db = CreateDbContext();
+        var reservation = await db.Set<Reservation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ReferenceId == referenceId);
+        return reservation.Id;
+    }
+
+    private sealed record InventoryScope(
+        Product Product,
+        Warehouse Warehouse,
+        InventoryLocation Location,
+        InventoryLot Lot);
+}

--- a/src/Tests/Inventario.IntegrationTests/Tests/WarehousingTraceabilityTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/WarehousingTraceabilityTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.EntityFrameworkCore;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+using XFramework.Inventario.Domain.Shared.Enums;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.Inventario)]
+public sealed class WarehousingTraceabilityTests : InventarioTestBase
+{
+    [Test]
+    [Category(TestCategories.Warehousing)]
+    public async Task CreateWarehouse_ValidRequest_PersistsWarehouseAndLocation()
+    {
+        var code = UniqueCode("WH");
+
+        var warehouseResult = await InventarioIntegrationTestFixture.ServiceWrapper.CreateWarehouse(
+            new CreateWarehouseRequest
+            {
+                Metadata = CreateMetadata(),
+                Code = code,
+                Name = "Integration Warehouse"
+            });
+
+        warehouseResult.IsSuccess.Should().BeTrue(warehouseResult.Message);
+        await using var db = CreateDbContext();
+        var warehouse = await db.Set<Warehouse>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.Code == code);
+        warehouse.Should().NotBeNull();
+
+        var locationCode = UniqueCode("BIN");
+        var locationResult = await InventarioIntegrationTestFixture.ServiceWrapper.CreateInventoryLocation(
+            new CreateInventoryLocationRequest
+            {
+                Metadata = CreateMetadata(),
+                WarehouseId = warehouse!.Id,
+                Code = locationCode,
+                Name = "Integration Bin",
+                LocationType = InventoryLocationType.Bin,
+                IsPickable = true
+            });
+
+        locationResult.IsSuccess.Should().BeTrue(locationResult.Message);
+        var location = await db.Set<InventoryLocation>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.WarehouseId == warehouse.Id && x.Code == locationCode);
+        location.Should().NotBeNull();
+        location!.WarehouseId.Should().Be(warehouse.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.Traceability)]
+    public async Task CreateInventoryLot_ValidRequest_PersistsLotForProduct()
+    {
+        await using var db = CreateDbContext();
+        var product = await TestInventarioSeed.SeedProduct(db);
+
+        var lotNumber = UniqueCode("LOT");
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.CreateInventoryLot(
+            new CreateInventoryLotRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = product.Id,
+                LotNumber = lotNumber,
+                SupplierReference = "supplier-batch",
+                ReceivedAt = DateTime.UtcNow,
+                ManufacturedAt = DateTime.UtcNow.AddDays(-10),
+                ExpiresAt = DateTime.UtcNow.AddDays(90),
+                UnitCost = 6m,
+                Status = InventoryLotStatus.Available
+            });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+
+        var persisted = await db.Set<InventoryLot>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.ProductId == product.Id && x.LotNumber == lotNumber);
+        persisted.Should().NotBeNull();
+        persisted!.ProductId.Should().Be(product.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.Traceability)]
+    public async Task CreateInventoryLot_SameProductAndLotNumber_ReturnsConflict()
+    {
+        await using var db = CreateDbContext();
+        var product = await TestInventarioSeed.SeedProduct(db);
+        var lotNumber = UniqueCode("LOT");
+        var request = new CreateInventoryLotRequest
+        {
+            Metadata = CreateMetadata(),
+            ProductId = product.Id,
+            LotNumber = lotNumber,
+            ReceivedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddDays(90),
+            Status = InventoryLotStatus.Available
+        };
+
+        var first = await InventarioIntegrationTestFixture.ServiceWrapper.CreateInventoryLot(request);
+        var duplicate = await InventarioIntegrationTestFixture.ServiceWrapper.CreateInventoryLot(request);
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        duplicate.IsSuccess.Should().BeFalse();
+        duplicate.HttpStatusCode.Should().Be(System.Net.HttpStatusCode.Conflict);
+
+        var lotCount = await db.Set<InventoryLot>()
+            .IgnoreQueryFilters()
+            .CountAsync(x => x.ProductId == product.Id && x.LotNumber == lotNumber);
+        lotCount.Should().Be(1);
+    }
+}

--- a/src/Tests/Wallets.IntegrationTests/Infrastructure/WalletsTestFixture.cs
+++ b/src/Tests/Wallets.IntegrationTests/Infrastructure/WalletsTestFixture.cs
@@ -19,9 +19,11 @@ using XFramework.Core.Middlewares;
 using XFramework.Domain.Contexts;
 using XFramework.Domain.Interceptors;
 using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.DataContext;
 using XFramework.Extensions;
 using XFramework.Integration.Abstractions.Wrappers;
 using XFramework.Integration.Extensions;
+using XFramework.TestInfrastructure;
 using BatchDecrementEndpoint = Wallets.Api.Features.Batch.DecrementBatch.Endpoint;
 using BatchIncrementEndpoint = Wallets.Api.Features.Batch.IncrementBatch.Endpoint;
 using BatchTransferEndpoint = Wallets.Api.Features.Batch.TransferBatch.Endpoint;
@@ -48,6 +50,8 @@ public class WalletsTestFixture
     public static IServiceProvider Services => _walletsApp.Services;
     public static IWalletsServiceWrapper ServiceWrapper =>
         _testClientApp.Services.GetRequiredService<IWalletsServiceWrapper>();
+    public static IDataContext DataContext =>
+        _testClientApp.Services.CreateScope().ServiceProvider.GetRequiredService<IDataContext>();
 
     public static readonly Guid TestTenantId = Guid.Parse("7602c2d3-01df-4bdb-9a67-02c144e4a2ac");
     public static readonly Guid TestWalletTypeId = Guid.Parse("e1e2e3e4-e5f6-7890-abcd-ef1234567890");
@@ -212,6 +216,12 @@ public class WalletsTestFixture
         builder.Services.AddSingleton(new DeviceAgentProvider("WalletTest"));
         builder.Services.AddXFrameworkBoltClient(builder.Configuration, autoConnect: false);
         builder.Services.AddWalletsWrapperServices();
+        builder.Services.AddRemoteDataContext();
+        builder.Services.AddScoped(_ => new RequestMetadata
+        {
+            TenantId = TestTenantId,
+            RequestId = Guid.NewGuid()
+        });
 
         var app = builder.Build();
         app.MapGet("/health/live", () => Results.Ok("healthy"));
@@ -382,17 +392,36 @@ public class WalletsTestFixture
     {
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            var tenantId = Request.Headers.TryGetValue("X-Wallets-Test-TenantId", out var tenantHeader) &&
+            if (Request.Headers.TryGetValue(TestAuthHeaders.Unauthenticated, out var unauthenticatedHeader) &&
+                bool.TryParse(unauthenticatedHeader.FirstOrDefault(), out var unauthenticated) &&
+                unauthenticated)
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var tenantId = TryGetGuidHeader(TestAuthHeaders.TenantId, out var standardTenantId)
+                ? standardTenantId
+                : Request.Headers.TryGetValue("X-Wallets-Test-TenantId", out var tenantHeader) &&
                            Guid.TryParse(tenantHeader.FirstOrDefault(), out var suppliedTenantId)
                 ? suppliedTenantId
                 : TestTenantId;
-            var credentialId = Request.Headers.TryGetValue("X-Wallets-Test-CredentialId", out var credentialHeader) &&
+            var credentialId = TryGetGuidHeader(TestAuthHeaders.CredentialId, out var standardCredentialId)
+                ? standardCredentialId
+                : Request.Headers.TryGetValue("X-Wallets-Test-CredentialId", out var credentialHeader) &&
                                Guid.TryParse(credentialHeader.FirstOrDefault(), out var suppliedCredentialId)
                 ? suppliedCredentialId
                 : (Guid?)null;
+            var identityId = TryGetGuidHeader(TestAuthHeaders.IdentityId, out var suppliedIdentityId)
+                ? suppliedIdentityId
+                : Guid.Parse("00000000-0000-0000-0000-000000000099");
+            var username = Request.Headers.TryGetValue(TestAuthHeaders.Username, out var usernameHeader)
+                ? usernameHeader.FirstOrDefault() ?? "wallets-test"
+                : "wallets-test";
             var claims = new List<Claim>
             {
-                new Claim(ClaimTypes.NameIdentifier, "wallets-test"),
+                new Claim(ClaimTypes.NameIdentifier, identityId.ToString()),
+                new Claim(ClaimTypes.Name, username),
+                new Claim("identity_id", identityId.ToString()),
                 new Claim("tenantId", tenantId.ToString()),
                 new Claim("TenantId", tenantId.ToString()),
                 new Claim("tid", tenantId.ToString())
@@ -406,7 +435,14 @@ public class WalletsTestFixture
             var suppressDefaultRole = Request.Headers.TryGetValue("X-Wallets-Test-No-Role", out var noRoleHeader) &&
                                       bool.TryParse(noRoleHeader.FirstOrDefault(), out var noRole) &&
                                       noRole;
-            if (Request.Headers.TryGetValue("X-Wallets-Test-Role", out var roleHeader))
+            if (Request.Headers.TryGetValue(TestAuthHeaders.Roles, out var standardRoleHeader))
+            {
+                foreach (var role in standardRoleHeader.SelectMany(static x => x?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? []))
+                {
+                    claims.Add(new Claim(ClaimTypes.Role, role));
+                }
+            }
+            else if (Request.Headers.TryGetValue("X-Wallets-Test-Role", out var roleHeader))
             {
                 foreach (var role in roleHeader.Where(static x => !string.IsNullOrWhiteSpace(x)))
                 {
@@ -423,6 +459,13 @@ public class WalletsTestFixture
             var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
             return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+
+        private bool TryGetGuidHeader(string headerName, out Guid value)
+        {
+            value = Guid.Empty;
+            return Request.Headers.TryGetValue(headerName, out var header) &&
+                   Guid.TryParse(header.FirstOrDefault(), out value);
         }
     }
 }

--- a/src/Tests/Wallets.IntegrationTests/Tests/DataContextTests.cs
+++ b/src/Tests/Wallets.IntegrationTests/Tests/DataContextTests.cs
@@ -1,0 +1,24 @@
+using Wallets.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using XFramework.TestInfrastructure;
+
+namespace Wallets.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.Wallets)]
+[Category(TestCategories.DataContext)]
+public class DataContextTests : WalletsTestBase
+{
+    [Test]
+    public async Task RemoteQuery_ToListAsync_ReturnsWalletTypesFromService()
+    {
+        var ctx = WalletsTestFixture.DataContext;
+
+        var walletTypes = await ctx.Query<WalletType>()
+            .Where(x => x.TenantId == WalletsTestFixture.TestTenantId)
+            .ToListAsync();
+
+        walletTypes.Should().Contain(x => x.Id == WalletsTestFixture.TestWalletTypeId);
+    }
+}

--- a/src/Tests/XFramework.TestInfrastructure/README.md
+++ b/src/Tests/XFramework.TestInfrastructure/README.md
@@ -1,0 +1,51 @@
+# XFramework Integration Test Standard
+
+Use this project as the shared kit for module-level API integration tests.
+
+## Project Shape
+
+Each module keeps its own integration test project:
+
+- `IdentityServer.IntegrationTests`
+- `Wallets.IntegrationTests`
+- `Inventario.IntegrationTests`
+
+Use this structure inside each project:
+
+- `Infrastructure/<Module>IntegrationTestFixture.cs`
+- `Infrastructure/<Module>TestBase.cs`
+- `Infrastructure/<Module>TestAuthHandler.cs`
+- `Tests/<Area>Tests.cs`
+
+## Runtime Pattern
+
+Integration suites should run a disposable PostgreSQL Testcontainer, migrate `AppDbContext`, seed shared identity/tenant/module data, start Bolt Hub, start the module API, then start a small test client app with the generated service wrapper and `AddRemoteDataContext()`.
+
+Tests should exercise behavior through HTTP, generated service wrappers, and remote `IDataContext`. Direct `AppDbContext` access is for seeding and final assertions only.
+
+## Categories
+
+Use constants from `TestCategories`:
+
+- `Kind:Integration`
+- `Module:IdentityServer`, `Module:Wallets`, `Module:Inventario`
+- `Area:Auth`, `Area:DataContext`, `Area:FeatureGates`, `Area:Catalog`, `Area:Warehousing`, `Area:Traceability`, `Area:Stock`, `Area:Reservations`, `Area:Planning`, `Area:Reporting`, `Area:Purchasing`
+
+Example filter:
+
+```powershell
+dotnet test src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj --filter "TestCategory=Area:Stock"
+```
+
+## Test Auth Headers
+
+Use constants from `TestAuthHeaders`:
+
+- `X-Test-TenantId`
+- `X-Test-IdentityId`
+- `X-Test-CredentialId`
+- `X-Test-Username`
+- `X-Test-Roles`
+- `X-Test-Unauthenticated`
+
+Default test auth should authenticate as a seeded admin user unless a test explicitly overrides headers.

--- a/src/Tests/XFramework.TestInfrastructure/TestAuthHeaders.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestAuthHeaders.cs
@@ -1,0 +1,11 @@
+namespace XFramework.TestInfrastructure;
+
+public static class TestAuthHeaders
+{
+    public const string TenantId = "X-Test-TenantId";
+    public const string IdentityId = "X-Test-IdentityId";
+    public const string CredentialId = "X-Test-CredentialId";
+    public const string Username = "X-Test-Username";
+    public const string Roles = "X-Test-Roles";
+    public const string Unauthenticated = "X-Test-Unauthenticated";
+}

--- a/src/Tests/XFramework.TestInfrastructure/TestCategories.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestCategories.cs
@@ -1,0 +1,22 @@
+namespace XFramework.TestInfrastructure;
+
+public static class TestCategories
+{
+    public const string Integration = "Kind:Integration";
+
+    public const string IdentityServer = "Module:IdentityServer";
+    public const string Wallets = "Module:Wallets";
+    public const string Inventario = "Module:Inventario";
+
+    public const string Auth = "Area:Auth";
+    public const string DataContext = "Area:DataContext";
+    public const string FeatureGates = "Area:FeatureGates";
+    public const string Catalog = "Area:Catalog";
+    public const string Warehousing = "Area:Warehousing";
+    public const string Traceability = "Area:Traceability";
+    public const string Stock = "Area:Stock";
+    public const string Reservations = "Area:Reservations";
+    public const string Planning = "Area:Planning";
+    public const string Reporting = "Area:Reporting";
+    public const string Purchasing = "Area:Purchasing";
+}

--- a/src/Tests/XFramework.TestInfrastructure/TestConstants.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestConstants.cs
@@ -44,6 +44,8 @@ public class TestConstants
         public const string SmsGatewayServer = "http://localhost:18561";
 
         // Inventario
+        public const string InventarioBolt = "http://localhost:17200";
         public const string InventarioServer = "http://localhost:18461";
+        public const string InventarioTestClient = "http://localhost:18462";
     }
 }

--- a/src/Tests/XFramework.TestInfrastructure/TestHostWaiter.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestHostWaiter.cs
@@ -1,0 +1,47 @@
+namespace XFramework.TestInfrastructure;
+
+public static class TestHostWaiter
+{
+    public static async Task WaitForHealth(
+        string url,
+        Task? appTask = null,
+        int timeoutSeconds = 30)
+    {
+        using var client = new HttpClient();
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            ThrowIfCrashed(appTask);
+
+            try
+            {
+                var response = await client.GetAsync(url);
+                if (response.IsSuccessStatusCode)
+                    return;
+            }
+            catch
+            {
+                // The host may not have bound its socket yet.
+            }
+
+            await Task.Delay(500);
+        }
+
+        ThrowIfCrashed(appTask);
+        throw new TimeoutException($"Service at {url} did not become healthy within {timeoutSeconds}s");
+    }
+
+    private static void ThrowIfCrashed(Task? appTask)
+    {
+        if (appTask is { IsFaulted: true })
+        {
+            throw new InvalidOperationException(
+                $"Application crashed during startup: {appTask.Exception?.GetBaseException().Message}",
+                appTask.Exception?.GetBaseException());
+        }
+
+        if (appTask is { IsCompleted: true })
+            throw new InvalidOperationException("Application stopped before the health endpoint became available.");
+    }
+}

--- a/src/Tests/XFramework.TestInfrastructure/TestInventarioSeed.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestInventarioSeed.cs
@@ -1,0 +1,201 @@
+using Microsoft.EntityFrameworkCore;
+using XFramework.Domain.Contexts;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Enums;
+
+namespace XFramework.TestInfrastructure;
+
+public static class TestInventarioSeed
+{
+    public static async Task<ProductCategory> SeedCategory(
+        AppDbContext db,
+        Guid? tenantId = null,
+        string? name = null)
+    {
+        var category = new ProductCategory
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId ?? TestConstants.TenantId,
+            Name = name ?? $"Category {Guid.NewGuid():N}",
+            Description = "Integration test category",
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        db.Set<ProductCategory>().Add(category);
+        await db.SaveChangesAsync();
+        return category;
+    }
+
+    public static async Task<Product> SeedProduct(
+        AppDbContext db,
+        Guid? tenantId = null,
+        Guid? categoryId = null,
+        string? sku = null,
+        string? name = null)
+    {
+        var resolvedTenantId = tenantId ?? TestConstants.TenantId;
+        var resolvedCategoryId = categoryId ?? (await SeedCategory(db, resolvedTenantId)).Id;
+        var product = new Product
+        {
+            Id = Guid.NewGuid(),
+            TenantId = resolvedTenantId,
+            CategoryId = resolvedCategoryId,
+            Name = name ?? $"Product {Guid.NewGuid():N}",
+            SKU = sku ?? $"SKU-{Guid.NewGuid():N}"[..16],
+            Price = 10m,
+            StockQuantity = 0,
+            IsAvailable = true,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        db.Set<Product>().Add(product);
+        await db.SaveChangesAsync();
+        return product;
+    }
+
+    public static async Task<Warehouse> SeedWarehouse(
+        AppDbContext db,
+        Guid? tenantId = null,
+        string? code = null)
+    {
+        var warehouse = new Warehouse
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId ?? TestConstants.TenantId,
+            Code = code ?? $"WH-{Guid.NewGuid():N}"[..12],
+            Name = "Integration Warehouse",
+            IsDefault = false,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        db.Set<Warehouse>().Add(warehouse);
+        await db.SaveChangesAsync();
+        return warehouse;
+    }
+
+    public static async Task<InventoryLocation> SeedLocation(
+        AppDbContext db,
+        Guid warehouseId,
+        Guid? tenantId = null,
+        string? code = null)
+    {
+        var location = new InventoryLocation
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId ?? TestConstants.TenantId,
+            WarehouseId = warehouseId,
+            Code = code ?? $"BIN-{Guid.NewGuid():N}"[..13],
+            Name = "Integration Bin",
+            LocationType = InventoryLocationType.Bin,
+            IsPickable = true,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        db.Set<InventoryLocation>().Add(location);
+        await db.SaveChangesAsync();
+        return location;
+    }
+
+    public static async Task<InventoryLot> SeedLot(
+        AppDbContext db,
+        Guid productId,
+        Guid? tenantId = null,
+        string? lotNumber = null,
+        DateTime? expiresAt = null)
+    {
+        var lot = new InventoryLot
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId ?? TestConstants.TenantId,
+            ProductId = productId,
+            LotNumber = lotNumber ?? $"LOT-{Guid.NewGuid():N}"[..16],
+            SupplierReference = "integration",
+            ReceivedAt = DateTime.UtcNow,
+            ManufacturedAt = DateTime.UtcNow.AddDays(-5),
+            ExpiresAt = expiresAt,
+            UnitCost = 5m,
+            Status = InventoryLotStatus.Available,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        db.Set<InventoryLot>().Add(lot);
+        await db.SaveChangesAsync();
+        return lot;
+    }
+
+    public static async Task<Supplier> SeedSupplier(
+        AppDbContext db,
+        Guid? tenantId = null,
+        string? code = null)
+    {
+        var supplier = new Supplier
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId ?? TestConstants.TenantId,
+            Code = code ?? $"SUP-{Guid.NewGuid():N}"[..13],
+            Name = "Integration Supplier",
+            ContactName = "Inventory Buyer",
+            Email = $"supplier-{Guid.NewGuid():N}@test.local",
+            IsActive = true,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        db.Set<Supplier>().Add(supplier);
+        await db.SaveChangesAsync();
+        return supplier;
+    }
+
+    public static async Task SetInventarioFeature(
+        AppDbContext db,
+        string? subFeatureKey,
+        bool isEnabled,
+        Guid? tenantId = null)
+    {
+        var resolvedTenantId = tenantId ?? TestConstants.TenantId;
+        var (moduleKey, normalizedSubFeatureKey) =
+            IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.Normalize(
+                IdentityServer.Domain.Shared.Contracts.TenantModuleFeatureKeys.Inventario,
+                subFeatureKey);
+        var feature = await db.Set<IdentityServer.Domain.Shared.Contracts.TenantModuleFeature>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x =>
+                x.TenantId == resolvedTenantId &&
+                x.ModuleKey == moduleKey &&
+                x.SubFeatureKey == normalizedSubFeatureKey);
+
+        if (feature is null)
+        {
+            feature = new IdentityServer.Domain.Shared.Contracts.TenantModuleFeature
+            {
+                Id = Guid.NewGuid(),
+                TenantId = resolvedTenantId,
+                ModuleKey = moduleKey,
+                SubFeatureKey = normalizedSubFeatureKey,
+                DisplayName = string.IsNullOrWhiteSpace(normalizedSubFeatureKey) ? "Inventario" : normalizedSubFeatureKey,
+                IsEnabled = isEnabled,
+                CreatedAt = DateTime.UtcNow
+            };
+            db.Set<IdentityServer.Domain.Shared.Contracts.TenantModuleFeature>().Add(feature);
+        }
+        else
+        {
+            feature.IsEnabled = isEnabled;
+            feature.ModifiedAt = DateTime.UtcNow;
+            db.Set<IdentityServer.Domain.Shared.Contracts.TenantModuleFeature>().Update(feature);
+        }
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/src/Tests/XFramework.TestInfrastructure/XFramework.TestInfrastructure.csproj
+++ b/src/Tests/XFramework.TestInfrastructure/XFramework.TestInfrastructure.csproj
@@ -22,6 +22,8 @@
         <ProjectReference Include="..\..\Kernel\XFramework.Domain\XFramework.Domain.csproj" />
         <ProjectReference Include="..\..\Infrastructure\XFramework.Integration\XFramework.Integration.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Bolt\Bolt.Hub\Bolt.Hub.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.IdentityServer\IdentityServer.Domain.Shared\IdentityServer.Domain.Shared.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.Inventario\Inventario.Domain.Shared\Inventario.Domain.Shared.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.Wallets\Wallets.Domain.Shared\Wallets.Domain.Shared.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- adds shared XFramework integration-test conventions, auth headers, categories, host wait helpers, and Inventario seed helpers
- adds `Inventario.IntegrationTests` with hosted Bolt + Inventario API + wrapper + remote `IDataContext` coverage
- aligns Wallets integration tests with remote `IDataContext` smoke coverage
- fixes Inventario runtime gaps exposed by integration tests: missing release endpoint, reservation completion concurrency ordering, staged lot receiving, server-side warehousing gates, and multi-step stock posting reuse of tracked EF entities
- fixes tenant module feature disabled-state persistence by configuring the EF bool sentinel/default explicitly

## Coverage Added
- Inventario smoke: health, auth, root feature gate, wrapper call, remote DataContext query/create
- Catalog: product/category create paths through remote DataContext
- Warehousing/traceability: warehouse, location, lot creation, duplicate lot conflict
- Stock/reservations: opening balance, idempotency replay/conflict, FEFO allocation, expired lot exclusion, release, fulfill, expire
- Planning/reporting/purchasing: reorder suggestions, low-stock report, stock position, near-expiry, expired stock, movement ledger, allocation status, supplier/PO/receiving, receiving idempotency

## Validation
- `dotnet test src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj -m:1 /nr:false --logger console;verbosity=minimal` -> 22 passed
- `dotnet test src\Tests\Wallets.IntegrationTests\Wallets.IntegrationTests.csproj -m:1 /nr:false --logger console;verbosity=minimal` -> 73 passed
- `dotnet test src\Tests\IdentityServer.IntegrationTests\IdentityServer.IntegrationTests.csproj -m:1 /nr:false --logger console;verbosity=minimal` -> 52 passed, 2 existing skipped
- `dotnet test src\Tests\XFramework.Core.Tests\XFramework.Core.Tests.csproj -c Release -m:1 /nr:false --filter FullyQualifiedName~TenantModuleFeature --logger console;verbosity=minimal` -> 12 passed
- `dotnet test src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj -c Release -m:1 /nr:false --logger console;verbosity=minimal` -> 29 passed
- `dotnet build XFramework.slnx -c Release -m:1 /nr:false --no-restore` -> passed with existing package prune/vulnerability warnings
- `git diff --check` -> clean except line-ending warnings

## Notes
- Integration tests use the xeon-dev Docker Testcontainers loopback tunnel (`DOCKER_HOST=tcp://127.0.0.1:23750`, `TESTCONTAINERS_HOST_OVERRIDE=100.75.11.49`). The tunnel was stopped after validation.
- No xeon-dev application deployment was run for this PR.