### PR TITLE
Guard ControlPanel login dependency failures

### DIFF
--- a/src/Presentation/ControlPanel.Server/Extensions/ControlPanelAuthEndpointExtensions.cs
+++ b/src/Presentation/ControlPanel.Server/Extensions/ControlPanelAuthEndpointExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication;
 using ControlPanel.Server.Services;
+using Microsoft.Extensions.Logging;
 
 namespace ControlPanel.Server.Extensions;
 
@@ -20,6 +21,7 @@ public static class ControlPanelAuthEndpointExtensions
     private static async Task<IResult> Login(
         HttpContext context,
         ControlPanelAuthService authService,
+        ILogger<ControlPanelAuthService> logger,
         CancellationToken ct)
     {
         var form = await context.Request.ReadFormAsync(ct);
@@ -28,7 +30,21 @@ public static class ControlPanelAuthEndpointExtensions
         var password = form["password"].ToString();
         var rememberMe = string.Equals(form["rememberMe"].ToString(), "true", StringComparison.OrdinalIgnoreCase);
 
-        var result = await authService.AuthenticateAsync(userName, password, rememberMe, context, ct);
+        ControlPanelLoginResult result;
+        try
+        {
+            result = await authService.AuthenticateAsync(userName, password, rememberMe, context, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "ControlPanel login failed because the authentication dependencies are unavailable.");
+            return Results.Redirect(BuildLoginUrl("Sign-in service is temporarily unavailable. Try again shortly.", returnUrl));
+        }
+
         if (!result.IsSuccess || result.Principal is null)
         {
             return Results.Redirect(BuildLoginUrl(result.Error, returnUrl));


### PR DESCRIPTION
## Summary
- Catch ControlPanel auth dependency exceptions during login and redirect back to the sign-in page with a generic temporary-unavailable error.
- Preserve cancellation behavior and existing invalid-credential redirects.

## Verification
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false
- Recovered xeon-dev by pruning dangling Docker images and builder cache only; Postgres now accepts connections.
- Submitted the deployed login form successfully; final page: Dashboard - Control Panel.