### PR TITLE
Fix Inventario wrapper contracts and generator options

### DIFF
--- a/.github/workflows/inventario-extended-integration-tests.yml
+++ b/.github/workflows/inventario-extended-integration-tests.yml
@@ -1,0 +1,41 @@
+name: Inventario Extended Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_filter:
+        description: NUnit test filter
+        required: false
+        default: TestCategory=Kind:ExtendedIntegration
+
+permissions:
+  contents: read
+
+jobs:
+  inventario-extended-tests:
+    name: Inventario extended integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore XFramework.slnx
+
+      - name: Run Inventario extended integration tests
+        run: >
+          dotnet test
+          src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj
+          --no-restore
+          -m:1
+          /nr:false
+          --filter "${{ inputs.test_filter }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Primary route:
 - [docs/README.md](docs/README.md) - repository documentation map.
 - [docs/solutions/README.md](docs/solutions/README.md) - durable solution knowledgebase and category index.
 - [docs/solutions/conventions/xframework-best-practices.md](docs/solutions/conventions/xframework-best-practices.md) - canonical implementation standard.
+- [docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md](docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md) - ControlPanel wrapper vs `IDataContext` rules and integration-test coverage tiers.
 - [docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md](docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md) - BlazorBlueprint ControlPanel usage, docs lookup, and visual verification rules.
 
 Task-specific OpenCode skills live under `.opencode/skills/`; use them as workflow helpers, not as the primary documentation authority.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Use this file to orient quickly, then follow the canonical docs. Do not treat th
 - Generated endpoints: [generated endpoint auto-discovery](docs/solutions/tooling-decisions/generated-endpoint-auto-discovery.md) and [GenerateEndpoints usage](docs/solutions/tooling-decisions/generate-endpoints-attribute-usage.md).
 - Bolt: [Bolt unified transport layer](docs/solutions/architecture-patterns/bolt-unified-transport-layer.md), [Bolt SignalR removal](docs/solutions/architecture-patterns/bolt-signalr-removal.md), `src/Libraries/Bolt/BOLT.md`, and `src/Libraries/Bolt/BOLT-MEDIA.md`.
 - EF Core/data access: [EF Core data access patterns](docs/solutions/conventions/ef-core-data-access-patterns.md).
+- ControlPanel API usage and broad integration tests: [ControlPanel service wrapper and integration test contract](docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md).
 - Caching: [XFramework caching strategy](docs/solutions/best-practices/xframework-caching-strategy.md).
 - Logging/observability: [logging standards](docs/solutions/conventions/logging-standards.md), [unified ZLogger logging pipeline](docs/solutions/architecture-patterns/unified-zlogger-logging-pipeline.md), and [OpenTelemetry integration guide](docs/solutions/tooling-decisions/opentelemetry-integration-guide.md).
 

--- a/docs/solutions/README.md
+++ b/docs/solutions/README.md
@@ -50,6 +50,7 @@ status: current
 - [Unified ZLogger logging pipeline](architecture-patterns/unified-zlogger-logging-pipeline.md) - current logging decision record and historical Serilog removal context.
 - [Decentralized remote data context](architecture-patterns/decentralized-remote-data-context.md) - remote `IDataContext` architecture over generated service wrappers.
 - [Blazor IDataContext migration](developer-experience/blazor-idatacontext-migration.md) - migrating Blazor generated CRUD wrapper calls to `IDataContext`.
+- [ControlPanel service wrapper and integration test contract](developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md) - wrapper-first ControlPanel business operations, direct `IDataContext` mutation rules, and standard/extended integration-test tiers.
 - [BlazorBlueprint ControlPanel agent guide](tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md) - BlazorBlueprint setup, overlay/trigger rules, docs lookup, and visual browser verification for ControlPanel UI work.
 
 ## Current Vs Historical Guidance

--- a/docs/solutions/developer-experience/blazor-idatacontext-migration.md
+++ b/docs/solutions/developer-experience/blazor-idatacontext-migration.md
@@ -27,7 +27,7 @@ walletsServiceWrapper.Wallet.GetList(...)
 walletsServiceWrapper.WithdrawalRequest.Patch(entity)
 ```
 
-Service wrappers should now be used only for business RPC operations, such as:
+Service wrappers should now be used for business RPC operations and custom endpoint actions, such as:
 
 ```csharp
 identityServerServiceWrapper.AuthenticateIdentity(request)
@@ -35,13 +35,14 @@ identityServerServiceWrapper.ChangePassword(request)
 walletsServiceWrapper.TransferWallet(request)
 ```
 
-Generic entity CRUD/query work should use `IDataContext`.
+Generic entity query work should use `IDataContext`. Generic entity mutation should use `IDataContext.Add/Update/Remove` only when the entity is intentionally allowlisted for remote mutation and no richer business endpoint exists for that user action. If a request contract or wrapper method exists, prefer the wrapper because it owns validators, feature gates, idempotency, tenant derivation, ledger/allocation logic, and status transitions.
 
 See also:
 
 - `docs/solutions/conventions/ef-core-data-access-patterns.md` for local EF and remote `IDataContext` behavior.
 - `docs/solutions/architecture-patterns/decentralized-remote-data-context.md` for generated remote service-wrapper routing.
 - `docs/solutions/best-practices/xframework-caching-strategy.md` for remote data-context client cache behavior.
+- `docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md` for the ControlPanel wrapper-vs-`IDataContext` decision rule and required integration-test coverage.
 
 ## Migration Target
 
@@ -119,6 +120,7 @@ walletsServiceWrapper.<Entity>.(Get|GetList|Create|Patch|Replace|Delete)
 - Use `.Skip(...)` and `.Take(...)` for paging.
 - Use `.Where(...)` expressions instead of manually building `QueryFilter` lists where practical.
 - Keep custom business wrapper calls unchanged.
+- Do not replace business wrapper calls with direct `IDataContext` saves.
 
 ## Build Verification
 

--- a/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
+++ b/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
@@ -1,0 +1,151 @@
+---
+title: "ControlPanel Service Wrapper And Integration Test Contract"
+date: 2026-06-20
+category: developer-experience
+module: XFramework
+problem_type: convention
+component: controlpanel_testing
+severity: high
+applies_when:
+  - "Building ControlPanel pages that call module APIs or mutate module data"
+  - "Adding module integration tests for wrappers, remote IDataContext, or ControlPanel smoke flows"
+  - "Deciding whether a Blazor page should use a service wrapper or IDataContext"
+tags: [control-panel, service-wrapper, datacontext, integration-tests, nunit, wrappers]
+status: current
+---
+
+# ControlPanel Service Wrapper And Integration Test Contract
+
+## Decision Rule
+
+ControlPanel pages must use the most business-aware API available.
+
+- Use module service wrapper methods for business operations and custom endpoints.
+- Use `IDataContext.Query<T>()` for read/query UI when the entity is registered for remote data-context querying.
+- Use `IDataContext.Add/Update/Remove` only for simple generated CRUD on entities explicitly allowlisted for remote mutation.
+- Do not use `IDataContext.SaveChangesAsync()` to bypass endpoint validators, feature gates, idempotency, allocation logic, ledger posting, tenant derivation, or status workflows.
+
+The Blazor `IDataContext` migration removed generated per-entity CRUD wrapper properties. It did not make `IDataContext` the default write path for every ControlPanel action.
+
+## Wrapper First For Business Workflows
+
+A ControlPanel action should call a service wrapper when any of these are true:
+
+- A request contract exists, such as `CreateInventoryReorderRuleRequest`, `PostStockMovementRequest`, or `ReceiveInventoryRequest`.
+- The action has module feature gates, tenant-module gates, auth metadata, or role checks.
+- The action creates ledger rows, allocation rows, notification rows, audit rows, or derived snapshots.
+- The action has idempotency or duplicate-prevention semantics.
+- The action has a state machine or status transition.
+- The action validates more than scalar shape or required fields.
+
+Examples:
+
+- Inventario reorder rules: use `IInventarioServiceWrapper.CreateInventoryReorderRule`, not `DataContext.Add(new InventoryReorderRule(...))`.
+- Inventario stock and reservations: use wrapper methods so movement ledgers, balances, allocations, FEFO, and idempotency run.
+- Purchasing and receiving: use wrapper methods so purchase-order status and receipt movements stay consistent.
+- Wallet operations: use wrapper methods for deposits, withdrawals, holds, transfers, closes, and status changes.
+- Identity authentication, credentials, sessions, and role assignment workflows should use the relevant IdentityServer wrapper operation when one exists.
+
+## IDataContext Is Still Valid
+
+`IDataContext` remains the preferred ControlPanel API for:
+
+- Remote read/query composition.
+- Simple catalog-style CRUD where direct mutation is part of the intended contract.
+- Entities marked with `[AllowRemoteDataContextMutation]` and no richer endpoint exists for that action.
+
+Before using `DataContext.Add/Update/Remove`, verify all of the following:
+
+1. The entity is intentionally registered for remote mutation.
+2. No wrapper method/request contract exists for the same user action.
+3. The write does not bypass module feature gates, tenant checks, validators, idempotency, or derived data updates.
+4. Integration tests cover the exact remote `IDataContext` mutation path.
+
+If any item fails, use or add a wrapper endpoint instead.
+
+## Integration Test Levels
+
+Keep fast CI useful, but make broad runtime validation available on demand.
+
+### Standard CI Suites
+
+Run these on PRs and normal CI:
+
+- Unit tests for services, validators, and core infrastructure.
+- Focused module integration smoke tests for critical wrappers.
+- A minimal remote `IDataContext` smoke query and mutation for each module that exposes remote data-context access.
+
+These tests should stay small enough to run frequently.
+
+### Extended Manual Runtime Suites
+
+Create an extended integration suite for broad module validation. It may be slow and should be manually dispatched or explicitly filtered, not part of every PR by default.
+
+The extended suite should cover:
+
+- Every public wrapper request contract, at least one success path and one meaningful failure path.
+- Every ControlPanel write path, including whether it uses the wrapper or remote `IDataContext`.
+- Every entity intentionally allowlisted for remote `IDataContext` mutation: create, update, remove or soft-delete where supported.
+- Remote `IDataContext` rejection for entities that must not be remotely mutated.
+- Tenant isolation, feature gates, auth metadata, and role-sensitive behavior.
+- Idempotent replay and conflict cases for workflows that accept idempotency keys.
+
+Use NUnit categories so the suite can be targeted:
+
+```text
+Kind:Integration
+Kind:ExtendedIntegration
+Module:IdentityServer
+Module:Wallets
+Module:Inventario
+Area:Wrappers
+Area:DataContext
+Area:ControlPanel
+Area:FeatureGates
+```
+
+Example commands:
+
+```bash
+dotnet test src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj --filter "TestCategory=Kind:ExtendedIntegration"
+dotnet test src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj --filter "TestCategory=Area:DataContext"
+dotnet test src/Tests/Wallets.IntegrationTests/Wallets.IntegrationTests.csproj --filter "TestCategory=Area:Wrappers"
+```
+
+## Required Agent Audit Before ControlPanel Changes
+
+When touching a ControlPanel module page:
+
+1. Search the page for `DataContext.Add`, `DataContext.Update`, `DataContext.Remove`, and `SaveChangesAsync`.
+2. Search the module shared contracts for matching `*Request` types.
+3. Prefer the matching service wrapper method when a request/endpoint exists.
+4. Check whether any direct `IDataContext` mutation entity has `[AllowRemoteDataContextMutation]`.
+5. Add or update tests for the exact path the page uses.
+6. Browser-smoke the page after the change when the page is user-facing.
+
+Useful searches:
+
+```bash
+rg -n "DataContext\.(Add|Update|Remove)|SaveChangesAsync\(" src/Presentation/ControlPanel.Server/Components/Pages
+rg -n "class .*Request|record .*Request" src/Modules/<Module>/<Module>.Domain.Shared/Contracts
+rg -n "\[AllowRemoteDataContextMutation\]" src/Modules/<Module>
+```
+
+## Failure Pattern To Avoid
+
+Do not consider wrapper tests sufficient when the UI uses `IDataContext`.
+
+If a test calls:
+
+```csharp
+await wrapper.CreateInventoryReorderRule(request);
+```
+
+but the UI calls:
+
+```csharp
+DataContext.Add(new InventoryReorderRule { ... });
+await DataContext.SaveChangesAsync();
+```
+
+then the test does not cover the UI path. The UI can fail even when the wrapper test passes.

--- a/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
+++ b/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
@@ -84,6 +84,7 @@ Create an extended integration suite for broad module validation. It may be slow
 The extended suite should cover:
 
 - Every public wrapper request contract, at least one success path and one meaningful failure path.
+- A generated wrapper coverage matrix by enumerating every module `IBoltRequest` contract and matching each one to a direct service-wrapper integration test.
 - Every ControlPanel write path, including whether it uses the wrapper or remote `IDataContext`.
 - Every entity intentionally allowlisted for remote `IDataContext` mutation: create, update, remove or soft-delete where supported.
 - Remote `IDataContext` rejection for entities that must not be remotely mutated.
@@ -100,7 +101,7 @@ Module:Wallets
 Module:Inventario
 Area:Wrappers
 Area:DataContext
-Area:ControlPanel
+Area:ControlPanelContract
 Area:FeatureGates
 ```
 
@@ -121,7 +122,8 @@ When touching a ControlPanel module page:
 3. Prefer the matching service wrapper method when a request/endpoint exists.
 4. Check whether any direct `IDataContext` mutation entity has `[AllowRemoteDataContextMutation]`.
 5. Add or update tests for the exact path the page uses.
-6. Browser-smoke the page after the change when the page is user-facing.
+6. If claiming wrapper coverage is complete, enumerate all `IBoltRequest` contracts and prove each generated wrapper method appears in the module integration tests.
+7. Browser-smoke the page after the change when the page is user-facing.
 
 Useful searches:
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/GetEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Purchasing/PurchaseOrders/GetEndpoint.cs
@@ -13,10 +13,10 @@ public static class GetPurchaseOrderEndpoint
         Summary = "Get purchase order",
         Description = "Gets a purchase order with line items.")]
     public static async Task<Result<PurchaseOrder>> Handle(
-        Guid id,
+        GetPurchaseOrderRequest request,
         PurchasingService purchasingService,
         CancellationToken ct)
     {
-        return await purchasingService.GetPurchaseOrderAsync(new GetPurchaseOrderRequest { Id = id }, ct);
+        return await purchasingService.GetPurchaseOrderAsync(request, ct);
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
@@ -1,5 +1,6 @@
 @page "/inventario/planning"
 @using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning
 @implements IDisposable
 
 <PageTitle>Inventario Planning - Control Panel</PageTitle>
@@ -179,6 +180,7 @@ else
 
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
@@ -331,11 +333,9 @@ else
         _savingRule = true;
         try
         {
-            var now = DateTime.UtcNow;
-            DataContext.Add(new InventoryReorderRule
+            var result = await Inventario.CreateInventoryReorderRule(new CreateInventoryReorderRuleRequest
             {
-                Id = Guid.NewGuid(),
-                TenantId = TenantFilter.SelectedTenantId!.Value,
+                Metadata = BuildMetadata(),
                 ProductId = productId,
                 WarehouseId = Guid.TryParse(_form.WarehouseId, out var warehouseId) ? warehouseId : null,
                 LocationId = Guid.TryParse(_form.LocationId, out var locationId) ? locationId : null,
@@ -344,14 +344,10 @@ else
                 ReorderPoint = point,
                 ReorderQuantity = qty,
                 PreferredSupplier = NullIfEmpty(_form.PreferredSupplier),
-                IsActive = _form.IsActive,
-                IsEnabled = true,
-                CreatedAt = now,
-                ConcurrencyStamp = Guid.NewGuid()
+                IsActive = _form.IsActive
             });
-            var save = await DataContext.SaveChangesAsync();
-            ToastService.Show(save.IsSuccess ? "Reorder rule created." : $"Failed: {save.Message}");
-            if (save.IsSuccess)
+            ToastService.Show(result.IsSuccess ? "Reorder rule created." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
             {
                 _ruleDialogOpen = false;
                 ResetForm();
@@ -413,6 +409,13 @@ else
 
     private string GetScopeLabel(InventoryReorderRule rule) =>
         $"{GetWarehouseName(rule.WarehouseId)} / {GetLocationName(rule.LocationId)}";
+
+    private RequestMetadata BuildMetadata() => new()
+    {
+        TenantId = TenantFilter.SelectedTenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "ControlPanel"
+    };
 
     private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
     private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";

--- a/src/SourceGenerators/XFramework.SourceGenerators/ServiceWrapperGenerator.cs
+++ b/src/SourceGenerators/XFramework.SourceGenerators/ServiceWrapperGenerator.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
 namespace XFramework.SourceGenerators;
@@ -14,16 +15,24 @@ namespace XFramework.SourceGenerators;
 [Generator]
 public class ServiceWrapperGenerator : IIncrementalGenerator
 {
+    private const string WrapperNameProperty = "build_property.XFrameworkServiceWrapperName";
+    private const string TargetClientNameProperty = "build_property.XFrameworkServiceWrapperTargetClientName";
+    private const string DiscoveryPrefixesProperty = "build_property.XFrameworkServiceWrapperDiscoveryPrefixes";
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Pure auto-discovery: use CompilationProvider to scan referenced assemblies
         // for [GenerateEndpoints] entities and IBoltRequest types.
         // Triggers only in *.Integration projects (by assembly name convention).
-        context.RegisterSourceOutput(context.CompilationProvider,
-            static (spc, compilation) => Execute(compilation, spc));
+        var source = context.CompilationProvider.Combine(context.AnalyzerConfigOptionsProvider);
+        context.RegisterSourceOutput(source,
+            static (spc, source) => Execute(source.Left, source.Right, spc));
     }
 
-    private static void Execute(Compilation compilation, SourceProductionContext context)
+    private static void Execute(
+        Compilation compilation,
+        AnalyzerConfigOptionsProvider analyzerConfigOptions,
+        SourceProductionContext context)
     {
         var assemblyName = compilation.AssemblyName ?? "";
 
@@ -31,11 +40,13 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
         if (!assemblyName.EndsWith(".Integration"))
             return;
 
-        var moduleName = assemblyName.Split('.').First();
-        var serviceId = moduleName.ToSha256();
+        var options = ResolveOptions(compilation, analyzerConfigOptions);
+        var serviceId = options.TargetClientName.ToSha256();
+        if (HasExistingServiceWrapperDeclaration(compilation, options.WrapperName))
+            return;
 
         // Discover entities from [GenerateEndpoints] in referenced assemblies
-        var (models, namespaces) = DiscoverGenerateEndpointEntities(compilation, moduleName);
+        var (models, namespaces) = DiscoverGenerateEndpointEntities(compilation, options.DiscoveryPrefixes);
 
         // Also check for [BoltWrapper] for backward compatibility (entities not yet migrated)
         var (legacyModels, legacyNamespace) = DiscoverBoltWrapperEntities(compilation);
@@ -47,16 +58,81 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
         if (!string.IsNullOrEmpty(legacyNamespace))
             namespaces.Add(legacyNamespace);
 
-        if (models.Count == 0)
-            return; // No entities discovered — skip (manual wrappers handle custom-only cases)
-
         // Discover custom Bolt request types (IBoltRequest implementations)
-        var customRequests = DiscoverBoltRequests(compilation, moduleName);
+        var customRequests = DiscoverBoltRequests(compilation, options.DiscoveryPrefixes);
+
+        if (models.Count == 0 && customRequests.Count == 0)
+            return;
 
         // Generate the wrapper
-        var source = GenerateWrapper(moduleName, serviceId, models, namespaces, customRequests);
-        context.AddSource($"{moduleName}ServiceWrapperGenerator.g.cs",
+        var source = GenerateWrapper(options.WrapperName, serviceId, models, namespaces, customRequests);
+        context.AddSource($"{options.WrapperName}ServiceWrapperGenerator.g.cs",
             SourceText.From(source, Encoding.UTF8));
+    }
+
+    private static WrapperGenerationOptions ResolveOptions(
+        Compilation compilation,
+        AnalyzerConfigOptionsProvider analyzerConfigOptions)
+    {
+        var assemblyName = compilation.AssemblyName ?? "";
+        var conventionalName = assemblyName.Split('.').FirstOrDefault() ?? "";
+
+        var wrapperName = GetGlobalOption(analyzerConfigOptions, WrapperNameProperty);
+        if (string.IsNullOrWhiteSpace(wrapperName))
+            wrapperName = conventionalName;
+
+        var targetClientName = GetGlobalOption(analyzerConfigOptions, TargetClientNameProperty);
+        if (string.IsNullOrWhiteSpace(targetClientName))
+            targetClientName = wrapperName;
+
+        var discoveryPrefixes = ParseDiscoveryPrefixes(
+            GetGlobalOption(analyzerConfigOptions, DiscoveryPrefixesProperty));
+        if (discoveryPrefixes.Count == 0)
+            discoveryPrefixes.Add(wrapperName);
+
+        return new WrapperGenerationOptions(wrapperName, targetClientName, discoveryPrefixes);
+    }
+
+    private static string GetGlobalOption(
+        AnalyzerConfigOptionsProvider analyzerConfigOptions,
+        string key) =>
+        analyzerConfigOptions.GlobalOptions.TryGetValue(key, out var value)
+            ? value.Trim()
+            : string.Empty;
+
+    private static List<string> ParseDiscoveryPrefixes(string rawValue)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue))
+            return [];
+
+        return rawValue
+            .Split([';', ','], StringSplitOptions.RemoveEmptyEntries)
+            .Select(static value => value.Trim())
+            .Where(static value => value.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static bool HasExistingServiceWrapperDeclaration(Compilation compilation, string wrapperName)
+    {
+        var interfaceName = $"I{wrapperName}ServiceWrapper";
+        var recordName = $"{wrapperName}ServiceWrapper";
+        var extensionsName = $"{wrapperName}ServiceWrapperExtensions";
+
+        foreach (var syntaxTree in compilation.SyntaxTrees)
+        {
+            var root = syntaxTree.GetRoot();
+            foreach (var declaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+            {
+                var identifier = declaration.Identifier.Text;
+                if (identifier.Equals(interfaceName, StringComparison.Ordinal) ||
+                    identifier.Equals(recordName, StringComparison.Ordinal) ||
+                    identifier.Equals(extensionsName, StringComparison.Ordinal))
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     private static string GenerateWrapper(string serviceName, string serviceId,
@@ -66,6 +142,8 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
 
         sb.AppendLine(
             $$"""
+            // <auto-generated/>
+            #nullable enable
             using XFramework.Domain.Shared.BusinessObjects;
             using XFramework.Domain.Shared.Contracts;
             using XFramework.Domain.Shared.Contracts.Requests;
@@ -118,11 +196,18 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
 
         // ── ServiceWrapper record ──
         sb.AppendLine($"public partial record {serviceName}ServiceWrapper(");
-        for (int i = 0; i < models.Count; i++)
+        var constructorParameters = models
+            .Select(static model => $"I{model}CrudService {model}")
+            .Concat([
+                "IMessageBusWrapper messageBusDriver",
+                "IConfiguration configuration",
+                "BoltClient boltClient"
+            ])
+            .ToList();
+        for (int i = 0; i < constructorParameters.Count; i++)
         {
-            sb.AppendLine($"I{models[i]}CrudService {models[i]}{(i < models.Count - 1 ? "," : "")}");
+            sb.AppendLine($"{constructorParameters[i]}{(i < constructorParameters.Count - 1 ? "," : "")}");
         }
-        sb.AppendLine($", IMessageBusWrapper messageBusDriver, IConfiguration configuration, BoltClient boltClient");
         sb.AppendLine($") : DriverBase(messageBusDriver, configuration), I{serviceName}ServiceWrapper");
         sb.AppendLine("{");
         sb.AppendLine($"    public override void Initialize() => TargetClient = \"{serviceId}\";");
@@ -131,7 +216,8 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
                             public async System.Threading.Tasks.Task<byte[]> ExecuteQueryAsync(byte[] queryDescriptorBytes, System.Threading.CancellationToken ct = default)
                             {
                                 if (string.IsNullOrEmpty(TargetClient)) Initialize();
-                                var (status, data) = await boltClient.InvokeAsync(TargetClient, "__db_query__", queryDescriptorBytes, ct);
+                                var targetClient = TargetClient ?? throw new System.InvalidOperationException("Target client was not initialized.");
+                                var (status, data) = await boltClient.InvokeAsync(targetClient, "__db_query__", queryDescriptorBytes, ct);
                                 if ((int)status < 200 || (int)status >= 300)
                                     throw new System.InvalidOperationException($"DataContext query request failed with status {(int)status} ({status}).");
 
@@ -141,7 +227,8 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
                             public async System.Threading.Tasks.Task<byte[]> ExecuteChangesAsync(byte[] saveChangesRequestBytes, System.Threading.CancellationToken ct = default)
                             {
                                 if (string.IsNullOrEmpty(TargetClient)) Initialize();
-                                var (status, data) = await boltClient.InvokeAsync(TargetClient, "__db_changes__", saveChangesRequestBytes, ct);
+                                var targetClient = TargetClient ?? throw new System.InvalidOperationException("Target client was not initialized.");
+                                var (status, data) = await boltClient.InvokeAsync(targetClient, "__db_changes__", saveChangesRequestBytes, ct);
                                 if ((int)status < 200 || (int)status >= 300)
                                 {
                                     var failure = DataContextResult.Failure($"DataContext change request failed with status {(int)status} ({status}).", (int)status);
@@ -156,7 +243,8 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
                                 [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken ct = default)
                             {
                                 if (string.IsNullOrEmpty(TargetClient)) Initialize();
-                                var stream = await boltClient.OpenStreamAsync(TargetClient, "__db_query_stream__", ct);
+                                var targetClient = TargetClient ?? throw new System.InvalidOperationException("Target client was not initialized.");
+                                var stream = await boltClient.OpenStreamAsync(targetClient, "__db_query_stream__", ct);
                                 try
                                 {
                                     await stream.SendAsync((System.ReadOnlyMemory<byte>)queryDescriptorBytes, ct);
@@ -369,7 +457,7 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
     }
 
     private static (List<string> Models, HashSet<string> Namespaces) DiscoverGenerateEndpointEntities(
-        Compilation compilation, string moduleName)
+        Compilation compilation, IReadOnlyCollection<string> discoveryPrefixes)
     {
         var models = new List<string>();
         var namespaces = new HashSet<string>();
@@ -384,8 +472,9 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
 
             // Scan module's own assemblies
             // Also scan XFramework.Domain.Shared for IdentityServer (manages StorageFile etc.)
-            var isModuleAssembly = assembly.Name.StartsWith(moduleName, StringComparison.OrdinalIgnoreCase);
-            var isSharedForIdentity = moduleName == "IdentityServer" &&
+            var isModuleAssembly = MatchesAnyPrefix(assembly.Name, discoveryPrefixes);
+            var isSharedForIdentity = discoveryPrefixes.Any(static prefix =>
+                    prefix.Equals("IdentityServer", StringComparison.OrdinalIgnoreCase)) &&
                 assembly.Name.StartsWith("XFramework.Domain.Shared", StringComparison.OrdinalIgnoreCase);
             if (!isModuleAssembly && !isSharedForIdentity)
                 continue;
@@ -454,7 +543,7 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
     }
 
     private static List<CustomRequestInfo> DiscoverBoltRequests(
-        Compilation compilation, string serviceName)
+        Compilation compilation, IReadOnlyCollection<string> discoveryPrefixes)
     {
         var results = new List<CustomRequestInfo>();
         var boltInterface = compilation.GetTypeByMetadataName(
@@ -472,7 +561,7 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
                 continue;
 
             var typeNamespace = type.ContainingNamespace?.ToDisplayString() ?? "";
-            if (!typeNamespace.Contains(serviceName, StringComparison.OrdinalIgnoreCase))
+            if (!MatchesAnyPrefix(typeNamespace, discoveryPrefixes))
                 continue;
 
             if (type.IsGenericType) continue;
@@ -554,9 +643,29 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
             CollectTypes(childNs, types);
     }
 
+    private static bool MatchesAnyPrefix(string value, IReadOnlyCollection<string> prefixes) =>
+        prefixes.Any(prefix => value.Contains(prefix, StringComparison.OrdinalIgnoreCase));
+
     private class CustomRequestInfo
     {
         public string InterfaceMethodSignature { get; set; } = "";
         public string ImplementationMethod { get; set; } = "";
+    }
+
+    private sealed class WrapperGenerationOptions
+    {
+        public WrapperGenerationOptions(
+            string wrapperName,
+            string targetClientName,
+            List<string> discoveryPrefixes)
+        {
+            WrapperName = wrapperName;
+            TargetClientName = targetClientName;
+            DiscoveryPrefixes = discoveryPrefixes;
+        }
+
+        public string WrapperName { get; }
+        public string TargetClientName { get; }
+        public List<string> DiscoveryPrefixes { get; }
     }
 }

--- a/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
@@ -50,10 +50,33 @@ public sealed class CatalogTests : InventarioTestBase
         var save = await ctx.SaveChangesAsync();
 
         save.IsSuccess.Should().BeTrue(save.Message);
-        var persisted = await db.Set<ProductCategory>()
+        await using var verifyDb = CreateDbContext();
+        var persisted = await verifyDb.Set<ProductCategory>()
             .IgnoreQueryFilters()
+            .AsNoTracking()
             .FirstAsync(x => x.Id == category.Id);
         persisted.Description.Should().Be(category.Description);
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    public async Task SaveChangesAsync_RemoteProductCategoryRemove_SoftDeletesThroughInventarioDataContext()
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+
+        ctx.Remove(category);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        await using var verifyDb = CreateDbContext();
+        var persisted = await verifyDb.Set<ProductCategory>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == category.Id);
+        persisted.IsDeleted.Should().BeTrue();
+        persisted.DeletedAt.Should().NotBeNull();
     }
 
     [Test]
@@ -88,6 +111,50 @@ public sealed class CatalogTests : InventarioTestBase
 
     [Test]
     [Category(TestCategories.ExtendedIntegration)]
+    public async Task SaveChangesAsync_RemoteProductUpdate_PersistsThroughInventarioDataContext()
+    {
+        await using var db = CreateDbContext();
+        var product = await TestInventarioSeed.SeedProduct(db);
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+
+        product.Name = $"Updated Product {Guid.NewGuid():N}";
+        product.Price = 42m;
+        ctx.Update(product);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        await using var verifyDb = CreateDbContext();
+        var persisted = await verifyDb.Set<Product>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == product.Id);
+        persisted.Name.Should().Be(product.Name);
+        persisted.Price.Should().Be(42m);
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    public async Task SaveChangesAsync_RemoteProductRemove_SoftDeletesThroughInventarioDataContext()
+    {
+        await using var db = CreateDbContext();
+        var product = await TestInventarioSeed.SeedProduct(db);
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+
+        ctx.Remove(product);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        await using var verifyDb = CreateDbContext();
+        var persisted = await verifyDb.Set<Product>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == product.Id);
+        persisted.IsDeleted.Should().BeTrue();
+        persisted.DeletedAt.Should().NotBeNull();
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
     public async Task SaveChangesAsync_RemoteProductVariationCreate_PersistsWithProduct()
     {
         await using var db = CreateDbContext();
@@ -114,6 +181,76 @@ public sealed class CatalogTests : InventarioTestBase
             .FirstOrDefaultAsync(x => x.Id == variation.Id);
         persisted.Should().NotBeNull();
         persisted!.ProductId.Should().Be(product.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    public async Task SaveChangesAsync_RemoteProductVariationUpdate_PersistsThroughInventarioDataContext()
+    {
+        await using var db = CreateDbContext();
+        var product = await TestInventarioSeed.SeedProduct(db);
+        var variation = new ProductVariation
+        {
+            Id = Guid.NewGuid(),
+            TenantId = InventarioIntegrationTestFixture.TestTenantId,
+            ProductId = product.Id,
+            Name = $"Variation {Guid.NewGuid():N}",
+            AdditionalPrice = 2m,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+        db.Set<ProductVariation>().Add(variation);
+        await db.SaveChangesAsync();
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+
+        variation.Name = $"Updated Variation {Guid.NewGuid():N}";
+        variation.AdditionalPrice = 4m;
+        ctx.Update(variation);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        await using var verifyDb = CreateDbContext();
+        var persisted = await verifyDb.Set<ProductVariation>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == variation.Id);
+        persisted.Name.Should().Be(variation.Name);
+        persisted.AdditionalPrice.Should().Be(4m);
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    public async Task SaveChangesAsync_RemoteProductVariationRemove_SoftDeletesThroughInventarioDataContext()
+    {
+        await using var db = CreateDbContext();
+        var product = await TestInventarioSeed.SeedProduct(db);
+        var variation = new ProductVariation
+        {
+            Id = Guid.NewGuid(),
+            TenantId = InventarioIntegrationTestFixture.TestTenantId,
+            ProductId = product.Id,
+            Name = $"Variation {Guid.NewGuid():N}",
+            AdditionalPrice = 2m,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+        db.Set<ProductVariation>().Add(variation);
+        await db.SaveChangesAsync();
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+
+        ctx.Remove(variation);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        await using var verifyDb = CreateDbContext();
+        var persisted = await verifyDb.Set<ProductVariation>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == variation.Id);
+        persisted.IsDeleted.Should().BeTrue();
+        persisted.DeletedAt.Should().NotBeNull();
     }
 
     [Test]
@@ -146,5 +283,72 @@ public sealed class CatalogTests : InventarioTestBase
         save.IsSuccess.Should().BeFalse();
         save.Message.Should().Contain("InventoryReorderRule");
         save.Message.Should().Contain("not registered for remote mutation");
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    [Category(TestCategories.ControlPanelContract)]
+    public async Task SaveChangesAsync_RemoteAdvancedInventarioEntityCreate_ReturnsNotRegisteredForRemoteMutation()
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var product = await TestInventarioSeed.SeedProduct(db, categoryId: category.Id);
+        var warehouse = await TestInventarioSeed.SeedWarehouse(db);
+        var location = await TestInventarioSeed.SeedLocation(db, warehouse.Id);
+        var lot = await TestInventarioSeed.SeedLot(db, product.Id);
+        var stockBalanceId = Guid.NewGuid();
+        var reservationId = Guid.NewGuid();
+        var supplierId = Guid.NewGuid();
+        var purchaseOrderId = Guid.NewGuid();
+        var purchaseOrderLineId = Guid.NewGuid();
+        var receivingDocumentId = Guid.NewGuid();
+
+        var rejectedEntities = new (string EntityName, object Entity)[]
+        {
+            ("Warehouse", WithBase(new Warehouse { Code = UniqueCode("WH"), Name = "Rejected Warehouse" })),
+            ("InventoryLocation", WithBase(new InventoryLocation { WarehouseId = warehouse.Id, Code = UniqueCode("BIN"), Name = "Rejected Location" })),
+            ("InventoryLot", WithBase(new InventoryLot { ProductId = product.Id, LotNumber = UniqueCode("LOT"), ReceivedAt = DateTime.UtcNow, Status = XFramework.Inventario.Domain.Shared.Enums.InventoryLotStatus.Available })),
+            ("InventoryReorderRule", WithBase(new InventoryReorderRule { ProductId = product.Id, MinimumQuantity = 0, MaximumQuantity = 100, ReorderPoint = 10, ReorderQuantity = 20, IsActive = true })),
+            ("StockBalance", WithBase(new StockBalance { Id = stockBalanceId, ProductId = product.Id, WarehouseId = warehouse.Id, LocationId = location.Id, LotId = lot.Id, OnHandQuantity = 10, AvailableQuantity = 10 })),
+            ("InventoryMovement", WithBase(new InventoryMovement { ProductId = product.Id, WarehouseId = warehouse.Id, LocationId = location.Id, LotId = lot.Id, StockBalanceId = stockBalanceId, MovementType = XFramework.Inventario.Domain.Shared.Enums.InventoryMovementType.Adjustment, QuantityDelta = 1, MovementDate = DateTime.UtcNow })),
+            ("Reservation", WithBase(new Reservation { Id = reservationId, ProductId = product.Id, WarehouseId = warehouse.Id, LocationId = location.Id, StockBalanceId = stockBalanceId, Quantity = 1, Status = XFramework.Inventario.Domain.Shared.Enums.ReservationStatus.Active, ReservedAt = DateTime.UtcNow })),
+            ("ReservationAllocation", WithBase(new ReservationAllocation { ReservationId = reservationId, ProductId = product.Id, WarehouseId = warehouse.Id, LocationId = location.Id, StockBalanceId = stockBalanceId, LotId = lot.Id, Quantity = 1, Status = XFramework.Inventario.Domain.Shared.Enums.ReservationAllocationStatus.Reserved, ReservedAt = DateTime.UtcNow })),
+            ("Supplier", WithBase(new Supplier { Id = supplierId, Code = UniqueCode("SUP"), Name = "Rejected Supplier", IsActive = true })),
+            ("PurchaseOrder", WithBase(new PurchaseOrder { Id = purchaseOrderId, OrderNumber = UniqueCode("PO"), SupplierId = supplierId, Status = XFramework.Inventario.Domain.Shared.Enums.PurchaseOrderStatus.Open, OrderDate = DateTime.UtcNow })),
+            ("PurchaseOrderLine", WithBase(new PurchaseOrderLine { Id = purchaseOrderLineId, PurchaseOrderId = purchaseOrderId, ProductId = product.Id, OrderedQuantity = 1, UnitOfMeasure = "ea" })),
+            ("ReceivingDocument", WithBase(new ReceivingDocument { Id = receivingDocumentId, ReceiptNumber = UniqueCode("RCV"), PurchaseOrderId = purchaseOrderId, WarehouseId = warehouse.Id, LocationId = location.Id, SupplierId = supplierId, Status = XFramework.Inventario.Domain.Shared.Enums.ReceivingDocumentStatus.Posted, ReceivedAt = DateTime.UtcNow })),
+            ("ReceivingLine", WithBase(new ReceivingLine { ReceivingDocumentId = receivingDocumentId, PurchaseOrderLineId = purchaseOrderLineId, ProductId = product.Id, LotId = lot.Id, StockBalanceId = stockBalanceId, Quantity = 1, UnitOfMeasure = "ea" })),
+            ("ProductTransaction", WithBase(new ProductTransaction { ProductId = product.Id, Quantity = 1, TotalPrice = 10m, TransactionDate = DateTime.UtcNow }))
+        };
+
+        foreach (var (entityName, entity) in rejectedEntities)
+        {
+            var ctx = InventarioIntegrationTestFixture.DataContext;
+            AddUntyped(ctx, entity);
+
+            var save = await ctx.SaveChangesAsync();
+
+            save.IsSuccess.Should().BeFalse(entityName);
+            save.Message.Should().Contain(entityName);
+            save.Message.Should().Contain("not registered for remote mutation");
+        }
+    }
+
+    private static T WithBase<T>(T entity) where T : XFramework.Domain.Shared.Contracts.Base.BaseModel
+    {
+        entity.Id = entity.Id == Guid.Empty ? Guid.NewGuid() : entity.Id;
+        entity.TenantId = InventarioIntegrationTestFixture.TestTenantId;
+        entity.IsEnabled = true;
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.ConcurrencyStamp = Guid.NewGuid();
+        return entity;
+    }
+
+    private static void AddUntyped(XFramework.Domain.Shared.DataContext.IDataContext ctx, object entity)
+    {
+        var method = typeof(XFramework.Domain.Shared.DataContext.IDataContext)
+            .GetMethod(nameof(XFramework.Domain.Shared.DataContext.IDataContext.Add))!
+            .MakeGenericMethod(entity.GetType());
+        method.Invoke(ctx, [entity]);
     }
 }

--- a/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
@@ -8,6 +8,7 @@ namespace Inventario.IntegrationTests.Tests;
 [Category(TestCategories.Integration)]
 [Category(TestCategories.Inventario)]
 [Category(TestCategories.Catalog)]
+[Category(TestCategories.DataContext)]
 public sealed class CatalogTests : InventarioTestBase
 {
     [Test]
@@ -34,6 +35,25 @@ public sealed class CatalogTests : InventarioTestBase
             .FirstOrDefaultAsync(x => x.Id == category.Id);
         persisted.Should().NotBeNull();
         persisted!.TenantId.Should().Be(InventarioIntegrationTestFixture.TestTenantId);
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    public async Task SaveChangesAsync_RemoteProductCategoryUpdate_PersistsThroughInventarioDataContext()
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+
+        category.Description = $"Updated {Guid.NewGuid():N}";
+        ctx.Update(category);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        var persisted = await db.Set<ProductCategory>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Id == category.Id);
+        persisted.Description.Should().Be(category.Description);
     }
 
     [Test]
@@ -64,5 +84,67 @@ public sealed class CatalogTests : InventarioTestBase
             .FirstOrDefaultAsync(x => x.Id == product.Id);
         persisted.Should().NotBeNull();
         persisted!.CategoryId.Should().Be(category.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    public async Task SaveChangesAsync_RemoteProductVariationCreate_PersistsWithProduct()
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var product = await TestInventarioSeed.SeedProduct(db, categoryId: category.Id);
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+        var variation = new ProductVariation
+        {
+            Id = Guid.NewGuid(),
+            TenantId = InventarioIntegrationTestFixture.TestTenantId,
+            ProductId = product.Id,
+            Name = $"Variation {Guid.NewGuid():N}",
+            AdditionalPrice = 2.5m,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        ctx.Add(variation);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeTrue(save.Message);
+        var persisted = await db.Set<ProductVariation>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x => x.Id == variation.Id);
+        persisted.Should().NotBeNull();
+        persisted!.ProductId.Should().Be(product.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    [Category(TestCategories.Planning)]
+    [Category(TestCategories.ControlPanelContract)]
+    public async Task SaveChangesAsync_RemoteInventoryReorderRuleCreate_ReturnsNotRegisteredForRemoteMutation()
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var product = await TestInventarioSeed.SeedProduct(db, categoryId: category.Id);
+        var ctx = InventarioIntegrationTestFixture.DataContext;
+        var rule = new InventoryReorderRule
+        {
+            Id = Guid.NewGuid(),
+            TenantId = InventarioIntegrationTestFixture.TestTenantId,
+            ProductId = product.Id,
+            MinimumQuantity = 0,
+            MaximumQuantity = 100,
+            ReorderPoint = 10,
+            ReorderQuantity = 25,
+            IsActive = true,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        ctx.Add(rule);
+        var save = await ctx.SaveChangesAsync();
+
+        save.IsSuccess.Should().BeFalse();
+        save.Message.Should().Contain("InventoryReorderRule");
+        save.Message.Should().Contain("not registered for remote mutation");
     }
 }

--- a/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -1,0 +1,68 @@
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.ExtendedIntegration)]
+[Category(TestCategories.Inventario)]
+[Category(TestCategories.ControlPanelContract)]
+public sealed class ControlPanelContractTests
+{
+    private static readonly string[] BusinessWorkflowEntities =
+    [
+        "InventoryReorderRule",
+        "Warehouse",
+        "InventoryLocation",
+        "InventoryLot",
+        "StockBalance",
+        "InventoryMovement",
+        "Reservation",
+        "ReservationAllocation",
+        "Supplier",
+        "PurchaseOrder",
+        "PurchaseOrderLine",
+        "ReceivingDocument",
+        "ReceivingLine"
+    ];
+
+    [Test]
+    public void InventarioPages_BusinessWorkflowCreates_DoNotUseDirectRemoteDataContextMutation()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario");
+
+        var offenders = Directory.EnumerateFiles(pagesRoot, "*.razor", SearchOption.AllDirectories)
+            .SelectMany(path =>
+            {
+                var text = File.ReadAllText(path);
+                return BusinessWorkflowEntities
+                    .Where(entity => text.Contains($"DataContext.Add(new {entity}", StringComparison.Ordinal))
+                    .Select(entity => $"{Path.GetRelativePath(repositoryRoot.FullName, path)} directly adds {entity}");
+            })
+            .ToArray();
+
+        offenders.Should().BeEmpty("business workflow entities must go through IInventarioServiceWrapper endpoints");
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "XFramework.slnx")))
+                return current;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate XFramework repository root.");
+    }
+}

--- a/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -1,4 +1,5 @@
 using XFramework.TestInfrastructure;
+using System.Text.RegularExpressions;
 
 namespace Inventario.IntegrationTests.Tests;
 
@@ -15,6 +16,7 @@ public sealed class ControlPanelContractTests
         "Warehouse",
         "InventoryLocation",
         "InventoryLot",
+        "ProductTransaction",
         "StockBalance",
         "InventoryMovement",
         "Reservation",
@@ -27,7 +29,7 @@ public sealed class ControlPanelContractTests
     ];
 
     [Test]
-    public void InventarioPages_BusinessWorkflowCreates_DoNotUseDirectRemoteDataContextMutation()
+    public void InventarioPages_BusinessWorkflowMutations_DoNotUseDirectRemoteDataContextMutation()
     {
         var repositoryRoot = FindRepositoryRoot();
         var pagesRoot = Path.Combine(
@@ -44,12 +46,46 @@ public sealed class ControlPanelContractTests
             {
                 var text = File.ReadAllText(path);
                 return BusinessWorkflowEntities
-                    .Where(entity => text.Contains($"DataContext.Add(new {entity}", StringComparison.Ordinal))
-                    .Select(entity => $"{Path.GetRelativePath(repositoryRoot.FullName, path)} directly adds {entity}");
+                    .SelectMany(entity => FindDirectMutations(repositoryRoot, path, text, entity));
             })
             .ToArray();
 
         offenders.Should().BeEmpty("business workflow entities must go through IInventarioServiceWrapper endpoints");
+    }
+
+    private static IEnumerable<string> FindDirectMutations(
+        DirectoryInfo repositoryRoot,
+        string path,
+        string text,
+        string entity)
+    {
+        var relativePath = Path.GetRelativePath(repositoryRoot.FullName, path);
+        var operations = new[] { "Add", "Update", "Remove" };
+
+        foreach (var operation in operations)
+        {
+            var inlinePattern = $@"DataContext\.{operation}\s*\(\s*new\s+{Regex.Escape(entity)}\b";
+            if (Regex.IsMatch(text, inlinePattern, RegexOptions.Multiline))
+                yield return $"{relativePath} directly {operation.ToLowerInvariant()}s {entity}";
+
+            var genericPattern = $@"DataContext\.{operation}\s*<\s*{Regex.Escape(entity)}\s*>";
+            if (Regex.IsMatch(text, genericPattern, RegexOptions.Multiline))
+                yield return $"{relativePath} directly {operation.ToLowerInvariant()}s {entity}";
+        }
+
+        foreach (Match declaration in Regex.Matches(
+            text,
+            $@"(?:var|{Regex.Escape(entity)})\s+(\w+)\s*=\s*new\s+{Regex.Escape(entity)}\b",
+            RegexOptions.Multiline))
+        {
+            var variableName = Regex.Escape(declaration.Groups[1].Value);
+            foreach (var operation in operations)
+            {
+                var variableMutationPattern = $@"DataContext\.{operation}\s*\(\s*{variableName}\s*\)";
+                if (Regex.IsMatch(text, variableMutationPattern, RegexOptions.Multiline))
+                    yield return $"{relativePath} directly {operation.ToLowerInvariant()}s {entity}";
+            }
+        }
     }
 
     private static DirectoryInfo FindRepositoryRoot()

--- a/src/Tests/Inventario.IntegrationTests/Tests/PlanningPurchasingReportingTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/PlanningPurchasingReportingTests.cs
@@ -16,6 +16,46 @@ namespace Inventario.IntegrationTests.Tests;
 public sealed class PlanningPurchasingReportingTests : InventarioTestBase
 {
     [Test]
+    [Category(TestCategories.ExtendedIntegration)]
+    [Category(TestCategories.Planning)]
+    [Category(TestCategories.Wrappers)]
+    [Category(TestCategories.ControlPanelContract)]
+    public async Task CreateInventoryReorderRule_ValidRequest_PersistsThroughWrapper()
+    {
+        var seed = await SeedInventoryScope();
+
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.CreateInventoryReorderRule(
+            new CreateInventoryReorderRuleRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                MinimumQuantity = 2,
+                MaximumQuantity = 20,
+                ReorderPoint = 5,
+                ReorderQuantity = 10,
+                PreferredSupplier = "control-panel-wrapper",
+                IsActive = true
+            });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+
+        await using var db = CreateDbContext();
+        var persisted = await db.Set<InventoryReorderRule>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(x =>
+                x.ProductId == seed.Product.Id &&
+                x.WarehouseId == seed.Warehouse.Id &&
+                x.LocationId == seed.Location.Id &&
+                x.PreferredSupplier == "control-panel-wrapper");
+
+        persisted.Should().NotBeNull();
+        persisted!.TenantId.Should().Be(InventarioIntegrationTestFixture.TestTenantId);
+        persisted.ReorderQuantity.Should().Be(10);
+    }
+
+    [Test]
     [Category(TestCategories.Planning)]
     [Category(TestCategories.Reporting)]
     public async Task GetReorderSuggestions_LowStockProduct_ReturnsSuggestedQuantity()

--- a/src/Tests/Inventario.IntegrationTests/Tests/WrapperContractCoverageTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/WrapperContractCoverageTests.cs
@@ -1,0 +1,493 @@
+using Microsoft.EntityFrameworkCore;
+using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
+using XFramework.Inventario.Domain.Shared.Enums;
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.ExtendedIntegration)]
+[Category(TestCategories.Inventario)]
+[Category(TestCategories.Wrappers)]
+public sealed class WrapperContractCoverageTests : InventarioTestBase
+{
+    [Test]
+    [Category(TestCategories.Warehousing)]
+    public async Task GetWarehouseAndLocationWrappers_TenantScopedRecords_ReturnOnlyRequestTenant()
+    {
+        await using var db = CreateDbContext();
+        var warehouse = await TestInventarioSeed.SeedWarehouse(db, code: UniqueCode("WH"));
+        var location = await TestInventarioSeed.SeedLocation(db, warehouse.Id, code: UniqueCode("BIN"));
+        var otherTenantId = Guid.NewGuid();
+        var otherWarehouse = await TestInventarioSeed.SeedWarehouse(db, otherTenantId, UniqueCode("WH"));
+        var otherLocation = await TestInventarioSeed.SeedLocation(db, otherWarehouse.Id, otherTenantId, UniqueCode("BIN"));
+
+        var warehouses = await InventarioIntegrationTestFixture.ServiceWrapper.GetWarehouses(
+            new GetWarehousesRequest { Metadata = CreateMetadata() });
+        var locations = await InventarioIntegrationTestFixture.ServiceWrapper.GetInventoryLocations(
+            new GetInventoryLocationsRequest { Metadata = CreateMetadata() });
+
+        warehouses.IsSuccess.Should().BeTrue(warehouses.Message);
+        warehouses.Response.Should().Contain(x => x.Id == warehouse.Id);
+        warehouses.Response.Should().NotContain(x => x.Id == otherWarehouse.Id);
+
+        locations.IsSuccess.Should().BeTrue(locations.Message);
+        locations.Response.Should().Contain(x => x.Id == location.Id);
+        locations.Response.Should().NotContain(x => x.Id == otherLocation.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.Traceability)]
+    public async Task GetInventoryLotWrappers_ProductScopedRecords_ReturnListAndDetail()
+    {
+        await using var db = CreateDbContext();
+        var product = await TestInventarioSeed.SeedProduct(db);
+        var lot = await TestInventarioSeed.SeedLot(db, product.Id, lotNumber: UniqueCode("LOT"));
+        var otherTenantId = Guid.NewGuid();
+        var otherCategory = await TestInventarioSeed.SeedCategory(db, otherTenantId);
+        var otherProduct = await TestInventarioSeed.SeedProduct(db, otherTenantId, otherCategory.Id);
+        var otherLot = await TestInventarioSeed.SeedLot(db, otherProduct.Id, otherTenantId, UniqueCode("LOT"));
+
+        var lots = await InventarioIntegrationTestFixture.ServiceWrapper.GetInventoryLots(
+            new GetInventoryLotsRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = product.Id,
+                IncludeExpired = true
+            });
+        var detail = await InventarioIntegrationTestFixture.ServiceWrapper.GetInventoryLot(
+            new GetInventoryLotRequest
+            {
+                Metadata = CreateMetadata(),
+                Id = lot.Id
+            });
+
+        lots.IsSuccess.Should().BeTrue(lots.Message);
+        lots.Response.Should().ContainSingle(x => x.Id == lot.Id);
+        lots.Response.Should().NotContain(x => x.Id == otherLot.Id);
+
+        detail.IsSuccess.Should().BeTrue(detail.Message);
+        detail.Response.Should().NotBeNull();
+        detail.Response!.Id.Should().Be(lot.Id);
+        detail.Response.ProductId.Should().Be(product.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.Planning)]
+    public async Task GetInventoryReorderRules_ProductFilter_ReturnsPersistedRule()
+    {
+        var seed = await SeedInventoryScope();
+        var create = await InventarioIntegrationTestFixture.ServiceWrapper.CreateInventoryReorderRule(
+            new CreateInventoryReorderRuleRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                MinimumQuantity = 2,
+                MaximumQuantity = 50,
+                ReorderPoint = 8,
+                ReorderQuantity = 20,
+                PreferredSupplier = "wrapper-coverage",
+                IsActive = true
+            });
+        create.IsSuccess.Should().BeTrue(create.Message);
+
+        var rules = await InventarioIntegrationTestFixture.ServiceWrapper.GetInventoryReorderRules(
+            new GetInventoryReorderRulesRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id
+            });
+
+        rules.IsSuccess.Should().BeTrue(rules.Message);
+        rules.Response.Should().ContainSingle(x =>
+            x.ProductId == seed.Product.Id &&
+            x.WarehouseId == seed.Warehouse.Id &&
+            x.LocationId == seed.Location.Id &&
+            x.ReorderQuantity == 20);
+    }
+
+    [Test]
+    [Category(TestCategories.Purchasing)]
+    public async Task PurchasingReadWrappers_TenantScopedRecords_ReturnExpectedRows()
+    {
+        var seed = await SeedInventoryScope();
+        var supplier = await CreateSupplier();
+        var order = await CreatePurchaseOrder(seed.Product.Id, supplier.Id, PurchaseOrderStatus.Open);
+        var receipt = await ReceiveInventory(seed, order);
+
+        await using var setupDb = CreateDbContext();
+        var otherTenantId = Guid.NewGuid();
+        var otherWarehouse = WithBase(
+            new Warehouse
+            {
+                Code = UniqueCode("WH"),
+                Name = "Other Tenant Warehouse"
+            },
+            otherTenantId);
+        var otherLocation = WithBase(
+            new InventoryLocation
+            {
+                WarehouseId = otherWarehouse.Id,
+                Code = UniqueCode("BIN"),
+                Name = "Other Tenant Location"
+            },
+            otherTenantId);
+        var otherSupplier = WithBase(
+            new Supplier
+            {
+                Code = UniqueCode("SUP"),
+                Name = "Other Tenant Supplier",
+                IsActive = true
+            },
+            otherTenantId);
+        var otherOrder = WithBase(
+            new PurchaseOrder
+            {
+                OrderNumber = UniqueCode("PO"),
+                SupplierId = otherSupplier.Id,
+                Status = PurchaseOrderStatus.Open,
+                OrderDate = DateTime.UtcNow
+            },
+            otherTenantId);
+        var otherReceipt = WithBase(
+            new ReceivingDocument
+            {
+                ReceiptNumber = UniqueCode("RCV"),
+                PurchaseOrderId = otherOrder.Id,
+                WarehouseId = otherWarehouse.Id,
+                LocationId = otherLocation.Id,
+                SupplierId = otherSupplier.Id,
+                Status = ReceivingDocumentStatus.Posted,
+                ReceivedAt = DateTime.UtcNow
+            },
+            otherTenantId);
+        setupDb.Set<Warehouse>().Add(otherWarehouse);
+        setupDb.Set<InventoryLocation>().Add(otherLocation);
+        setupDb.Set<Supplier>().Add(otherSupplier);
+        setupDb.Set<PurchaseOrder>().Add(otherOrder);
+        setupDb.Set<ReceivingDocument>().Add(otherReceipt);
+        await setupDb.SaveChangesAsync();
+
+        var suppliers = await InventarioIntegrationTestFixture.ServiceWrapper.GetSuppliers(
+            new GetSuppliersRequest { Metadata = CreateMetadata() });
+        var orders = await InventarioIntegrationTestFixture.ServiceWrapper.GetPurchaseOrders(
+            new GetPurchaseOrdersRequest
+            {
+                Metadata = CreateMetadata()
+            });
+        var orderDetail = await InventarioIntegrationTestFixture.ServiceWrapper.GetPurchaseOrder(
+            new GetPurchaseOrderRequest
+            {
+                Metadata = CreateMetadata(),
+                Id = order.Id
+            });
+        var receivingDocuments = await InventarioIntegrationTestFixture.ServiceWrapper.GetReceivingDocuments(
+            new GetReceivingDocumentsRequest
+            {
+                Metadata = CreateMetadata(),
+                Status = ReceivingDocumentStatus.Posted
+            });
+
+        suppliers.IsSuccess.Should().BeTrue(suppliers.Message);
+        suppliers.Response.Should().Contain(x => x.Id == supplier.Id);
+        suppliers.Response.Should().NotContain(x => x.Id == otherSupplier.Id);
+
+        orders.IsSuccess.Should().BeTrue(orders.Message);
+        orders.Response.Should().Contain(x => x.Id == order.Id);
+        orders.Response.Should().NotContain(x => x.Id == otherOrder.Id);
+
+        orderDetail.IsSuccess.Should().BeTrue(orderDetail.Message);
+        orderDetail.Response.Should().NotBeNull();
+        orderDetail.Response!.Id.Should().Be(order.Id);
+        orderDetail.Response.SupplierId.Should().Be(supplier.Id);
+
+        receivingDocuments.IsSuccess.Should().BeTrue(receivingDocuments.Message);
+        receivingDocuments.Response.Should().Contain(x => x.Id == receipt.Id);
+        receivingDocuments.Response.Should().NotContain(x => x.Id == otherReceipt.Id);
+    }
+
+    [Test]
+    [Category(TestCategories.Purchasing)]
+    public async Task SetPurchaseOrderStatus_OpenOrder_UpdatesStatusAndRejectsMissingOrder()
+    {
+        var product = await SeedProduct();
+        var supplier = await CreateSupplier();
+        var order = await CreatePurchaseOrder(product.Id, supplier.Id, PurchaseOrderStatus.Open);
+
+        var update = await InventarioIntegrationTestFixture.ServiceWrapper.SetPurchaseOrderStatus(
+            new SetPurchaseOrderStatusRequest
+            {
+                Metadata = CreateMetadata(),
+                PurchaseOrderId = order.Id,
+                Status = PurchaseOrderStatus.Cancelled
+            });
+        var missing = await InventarioIntegrationTestFixture.ServiceWrapper.SetPurchaseOrderStatus(
+            new SetPurchaseOrderStatusRequest
+            {
+                Metadata = CreateMetadata(),
+                PurchaseOrderId = Guid.NewGuid(),
+                Status = PurchaseOrderStatus.Cancelled
+            });
+
+        update.IsSuccess.Should().BeTrue(update.Message);
+        await using var db = CreateDbContext();
+        var persisted = await db.Set<PurchaseOrder>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Id == order.Id);
+        persisted.Status.Should().Be(PurchaseOrderStatus.Cancelled);
+
+        missing.IsSuccess.Should().BeFalse();
+        missing.HttpStatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    [Category(TestCategories.Stock)]
+    [Category(TestCategories.Reservations)]
+    public async Task StockAndReservationReadWrappers_PostedAndReservedStock_ReturnExpectedRows()
+    {
+        var seed = await SeedInventoryScope(withLot: true);
+        var movementKey = $"movement-read-{Guid.NewGuid():N}";
+        var post = await InventarioIntegrationTestFixture.ServiceWrapper.PostStockMovement(
+            new PostStockMovementRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                LotId = seed.Lot!.Id,
+                MovementType = InventoryMovementType.OpeningBalance,
+                Quantity = 10,
+                IdempotencyKey = movementKey
+            });
+        post.IsSuccess.Should().BeTrue(post.Message);
+
+        var referenceId = Guid.NewGuid();
+        var reserve = await InventarioIntegrationTestFixture.ServiceWrapper.ReserveInventory(
+            new ReserveInventoryRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                LotId = seed.Lot.Id,
+                Quantity = 3,
+                ReferenceType = "wrapper-coverage",
+                ReferenceId = referenceId
+            });
+        reserve.IsSuccess.Should().BeTrue(reserve.Message);
+
+        await using var setupDb = CreateDbContext();
+        var reservation = await setupDb.Set<Reservation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ReferenceId == referenceId);
+        var allocation = await setupDb.Set<ReservationAllocation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ReservationId == reservation.Id);
+
+        var balances = await InventarioIntegrationTestFixture.ServiceWrapper.GetStockBalances(
+            new GetStockBalancesRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                LotId = seed.Lot.Id
+            });
+        var movements = await InventarioIntegrationTestFixture.ServiceWrapper.GetInventoryMovements(
+            new GetInventoryMovementsRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                LotId = seed.Lot.Id,
+                IdempotencyKey = movementKey
+            });
+        var reservations = await InventarioIntegrationTestFixture.ServiceWrapper.GetReservations(
+            new GetReservationsRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = seed.Product.Id,
+                Status = ReservationStatus.Active,
+                ReferenceType = "wrapper-coverage",
+                ReferenceId = referenceId
+            });
+        var allocations = await InventarioIntegrationTestFixture.ServiceWrapper.GetReservationAllocations(
+            new GetReservationAllocationsRequest
+            {
+                Metadata = CreateMetadata(),
+                ReservationId = reservation.Id,
+                ProductId = seed.Product.Id,
+                LotId = seed.Lot.Id,
+                Status = ReservationAllocationStatus.Reserved
+            });
+
+        balances.IsSuccess.Should().BeTrue(balances.Message);
+        balances.Response.Should().ContainSingle(x => x.ProductId == seed.Product.Id && x.ReservedQuantity == 3);
+
+        movements.IsSuccess.Should().BeTrue(movements.Message);
+        movements.Response.Should().ContainSingle(x => x.IdempotencyKey == movementKey);
+
+        reservations.IsSuccess.Should().BeTrue(reservations.Message);
+        reservations.Response.Should().ContainSingle(x => x.Id == reservation.Id);
+
+        allocations.IsSuccess.Should().BeTrue(allocations.Message);
+        allocations.Response.Should().ContainSingle(x => x.Id == allocation.Id);
+
+        var cancel = await InventarioIntegrationTestFixture.ServiceWrapper.CancelReservation(
+            new CancelReservationRequest
+            {
+                Metadata = CreateMetadata(),
+                ReservationId = reservation.Id,
+                Reason = "wrapper coverage cancel"
+            });
+        var missingCancel = await InventarioIntegrationTestFixture.ServiceWrapper.CancelReservation(
+            new CancelReservationRequest
+            {
+                Metadata = CreateMetadata(),
+                ReservationId = Guid.NewGuid(),
+                Reason = "missing reservation"
+            });
+
+        cancel.IsSuccess.Should().BeTrue(cancel.Message);
+        missingCancel.IsSuccess.Should().BeFalse();
+        missingCancel.HttpStatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+    }
+
+    private async Task<Product> SeedProduct()
+    {
+        await using var db = CreateDbContext();
+        return await TestInventarioSeed.SeedProduct(db);
+    }
+
+    private async Task<InventoryScope> SeedInventoryScope(bool withLot = false)
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var product = await TestInventarioSeed.SeedProduct(db, categoryId: category.Id);
+        var warehouse = await TestInventarioSeed.SeedWarehouse(db);
+        var location = await TestInventarioSeed.SeedLocation(db, warehouse.Id);
+        var lot = withLot
+            ? await TestInventarioSeed.SeedLot(db, product.Id, expiresAt: DateTime.UtcNow.AddDays(120))
+            : null;
+        return new InventoryScope(product, warehouse, location, lot);
+    }
+
+    private async Task<Supplier> CreateSupplier()
+    {
+        var code = UniqueCode("SUP");
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.CreateSupplier(
+            new CreateSupplierRequest
+            {
+                Metadata = CreateMetadata(),
+                Code = code,
+                Name = $"Supplier {code}",
+                IsActive = true
+            });
+        result.IsSuccess.Should().BeTrue(result.Message);
+
+        await using var db = CreateDbContext();
+        return await db.Set<Supplier>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Code == code);
+    }
+
+    private async Task<PurchaseOrder> CreatePurchaseOrder(
+        Guid productId,
+        Guid supplierId,
+        PurchaseOrderStatus status)
+    {
+        var orderNumber = UniqueCode("PO");
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.CreatePurchaseOrder(
+            new CreatePurchaseOrderRequest
+            {
+                Metadata = CreateMetadata(),
+                OrderNumber = orderNumber,
+                SupplierId = supplierId,
+                Status = status,
+                Lines =
+                [
+                    new PurchaseOrderLineRequest
+                    {
+                        ProductId = productId,
+                        OrderedQuantity = 10,
+                        UnitCost = 5m,
+                        UnitOfMeasure = "ea"
+                    }
+                ]
+            });
+        result.IsSuccess.Should().BeTrue(result.Message);
+
+        await using var db = CreateDbContext();
+        return await db.Set<PurchaseOrder>()
+            .IgnoreQueryFilters()
+            .Include(x => x.Lines)
+            .FirstAsync(x => x.OrderNumber == orderNumber);
+    }
+
+    private async Task<ReceivingDocument> ReceiveInventory(
+        InventoryScope seed,
+        PurchaseOrder order)
+    {
+        var receiptNumber = UniqueCode("RCV");
+        var line = order.Lines.Single();
+        var result = await InventarioIntegrationTestFixture.ServiceWrapper.ReceiveInventory(
+            new ReceiveInventoryRequest
+            {
+                Metadata = CreateMetadata(),
+                ReceiptNumber = receiptNumber,
+                PurchaseOrderId = order.Id,
+                WarehouseId = seed.Warehouse.Id,
+                LocationId = seed.Location.Id,
+                SupplierId = order.SupplierId,
+                ReceivedAt = DateTime.UtcNow,
+                IdempotencyKey = $"wrapper-receive-{Guid.NewGuid():N}",
+                Lines =
+                [
+                    new ReceivingLineRequest
+                    {
+                        PurchaseOrderLineId = line.Id,
+                        ProductId = seed.Product.Id,
+                        Quantity = 2,
+                        UnitCost = 5m,
+                        UnitOfMeasure = "ea",
+                        LotNumber = UniqueCode("LOT"),
+                        ExpiresAt = DateTime.UtcNow.AddDays(180)
+                    }
+                ]
+            });
+        result.IsSuccess.Should().BeTrue(result.Message);
+
+        await using var db = CreateDbContext();
+        return await db.Set<ReceivingDocument>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ReceiptNumber == receiptNumber);
+    }
+
+    private static T WithBase<T>(T entity, Guid tenantId)
+        where T : XFramework.Domain.Shared.Contracts.Base.BaseModel
+    {
+        entity.Id = entity.Id == Guid.Empty ? Guid.NewGuid() : entity.Id;
+        entity.TenantId = tenantId;
+        entity.IsEnabled = true;
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.ConcurrencyStamp = Guid.NewGuid();
+        return entity;
+    }
+
+    private sealed record InventoryScope(
+        Product Product,
+        Warehouse Warehouse,
+        InventoryLocation Location,
+        InventoryLot? Lot);
+}

--- a/src/Tests/Inventario.IntegrationTests/Tests/WrapperCoverageCompletenessTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/WrapperCoverageCompletenessTests.cs
@@ -1,0 +1,71 @@
+using XFramework.TestInfrastructure;
+
+namespace Inventario.IntegrationTests.Tests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.ExtendedIntegration)]
+[Category(TestCategories.Inventario)]
+[Category(TestCategories.Wrappers)]
+public sealed class WrapperCoverageCompletenessTests
+{
+    [Test]
+    public void InventarioWrapperRequestContracts_AllHaveDirectIntegrationCoverage()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var requestsRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.Inventario",
+            "Inventario.Domain.Shared",
+            "Contracts",
+            "Requests");
+        var testsRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Tests",
+            "Inventario.IntegrationTests",
+            "Tests");
+
+        var requestContracts = Directory
+            .EnumerateFiles(requestsRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => File.ReadAllText(path).Contains("IBoltRequest", StringComparison.Ordinal))
+            .Select(path => Path.GetFileNameWithoutExtension(path))
+            .Where(name => name.EndsWith("Request", StringComparison.Ordinal))
+            .Select(name => name[..^"Request".Length])
+            .OrderBy(name => name)
+            .ToArray();
+
+        var testSource = string.Join(
+            Environment.NewLine,
+            Directory
+                .EnumerateFiles(testsRoot, "*.cs", SearchOption.TopDirectoryOnly)
+                .Where(path => !string.Equals(
+                    Path.GetFileName(path),
+                    nameof(WrapperCoverageCompletenessTests) + ".cs",
+                    StringComparison.Ordinal))
+                .Select(File.ReadAllText));
+
+        var missing = requestContracts
+            .Where(methodName => !testSource.Contains($".{methodName}(", StringComparison.Ordinal))
+            .ToArray();
+
+        missing.Should().BeEmpty(
+            "every Inventario IBoltRequest contract must have at least one direct service-wrapper integration test");
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "XFramework.slnx")))
+                return current;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate XFramework repository root.");
+    }
+}

--- a/src/Tests/XFramework.SourceGenerators.Tests/ServiceWrapperGeneratorTests.cs
+++ b/src/Tests/XFramework.SourceGenerators.Tests/ServiceWrapperGeneratorTests.cs
@@ -1,0 +1,316 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+using XFramework.SourceGenerators;
+
+namespace XFramework.SourceGenerators.Tests;
+
+[TestFixture]
+public sealed class ServiceWrapperGeneratorTests
+{
+    [Test]
+    public void GenerateWrapper_CustomExternalServiceName_UsesConfiguredNameTargetAndDiscoveryPrefix()
+    {
+        var domainReference = CreateReference(
+            "Juan.Barangay.Domain.Shared",
+            """
+            namespace Juan.Barangay.Domain.Shared.Entities
+            {
+                using XFramework.Domain.Shared.Attributes;
+                using XFramework.Domain.Shared.Contracts.Base;
+
+                [GenerateEndpoints(Actions = EndpointActions.None, RequireAuthorization = true)]
+                public sealed class Resident : BaseModel;
+            }
+
+            namespace Juan.Barangay.Domain.Shared.Contracts.Residents
+            {
+                using Bolt.Domain.Shared.Contracts.Requests;
+                using XFramework.Domain.Shared.BusinessObjects;
+                using XFramework.Domain.Shared.Contracts.Requests;
+
+                public sealed record ResidentResponse;
+
+                public partial record ValidateBarangayIdRequest : RequestBase,
+                    IQuery<QueryResponse<ResidentResponse>>,
+                    IBoltRequest<ValidateBarangayIdRequest, QueryResponse<ResidentResponse>>;
+            }
+            """);
+
+        var generatedSource = RunGenerator(
+            "Juan.Barangay.Integration",
+            domainReference,
+            new Dictionary<string, string>
+            {
+                ["build_property.XFrameworkServiceWrapperName"] = "JuanBarangay",
+                ["build_property.XFrameworkServiceWrapperTargetClientName"] = "JuanBarangay",
+                ["build_property.XFrameworkServiceWrapperDiscoveryPrefixes"] = "Juan.Barangay"
+            });
+
+        generatedSource.Should().Contain("namespace JuanBarangay.Integration.Drivers");
+        generatedSource.Should().Contain("#nullable enable");
+        generatedSource.Should().Contain("public partial interface IJuanBarangayServiceWrapper");
+        generatedSource.Should().Contain("public partial record JuanBarangayServiceWrapper(");
+        generatedSource.Should().Contain($"TargetClient = \"{"JuanBarangay".ToSha256()}\"");
+        generatedSource.Should().Contain("public IResidentCrudService Resident { get; init; }");
+        generatedSource.Should().Contain("ValidateBarangayId(");
+        generatedSource.Should().NotContain("namespace Juan.Integration.Drivers");
+    }
+
+    [Test]
+    public void GenerateWrapper_ConventionModuleName_RemainsBackwardCompatible()
+    {
+        var domainReference = CreateReference(
+            "Inventario.Domain.Shared",
+            """
+            namespace XFramework.Inventario.Domain.Shared.Contracts
+            {
+                using XFramework.Domain.Shared.Attributes;
+                using XFramework.Domain.Shared.Contracts.Base;
+
+                [GenerateEndpoints(Actions = EndpointActions.None)]
+                public sealed class Product : BaseModel;
+            }
+
+            namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations
+            {
+                using Bolt.Domain.Shared.Contracts.Requests;
+                using XFramework.Domain.Shared.BusinessObjects;
+                using XFramework.Domain.Shared.Contracts.Requests;
+
+                public partial record ReserveInventoryRequest : RequestBase,
+                    ICommand<CmdResponse>,
+                    IBoltRequest<ReserveInventoryRequest, CmdResponse>;
+            }
+            """);
+
+        var generatedSource = RunGenerator(
+            "Inventario.Integration",
+            domainReference,
+            new Dictionary<string, string>());
+
+        generatedSource.Should().Contain("namespace Inventario.Integration.Drivers");
+        generatedSource.Should().Contain("public partial interface IInventarioServiceWrapper");
+        generatedSource.Should().Contain($"TargetClient = \"{"Inventario".ToSha256()}\"");
+        generatedSource.Should().Contain("public IProductCrudService Product { get; init; }");
+        generatedSource.Should().Contain("ReserveInventory(");
+    }
+
+    [Test]
+    public void GenerateWrapper_ProjectWithManualWrapperDeclaration_SkipsGeneratedWrapper()
+    {
+        var domainReference = CreateReference(
+            "Messaging.Domain.Shared",
+            """
+            namespace Messaging.Domain.Shared.Contracts.Requests.Create
+            {
+                using Bolt.Domain.Shared.Contracts.Requests;
+                using XFramework.Domain.Shared.BusinessObjects;
+                using XFramework.Domain.Shared.Contracts.Requests;
+
+                public partial record CreateDirectMessageRequest : RequestBase,
+                    ICommand<CmdResponse>,
+                    IBoltRequest<CreateDirectMessageRequest, CmdResponse>;
+            }
+            """);
+
+        var generatedSources = RunGeneratorSources(
+            "Messaging.Integration",
+            domainReference,
+            new Dictionary<string, string>(),
+            """
+            namespace Messaging.Integration.Drivers
+            {
+                public interface IMessagingServiceWrapper { }
+                public sealed record MessagingServiceWrapper { }
+                public static class MessagingServiceWrapperExtensions { }
+            }
+            """);
+
+        generatedSources.Should().BeEmpty();
+    }
+
+    private static string RunGenerator(
+        string assemblyName,
+        MetadataReference domainReference,
+        IReadOnlyDictionary<string, string> globalOptions)
+    {
+        var generatedSources = RunGeneratorSources(
+            assemblyName,
+            domainReference,
+            globalOptions,
+            "");
+
+        var generatedSource = generatedSources.Single();
+        generatedSource.Should().NotBeNullOrWhiteSpace();
+        return generatedSource;
+    }
+
+    private static List<string> RunGeneratorSources(
+        string assemblyName,
+        MetadataReference domainReference,
+        IReadOnlyDictionary<string, string> globalOptions,
+        string projectSource)
+    {
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(projectSource, parseOptions)],
+            GetMetadataReferences().Append(domainReference),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var inputDiagnostics = compilation.GetDiagnostics()
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        inputDiagnostics.Should().BeEmpty();
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [new ServiceWrapperGenerator().AsSourceGenerator()],
+            parseOptions: parseOptions,
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(globalOptions));
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(
+            compilation,
+            out _,
+            out var generatorDiagnostics);
+
+        generatorDiagnostics
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .Should()
+            .BeEmpty();
+
+        return driver.GetRunResult()
+            .GeneratedTrees
+            .Where(tree => tree.FilePath.EndsWith("ServiceWrapperGenerator.g.cs", StringComparison.Ordinal))
+            .Select(tree => tree.GetText().ToString())
+            .ToList();
+    }
+
+    private static MetadataReference CreateReference(string assemblyName, string source)
+    {
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [
+                CSharpSyntaxTree.ParseText(CommonStubs, parseOptions),
+                CSharpSyntaxTree.ParseText(source, parseOptions)
+            ],
+            GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+
+        emitResult.Diagnostics
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .Should()
+            .BeEmpty();
+
+        emitResult.Success.Should().BeTrue();
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+
+    private static IEnumerable<MetadataReference> GetMetadataReferences()
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(static assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
+            .Select(static assembly => MetadataReference.CreateFromFile(assembly.Location))
+            .DistinctBy(static reference => reference.Display);
+    }
+
+    private sealed class TestAnalyzerConfigOptionsProvider(
+        IReadOnlyDictionary<string, string> globalOptions) : AnalyzerConfigOptionsProvider
+    {
+        private readonly AnalyzerConfigOptions _globalOptions = new DictionaryAnalyzerConfigOptions(globalOptions);
+        private readonly AnalyzerConfigOptions _emptyOptions = new DictionaryAnalyzerConfigOptions(
+            ImmutableDictionary<string, string>.Empty);
+
+        public override AnalyzerConfigOptions GlobalOptions => _globalOptions;
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => _emptyOptions;
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => _emptyOptions;
+    }
+
+    private sealed class DictionaryAnalyzerConfigOptions(
+        IReadOnlyDictionary<string, string> options) : AnalyzerConfigOptions
+    {
+        public override bool TryGetValue(string key, out string value)
+        {
+            if (options.TryGetValue(key, out var found))
+            {
+                value = found;
+                return true;
+            }
+
+            value = string.Empty;
+            return false;
+        }
+    }
+
+    private const string CommonStubs = """
+    using System;
+
+    namespace XFramework.Domain.Shared.Attributes
+    {
+        public enum EndpointType
+        {
+            Rest = 1
+        }
+
+        [Flags]
+        public enum EndpointActions
+        {
+            None = 0,
+            Create = 1,
+            Get = 2,
+            GetList = 4,
+            Update = 8,
+            Delete = 16,
+            All = Create | Get | GetList | Update | Delete
+        }
+
+        [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+        public sealed class GenerateEndpointsAttribute : Attribute
+        {
+            public EndpointType Type { get; set; } = EndpointType.Rest;
+            public EndpointActions Actions { get; set; } = EndpointActions.All;
+            public bool RequireAuthorization { get; set; }
+        }
+    }
+
+    namespace XFramework.Domain.Shared.Contracts.Base
+    {
+        public abstract class BaseModel
+        {
+            public Guid Id { get; set; }
+            public Guid TenantId { get; set; }
+        }
+
+        public interface IHasRequestServer;
+    }
+
+    namespace XFramework.Domain.Shared.Contracts.Requests
+    {
+        using XFramework.Domain.Shared.Contracts.Base;
+
+        public abstract record RequestBase : IHasRequestServer;
+        public interface ICommand<TResponse> : IHasRequestServer;
+        public interface IQuery<TResponse> : IHasRequestServer;
+    }
+
+    namespace XFramework.Domain.Shared.BusinessObjects
+    {
+        public class CmdResponse;
+        public class CmdResponse<T> : CmdResponse;
+        public class QueryResponse<T>;
+    }
+
+    namespace Bolt.Domain.Shared.Contracts.Requests
+    {
+        public interface IBoltRequest<TRequest, TResponse>;
+    }
+    """;
+}

--- a/src/Tests/XFramework.TestInfrastructure/TestCategories.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestCategories.cs
@@ -3,6 +3,7 @@ namespace XFramework.TestInfrastructure;
 public static class TestCategories
 {
     public const string Integration = "Kind:Integration";
+    public const string ExtendedIntegration = "Kind:ExtendedIntegration";
 
     public const string IdentityServer = "Module:IdentityServer";
     public const string Wallets = "Module:Wallets";
@@ -10,6 +11,8 @@ public static class TestCategories
 
     public const string Auth = "Area:Auth";
     public const string DataContext = "Area:DataContext";
+    public const string Wrappers = "Area:Wrappers";
+    public const string ControlPanelContract = "Area:ControlPanelContract";
     public const string FeatureGates = "Area:FeatureGates";
     public const string Catalog = "Area:Catalog";
     public const string Warehousing = "Area:Warehousing";


### PR DESCRIPTION
﻿## Summary

- fixes the Inventario ControlPanel planning create flow to use `IInventarioServiceWrapper.CreateInventoryReorderRule` instead of direct remote `IDataContext` mutation
- broadens Inventario integration coverage for wrapper-first business workflows and intended remote `IDataContext` CRUD behavior
- adds a manual-only Inventario extended integration workflow for large API/wrapper/DataContext coverage runs
- documents the ControlPanel wrapper-vs-`IDataContext` contract and links it from agent docs
- updates `ServiceWrapperGenerator` so external modules can configure wrapper name, target client, and discovery prefixes while preserving existing module conventions

## Validation

- `dotnet test src/Tests/XFramework.SourceGenerators.Tests/XFramework.SourceGenerators.Tests.csproj -m:1 /nr:false --logger "console;verbosity=minimal"` passed 6/6
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false` passed
- `dotnet test src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj -m:1 /nr:false --logger "console;verbosity=minimal"` passed 27/27 through the xeon-dev Testcontainers loopback tunnel
- `dotnet build XFramework.slnx -m:1 /nr:false --verbosity:minimal` passed

## Notes

The new extended Inventario workflow is `workflow_dispatch` only and defaults to `TestCategory=Kind:ExtendedIntegration`, so it does not expand normal CI runtime. IdentityServer and Wallets should follow the same wrapper/DataContext contract in later module-specific work.
