### PR TITLE
Make Inventario product detail product-centric

### DIFF
--- a/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
+++ b/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
@@ -52,7 +52,8 @@ Inventario product detail is the operational hub for product-specific inventory 
 
 - Keep the operator on `/inventario/products/{id}` or one of its detail-sidebar section routes.
 - Use product-preselected dialogs for product-specific stock movements, receiving, lot creation, and reorder rules.
-- Create warehouse/location prerequisites inline inside the product workflow when the tenant has no usable warehouse/location yet.
+- Use shared entity pickers for dependency entities such as warehouse, location, lot, supplier, and purchase order.
+- Dependency creation belongs to picker-owned `Create New` dialogs and picker-owned `Advanced Search` dialogs. Do not embed warehouse/location/supplier create forms directly inside product stock, receiving, or replenishment forms.
 - Do not put existing-record edit workflows into list-page modals. List pages should navigate to detail pages; detail pages are the edit/operation surface.
 - Keep wrapper calls authoritative for stock, receiving, lots, reservations, planning, purchasing, reporting, and other advanced workflows.
 - Keep direct `IDataContext` mutations limited to the explicit Inventario catalog allowlist unless the contract is deliberately expanded and covered by tests.

--- a/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
+++ b/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
@@ -46,6 +46,17 @@ Examples:
 - Wallet operations: use wrapper methods for deposits, withdrawals, holds, transfers, closes, and status changes.
 - Identity authentication, credentials, sessions, and role assignment workflows should use the relevant IdentityServer wrapper operation when one exists.
 
+## Product-Centric Inventory UI
+
+Inventario product detail is the operational hub for product-specific inventory workflows. When adding UI for product stock, lots/batches, receiving, replenishment, variations, or product transaction history:
+
+- Keep the operator on `/inventario/products/{id}` or one of its detail-sidebar section routes.
+- Use product-preselected dialogs for product-specific stock movements, receiving, lot creation, and reorder rules.
+- Create warehouse/location prerequisites inline inside the product workflow when the tenant has no usable warehouse/location yet.
+- Do not put existing-record edit workflows into list-page modals. List pages should navigate to detail pages; detail pages are the edit/operation surface.
+- Keep wrapper calls authoritative for stock, receiving, lots, reservations, planning, purchasing, reporting, and other advanced workflows.
+- Keep direct `IDataContext` mutations limited to the explicit Inventario catalog allowlist unless the contract is deliberately expanded and covered by tests.
+
 ## IDataContext Is Still Valid
 
 `IDataContext` remains the preferred ControlPanel API for:

--- a/docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md
+++ b/docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md
@@ -116,6 +116,8 @@ ControlPanel forms should use framework controls that match the data type:
 
 For `BbCombobox`, prefer typed `SelectOption<TValue>` options when the selection is simple. Use compositional `BbComboboxItem` only when the option rows need rich custom markup.
 
+For parent dependency entities, use the shared `XfEntityPicker<TItem>` pattern instead of embedding prerequisite forms in the parent workflow. The picker trigger should provide search/select, an `Advanced Search` dialog, and a `Create New` dialog. For example, a product stock dialog should pick a warehouse/location/lot through entity pickers; warehouse and location creation belongs to the picker-owned create dialogs, not directly inside the stock form.
+
 ## Operational Page Layout
 
 For module admin surfaces such as Inventario, keep list and detail workflows distinct:

--- a/src/Kernel/XFramework.Domain/Migrations/20260622071204_AddProductVariationType.Designer.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260622071204_AddProductVariationType.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XFramework.Domain.Contexts;
@@ -11,9 +12,11 @@ using XFramework.Domain.Contexts;
 namespace XFramework.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260622071204_AddProductVariationType")]
+    partial class AddProductVariationType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kernel/XFramework.Domain/Migrations/20260622071204_AddProductVariationType.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260622071204_AddProductVariationType.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProductVariationType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "VariationType",
+                schema: "Inventario",
+                table: "ProductVariation",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VariationType",
+                schema: "Inventario",
+                table: "ProductVariation");
+        }
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductVariationEntity.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Entities/ProductVariationEntity.cs
@@ -8,6 +8,7 @@ public partial class ProductVariationEntity
 {
     public Guid Id { get; set; }
     public string? Name { get; set; }
+    public string? VariationType { get; set; }
     public decimal AdditionalPrice { get; set; }
     public Guid ProductId { get; set; }
     
@@ -25,6 +26,7 @@ public partial class ProductVariationEntity
 public class CreateProductVariationEntityRequest
 {
     public string Name { get; set; } = string.Empty;
+    public string? VariationType { get; set; }
     public decimal AdditionalPrice { get; set; }
     public Guid ProductId { get; set; }
 }
@@ -35,6 +37,7 @@ public class CreateProductVariationEntityRequest
 public class UpdateProductVariationEntityRequest
 {
     public string Name { get; set; } = string.Empty;
+    public string? VariationType { get; set; }
     public decimal AdditionalPrice { get; set; }
     public Guid ProductId { get; set; }
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductVariationConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductVariationConfiguration.cs
@@ -12,6 +12,7 @@ public class ProductVariationConfiguration : IEntityTypeConfiguration<ProductVar
         entity.ConfigureBaseModel("PK_Inventario_ProductVariation");
 
         entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        entity.Property(e => e.VariationType).HasMaxLength(100);
         entity.Property(e => e.AdditionalPrice).HasPrecision(18, 2);
 
         entity.HasIndex(e => new { e.TenantId, e.ProductId });

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductVariation.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/ProductVariation.cs
@@ -22,4 +22,6 @@ public partial class ProductVariation : BaseModel
     public Guid ProductId { get; set; }
     [MemoryPackOrder(3)]
     public Product? Product { get; set; }
+    [MemoryPackOrder(4)]
+    public string? VariationType { get; set; }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -24,6 +24,10 @@
                 {
                     <TenantListSidebar />
                 }
+                else if (TryGetInventarioProductDetailRoute(out var productRouteId, out _))
+                {
+                    <ProductDetailSidebar ProductId="@productRouteId" />
+                }
                 else if (TryGetTenantDetailRoute(out var tenantRouteId, out _))
                 {
                     <TenantDetailSidebar TenantId="@tenantRouteId" />
@@ -340,6 +344,31 @@
             || !string.Equals(segments[0], "identity", StringComparison.OrdinalIgnoreCase)
             || !string.Equals(segments[1], "tenants", StringComparison.OrdinalIgnoreCase)
             || !Guid.TryParse(segments[2], out tenantId))
+        {
+            return false;
+        }
+
+        if (segments.Length >= 4)
+        {
+            section = segments[3];
+        }
+
+        return true;
+    }
+
+    private bool TryGetInventarioProductDetailRoute(out Guid productId, out string section)
+    {
+        productId = Guid.Empty;
+        section = "summary";
+
+        var segments = CurrentPath
+            .Trim('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (segments.Length < 3
+            || !string.Equals(segments[0], "inventario", StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(segments[1], "products", StringComparison.OrdinalIgnoreCase)
+            || !Guid.TryParse(segments[2], out productId))
         {
             return false;
         }

--- a/src/Presentation/ControlPanel.Server/Components/Layout/ProductDetailSidebar.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/ProductDetailSidebar.razor
@@ -1,0 +1,118 @@
+@inject NavigationManager Navigation
+@inject TenantModuleNavigationService ModuleNavigation
+@implements IDisposable
+
+<div class="space-y-1">
+    <NavLink href="/inventario/products"
+             Match="NavLinkMatch.All"
+             class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground">
+        <LucideIcon Name="arrow-left" class="h-4 w-4" />
+        Product List
+    </NavLink>
+</div>
+
+<div class="mt-4">
+    <p class="px-3 mb-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Product Detail</p>
+    <div class="space-y-0.5">
+        <a href="@SectionHref("summary")" class="@SectionClass("summary")">
+            <LucideIcon Name="file-text" class="h-4 w-4" />
+            Summary
+        </a>
+        @if (ShowStock)
+        {
+            <a href="@SectionHref("stock")" class="@SectionClass("stock")">
+                <LucideIcon Name="boxes" class="h-4 w-4" />
+                Stock
+            </a>
+        }
+        @if (ShowLots)
+        {
+            <a href="@SectionHref("lots")" class="@SectionClass("lots")">
+                <LucideIcon Name="package-search" class="h-4 w-4" />
+                Lots / Batches
+            </a>
+        }
+        @if (ShowReplenishment)
+        {
+            <a href="@SectionHref("replenishment")" class="@SectionClass("replenishment")">
+                <LucideIcon Name="chart-no-axes-combined" class="h-4 w-4" />
+                Replenishment
+            </a>
+        }
+        @if (ShowVariations)
+        {
+            <a href="@SectionHref("variations")" class="@SectionClass("variations")">
+                <LucideIcon Name="sliders-horizontal" class="h-4 w-4" />
+                Variations
+            </a>
+        }
+        @if (ShowTransactions)
+        {
+            <a href="@SectionHref("transactions")" class="@SectionClass("transactions")">
+                <LucideIcon Name="history" class="h-4 w-4" />
+                Transactions
+            </a>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public Guid ProductId { get; set; }
+
+    private string CurrentPath => new Uri(Navigation.Uri).AbsolutePath.TrimEnd('/');
+    private string BaseHref => $"/inventario/products/{ProductId}";
+    private bool ShowStock =>
+        ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances")
+        || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "movements")
+        || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "purchasing");
+    private bool ShowLots => ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability");
+    private bool ShowReplenishment => ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "planning");
+    private bool ShowVariations => ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "variations");
+    private bool ShowTransactions => ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "transactions");
+
+    private string CurrentSection
+    {
+        get
+        {
+            var segments = CurrentPath
+                .Trim('/')
+                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            return segments.Length >= 4 ? NormalizeSection(segments[3]) : "summary";
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        ModuleNavigation.OnChanged += OnModuleNavigationChanged;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await ModuleNavigation.EnsureLoadedAsync();
+    }
+
+    private void OnModuleNavigationChanged() => _ = InvokeAsync(StateHasChanged);
+
+    private string SectionHref(string section) =>
+        section == "summary" ? BaseHref : $"{BaseHref}/{section}";
+
+    private string SectionClass(string section) =>
+        "flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-sidebar-accent "
+        + (CurrentSection == section ? "bg-sidebar-accent text-sidebar-accent-foreground" : "");
+
+    private static string NormalizeSection(string section) =>
+        section.ToLowerInvariant() switch
+        {
+            "batches" => "lots",
+            "lots-batches" => "lots",
+            "reorder" => "replenishment",
+            "rules" => "replenishment",
+            _ => section.ToLowerInvariant()
+        };
+
+    public void Dispose()
+    {
+        ModuleNavigation.OnChanged -= OnModuleNavigationChanged;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -1,5 +1,13 @@
 @page "/inventario/products/{Id:guid}"
+@page "/inventario/products/{Id:guid}/{Section}"
 @using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses
+@using XFramework.Inventario.Domain.Shared.Enums
 @implements IDisposable
 
 <PageTitle>Inventario Product - Control Panel</PageTitle>
@@ -33,310 +41,431 @@ else if (_product is null)
 {
     <BbTypographyMuted>Product not found.</BbTypographyMuted>
 }
+else if (!IsSectionAvailable(CurrentSection))
+{
+    <div class="space-y-4">
+        @ProductHeader
+        <ModuleUnavailable ModuleName="@UnavailableSectionName" />
+    </div>
+}
 else
 {
     <FadeInContent>
         <div class="space-y-6">
-            <div class="xf-detail-header">
-                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to products"
-                          OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
-                    <LucideIcon Name="arrow-left" class="h-4 w-4" />
-                </BbButton>
-                <div class="xf-detail-header-main">
-                    <div class="xf-detail-header-title">
-                        <BbTypographyH3>@(_product.Name ?? "Unnamed Product")</BbTypographyH3>
-                        <StatusBadge Text="@(_product.IsAvailable ? "Available" : "Unavailable")"
-                                     Status="@(_product.IsAvailable ? "active" : "inactive")" />
-                    </div>
-                    <BbTypographyMuted>SKU: @(_product.SKU ?? "N/A") - Category: @GetCategoryName(_product.CategoryId)</BbTypographyMuted>
-                </div>
-                <div class="xf-page-actions">
-                    @if (_editMode)
-                    {
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@CancelEdit" Disabled="@_saving">
-                            Discard
-                        </BbButton>
-                        <BbButton OnClick="@SaveProduct" Disabled="@_saving">
-                            <LucideIcon Name="save" class="mr-2 h-4 w-4" />
-                            Save
-                        </BbButton>
-                    }
-                    else
-                    {
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
-                            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-                            Refresh
-                        </BbButton>
-                        <BbButton OnClick="@StartEdit">
-                            <LucideIcon Name="pencil" class="mr-2 h-4 w-4" />
-                            Edit
-                        </BbButton>
-                    }
-                </div>
-            </div>
+            @ProductHeader
 
-            <div class="xf-summary-grid xf-summary-grid-4">
-                <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Price</BbTypographyMuted><BbTypographyH3>@_product.Price.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
-                <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Available Stock</BbTypographyMuted><BbTypographyH3>@TotalAvailable.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
-                <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Locations</BbTypographyMuted><BbTypographyH3>@ActiveLocationCount</BbTypographyH3></div></BbCardContent></BbCard>
-                <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Reorder Rules</BbTypographyMuted><BbTypographyH3>@_reorderRules.Count</BbTypographyH3></div></BbCardContent></BbCard>
-            </div>
-
-            <BbCard>
-                <BbCardHeader>
-                    <BbCardTitle>Product Summary</BbCardTitle>
-                    <BbCardDescription>Catalog fields, availability, and lifecycle metadata.</BbCardDescription>
-                </BbCardHeader>
-                <BbCardContent>
-                    @if (_editMode)
-                    {
-                        <div class="grid gap-4">
-                            <div class="xf-detail-field-grid">
-                                <BbFormFieldInput TValue="string" @bind-Value="_productForm.Name" Label="Name" Required="true" />
-                                <BbFormFieldInput TValue="string" @bind-Value="_productForm.Sku" Label="SKU" />
-                            </div>
-                            <BbFormFieldCombobox TValue="string"
-                                                  @bind-Value="_productForm.CategoryId"
-                                                  Options="@CategoryOptions"
-                                                  Label="Category"
-                                                  Placeholder="Select category"
-                                                  SearchPlaceholder="Search categories..."
-                                                  EmptyMessage="No categories found."
-                                                  MatchTriggerWidth="true"
-                                                  Required="true" />
-                            <div class="xf-detail-field-grid">
-                                <BbFormFieldInput TValue="string" @bind-Value="_productForm.Price" Label="Price" />
-                                <BbFormFieldInput TValue="string" @bind-Value="_productForm.Brand" Label="Brand" />
-                            </div>
-                            <BbFormFieldInput TValue="string" @bind-Value="_productForm.Description" Label="Description" />
-                            <BbFormFieldSwitch Checked="@_productForm.IsAvailable"
-                                               CheckedChanged="@((bool value) => _productForm.IsAvailable = value)"
-                                               Label="Available" />
-                        </div>
-                    }
-                    else
-                    {
-                        <div class="xf-detail-field-grid">
-                            <div>
-                                <BbTypographyMuted>Description</BbTypographyMuted>
-                                <div>@(_product.Description ?? "No description")</div>
-                            </div>
-                            <div>
-                                <BbTypographyMuted>Brand</BbTypographyMuted>
-                                <div>@(_product.Brand ?? "N/A")</div>
-                            </div>
-                            <div>
-                                <BbTypographyMuted>Created</BbTypographyMuted>
-                                <div>@_product.CreatedAt.ToLocalTime().ToString("g")</div>
-                            </div>
-                            <div>
-                                <BbTypographyMuted>Last Modified</BbTypographyMuted>
-                                <div>@(_product.ModifiedAt?.ToLocalTime().ToString("g") ?? "Never")</div>
-                            </div>
-                        </div>
-                    }
-                </BbCardContent>
-            </BbCard>
-
-            @if (_planningEnabled)
+            @if (CurrentSection == "summary")
             {
-                <BbCard>
-                    <BbCardHeader>
-                        <div class="xf-page-header">
-                            <div>
-                                <BbCardTitle>Replenishment Rules</BbCardTitle>
-                                <BbCardDescription>Min, max, reorder point, and scoped warehouse/location rules for this product.</BbCardDescription>
-                            </div>
-                            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => Navigation.NavigateTo("/inventario/planning"))">
-                                <LucideIcon Name="external-link" class="mr-2 h-4 w-4" />
-                                Manage Rules
-                            </BbButton>
-                        </div>
-                    </BbCardHeader>
-                    <BbCardContent>
-                        <BbDataGrid Items="@_reorderRules" ShowPagination="true" InitialPageSize="10">
-                            <Columns>
-                                <BbDataGridTemplateColumn Title="Scope">
-                                    <ChildContent Context="item">@GetRuleScope(item)</ChildContent>
-                                </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.MinimumQuantity)" Title="Min" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.MaximumQuantity)" Title="Max" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReorderQuantity)" Title="Reorder Qty" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Preferred Supplier" />
-                                <BbDataGridTemplateColumn Title="Status">
-                                    <ChildContent Context="item">
-                                        <StatusBadge Text="@(item.IsActive ? "Active" : "Inactive")" Status="@(item.IsActive ? "active" : "inactive")" />
-                                    </ChildContent>
-                                </BbDataGridTemplateColumn>
-                            </Columns>
-                        </BbDataGrid>
-                    </BbCardContent>
-                </BbCard>
+                @SummarySection
             }
-
-            @if (_stockEnabled)
+            else if (CurrentSection == "stock")
             {
-                <BbCard>
-                    <BbCardHeader>
-                        <BbCardTitle>Warehouse and Location Stock</BbCardTitle>
-                        <BbCardDescription>Current stock balances for this product.</BbCardDescription>
-                    </BbCardHeader>
-                    <BbCardContent>
-                        <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="10"
-                                    OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
-                                    Class="cursor-pointer">
-                            <Columns>
-                                <BbDataGridTemplateColumn Title="Warehouse">
-                                    <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
-                                </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Location">
-                                    <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
-                                </BbDataGridTemplateColumn>
-                                @if (_traceabilityEnabled)
-                                {
-                                    <BbDataGridTemplateColumn Title="Lot">
-                                        <ChildContent Context="item">@GetLotNumber(item.LotId)</ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                }
-                                <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
-                            </Columns>
-                        </BbDataGrid>
-                    </BbCardContent>
-                </BbCard>
+                @StockSection
             }
-
-            @if (_traceabilityEnabled)
+            else if (CurrentSection == "lots")
             {
-                <BbCard>
-                    <BbCardHeader>
-                        <BbCardTitle>Lots and Batches</BbCardTitle>
-                        <BbCardDescription>Traceability records connected to this product.</BbCardDescription>
-                    </BbCardHeader>
-                    <BbCardContent>
-                        <BbDataGrid Items="@_lots" ShowPagination="true" InitialPageSize="10"
-                                    OnRowClick="@((InventoryLot item) => Navigation.NavigateTo($"/inventario/lots/{item.Id}"))"
-                                    Class="cursor-pointer">
-                            <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot / Batch" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="On Hand">
-                                    <ChildContent Context="item">@GetLotOnHand(item.Id).ToString("N2")</ChildContent>
-                                </BbDataGridTemplateColumn>
-                            </Columns>
-                        </BbDataGrid>
-                    </BbCardContent>
-                </BbCard>
+                @LotsSection
             }
-
-            <BbCard>
-                <BbCardHeader>
-                    <div class="xf-page-header">
-                        <div>
-                            <BbCardTitle>Variations</BbCardTitle>
-                            <BbCardDescription>Optional product options and price adjustments.</BbCardDescription>
-                        </div>
-                        <BbButton Size="ButtonSize.Small" OnClick="@OpenVariationDialog">
-                            <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
-                            Add Variation
-                        </BbButton>
-                    </div>
-                </BbCardHeader>
-                <BbCardContent>
-                    <BbDataGrid Items="@_variations" ShowPagination="true" InitialPageSize="10">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Additional Price">
-                                <ChildContent Context="item">@item.AdditionalPrice.ToString("N2")</ChildContent>
-                            </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                        </Columns>
-                    </BbDataGrid>
-                </BbCardContent>
-            </BbCard>
-
-            <BbCard>
-                <BbCardHeader>
-                    <BbCardTitle>Transaction History</BbCardTitle>
-                    <BbCardDescription>Read-only product transaction history.</BbCardDescription>
-                </BbCardHeader>
-                <BbCardContent>
-                    <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="10">
-                        <Columns>
-                            <BbDataGridTemplateColumn Title="Quantity">
-                                <ChildContent Context="item">@item.Quantity</ChildContent>
-                            </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Total">
-                                <ChildContent Context="item">@item.TotalPrice.ToString("N2")</ChildContent>
-                            </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                        </Columns>
-                    </BbDataGrid>
-                </BbCardContent>
-            </BbCard>
+            else if (CurrentSection == "replenishment")
+            {
+                @ReplenishmentSection
+            }
+            else if (CurrentSection == "variations")
+            {
+                @VariationsSection
+            }
+            else if (CurrentSection == "transactions")
+            {
+                @TransactionsSection
+            }
         </div>
     </FadeInContent>
 }
 
-<BbDialog Open="@_variationDialogOpen" OpenChanged="@(v => _variationDialogOpen = v)">
-    <BbDialogContent>
-        <BbDialogHeader>
-            <BbDialogTitle>Add Variation</BbDialogTitle>
-            <BbDialogDescription>Add an option for this product.</BbDialogDescription>
-        </BbDialogHeader>
-        <div class="grid gap-4 py-4">
-            <BbFormFieldInput TValue="string" @bind-Value="_variationName" Label="Name" Required="true" />
-            <BbFormFieldInput TValue="string" @bind-Value="_variationAdditionalPrice" Label="Additional Price" />
-        </div>
-        <BbDialogFooter>
-            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _variationDialogOpen = false)">Cancel</BbButton>
-            <BbButton OnClick="@SaveVariation" Disabled="@_saving">Create</BbButton>
-        </BbDialogFooter>
-    </BbDialogContent>
-</BbDialog>
+@if (_product is not null)
+{
+    <BbDialog Open="@_variationDialogOpen" OpenChanged="@(value => _variationDialogOpen = value)">
+        <BbDialogContent TrapFocus="false">
+            <BbDialogHeader>
+                <BbDialogTitle>Add Variation</BbDialogTitle>
+                <BbDialogDescription>Add a product option for @_product.Name.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
+                <BbFormFieldInput TValue="string" @bind-Value="_variationForm.VariationType" Label="Variation Type" Placeholder="Size, Color, Packaging, etc." />
+                <BbFormFieldInput TValue="string" @bind-Value="_variationForm.Name" Label="Name" Required="true" />
+                <BbFormFieldInput TValue="string" @bind-Value="_variationForm.AdditionalPrice" Label="Additional Price" />
+            </div>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _variationDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@SaveVariation" Disabled="@_saving">Create Variation</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+
+    <BbDialog Open="@_movementDialogOpen" OpenChanged="@(value => _movementDialogOpen = value)">
+        <BbDialogContent TrapFocus="false" class="max-w-4xl">
+            <BbDialogHeader>
+                <BbDialogTitle>Post Stock Movement</BbDialogTitle>
+                <BbDialogDescription>Post movement for @_product.Name. The product is fixed by the open detail page.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
+                @FixedProductField
+                @PrerequisiteCreateBlock(ProductWorkflow.Movement)
+
+                <div class="grid gap-3 md:grid-cols-2">
+                    <div class="xf-form-field">
+                        <BbLabel>Warehouse</BbLabel>
+                        <BbCombobox TValue="string"
+                                     Value="@_movementForm.WarehouseId"
+                                     ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Movement, value))"
+                                     Options="@WarehouseOptions"
+                                     Placeholder="Select warehouse"
+                                     SearchPlaceholder="Search warehouses..."
+                                     EmptyMessage="No warehouses found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                    <div class="xf-form-field">
+                        <BbLabel>Location</BbLabel>
+                        <BbCombobox TValue="string"
+                                     @bind-Value="_movementForm.LocationId"
+                                     Options="@MovementLocationOptions"
+                                     Placeholder="Select location"
+                                     SearchPlaceholder="Search locations..."
+                                     EmptyMessage="No locations found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                    @if (_traceabilityEnabled)
+                    {
+                        <div class="xf-form-field">
+                            <BbLabel>Existing Lot / Batch</BbLabel>
+                            <BbCombobox TValue="string"
+                                         @bind-Value="_movementForm.LotId"
+                                         Options="@LotOptions"
+                                         Placeholder="No lot"
+                                         SearchPlaceholder="Search lots..."
+                                         EmptyMessage="No lots found."
+                                         Class="xf-entity-combobox"
+                                         MatchTriggerWidth="true" />
+                        </div>
+                        <BbFormFieldInput TValue="string" @bind-Value="_movementForm.NewLotNumber" Label="New Lot Number" />
+                    }
+                    <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.MovementType" Label="Movement Type">
+                        @foreach (var type in Enum.GetValues<InventoryMovementType>())
+                        {
+                            <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
+                        }
+                    </BbFormFieldSelect>
+                </div>
+
+                <div class="grid gap-3 md:grid-cols-3">
+                    <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Quantity" Label="Quantity" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_movementForm.UnitOfMeasure" Label="Unit" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_movementForm.ReferenceType" Label="Reference Type" />
+                </div>
+                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Reason" Label="Reason" />
+                @if (_negativeStockEnabled)
+                {
+                    <BbFormFieldSwitch Checked="@_movementForm.AllowNegativeStock"
+                                       CheckedChanged="@((bool value) => _movementForm.AllowNegativeStock = value)"
+                                       Label="Allow negative stock for this posting" />
+                }
+            </div>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _movementDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@PostMovement" Disabled="@IsPostMovementDisabled">Post Movement</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+
+    <BbDialog Open="@_lotDialogOpen" OpenChanged="@(value => _lotDialogOpen = value)">
+        <BbDialogContent TrapFocus="false">
+            <BbDialogHeader>
+                <BbDialogTitle>Create Lot / Batch</BbDialogTitle>
+                <BbDialogDescription>Create a traceability lot for @_product.Name.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
+                @FixedProductField
+                <div class="grid gap-3 md:grid-cols-2">
+                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.LotNumber" Label="Lot / Batch Number" Required="true" />
+                    <BbFormFieldSelect TValue="string" @bind-Value="_lotForm.Status" Label="Status">
+                        @foreach (var status in Enum.GetValues<InventoryLotStatus>())
+                        {
+                            <BbSelectItem Value="@status.ToString()">@status</BbSelectItem>
+                        }
+                    </BbFormFieldSelect>
+                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.SupplierReference" Label="Supplier / Source Reference" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.UnitCost" Label="Unit Cost" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.ReceivedAt" Label="Received Date" Placeholder="YYYY-MM-DD" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.ManufacturedAt" Label="Manufacture Date" Placeholder="YYYY-MM-DD" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.ExpiresAt" Label="Expiration Date" Placeholder="YYYY-MM-DD" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.SourceReferenceType" Label="Source Type" />
+                </div>
+            </div>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _lotDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@CreateLot" Disabled="@_savingLot">Create Lot</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+
+    <BbDialog Open="@_receiveDialogOpen" OpenChanged="@(value => _receiveDialogOpen = value)">
+        <BbDialogContent TrapFocus="false" class="max-w-4xl">
+            <BbDialogHeader>
+                <BbDialogTitle>Receive Batch / Stock</BbDialogTitle>
+                <BbDialogDescription>Receive stock for @_product.Name into a warehouse location.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
+                @FixedProductField
+                @PrerequisiteCreateBlock(ProductWorkflow.Receiving)
+
+                <div class="grid gap-3 md:grid-cols-3">
+                    <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.ReceiptNumber" Label="Receipt Number" />
+                    <div class="xf-form-field">
+                        <BbLabel>Purchase Order</BbLabel>
+                        <BbCombobox TValue="string"
+                                     @bind-Value="_receiveForm.PurchaseOrderId"
+                                     Options="@PurchaseOrderOptions"
+                                     Placeholder="No purchase order"
+                                     SearchPlaceholder="Search purchase orders..."
+                                     EmptyMessage="No purchase orders found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                    <div class="xf-form-field">
+                        <BbLabel>Supplier</BbLabel>
+                        <BbCombobox TValue="string"
+                                     @bind-Value="_receiveForm.SupplierId"
+                                     Options="@SupplierOptions"
+                                     Placeholder="No supplier"
+                                     SearchPlaceholder="Search suppliers..."
+                                     EmptyMessage="No suppliers found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                </div>
+
+                <div class="grid gap-3 md:grid-cols-3">
+                    <div class="xf-form-field">
+                        <BbLabel>Warehouse</BbLabel>
+                        <BbCombobox TValue="string"
+                                     Value="@_receiveForm.WarehouseId"
+                                     ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Receiving, value))"
+                                     Options="@WarehouseOptions"
+                                     Placeholder="Select warehouse"
+                                     SearchPlaceholder="Search warehouses..."
+                                     EmptyMessage="No warehouses found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                    <div class="xf-form-field">
+                        <BbLabel>Location</BbLabel>
+                        <BbCombobox TValue="string"
+                                     @bind-Value="_receiveForm.LocationId"
+                                     Options="@ReceiveLocationOptions"
+                                     Placeholder="Select location"
+                                     SearchPlaceholder="Search locations..."
+                                     EmptyMessage="No locations found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                    <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.ReferenceNumber" Label="Reference" />
+                </div>
+
+                <div class="grid gap-3 md:grid-cols-3">
+                    <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.Quantity" Label="Quantity" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.UnitCost" Label="Unit Cost" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.UnitOfMeasure" Label="Unit" />
+                </div>
+
+                @if (_traceabilityEnabled)
+                {
+                    <div class="grid gap-3 md:grid-cols-2">
+                        <div class="xf-form-field">
+                            <BbLabel>Existing Lot / Batch</BbLabel>
+                            <BbCombobox TValue="string"
+                                         @bind-Value="_receiveForm.LotId"
+                                         Options="@LotOptions"
+                                         Placeholder="Create/no lot"
+                                         SearchPlaceholder="Search lots..."
+                                         EmptyMessage="No lots found."
+                                         Class="xf-entity-combobox"
+                                         MatchTriggerWidth="true" />
+                        </div>
+                        <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.LotNumber" Label="New Lot Number" />
+                        <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.ManufacturedAt" Label="Manufacture Date" Placeholder="YYYY-MM-DD" />
+                        <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.ExpiresAt" Label="Expiration Date" Placeholder="YYYY-MM-DD" />
+                    </div>
+                }
+            </div>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _receiveDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@ReceiveStock" Disabled="@IsReceiveDisabled">Post Receiving</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+
+    <BbDialog Open="@_ruleDialogOpen" OpenChanged="@(value => _ruleDialogOpen = value)">
+        <BbDialogContent TrapFocus="false">
+            <BbDialogHeader>
+                <BbDialogTitle>Add Reorder Rule</BbDialogTitle>
+                <BbDialogDescription>Add min/max/reorder rules for @_product.Name.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
+                @FixedProductField
+                @PrerequisiteCreateBlock(ProductWorkflow.Replenishment)
+
+                <div class="grid gap-3 md:grid-cols-2">
+                    <div class="xf-form-field">
+                        <BbLabel>Warehouse</BbLabel>
+                        <BbCombobox TValue="string"
+                                     Value="@_ruleForm.WarehouseId"
+                                     ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Replenishment, value))"
+                                     Options="@OptionalWarehouseOptions"
+                                     Placeholder="Any warehouse"
+                                     SearchPlaceholder="Search warehouses..."
+                                     EmptyMessage="No warehouses found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                    <div class="xf-form-field">
+                        <BbLabel>Location</BbLabel>
+                        <BbCombobox TValue="string"
+                                     @bind-Value="_ruleForm.LocationId"
+                                     Options="@RuleLocationOptions"
+                                     Placeholder="Any location"
+                                     SearchPlaceholder="Search locations..."
+                                     EmptyMessage="No locations found."
+                                     Class="xf-entity-combobox"
+                                     MatchTriggerWidth="true" />
+                    </div>
+                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.PreferredSupplier" Label="Preferred Supplier" />
+                </div>
+                <div class="grid gap-3 md:grid-cols-4">
+                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.MinimumQuantity" Label="Minimum" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.MaximumQuantity" Label="Maximum" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.ReorderPoint" Label="Reorder Point" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.ReorderQuantity" Label="Reorder Qty" />
+                </div>
+                <BbFormFieldSwitch Checked="@_ruleForm.IsActive"
+                                   CheckedChanged="@((bool value) => _ruleForm.IsActive = value)"
+                                   Label="Rule active" />
+            </div>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _ruleDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@CreateRule" Disabled="@_savingRule">Create Rule</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+}
 
 @code {
     [Parameter] public Guid Id { get; set; }
+    [Parameter] public string? Section { get; set; }
 
     [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
 
     private readonly ProductForm _productForm = new();
+    private readonly VariationForm _variationForm = new();
+    private readonly MovementForm _movementForm = new();
+    private readonly LotForm _lotForm = new();
+    private readonly ReceiveForm _receiveForm = new();
+    private readonly RuleForm _ruleForm = new();
+    private readonly WarehouseQuickForm _warehouseQuickForm = new();
+    private readonly LocationQuickForm _locationQuickForm = new();
+
     private Product? _product;
     private List<ProductCategory> _categories = [];
     private List<ProductVariation> _variations = [];
     private List<ProductTransaction> _transactions = [];
     private List<InventoryReorderRule> _reorderRules = [];
     private List<StockBalance> _balances = [];
+    private List<InventoryMovement> _movements = [];
     private List<InventoryLot> _lots = [];
     private List<Warehouse> _warehouses = [];
     private List<InventoryLocation> _locations = [];
+    private List<Supplier> _suppliers = [];
+    private List<PurchaseOrder> _purchaseOrders = [];
+    private List<PurchaseOrderLine> _purchaseOrderLines = [];
     private bool _loading = true;
     private bool _saving;
+    private bool _savingLot;
+    private bool _savingRule;
+    private bool _savingMovement;
+    private bool _savingReceive;
+    private bool _savingWarehouse;
+    private bool _savingLocation;
     private bool _hasTenant;
     private bool _moduleEnabled;
     private bool _planningEnabled;
     private bool _stockEnabled;
+    private bool _movementsEnabled;
     private bool _traceabilityEnabled;
+    private bool _variationsEnabled;
+    private bool _transactionsEnabled;
+    private bool _purchasingEnabled;
+    private bool _negativeStockEnabled;
     private bool _outsideTenantContext;
     private bool _editMode;
     private bool _variationDialogOpen;
-    private string _variationName = "";
-    private string _variationAdditionalPrice = "0";
+    private bool _movementDialogOpen;
+    private bool _lotDialogOpen;
+    private bool _receiveDialogOpen;
+    private bool _ruleDialogOpen;
     private Guid? _loadedId;
 
+    private string CurrentSection => NormalizeSection(Section);
+    private string UnavailableSectionName => CurrentSection switch
+    {
+        "stock" => "Inventario Stock",
+        "lots" => "Inventario Traceability",
+        "replenishment" => "Inventario Planning",
+        "variations" => "Inventario Variations",
+        "transactions" => "Inventario Transactions",
+        _ => "Inventario Product"
+    };
+
     private decimal TotalAvailable => _balances.Sum(x => x.AvailableQuantity);
+    private decimal TotalOnHand => _balances.Sum(x => x.OnHandQuantity);
+    private decimal TotalReserved => _balances.Sum(x => x.ReservedQuantity);
     private int ActiveLocationCount => _balances.Select(x => x.LocationId).Distinct().Count();
+    private bool IsPostMovementDisabled =>
+        _savingMovement ||
+        _warehouses.Count == 0 ||
+        _locations.Count == 0 ||
+        string.IsNullOrWhiteSpace(_movementForm.WarehouseId) ||
+        string.IsNullOrWhiteSpace(_movementForm.LocationId);
+    private bool IsReceiveDisabled =>
+        _savingReceive ||
+        _warehouses.Count == 0 ||
+        _locations.Count == 0 ||
+        string.IsNullOrWhiteSpace(_receiveForm.WarehouseId) ||
+        string.IsNullOrWhiteSpace(_receiveForm.LocationId);
+
     private List<SelectOption<string>> CategoryOptions =>
         _categories.Select(category => new SelectOption<string>(category.Id.ToString(), category.Name ?? category.Id.ToString()[..8])).ToList();
+    private List<SelectOption<string>> WarehouseOptions =>
+        _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
+    private List<SelectOption<string>> OptionalWarehouseOptions =>
+        [new("", "Any warehouse"), .. WarehouseOptions];
+    private List<SelectOption<string>> MovementLocationOptions =>
+        LocationsForWarehouse(_movementForm.WarehouseId).Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
+    private List<SelectOption<string>> ReceiveLocationOptions =>
+        LocationsForWarehouse(_receiveForm.WarehouseId).Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
+    private List<SelectOption<string>> RuleLocationOptions =>
+        [new("", "Any location"), .. LocationsForWarehouse(_ruleForm.WarehouseId).Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location)))];
+    private List<SelectOption<string>> LotOptions =>
+        [new("", "No lot / untracked"), .. _lots.Select(lot => new SelectOption<string>(lot.Id.ToString(), GetLotLabel(lot)))];
+    private List<SelectOption<string>> PurchaseOrderOptions =>
+        [new("", "No purchase order"), .. _purchaseOrders.Where(x => x.Status is PurchaseOrderStatus.Open or PurchaseOrderStatus.PartiallyReceived).Select(order => new SelectOption<string>(order.Id.ToString(), $"{order.OrderNumber} ({order.Status})"))];
+    private List<SelectOption<string>> SupplierOptions =>
+        [new("", "No supplier"), .. _suppliers.Select(supplier => new SelectOption<string>(supplier.Id.ToString(), $"{supplier.Code} - {supplier.Name}"))];
 
     protected override void OnInitialized()
     {
@@ -346,15 +475,12 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
-        if (_loadedId == Id) return;
+        if (_loadedId == Id && _product is not null) return;
         _loadedId = Id;
         await Reload();
     }
 
-    private void OnTenantChanged()
-    {
-        _ = InvokeAsync(Reload);
-    }
+    private void OnTenantChanged() => _ = InvokeAsync(Reload);
 
     private async Task Reload()
     {
@@ -362,21 +488,8 @@ else
         try
         {
             await ModuleNavigation.EnsureLoadedAsync();
-            _hasTenant = TenantFilter.SelectedTenantId is Guid;
-            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
-            _planningEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "planning");
-            _stockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances");
-            _traceabilityEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability");
-            _outsideTenantContext = false;
-            _product = null;
-            _categories = [];
-            _variations = [];
-            _transactions = [];
-            _reorderRules = [];
-            _balances = [];
-            _lots = [];
-            _warehouses = [];
-            _locations = [];
+            LoadFeatureFlags();
+            ResetData();
 
             if (!_hasTenant || !_moduleEnabled) return;
 
@@ -389,85 +502,7 @@ else
             _outsideTenantContext = _product is not null && _product.TenantId != TenantFilter.SelectedTenantId;
             if (_product is null || _outsideTenantContext) return;
 
-            var tenantId = _product.TenantId;
-            _categories = await DataContext.Query<ProductCategory>()
-                .IgnoreQueryFilters()
-                .NoCache()
-                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-                .OrderBy(x => x.Name)
-                .Take(200)
-                .ToListAsync();
-
-            _variations = await DataContext.Query<ProductVariation>()
-                .IgnoreQueryFilters()
-                .NoCache()
-                .Where(x => x.ProductId == Id && x.TenantId == tenantId && !x.IsDeleted)
-                .OrderBy(x => x.Name)
-                .Take(100)
-                .ToListAsync();
-
-            _transactions = await DataContext.Query<ProductTransaction>()
-                .IgnoreQueryFilters()
-                .NoCache()
-                .Where(x => x.ProductId == Id && x.TenantId == tenantId && !x.IsDeleted)
-                .OrderByDescending(x => x.TransactionDate)
-                .Take(100)
-                .ToListAsync();
-
-            if (_planningEnabled)
-                _reorderRules = await DataContext.Query<InventoryReorderRule>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
-                    .OrderBy(x => x.WarehouseId)
-                    .ThenBy(x => x.LocationId)
-                    .Take(100)
-                    .ToListAsync();
-
-            if (_stockEnabled || _traceabilityEnabled)
-                _balances = await DataContext.Query<StockBalance>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
-                    .OrderBy(x => x.WarehouseId)
-                    .ThenBy(x => x.LocationId)
-                    .Take(500)
-                    .ToListAsync();
-
-            if (_traceabilityEnabled)
-                _lots = await DataContext.Query<InventoryLot>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
-                    .OrderBy(x => x.ExpiresAt)
-                    .ThenBy(x => x.LotNumber)
-                    .Take(500)
-                    .ToListAsync();
-
-            var warehouseIds = _balances.Select(x => x.WarehouseId)
-                .Concat(_reorderRules.Where(x => x.WarehouseId is not null).Select(x => x.WarehouseId!.Value))
-                .Distinct()
-                .ToList();
-            if (warehouseIds.Count > 0)
-                _warehouses = await DataContext.Query<Warehouse>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.TenantId == tenantId && warehouseIds.Contains(x.Id) && !x.IsDeleted)
-                    .Take(200)
-                    .ToListAsync();
-
-            var locationIds = _balances.Select(x => x.LocationId)
-                .Concat(_reorderRules.Where(x => x.LocationId is not null).Select(x => x.LocationId!.Value))
-                .Distinct()
-                .ToList();
-            if (locationIds.Count > 0)
-                _locations = await DataContext.Query<InventoryLocation>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.TenantId == tenantId && locationIds.Contains(x.Id) && !x.IsDeleted)
-                    .Take(500)
-                    .ToListAsync();
-
+            await LoadProductData(_product.TenantId);
             if (!_editMode)
                 LoadProductForm();
         }
@@ -481,6 +516,569 @@ else
             StateHasChanged();
         }
     }
+
+    private void LoadFeatureFlags()
+    {
+        _hasTenant = TenantFilter.SelectedTenantId is Guid;
+        _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario);
+        _planningEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "planning");
+        _stockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "stock_balances");
+        _movementsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "movements");
+        _traceabilityEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "traceability");
+        _variationsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "variations");
+        _transactionsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "transactions");
+        _purchasingEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "purchasing");
+        _negativeStockEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Inventario, "negative_stock");
+        if (!_negativeStockEnabled)
+            _movementForm.AllowNegativeStock = false;
+    }
+
+    private void ResetData()
+    {
+        _outsideTenantContext = false;
+        _product = null;
+        _categories = [];
+        _variations = [];
+        _transactions = [];
+        _reorderRules = [];
+        _balances = [];
+        _movements = [];
+        _lots = [];
+        _warehouses = [];
+        _locations = [];
+        _suppliers = [];
+        _purchaseOrders = [];
+        _purchaseOrderLines = [];
+    }
+
+    private async Task LoadProductData(Guid tenantId)
+    {
+        _categories = await DataContext.Query<ProductCategory>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .OrderBy(x => x.Name)
+            .Take(500)
+            .ToListAsync();
+
+        if (_variationsEnabled)
+            _variations = await DataContext.Query<ProductVariation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.ProductId == Id && x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.VariationType)
+                .ThenBy(x => x.Name)
+                .Take(500)
+                .ToListAsync();
+
+        if (_transactionsEnabled)
+            _transactions = await DataContext.Query<ProductTransaction>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.ProductId == Id && x.TenantId == tenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.TransactionDate)
+                .Take(250)
+                .ToListAsync();
+
+        if (_planningEnabled)
+            _reorderRules = await DataContext.Query<InventoryReorderRule>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
+                .OrderBy(x => x.WarehouseId)
+                .ThenBy(x => x.LocationId)
+                .Take(250)
+                .ToListAsync();
+
+        if (_stockEnabled)
+            _balances = await DataContext.Query<StockBalance>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
+                .OrderBy(x => x.WarehouseId)
+                .ThenBy(x => x.LocationId)
+                .Take(1000)
+                .ToListAsync();
+
+        if (_movementsEnabled)
+            _movements = await DataContext.Query<InventoryMovement>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
+                .OrderByDescending(x => x.MovementDate)
+                .Take(500)
+                .ToListAsync();
+
+        if (_traceabilityEnabled)
+            _lots = await DataContext.Query<InventoryLot>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
+                .OrderBy(x => x.ExpiresAt)
+                .ThenBy(x => x.LotNumber)
+                .Take(500)
+                .ToListAsync();
+
+        if (_stockEnabled || _movementsEnabled || _purchasingEnabled || _planningEnabled)
+        {
+            await LoadOperationalLookups(tenantId);
+            ApplyWorkflowDefaults();
+        }
+    }
+
+    private async Task LoadOperationalLookups(Guid tenantId)
+    {
+        _warehouses = await DataContext.Query<Warehouse>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .OrderBy(x => x.Code)
+            .Take(500)
+            .ToListAsync();
+
+        _locations = await DataContext.Query<InventoryLocation>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .OrderBy(x => x.Code)
+            .Take(1000)
+            .ToListAsync();
+
+        if (_purchasingEnabled)
+        {
+            _suppliers = await DataContext.Query<Supplier>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderBy(x => x.Name)
+                .Take(500)
+                .ToListAsync();
+
+            _purchaseOrders = await DataContext.Query<PurchaseOrder>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+                .OrderByDescending(x => x.OrderDate)
+                .Take(500)
+                .ToListAsync();
+
+            _purchaseOrderLines = await DataContext.Query<PurchaseOrderLine>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.ProductId == Id)
+                .Take(500)
+                .ToListAsync();
+        }
+    }
+
+    private RenderFragment ProductHeader => @<div class="xf-detail-header">
+        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to products"
+                  OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
+            <LucideIcon Name="arrow-left" class="h-4 w-4" />
+        </BbButton>
+        <div class="xf-detail-header-main">
+            <div class="xf-detail-header-title">
+                <BbTypographyH3>@(_product?.Name ?? "Unnamed Product")</BbTypographyH3>
+                <StatusBadge Text="@(_product?.IsAvailable == true ? "Available" : "Unavailable")"
+                             Status="@(_product?.IsAvailable == true ? "active" : "inactive")" />
+            </div>
+            <BbTypographyMuted>SKU: @(_product?.SKU ?? "N/A") - Category: @GetCategoryName(_product?.CategoryId ?? Guid.Empty)</BbTypographyMuted>
+        </div>
+        <div class="xf-page-actions">
+            @if (CurrentSection == "summary" && _editMode)
+            {
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@CancelEdit" Disabled="@_saving">Discard</BbButton>
+                <BbButton OnClick="@SaveProduct" Disabled="@_saving">
+                    <LucideIcon Name="save" class="mr-2 h-4 w-4" />
+                    Save
+                </BbButton>
+            }
+            else
+            {
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+                @if (CurrentSection == "summary")
+                {
+                    <BbButton OnClick="@StartEdit">
+                        <LucideIcon Name="pencil" class="mr-2 h-4 w-4" />
+                        Edit
+                    </BbButton>
+                }
+            }
+        </div>
+    </div>;
+
+    private RenderFragment SummarySection => @<div class="space-y-6">
+        <div class="xf-summary-grid xf-summary-grid-4">
+            <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Price</BbTypographyMuted><BbTypographyH3>@(_product?.Price.ToString("N2") ?? "0.00")</BbTypographyH3></div></BbCardContent></BbCard>
+            <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Available Stock</BbTypographyMuted><BbTypographyH3>@TotalAvailable.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
+            <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Locations</BbTypographyMuted><BbTypographyH3>@ActiveLocationCount</BbTypographyH3></div></BbCardContent></BbCard>
+            <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Reorder Rules</BbTypographyMuted><BbTypographyH3>@_reorderRules.Count</BbTypographyH3></div></BbCardContent></BbCard>
+        </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Product Summary</BbCardTitle>
+                <BbCardDescription>Catalog fields, availability, and lifecycle metadata.</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                @if (_editMode)
+                {
+                    <div class="grid gap-4">
+                        <div class="xf-detail-field-grid">
+                            <BbFormFieldInput TValue="string" @bind-Value="_productForm.Name" Label="Name" Required="true" />
+                            <BbFormFieldInput TValue="string" @bind-Value="_productForm.Sku" Label="SKU" />
+                        </div>
+                        <BbFormFieldCombobox TValue="string"
+                                             @bind-Value="_productForm.CategoryId"
+                                             Options="@CategoryOptions"
+                                             Label="Category"
+                                             Placeholder="Select category"
+                                             SearchPlaceholder="Search categories..."
+                                             EmptyMessage="No categories found."
+                                             MatchTriggerWidth="true"
+                                             Required="true" />
+                        <div class="xf-detail-field-grid">
+                            <BbFormFieldInput TValue="string" @bind-Value="_productForm.Price" Label="Price" />
+                            <BbFormFieldInput TValue="string" @bind-Value="_productForm.Brand" Label="Brand" />
+                        </div>
+                        <BbFormFieldInput TValue="string" @bind-Value="_productForm.Description" Label="Description" />
+                        <BbFormFieldSwitch Checked="@_productForm.IsAvailable"
+                                           CheckedChanged="@((bool value) => _productForm.IsAvailable = value)"
+                                           Label="Available" />
+                    </div>
+                }
+                else
+                {
+                    <div class="xf-detail-field-grid">
+                        <div>
+                            <BbTypographyMuted>Description</BbTypographyMuted>
+                            <div>@(_product?.Description ?? "No description")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Brand</BbTypographyMuted>
+                            <div>@(_product?.Brand ?? "N/A")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div>@(_product?.CreatedAt.ToLocalTime().ToString("g") ?? "N/A")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Last Modified</BbTypographyMuted>
+                            <div>@(_product?.ModifiedAt?.ToLocalTime().ToString("g") ?? "Never")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Warehouse Assignment</BbTypographyMuted>
+                            <div>Products are assigned to warehouses through stock balances, movements, receiving, and replenishment rules.</div>
+                        </div>
+                    </div>
+                }
+            </BbCardContent>
+        </BbCard>
+    </div>;
+
+    private RenderFragment StockSection => @<div class="space-y-6">
+        <div class="xf-page-header">
+            <div>
+                <BbTypographyH3>Stock</BbTypographyH3>
+                <BbTypographyMuted>Post stock, receive batches, and inspect balances for this product.</BbTypographyMuted>
+            </div>
+            <div class="xf-page-actions">
+                @if (_movementsEnabled)
+                {
+                    <BbButton OnClick="@OpenMovementDialog">
+                        <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                        Post Stock Movement
+                    </BbButton>
+                }
+                @if (_purchasingEnabled)
+                {
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@OpenReceiveDialog">
+                        <LucideIcon Name="package-plus" class="mr-2 h-4 w-4" />
+                        Receive Batch / Stock
+                    </BbButton>
+                }
+            </div>
+        </div>
+
+        <div class="xf-summary-grid xf-summary-grid-3">
+            <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>On Hand</BbTypographyMuted><BbTypographyH3>@TotalOnHand.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
+            <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Reserved</BbTypographyMuted><BbTypographyH3>@TotalReserved.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
+            <BbCard><BbCardContent><div class="space-y-1 pt-4"><BbTypographyMuted>Available</BbTypographyMuted><BbTypographyH3>@TotalAvailable.ToString("N2")</BbTypographyH3></div></BbCardContent></BbCard>
+        </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Stock Balances</BbCardTitle>
+                <BbCardDescription>@_balances.Count balance row(s) for this product</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                <BbDataGrid Items="@_balances" ShowPagination="true" InitialPageSize="20"
+                            OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
+                            Class="cursor-pointer">
+                    <Columns>
+                        <BbDataGridTemplateColumn Title="Warehouse">
+                            <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridTemplateColumn Title="Location">
+                            <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
+                        </BbDataGridTemplateColumn>
+                        @if (_traceabilityEnabled)
+                        {
+                            <BbDataGridTemplateColumn Title="Lot">
+                                <ChildContent Context="item">@GetLotNumber(item.LotId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                        }
+                        <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                    </Columns>
+                </BbDataGrid>
+            </BbCardContent>
+        </BbCard>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Movement Ledger</BbCardTitle>
+                <BbCardDescription>@_movements.Count movement(s) for this product</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="20">
+                    <Columns>
+                        <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
+                        <BbDataGridTemplateColumn Title="Warehouse">
+                            <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridTemplateColumn Title="Location">
+                            <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
+                        </BbDataGridTemplateColumn>
+                        @if (_traceabilityEnabled)
+                        {
+                            <BbDataGridTemplateColumn Title="Lot">
+                                <ChildContent Context="item">@GetLotNumber(item.LotId)</ChildContent>
+                            </BbDataGridTemplateColumn>
+                        }
+                        <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" />
+                        <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                    </Columns>
+                </BbDataGrid>
+            </BbCardContent>
+        </BbCard>
+    </div>;
+
+    private RenderFragment LotsSection => @<div class="space-y-6">
+        <div class="xf-page-header">
+            <div>
+                <BbTypographyH3>Lots / Batches</BbTypographyH3>
+                <BbTypographyMuted>Traceability records scoped to this product.</BbTypographyMuted>
+            </div>
+            <div class="xf-page-actions">
+                <BbButton OnClick="@OpenLotDialog">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    Create Lot
+                </BbButton>
+            </div>
+        </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Lots and Batches</BbCardTitle>
+                <BbCardDescription>@_lots.Count lot(s) connected to this product</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                <BbDataGrid Items="@_lots" ShowPagination="true" InitialPageSize="20"
+                            OnRowClick="@((InventoryLot item) => Navigation.NavigateTo($"/inventario/lots/{item.Id}"))"
+                            Class="cursor-pointer">
+                    <Columns>
+                        <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot / Batch" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.SupplierReference)" Title="Supplier Ref" />
+                        <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                        <BbDataGridTemplateColumn Title="On Hand">
+                            <ChildContent Context="item">@GetLotOnHand(item.Id).ToString("N2")</ChildContent>
+                        </BbDataGridTemplateColumn>
+                    </Columns>
+                </BbDataGrid>
+            </BbCardContent>
+        </BbCard>
+    </div>;
+
+    private RenderFragment ReplenishmentSection => @<div class="space-y-6">
+        <div class="xf-page-header">
+            <div>
+                <BbTypographyH3>Replenishment</BbTypographyH3>
+                <BbTypographyMuted>Min, max, reorder point, and warehouse/location-scoped rules.</BbTypographyMuted>
+            </div>
+            <div class="xf-page-actions">
+                <BbButton OnClick="@OpenRuleDialog">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    Add Reorder Rule
+                </BbButton>
+            </div>
+        </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Reorder Rules</BbCardTitle>
+                <BbCardDescription>@_reorderRules.Count rule(s) configured for this product</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                <BbDataGrid Items="@_reorderRules" ShowPagination="true" InitialPageSize="20">
+                    <Columns>
+                        <BbDataGridTemplateColumn Title="Scope">
+                            <ChildContent Context="item">@GetRuleScope(item)</ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridPropertyColumn Property="@(x => x.MinimumQuantity)" Title="Min" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.MaximumQuantity)" Title="Max" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.ReorderQuantity)" Title="Reorder Qty" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Preferred Supplier" />
+                        <BbDataGridTemplateColumn Title="Status">
+                            <ChildContent Context="item">
+                                <StatusBadge Text="@(item.IsActive ? "Active" : "Inactive")" Status="@(item.IsActive ? "active" : "inactive")" />
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                    </Columns>
+                </BbDataGrid>
+            </BbCardContent>
+        </BbCard>
+    </div>;
+
+    private RenderFragment VariationsSection => @<div class="space-y-6">
+        <div class="xf-page-header">
+            <div>
+                <BbTypographyH3>Variations</BbTypographyH3>
+                <BbTypographyMuted>Product option types, names, and price adjustments.</BbTypographyMuted>
+            </div>
+            <div class="xf-page-actions">
+                <BbButton OnClick="@OpenVariationDialog">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    Add Variation
+                </BbButton>
+            </div>
+        </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Variation List</BbCardTitle>
+                <BbCardDescription>@_variations.Count variation(s) configured</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                <BbDataGrid Items="@_variations" ShowPagination="true" InitialPageSize="20">
+                    <Columns>
+                        <BbDataGridPropertyColumn Property="@(x => x.VariationType)" Title="Type" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                        <BbDataGridTemplateColumn Title="Additional Price">
+                            <ChildContent Context="item">@item.AdditionalPrice.ToString("N2")</ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                    </Columns>
+                </BbDataGrid>
+            </BbCardContent>
+        </BbCard>
+    </div>;
+
+    private RenderFragment TransactionsSection => @<div class="space-y-6">
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Transaction History</BbCardTitle>
+                <BbCardDescription>@_transactions.Count product transaction(s) loaded</BbCardDescription>
+            </BbCardHeader>
+            <BbCardContent>
+                <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
+                    <Columns>
+                        <BbDataGridTemplateColumn Title="Quantity">
+                            <ChildContent Context="item">@item.Quantity</ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridTemplateColumn Title="Total">
+                            <ChildContent Context="item">@item.TotalPrice.ToString("N2")</ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                    </Columns>
+                </BbDataGrid>
+            </BbCardContent>
+        </BbCard>
+    </div>;
+
+    private RenderFragment FixedProductField => @<div class="rounded-md border p-3">
+        <BbTypographyMuted>Product</BbTypographyMuted>
+        <div class="font-medium">@GetProductLabel(_product)</div>
+    </div>;
+
+    private RenderFragment<ProductWorkflow> PrerequisiteCreateBlock => workflow => @<div class="grid gap-3">
+        @if (_warehouses.Count == 0)
+        {
+            <div class="rounded-md border p-3">
+                <div class="mb-3">
+                    <BbTypographyH4>Create Warehouse</BbTypographyH4>
+                    <BbTypographyMuted>Create the first warehouse without leaving this product workflow.</BbTypographyMuted>
+                </div>
+                <div class="grid gap-3 md:grid-cols-3">
+                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseQuickForm.Code" Label="Code" Required="true" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseQuickForm.Name" Label="Name" Required="true" />
+                    <div class="flex items-end">
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => CreateWarehouseForWorkflow(workflow))" Disabled="@_savingWarehouse">
+                            Create Warehouse
+                        </BbButton>
+                    </div>
+                </div>
+            </div>
+        }
+        else if (NeedsLocation(workflow))
+        {
+            <div class="rounded-md border p-3">
+                <div class="mb-3">
+                    <BbTypographyH4>Create Location</BbTypographyH4>
+                    <BbTypographyMuted>The selected warehouse has no locations yet.</BbTypographyMuted>
+                </div>
+                <div class="grid gap-3 md:grid-cols-[1fr_1fr_1fr_auto]">
+                    <BbFormFieldInput TValue="string" @bind-Value="_locationQuickForm.Code" Label="Code" Required="true" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_locationQuickForm.Name" Label="Name" Required="true" />
+                    <BbFormFieldSelect TValue="string" @bind-Value="_locationQuickForm.LocationType" Label="Type">
+                        @foreach (var type in Enum.GetValues<InventoryLocationType>())
+                        {
+                            <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
+                        }
+                    </BbFormFieldSelect>
+                    <div class="flex items-end">
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => CreateLocationForWorkflow(workflow))" Disabled="@_savingLocation">
+                            Create Location
+                        </BbButton>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>;
+
+    private bool IsSectionAvailable(string section) => section switch
+    {
+        "summary" => true,
+        "stock" => _stockEnabled || _movementsEnabled || _purchasingEnabled,
+        "lots" => _traceabilityEnabled,
+        "replenishment" => _planningEnabled,
+        "variations" => _variationsEnabled,
+        "transactions" => _transactionsEnabled,
+        _ => false
+    };
+
+    private static string NormalizeSection(string? section) =>
+        string.IsNullOrWhiteSpace(section)
+            ? "summary"
+            : section.ToLowerInvariant() switch
+            {
+                "batches" => "lots",
+                "lots-batches" => "lots",
+                "reorder" => "replenishment",
+                "rules" => "replenishment",
+                "stock-movements" => "stock",
+                _ => section.ToLowerInvariant()
+            };
 
     private void StartEdit()
     {
@@ -573,21 +1171,20 @@ else
 
     private void OpenVariationDialog()
     {
-        _variationName = "";
-        _variationAdditionalPrice = "0";
+        _variationForm.Reset();
         _variationDialogOpen = true;
     }
 
     private async Task SaveVariation()
     {
         if (_product is null) return;
-        if (string.IsNullOrWhiteSpace(_variationName))
+        if (string.IsNullOrWhiteSpace(_variationForm.Name))
         {
             ToastService.Show("Variation name is required.");
             return;
         }
 
-        if (!decimal.TryParse(_variationAdditionalPrice, out var additionalPrice))
+        if (!decimal.TryParse(_variationForm.AdditionalPrice, out var additionalPrice))
         {
             ToastService.Show("Additional price must be a valid number.");
             return;
@@ -601,7 +1198,8 @@ else
                 Id = Guid.NewGuid(),
                 TenantId = _product.TenantId,
                 ProductId = _product.Id,
-                Name = _variationName.Trim(),
+                VariationType = NullIfEmpty(_variationForm.VariationType),
+                Name = _variationForm.Name.Trim(),
                 AdditionalPrice = additionalPrice,
                 CreatedAt = DateTime.UtcNow,
                 IsEnabled = true
@@ -629,6 +1227,434 @@ else
         }
     }
 
+    private void OpenMovementDialog()
+    {
+        _movementForm.Reset();
+        _movementForm.ProductId = Id.ToString();
+        _movementForm.WarehouseId = _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
+        _movementForm.LocationId = FirstLocationForWarehouse(_movementForm.WarehouseId)?.Id.ToString() ?? "";
+        _movementDialogOpen = true;
+    }
+
+    private async Task PostMovement()
+    {
+        if (_product is null ||
+            !Guid.TryParse(_movementForm.WarehouseId, out var warehouseId) ||
+            !Guid.TryParse(_movementForm.LocationId, out var locationId))
+        {
+            ToastService.Show("Select warehouse and location.");
+            return;
+        }
+
+        if (!decimal.TryParse(_movementForm.Quantity, out var quantity) || quantity == 0)
+        {
+            ToastService.Show("Quantity must not be zero.");
+            return;
+        }
+
+        _savingMovement = true;
+        try
+        {
+            var lotId = await ResolveLotId(_movementForm.LotId, _movementForm.NewLotNumber);
+            if (!string.IsNullOrWhiteSpace(_movementForm.NewLotNumber) && lotId is null)
+                return;
+
+            var result = await Inventario.PostStockMovement(new PostStockMovementRequest
+            {
+                Metadata = BuildMetadata(),
+                ProductId = _product.Id,
+                WarehouseId = warehouseId,
+                LocationId = locationId,
+                LotId = lotId,
+                MovementType = Enum.TryParse<InventoryMovementType>(_movementForm.MovementType, out var type) ? type : InventoryMovementType.Adjustment,
+                Quantity = quantity,
+                UnitOfMeasure = NullIfEmpty(_movementForm.UnitOfMeasure),
+                ReferenceType = NullIfEmpty(_movementForm.ReferenceType),
+                Reason = NullIfEmpty(_movementForm.Reason),
+                AllowNegativeStock = _negativeStockEnabled && _movementForm.AllowNegativeStock
+            });
+
+            ToastService.Show(result.IsSuccess ? "Stock movement posted." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _movementDialogOpen = false;
+                await Reload();
+            }
+        }
+        finally
+        {
+            _savingMovement = false;
+        }
+    }
+
+    private void OpenLotDialog()
+    {
+        _lotForm.Reset();
+        _lotDialogOpen = true;
+    }
+
+    private async Task CreateLot()
+    {
+        if (_product is null) return;
+        if (string.IsNullOrWhiteSpace(_lotForm.LotNumber))
+        {
+            ToastService.Show("Lot number is required.");
+            return;
+        }
+
+        _savingLot = true;
+        try
+        {
+            var result = await Inventario.CreateInventoryLot(new CreateInventoryLotRequest
+            {
+                Metadata = BuildMetadata(),
+                ProductId = _product.Id,
+                LotNumber = _lotForm.LotNumber.Trim(),
+                SupplierReference = NullIfEmpty(_lotForm.SupplierReference),
+                SourceReferenceType = NullIfEmpty(_lotForm.SourceReferenceType),
+                ReceivedAt = ParseDate(_lotForm.ReceivedAt),
+                ManufacturedAt = ParseDate(_lotForm.ManufacturedAt),
+                ExpiresAt = ParseDate(_lotForm.ExpiresAt),
+                UnitCost = decimal.TryParse(_lotForm.UnitCost, out var cost) ? cost : null,
+                Status = Enum.TryParse<InventoryLotStatus>(_lotForm.Status, out var status) ? status : InventoryLotStatus.Available
+            });
+
+            ToastService.Show(result.IsSuccess ? "Lot created." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _lotDialogOpen = false;
+                await Reload();
+            }
+        }
+        finally
+        {
+            _savingLot = false;
+        }
+    }
+
+    private void OpenReceiveDialog()
+    {
+        _receiveForm.Reset();
+        _receiveForm.WarehouseId = _warehouses.FirstOrDefault()?.Id.ToString() ?? "";
+        _receiveForm.LocationId = FirstLocationForWarehouse(_receiveForm.WarehouseId)?.Id.ToString() ?? "";
+        _receiveDialogOpen = true;
+    }
+
+    private async Task ReceiveStock()
+    {
+        if (_product is null ||
+            !Guid.TryParse(_receiveForm.WarehouseId, out var warehouseId) ||
+            !Guid.TryParse(_receiveForm.LocationId, out var locationId))
+        {
+            ToastService.Show("Select warehouse and location.");
+            return;
+        }
+
+        if (!decimal.TryParse(_receiveForm.Quantity, out var quantity) || quantity <= 0)
+        {
+            ToastService.Show("Quantity must be greater than zero.");
+            return;
+        }
+
+        _savingReceive = true;
+        try
+        {
+            var result = await Inventario.ReceiveInventory(new ReceiveInventoryRequest
+            {
+                Metadata = BuildMetadata(),
+                ReceiptNumber = NullIfEmpty(_receiveForm.ReceiptNumber),
+                PurchaseOrderId = Guid.TryParse(_receiveForm.PurchaseOrderId, out var poId) ? poId : null,
+                WarehouseId = warehouseId,
+                LocationId = locationId,
+                SupplierId = Guid.TryParse(_receiveForm.SupplierId, out var supplierId) ? supplierId : null,
+                ReferenceNumber = NullIfEmpty(_receiveForm.ReferenceNumber),
+                IdempotencyKey = NullIfEmpty(_receiveForm.IdempotencyKey),
+                Lines =
+                [
+                    new ReceivingLineRequest
+                    {
+                        PurchaseOrderLineId = Guid.TryParse(_receiveForm.PurchaseOrderLineId, out var lineId) ? lineId : null,
+                        ProductId = _product.Id,
+                        Quantity = quantity,
+                        UnitCost = decimal.TryParse(_receiveForm.UnitCost, out var unitCost) ? unitCost : null,
+                        UnitOfMeasure = NullIfEmpty(_receiveForm.UnitOfMeasure),
+                        LotId = Guid.TryParse(_receiveForm.LotId, out var lotId) ? lotId : null,
+                        LotNumber = NullIfEmpty(_receiveForm.LotNumber),
+                        ManufacturedAt = ParseDate(_receiveForm.ManufacturedAt),
+                        ExpiresAt = ParseDate(_receiveForm.ExpiresAt)
+                    }
+                ]
+            });
+
+            ToastService.Show(result.IsSuccess ? "Receiving posted." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _receiveDialogOpen = false;
+                await Reload();
+            }
+        }
+        finally
+        {
+            _savingReceive = false;
+        }
+    }
+
+    private void OpenRuleDialog()
+    {
+        _ruleForm.Reset();
+        _ruleDialogOpen = true;
+    }
+
+    private async Task CreateRule()
+    {
+        if (_product is null) return;
+        if (!decimal.TryParse(_ruleForm.MinimumQuantity, out var min) ||
+            !decimal.TryParse(_ruleForm.ReorderPoint, out var point) ||
+            !decimal.TryParse(_ruleForm.ReorderQuantity, out var qty) ||
+            min < 0 ||
+            point < 0 ||
+            qty <= 0)
+        {
+            ToastService.Show("Quantities must be valid.");
+            return;
+        }
+
+        decimal? max = null;
+        if (!string.IsNullOrWhiteSpace(_ruleForm.MaximumQuantity))
+        {
+            if (!decimal.TryParse(_ruleForm.MaximumQuantity, out var parsedMax) || parsedMax < min)
+            {
+                ToastService.Show("Maximum must be greater than or equal to minimum.");
+                return;
+            }
+            max = parsedMax;
+        }
+
+        _savingRule = true;
+        try
+        {
+            var result = await Inventario.CreateInventoryReorderRule(new CreateInventoryReorderRuleRequest
+            {
+                Metadata = BuildMetadata(),
+                ProductId = _product.Id,
+                WarehouseId = Guid.TryParse(_ruleForm.WarehouseId, out var warehouseId) ? warehouseId : null,
+                LocationId = Guid.TryParse(_ruleForm.LocationId, out var locationId) ? locationId : null,
+                MinimumQuantity = min,
+                MaximumQuantity = max,
+                ReorderPoint = point,
+                ReorderQuantity = qty,
+                PreferredSupplier = NullIfEmpty(_ruleForm.PreferredSupplier),
+                IsActive = _ruleForm.IsActive
+            });
+
+            ToastService.Show(result.IsSuccess ? "Reorder rule created." : $"Failed: {result.Message}");
+            if (result.IsSuccess)
+            {
+                _ruleDialogOpen = false;
+                await Reload();
+            }
+        }
+        finally
+        {
+            _savingRule = false;
+        }
+    }
+
+    private async Task<Guid?> ResolveLotId(string? selectedLotId, string? newLotNumber)
+    {
+        if (!_traceabilityEnabled)
+            return null;
+
+        if (Guid.TryParse(selectedLotId, out var existingLotId))
+            return existingLotId;
+
+        if (_product is null || string.IsNullOrWhiteSpace(newLotNumber))
+            return null;
+
+        var result = await Inventario.CreateInventoryLot(new CreateInventoryLotRequest
+        {
+            Metadata = BuildMetadata(),
+            ProductId = _product.Id,
+            LotNumber = newLotNumber.Trim(),
+            ReceivedAt = DateTime.UtcNow,
+            Status = InventoryLotStatus.Available
+        });
+
+        if (!result.IsSuccess)
+        {
+            ToastService.Show($"Failed to create lot: {result.Message}");
+            return null;
+        }
+
+        await RefreshLots(_product.TenantId);
+        return _lots.FirstOrDefault(x => string.Equals(x.LotNumber, newLotNumber.Trim(), StringComparison.OrdinalIgnoreCase))?.Id;
+    }
+
+    private async Task RefreshLots(Guid tenantId)
+    {
+        if (!_traceabilityEnabled) return;
+        _lots = await DataContext.Query<InventoryLot>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
+            .OrderBy(x => x.ExpiresAt)
+            .ThenBy(x => x.LotNumber)
+            .Take(500)
+            .ToListAsync();
+    }
+
+    private async Task CreateWarehouseForWorkflow(ProductWorkflow workflow)
+    {
+        if (_product is null) return;
+        if (string.IsNullOrWhiteSpace(_warehouseQuickForm.Code) || string.IsNullOrWhiteSpace(_warehouseQuickForm.Name))
+        {
+            ToastService.Show("Warehouse code and name are required.");
+            return;
+        }
+
+        var code = _warehouseQuickForm.Code.Trim();
+        _savingWarehouse = true;
+        try
+        {
+            var result = await Inventario.CreateWarehouse(new CreateWarehouseRequest
+            {
+                Metadata = BuildMetadata(),
+                Code = code,
+                Name = _warehouseQuickForm.Name.Trim(),
+                IsDefault = _warehouses.Count == 0
+            });
+
+            ToastService.Show(result.IsSuccess ? "Warehouse created." : $"Failed: {result.Message}");
+            if (!result.IsSuccess) return;
+
+            _warehouseQuickForm.Reset();
+            await LoadOperationalLookups(_product.TenantId);
+            var created = _warehouses.FirstOrDefault(x => string.Equals(x.Code, code, StringComparison.OrdinalIgnoreCase));
+            if (created is not null)
+                ApplyWorkflowWarehouse(workflow, created.Id.ToString());
+        }
+        finally
+        {
+            _savingWarehouse = false;
+        }
+    }
+
+    private async Task CreateLocationForWorkflow(ProductWorkflow workflow)
+    {
+        if (_product is null) return;
+        var warehouseIdText = GetWorkflowWarehouseId(workflow);
+        if (!Guid.TryParse(warehouseIdText, out var warehouseId))
+        {
+            ToastService.Show("Select a warehouse before creating a location.");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(_locationQuickForm.Code) || string.IsNullOrWhiteSpace(_locationQuickForm.Name))
+        {
+            ToastService.Show("Location code and name are required.");
+            return;
+        }
+
+        var code = _locationQuickForm.Code.Trim();
+        _savingLocation = true;
+        try
+        {
+            var result = await Inventario.CreateInventoryLocation(new CreateInventoryLocationRequest
+            {
+                Metadata = BuildMetadata(),
+                WarehouseId = warehouseId,
+                Code = code,
+                Name = _locationQuickForm.Name.Trim(),
+                LocationType = Enum.TryParse<InventoryLocationType>(_locationQuickForm.LocationType, out var type) ? type : InventoryLocationType.Bin,
+                IsPickable = true
+            });
+
+            ToastService.Show(result.IsSuccess ? "Location created." : $"Failed: {result.Message}");
+            if (!result.IsSuccess) return;
+
+            _locationQuickForm.Reset();
+            await LoadOperationalLookups(_product.TenantId);
+            var created = _locations.FirstOrDefault(x => x.WarehouseId == warehouseId && string.Equals(x.Code, code, StringComparison.OrdinalIgnoreCase));
+            if (created is not null)
+                ApplyWorkflowLocation(workflow, created.Id.ToString());
+        }
+        finally
+        {
+            _savingLocation = false;
+        }
+    }
+
+    private void OnWorkflowWarehouseChanged(ProductWorkflow workflow, string? value) =>
+        ApplyWorkflowWarehouse(workflow, value ?? "");
+
+    private void ApplyWorkflowWarehouse(ProductWorkflow workflow, string warehouseId)
+    {
+        switch (workflow)
+        {
+            case ProductWorkflow.Movement:
+                _movementForm.WarehouseId = warehouseId;
+                _movementForm.LocationId = FirstLocationForWarehouse(warehouseId)?.Id.ToString() ?? "";
+                break;
+            case ProductWorkflow.Receiving:
+                _receiveForm.WarehouseId = warehouseId;
+                _receiveForm.LocationId = FirstLocationForWarehouse(warehouseId)?.Id.ToString() ?? "";
+                break;
+            case ProductWorkflow.Replenishment:
+                _ruleForm.WarehouseId = warehouseId;
+                _ruleForm.LocationId = "";
+                break;
+        }
+    }
+
+    private void ApplyWorkflowLocation(ProductWorkflow workflow, string locationId)
+    {
+        switch (workflow)
+        {
+            case ProductWorkflow.Movement:
+                _movementForm.LocationId = locationId;
+                break;
+            case ProductWorkflow.Receiving:
+                _receiveForm.LocationId = locationId;
+                break;
+            case ProductWorkflow.Replenishment:
+                _ruleForm.LocationId = locationId;
+                break;
+        }
+    }
+
+    private string GetWorkflowWarehouseId(ProductWorkflow workflow) => workflow switch
+    {
+        ProductWorkflow.Movement => _movementForm.WarehouseId,
+        ProductWorkflow.Receiving => _receiveForm.WarehouseId,
+        ProductWorkflow.Replenishment => _ruleForm.WarehouseId,
+        _ => ""
+    };
+
+    private bool NeedsLocation(ProductWorkflow workflow)
+    {
+        var warehouseId = GetWorkflowWarehouseId(workflow);
+        return Guid.TryParse(warehouseId, out var parsedWarehouseId)
+            && !_locations.Any(x => x.WarehouseId == parsedWarehouseId);
+    }
+
+    private void ApplyWorkflowDefaults()
+    {
+        if (string.IsNullOrWhiteSpace(_movementForm.WarehouseId))
+            ApplyWorkflowWarehouse(ProductWorkflow.Movement, _warehouses.FirstOrDefault()?.Id.ToString() ?? "");
+        if (string.IsNullOrWhiteSpace(_receiveForm.WarehouseId))
+            ApplyWorkflowWarehouse(ProductWorkflow.Receiving, _warehouses.FirstOrDefault()?.Id.ToString() ?? "");
+    }
+
+    private IEnumerable<InventoryLocation> LocationsForWarehouse(string? warehouseId)
+    {
+        if (!Guid.TryParse(warehouseId, out var parsedWarehouseId))
+            return _locations;
+
+        return _locations.Where(x => x.WarehouseId == parsedWarehouseId);
+    }
+
+    private InventoryLocation? FirstLocationForWarehouse(string? warehouseId) =>
+        LocationsForWarehouse(warehouseId).FirstOrDefault();
+
     private string GetCategoryName(Guid categoryId) =>
         _categories.FirstOrDefault(x => x.Id == categoryId)?.Name ?? "Uncategorized";
 
@@ -636,10 +1662,10 @@ else
         $"{GetWarehouseName(rule.WarehouseId)} / {GetLocationName(rule.LocationId)}";
 
     private string GetWarehouseName(Guid? warehouseId) =>
-        warehouseId is { } id ? _warehouses.FirstOrDefault(x => x.Id == id) is { } warehouse ? $"{warehouse.Code} - {warehouse.Name}" : id.ToString()[..8] : "Any warehouse";
+        warehouseId is { } id ? _warehouses.FirstOrDefault(x => x.Id == id) is { } warehouse ? GetWarehouseLabel(warehouse) : id.ToString()[..8] : "Any warehouse";
 
     private string GetLocationName(Guid? locationId) =>
-        locationId is { } id ? _locations.FirstOrDefault(x => x.Id == id) is { } location ? $"{location.Code} - {location.Name}" : id.ToString()[..8] : "Any location";
+        locationId is { } id ? _locations.FirstOrDefault(x => x.Id == id) is { } location ? GetLocationLabel(location) : id.ToString()[..8] : "Any location";
 
     private string GetLotNumber(Guid? lotId) =>
         lotId is { } id ? _lots.FirstOrDefault(x => x.Id == id)?.LotNumber ?? id.ToString()[..8] : "Untracked";
@@ -647,13 +1673,41 @@ else
     private decimal GetLotOnHand(Guid lotId) =>
         _balances.Where(x => x.LotId == lotId).Sum(x => x.OnHandQuantity);
 
+    private static string GetProductLabel(Product? product)
+    {
+        if (product is null) return "Product";
+        return string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
+    }
+
+    private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+    private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
+    private static string GetLotLabel(InventoryLot lot) =>
+        string.IsNullOrWhiteSpace(lot.LotNumber) ? lot.Id.ToString()[..8] : lot.LotNumber;
+
+    private RequestMetadata BuildMetadata() => new()
+    {
+        TenantId = TenantFilter.SelectedTenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "ControlPanel"
+    };
+
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static DateTime? ParseDate(string? value) =>
+        DateTime.TryParse(value, out var date) ? date : null;
 
     public void Dispose()
     {
         TenantFilter.OnChanged -= OnTenantChanged;
         ModuleNavigation.OnChanged -= OnTenantChanged;
+    }
+
+    private enum ProductWorkflow
+    {
+        Movement,
+        Receiving,
+        Replenishment
     }
 
     private sealed class ProductForm
@@ -665,5 +1719,161 @@ else
         public string Brand { get; set; } = "";
         public string Description { get; set; } = "";
         public bool IsAvailable { get; set; } = true;
+    }
+
+    private sealed class VariationForm
+    {
+        public string VariationType { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string AdditionalPrice { get; set; } = "0";
+
+        public void Reset()
+        {
+            VariationType = "";
+            Name = "";
+            AdditionalPrice = "0";
+        }
+    }
+
+    private sealed class MovementForm
+    {
+        public string ProductId { get; set; } = "";
+        public string WarehouseId { get; set; } = "";
+        public string LocationId { get; set; } = "";
+        public string LotId { get; set; } = "";
+        public string NewLotNumber { get; set; } = "";
+        public string MovementType { get; set; } = InventoryMovementType.Adjustment.ToString();
+        public string Quantity { get; set; } = "0";
+        public string UnitOfMeasure { get; set; } = "each";
+        public string ReferenceType { get; set; } = "";
+        public string Reason { get; set; } = "";
+        public bool AllowNegativeStock { get; set; }
+
+        public void Reset()
+        {
+            ProductId = "";
+            WarehouseId = "";
+            LocationId = "";
+            LotId = "";
+            NewLotNumber = "";
+            MovementType = InventoryMovementType.Adjustment.ToString();
+            Quantity = "0";
+            UnitOfMeasure = "each";
+            ReferenceType = "";
+            Reason = "";
+            AllowNegativeStock = false;
+        }
+    }
+
+    private sealed class LotForm
+    {
+        public string LotNumber { get; set; } = "";
+        public string SupplierReference { get; set; } = "";
+        public string SourceReferenceType { get; set; } = "";
+        public string ReceivedAt { get; set; } = "";
+        public string ManufacturedAt { get; set; } = "";
+        public string ExpiresAt { get; set; } = "";
+        public string UnitCost { get; set; } = "";
+        public string Status { get; set; } = InventoryLotStatus.Available.ToString();
+
+        public void Reset()
+        {
+            LotNumber = "";
+            SupplierReference = "";
+            SourceReferenceType = "";
+            ReceivedAt = "";
+            ManufacturedAt = "";
+            ExpiresAt = "";
+            UnitCost = "";
+            Status = InventoryLotStatus.Available.ToString();
+        }
+    }
+
+    private sealed class ReceiveForm
+    {
+        public string ReceiptNumber { get; set; } = "";
+        public string PurchaseOrderId { get; set; } = "";
+        public string PurchaseOrderLineId { get; set; } = "";
+        public string SupplierId { get; set; } = "";
+        public string WarehouseId { get; set; } = "";
+        public string LocationId { get; set; } = "";
+        public string ReferenceNumber { get; set; } = "";
+        public string IdempotencyKey { get; set; } = "";
+        public string Quantity { get; set; } = "1";
+        public string UnitCost { get; set; } = "";
+        public string UnitOfMeasure { get; set; } = "each";
+        public string LotId { get; set; } = "";
+        public string LotNumber { get; set; } = "";
+        public string ManufacturedAt { get; set; } = "";
+        public string ExpiresAt { get; set; } = "";
+
+        public void Reset()
+        {
+            ReceiptNumber = "";
+            PurchaseOrderId = "";
+            PurchaseOrderLineId = "";
+            SupplierId = "";
+            WarehouseId = "";
+            LocationId = "";
+            ReferenceNumber = "";
+            IdempotencyKey = "";
+            Quantity = "1";
+            UnitCost = "";
+            UnitOfMeasure = "each";
+            LotId = "";
+            LotNumber = "";
+            ManufacturedAt = "";
+            ExpiresAt = "";
+        }
+    }
+
+    private sealed class RuleForm
+    {
+        public string WarehouseId { get; set; } = "";
+        public string LocationId { get; set; } = "";
+        public string MinimumQuantity { get; set; } = "0";
+        public string MaximumQuantity { get; set; } = "";
+        public string ReorderPoint { get; set; } = "0";
+        public string ReorderQuantity { get; set; } = "1";
+        public string PreferredSupplier { get; set; } = "";
+        public bool IsActive { get; set; } = true;
+
+        public void Reset()
+        {
+            WarehouseId = "";
+            LocationId = "";
+            MinimumQuantity = "0";
+            MaximumQuantity = "";
+            ReorderPoint = "0";
+            ReorderQuantity = "1";
+            PreferredSupplier = "";
+            IsActive = true;
+        }
+    }
+
+    private sealed class WarehouseQuickForm
+    {
+        public string Code { get; set; } = "";
+        public string Name { get; set; } = "";
+
+        public void Reset()
+        {
+            Code = "";
+            Name = "";
+        }
+    }
+
+    private sealed class LocationQuickForm
+    {
+        public string Code { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string LocationType { get; set; } = InventoryLocationType.Bin.ToString();
+
+        public void Reset()
+        {
+            Code = "";
+            Name = "";
+            LocationType = InventoryLocationType.Bin.ToString();
+        }
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -110,46 +110,62 @@ else
             </BbDialogHeader>
             <div class="grid gap-4 py-4">
                 @FixedProductField
-                @PrerequisiteCreateBlock(ProductWorkflow.Movement)
 
                 <div class="grid gap-3 md:grid-cols-2">
-                    <div class="xf-form-field">
-                        <BbLabel>Warehouse</BbLabel>
-                        <BbCombobox TValue="string"
-                                     Value="@_movementForm.WarehouseId"
-                                     ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Movement, value))"
-                                     Options="@WarehouseOptions"
-                                     Placeholder="Select warehouse"
-                                     SearchPlaceholder="Search warehouses..."
-                                     EmptyMessage="No warehouses found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
-                    <div class="xf-form-field">
-                        <BbLabel>Location</BbLabel>
-                        <BbCombobox TValue="string"
-                                     @bind-Value="_movementForm.LocationId"
-                                     Options="@MovementLocationOptions"
-                                     Placeholder="Select location"
-                                     SearchPlaceholder="Search locations..."
-                                     EmptyMessage="No locations found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
+                    <XfEntityPicker TItem="Warehouse"
+                                    Label="Warehouse"
+                                    Value="@_movementForm.WarehouseId"
+                                    ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Movement, value))"
+                                    Items="@_warehouses"
+                                    ValueSelector="@GetWarehousePickerValue"
+                                    TextSelector="@GetWarehouseLabel"
+                                    SearchTextSelector="@GetWarehouseSearchText"
+                                    Placeholder="Select warehouse"
+                                    SearchPlaceholder="Search warehouses..."
+                                    EmptyMessage="No warehouses found."
+                                    ShowCreate="true"
+                                    CreateLabel="Create Warehouse"
+                                    AdvancedSearchTitle="Find Warehouse"
+                                    AdvancedSearchDescription="Search all warehouses in the active tenant."
+                                    OnCreate="@(() => OpenWarehouseCreateDialog(ProductWorkflow.Movement))" />
+                    <XfEntityPicker TItem="InventoryLocation"
+                                    Label="Location"
+                                    Value="@_movementForm.LocationId"
+                                    ValueChanged="@(value => _movementForm.LocationId = value ?? "")"
+                                    Items="@MovementLocations"
+                                    ValueSelector="@GetLocationPickerValue"
+                                    TextSelector="@GetLocationLabel"
+                                    SearchTextSelector="@GetLocationSearchText"
+                                    Placeholder="Select location"
+                                    SearchPlaceholder="Search locations..."
+                                    EmptyMessage="No locations found."
+                                    ShowCreate="@CanCreateMovementLocation"
+                                    Disabled="@(!CanCreateMovementLocation)"
+                                    HelpText="@MovementLocationHelpText"
+                                    CreateLabel="Create Location"
+                                    AdvancedSearchTitle="Find Location"
+                                    AdvancedSearchDescription="Search locations for the selected warehouse."
+                                    OnCreate="@(() => OpenLocationCreateDialog(ProductWorkflow.Movement))" />
                     @if (_traceabilityEnabled)
                     {
-                        <div class="xf-form-field">
-                            <BbLabel>Existing Lot / Batch</BbLabel>
-                            <BbCombobox TValue="string"
-                                         @bind-Value="_movementForm.LotId"
-                                         Options="@LotOptions"
-                                         Placeholder="No lot"
-                                         SearchPlaceholder="Search lots..."
-                                         EmptyMessage="No lots found."
-                                         Class="xf-entity-combobox"
-                                         MatchTriggerWidth="true" />
-                        </div>
-                        <BbFormFieldInput TValue="string" @bind-Value="_movementForm.NewLotNumber" Label="New Lot Number" />
+                        <XfEntityPicker TItem="InventoryLot"
+                                        Label="Lot / Batch"
+                                        Value="@_movementForm.LotId"
+                                        ValueChanged="@(value => _movementForm.LotId = value ?? "")"
+                                        Items="@_lots"
+                                        ValueSelector="@GetLotPickerValue"
+                                        TextSelector="@GetLotLabel"
+                                        SearchTextSelector="@GetLotSearchText"
+                                        Placeholder="No lot / untracked"
+                                        SearchPlaceholder="Search lots..."
+                                        EmptyMessage="No lots found."
+                                        AllowClear="true"
+                                        ClearText="No lot / untracked"
+                                        ShowCreate="true"
+                                        CreateLabel="Create Lot / Batch"
+                                        AdvancedSearchTitle="Find Lot / Batch"
+                                        AdvancedSearchDescription="Search lots and batches for this product."
+                                        OnCreate="@(() => OpenLotDialog(ProductWorkflow.Movement))" />
                     }
                     <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.MovementType" Label="Movement Type">
                         @foreach (var type in Enum.GetValues<InventoryMovementType>())
@@ -218,58 +234,80 @@ else
             </BbDialogHeader>
             <div class="grid gap-4 py-4">
                 @FixedProductField
-                @PrerequisiteCreateBlock(ProductWorkflow.Receiving)
 
                 <div class="grid gap-3 md:grid-cols-3">
                     <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.ReceiptNumber" Label="Receipt Number" />
-                    <div class="xf-form-field">
-                        <BbLabel>Purchase Order</BbLabel>
-                        <BbCombobox TValue="string"
-                                     @bind-Value="_receiveForm.PurchaseOrderId"
-                                     Options="@PurchaseOrderOptions"
-                                     Placeholder="No purchase order"
-                                     SearchPlaceholder="Search purchase orders..."
-                                     EmptyMessage="No purchase orders found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
-                    <div class="xf-form-field">
-                        <BbLabel>Supplier</BbLabel>
-                        <BbCombobox TValue="string"
-                                     @bind-Value="_receiveForm.SupplierId"
-                                     Options="@SupplierOptions"
-                                     Placeholder="No supplier"
-                                     SearchPlaceholder="Search suppliers..."
-                                     EmptyMessage="No suppliers found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
+                    <XfEntityPicker TItem="PurchaseOrder"
+                                    Label="Purchase Order"
+                                    Value="@_receiveForm.PurchaseOrderId"
+                                    ValueChanged="@(value => _receiveForm.PurchaseOrderId = value ?? "")"
+                                    Items="@OpenPurchaseOrders"
+                                    ValueSelector="@GetPurchaseOrderPickerValue"
+                                    TextSelector="@GetPurchaseOrderLabel"
+                                    SearchTextSelector="@GetPurchaseOrderSearchText"
+                                    Placeholder="No purchase order"
+                                    SearchPlaceholder="Search purchase orders..."
+                                    EmptyMessage="No purchase orders found."
+                                    AllowClear="true"
+                                    ClearText="No purchase order"
+                                    ShowCreate="false"
+                                    AdvancedSearchTitle="Find Purchase Order"
+                                    AdvancedSearchDescription="Search open and partially received purchase orders." />
+                    <XfEntityPicker TItem="Supplier"
+                                    Label="Supplier"
+                                    Value="@_receiveForm.SupplierId"
+                                    ValueChanged="@(value => _receiveForm.SupplierId = value ?? "")"
+                                    Items="@_suppliers"
+                                    ValueSelector="@GetSupplierPickerValue"
+                                    TextSelector="@GetSupplierLabel"
+                                    SearchTextSelector="@GetSupplierSearchText"
+                                    Placeholder="No supplier"
+                                    SearchPlaceholder="Search suppliers..."
+                                    EmptyMessage="No suppliers found."
+                                    AllowClear="true"
+                                    ClearText="No supplier"
+                                    ShowCreate="true"
+                                    CreateLabel="Create Supplier"
+                                    AdvancedSearchTitle="Find Supplier"
+                                    AdvancedSearchDescription="Search suppliers in the active tenant."
+                                    OnCreate="@(() => OpenSupplierCreateDialog(ProductWorkflow.Receiving))" />
                 </div>
 
                 <div class="grid gap-3 md:grid-cols-3">
-                    <div class="xf-form-field">
-                        <BbLabel>Warehouse</BbLabel>
-                        <BbCombobox TValue="string"
-                                     Value="@_receiveForm.WarehouseId"
-                                     ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Receiving, value))"
-                                     Options="@WarehouseOptions"
-                                     Placeholder="Select warehouse"
-                                     SearchPlaceholder="Search warehouses..."
-                                     EmptyMessage="No warehouses found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
-                    <div class="xf-form-field">
-                        <BbLabel>Location</BbLabel>
-                        <BbCombobox TValue="string"
-                                     @bind-Value="_receiveForm.LocationId"
-                                     Options="@ReceiveLocationOptions"
-                                     Placeholder="Select location"
-                                     SearchPlaceholder="Search locations..."
-                                     EmptyMessage="No locations found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
+                    <XfEntityPicker TItem="Warehouse"
+                                    Label="Warehouse"
+                                    Value="@_receiveForm.WarehouseId"
+                                    ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Receiving, value))"
+                                    Items="@_warehouses"
+                                    ValueSelector="@GetWarehousePickerValue"
+                                    TextSelector="@GetWarehouseLabel"
+                                    SearchTextSelector="@GetWarehouseSearchText"
+                                    Placeholder="Select warehouse"
+                                    SearchPlaceholder="Search warehouses..."
+                                    EmptyMessage="No warehouses found."
+                                    ShowCreate="true"
+                                    CreateLabel="Create Warehouse"
+                                    AdvancedSearchTitle="Find Warehouse"
+                                    AdvancedSearchDescription="Search all warehouses in the active tenant."
+                                    OnCreate="@(() => OpenWarehouseCreateDialog(ProductWorkflow.Receiving))" />
+                    <XfEntityPicker TItem="InventoryLocation"
+                                    Label="Location"
+                                    Value="@_receiveForm.LocationId"
+                                    ValueChanged="@(value => _receiveForm.LocationId = value ?? "")"
+                                    Items="@ReceiveLocations"
+                                    ValueSelector="@GetLocationPickerValue"
+                                    TextSelector="@GetLocationLabel"
+                                    SearchTextSelector="@GetLocationSearchText"
+                                    Placeholder="Select location"
+                                    SearchPlaceholder="Search locations..."
+                                    EmptyMessage="No locations found."
+                                    ShowCreate="@CanCreateReceiveLocation"
+                                    Disabled="@(!CanCreateReceiveLocation)"
+                                    HelpText="@ReceiveLocationHelpText"
+                                    CreateLabel="Create Location"
+                                    AdvancedSearchTitle="Find Location"
+                                    AdvancedSearchDescription="Search locations for the selected warehouse."
+                                    OnCreate="@(() => OpenLocationCreateDialog(ProductWorkflow.Receiving))" />
                     <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.ReferenceNumber" Label="Reference" />
                 </div>
 
@@ -281,22 +319,24 @@ else
 
                 @if (_traceabilityEnabled)
                 {
-                    <div class="grid gap-3 md:grid-cols-2">
-                        <div class="xf-form-field">
-                            <BbLabel>Existing Lot / Batch</BbLabel>
-                            <BbCombobox TValue="string"
-                                         @bind-Value="_receiveForm.LotId"
-                                         Options="@LotOptions"
-                                         Placeholder="Create/no lot"
-                                         SearchPlaceholder="Search lots..."
-                                         EmptyMessage="No lots found."
-                                         Class="xf-entity-combobox"
-                                         MatchTriggerWidth="true" />
-                        </div>
-                        <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.LotNumber" Label="New Lot Number" />
-                        <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.ManufacturedAt" Label="Manufacture Date" Placeholder="YYYY-MM-DD" />
-                        <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.ExpiresAt" Label="Expiration Date" Placeholder="YYYY-MM-DD" />
-                    </div>
+                    <XfEntityPicker TItem="InventoryLot"
+                                    Label="Lot / Batch"
+                                    Value="@_receiveForm.LotId"
+                                    ValueChanged="@(value => _receiveForm.LotId = value ?? "")"
+                                    Items="@_lots"
+                                    ValueSelector="@GetLotPickerValue"
+                                    TextSelector="@GetLotLabel"
+                                    SearchTextSelector="@GetLotSearchText"
+                                    Placeholder="No lot / untracked"
+                                    SearchPlaceholder="Search lots..."
+                                    EmptyMessage="No lots found."
+                                    AllowClear="true"
+                                    ClearText="No lot / untracked"
+                                    ShowCreate="true"
+                                    CreateLabel="Create Lot / Batch"
+                                    AdvancedSearchTitle="Find Lot / Batch"
+                                    AdvancedSearchDescription="Search lots and batches for this product."
+                                    OnCreate="@(() => OpenLotDialog(ProductWorkflow.Receiving))" />
                 }
             </div>
             <BbDialogFooter>
@@ -314,33 +354,71 @@ else
             </BbDialogHeader>
             <div class="grid gap-4 py-4">
                 @FixedProductField
-                @PrerequisiteCreateBlock(ProductWorkflow.Replenishment)
 
                 <div class="grid gap-3 md:grid-cols-2">
-                    <div class="xf-form-field">
-                        <BbLabel>Warehouse</BbLabel>
-                        <BbCombobox TValue="string"
-                                     Value="@_ruleForm.WarehouseId"
-                                     ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Replenishment, value))"
-                                     Options="@OptionalWarehouseOptions"
-                                     Placeholder="Any warehouse"
-                                     SearchPlaceholder="Search warehouses..."
-                                     EmptyMessage="No warehouses found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
-                    <div class="xf-form-field">
-                        <BbLabel>Location</BbLabel>
-                        <BbCombobox TValue="string"
-                                     @bind-Value="_ruleForm.LocationId"
-                                     Options="@RuleLocationOptions"
-                                     Placeholder="Any location"
-                                     SearchPlaceholder="Search locations..."
-                                     EmptyMessage="No locations found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
-                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.PreferredSupplier" Label="Preferred Supplier" />
+                    <XfEntityPicker TItem="Warehouse"
+                                    Label="Warehouse"
+                                    Value="@_ruleForm.WarehouseId"
+                                    ValueChanged="@(value => OnWorkflowWarehouseChanged(ProductWorkflow.Replenishment, value))"
+                                    Items="@_warehouses"
+                                    ValueSelector="@GetWarehousePickerValue"
+                                    TextSelector="@GetWarehouseLabel"
+                                    SearchTextSelector="@GetWarehouseSearchText"
+                                    Placeholder="Any warehouse"
+                                    SearchPlaceholder="Search warehouses..."
+                                    EmptyMessage="No warehouses found."
+                                    AllowClear="true"
+                                    ClearText="Any warehouse"
+                                    ShowCreate="true"
+                                    CreateLabel="Create Warehouse"
+                                    AdvancedSearchTitle="Find Warehouse"
+                                    AdvancedSearchDescription="Search all warehouses in the active tenant."
+                                    OnCreate="@(() => OpenWarehouseCreateDialog(ProductWorkflow.Replenishment))" />
+                    <XfEntityPicker TItem="InventoryLocation"
+                                    Label="Location"
+                                    Value="@_ruleForm.LocationId"
+                                    ValueChanged="@(value => _ruleForm.LocationId = value ?? "")"
+                                    Items="@RuleLocations"
+                                    ValueSelector="@GetLocationPickerValue"
+                                    TextSelector="@GetLocationLabel"
+                                    SearchTextSelector="@GetLocationSearchText"
+                                    Placeholder="Any location"
+                                    SearchPlaceholder="Search locations..."
+                                    EmptyMessage="No locations found."
+                                    AllowClear="true"
+                                    ClearText="Any location"
+                                    ShowCreate="@CanCreateRuleLocation"
+                                    Disabled="@(!CanCreateRuleLocation)"
+                                    HelpText="@RuleLocationHelpText"
+                                    CreateLabel="Create Location"
+                                    AdvancedSearchTitle="Find Location"
+                                    AdvancedSearchDescription="Search locations for the selected warehouse."
+                                    OnCreate="@(() => OpenLocationCreateDialog(ProductWorkflow.Replenishment))" />
+                    @if (_purchasingEnabled)
+                    {
+                        <XfEntityPicker TItem="Supplier"
+                                        Label="Preferred Supplier"
+                                        Value="@_ruleForm.PreferredSupplier"
+                                        ValueChanged="@(value => _ruleForm.PreferredSupplier = value ?? "")"
+                                        Items="@_suppliers"
+                                        ValueSelector="@GetSupplierPreferredValue"
+                                        TextSelector="@GetSupplierLabel"
+                                        SearchTextSelector="@GetSupplierSearchText"
+                                        Placeholder="No preferred supplier"
+                                        SearchPlaceholder="Search suppliers..."
+                                        EmptyMessage="No suppliers found."
+                                        AllowClear="true"
+                                        ClearText="No preferred supplier"
+                                        ShowCreate="true"
+                                        CreateLabel="Create Supplier"
+                                        AdvancedSearchTitle="Find Supplier"
+                                        AdvancedSearchDescription="Search suppliers in the active tenant."
+                                        OnCreate="@(() => OpenSupplierCreateDialog(ProductWorkflow.Replenishment))" />
+                    }
+                    else
+                    {
+                        <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.PreferredSupplier" Label="Preferred Supplier" />
+                    }
                 </div>
                 <div class="grid gap-3 md:grid-cols-4">
                     <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.MinimumQuantity" Label="Minimum" />
@@ -355,6 +433,105 @@ else
             <BbDialogFooter>
                 <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _ruleDialogOpen = false)">Cancel</BbButton>
                 <BbButton OnClick="@CreateRule" Disabled="@_savingRule">Create Rule</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+
+    <BbDialog Open="@_warehouseCreateDialogOpen" OpenChanged="@(value => _warehouseCreateDialogOpen = value)">
+        <BbDialogContent TrapFocus="false">
+            <BbDialogHeader>
+                <BbDialogTitle>Create Warehouse</BbDialogTitle>
+                <BbDialogDescription>Create a warehouse, then return to the product workflow with it selected.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
+                <div class="grid gap-3 md:grid-cols-2">
+                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Code" Label="Code" Required="true" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Name" Label="Name" Required="true" />
+                </div>
+                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Description" Label="Description" />
+                <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.AddressLine" Label="Address" />
+                <div class="grid gap-3 md:grid-cols-3">
+                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.City" Label="City" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.Region" Label="Region" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseForm.CountryCode" Label="Country Code" />
+                </div>
+                <BbFormFieldSwitch Checked="@_warehouseForm.IsDefault"
+                                   CheckedChanged="@((bool value) => _warehouseForm.IsDefault = value)"
+                                   Label="Default warehouse" />
+            </div>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _warehouseCreateDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@CreateWarehouseFromPicker" Disabled="@_savingWarehouse">Create Warehouse</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+
+    <BbDialog Open="@_locationCreateDialogOpen" OpenChanged="@(value => _locationCreateDialogOpen = value)">
+        <BbDialogContent TrapFocus="false">
+            <BbDialogHeader>
+                <BbDialogTitle>Create Location</BbDialogTitle>
+                <BbDialogDescription>Create a location for the selected warehouse, then return to the product workflow.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
+                <XfEntityPicker TItem="Warehouse"
+                                Label="Warehouse"
+                                Value="@_locationForm.WarehouseId"
+                                ValueChanged="@(value => _locationForm.WarehouseId = value ?? "")"
+                                Items="@_warehouses"
+                                ValueSelector="@GetWarehousePickerValue"
+                                TextSelector="@GetWarehouseLabel"
+                                SearchTextSelector="@GetWarehouseSearchText"
+                                Placeholder="Select warehouse"
+                                SearchPlaceholder="Search warehouses..."
+                                EmptyMessage="No warehouses found."
+                                ShowCreate="false"
+                                AdvancedSearchTitle="Find Warehouse"
+                                AdvancedSearchDescription="Select the warehouse that owns the new location." />
+                <div class="grid gap-3 md:grid-cols-2">
+                    <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Code" Label="Code" Required="true" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Name" Label="Name" Required="true" />
+                </div>
+                <BbFormFieldSelect TValue="string" @bind-Value="_locationForm.LocationType" Label="Location Type">
+                    @foreach (var type in Enum.GetValues<InventoryLocationType>())
+                    {
+                        <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
+                    }
+                </BbFormFieldSelect>
+                <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Description" Label="Description" />
+                <BbFormFieldSwitch Checked="@_locationForm.IsPickable"
+                                   CheckedChanged="@((bool value) => _locationForm.IsPickable = value)"
+                                   Label="Pickable location" />
+            </div>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _locationCreateDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@CreateLocationFromPicker" Disabled="@_savingLocation">Create Location</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+
+    <BbDialog Open="@_supplierCreateDialogOpen" OpenChanged="@(value => _supplierCreateDialogOpen = value)">
+        <BbDialogContent TrapFocus="false">
+            <BbDialogHeader>
+                <BbDialogTitle>Create Supplier</BbDialogTitle>
+                <BbDialogDescription>Create a supplier, then return to the product workflow with it selected.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
+                <div class="grid gap-3 md:grid-cols-2">
+                    <BbFormFieldInput TValue="string" @bind-Value="_supplierForm.Code" Label="Code" Required="true" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_supplierForm.Name" Label="Name" Required="true" />
+                </div>
+                <div class="grid gap-3 md:grid-cols-2">
+                    <BbFormFieldInput TValue="string" @bind-Value="_supplierForm.ContactName" Label="Contact Name" />
+                    <BbFormFieldInput TValue="string" @bind-Value="_supplierForm.Email" Label="Email" />
+                </div>
+                <BbFormFieldInput TValue="string" @bind-Value="_supplierForm.Phone" Label="Phone" />
+                <BbFormFieldSwitch Checked="@_supplierForm.IsActive"
+                                   CheckedChanged="@((bool value) => _supplierForm.IsActive = value)"
+                                   Label="Active supplier" />
+            </div>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _supplierCreateDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@CreateSupplierFromPicker" Disabled="@_savingSupplier">Create Supplier</BbButton>
             </BbDialogFooter>
         </BbDialogContent>
     </BbDialog>
@@ -377,8 +554,9 @@ else
     private readonly LotForm _lotForm = new();
     private readonly ReceiveForm _receiveForm = new();
     private readonly RuleForm _ruleForm = new();
-    private readonly WarehouseQuickForm _warehouseQuickForm = new();
-    private readonly LocationQuickForm _locationQuickForm = new();
+    private readonly WarehouseForm _warehouseForm = new();
+    private readonly LocationForm _locationForm = new();
+    private readonly SupplierForm _supplierForm = new();
 
     private Product? _product;
     private List<ProductCategory> _categories = [];
@@ -401,6 +579,7 @@ else
     private bool _savingReceive;
     private bool _savingWarehouse;
     private bool _savingLocation;
+    private bool _savingSupplier;
     private bool _hasTenant;
     private bool _moduleEnabled;
     private bool _planningEnabled;
@@ -418,7 +597,14 @@ else
     private bool _lotDialogOpen;
     private bool _receiveDialogOpen;
     private bool _ruleDialogOpen;
+    private bool _warehouseCreateDialogOpen;
+    private bool _locationCreateDialogOpen;
+    private bool _supplierCreateDialogOpen;
     private Guid? _loadedId;
+    private ProductWorkflow? _warehouseCreateTarget;
+    private ProductWorkflow? _locationCreateTarget;
+    private ProductWorkflow? _supplierCreateTarget;
+    private ProductWorkflow? _lotCreateTarget;
 
     private string CurrentSection => NormalizeSection(Section);
     private string UnavailableSectionName => CurrentSection switch
@@ -448,24 +634,22 @@ else
         string.IsNullOrWhiteSpace(_receiveForm.WarehouseId) ||
         string.IsNullOrWhiteSpace(_receiveForm.LocationId);
 
+    private IReadOnlyList<InventoryLocation> MovementLocations => LocationsForWarehouse(_movementForm.WarehouseId).ToList();
+    private IReadOnlyList<InventoryLocation> ReceiveLocations => LocationsForWarehouse(_receiveForm.WarehouseId).ToList();
+    private IReadOnlyList<InventoryLocation> RuleLocations => string.IsNullOrWhiteSpace(_ruleForm.WarehouseId)
+        ? _locations
+        : LocationsForWarehouse(_ruleForm.WarehouseId).ToList();
+    private IReadOnlyList<PurchaseOrder> OpenPurchaseOrders =>
+        _purchaseOrders.Where(x => x.Status is PurchaseOrderStatus.Open or PurchaseOrderStatus.PartiallyReceived).ToList();
+    private bool CanCreateMovementLocation => Guid.TryParse(_movementForm.WarehouseId, out _);
+    private bool CanCreateReceiveLocation => Guid.TryParse(_receiveForm.WarehouseId, out _);
+    private bool CanCreateRuleLocation => Guid.TryParse(_ruleForm.WarehouseId, out _);
+    private string? MovementLocationHelpText => CanCreateMovementLocation ? null : "Select or create a warehouse first.";
+    private string? ReceiveLocationHelpText => CanCreateReceiveLocation ? null : "Select or create a warehouse first.";
+    private string? RuleLocationHelpText => CanCreateRuleLocation ? null : "Select a warehouse before scoping this rule to a location.";
+
     private List<SelectOption<string>> CategoryOptions =>
         _categories.Select(category => new SelectOption<string>(category.Id.ToString(), category.Name ?? category.Id.ToString()[..8])).ToList();
-    private List<SelectOption<string>> WarehouseOptions =>
-        _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
-    private List<SelectOption<string>> OptionalWarehouseOptions =>
-        [new("", "Any warehouse"), .. WarehouseOptions];
-    private List<SelectOption<string>> MovementLocationOptions =>
-        LocationsForWarehouse(_movementForm.WarehouseId).Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
-    private List<SelectOption<string>> ReceiveLocationOptions =>
-        LocationsForWarehouse(_receiveForm.WarehouseId).Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
-    private List<SelectOption<string>> RuleLocationOptions =>
-        [new("", "Any location"), .. LocationsForWarehouse(_ruleForm.WarehouseId).Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location)))];
-    private List<SelectOption<string>> LotOptions =>
-        [new("", "No lot / untracked"), .. _lots.Select(lot => new SelectOption<string>(lot.Id.ToString(), GetLotLabel(lot)))];
-    private List<SelectOption<string>> PurchaseOrderOptions =>
-        [new("", "No purchase order"), .. _purchaseOrders.Where(x => x.Status is PurchaseOrderStatus.Open or PurchaseOrderStatus.PartiallyReceived).Select(order => new SelectOption<string>(order.Id.ToString(), $"{order.OrderNumber} ({order.Status})"))];
-    private List<SelectOption<string>> SupplierOptions =>
-        [new("", "No supplier"), .. _suppliers.Select(supplier => new SelectOption<string>(supplier.Id.ToString(), $"{supplier.Code} - {supplier.Name}"))];
 
     protected override void OnInitialized()
     {
@@ -1011,51 +1195,6 @@ else
         <div class="font-medium">@GetProductLabel(_product)</div>
     </div>;
 
-    private RenderFragment<ProductWorkflow> PrerequisiteCreateBlock => workflow => @<div class="grid gap-3">
-        @if (_warehouses.Count == 0)
-        {
-            <div class="rounded-md border p-3">
-                <div class="mb-3">
-                    <BbTypographyH4>Create Warehouse</BbTypographyH4>
-                    <BbTypographyMuted>Create the first warehouse without leaving this product workflow.</BbTypographyMuted>
-                </div>
-                <div class="grid gap-3 md:grid-cols-3">
-                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseQuickForm.Code" Label="Code" Required="true" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_warehouseQuickForm.Name" Label="Name" Required="true" />
-                    <div class="flex items-end">
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => CreateWarehouseForWorkflow(workflow))" Disabled="@_savingWarehouse">
-                            Create Warehouse
-                        </BbButton>
-                    </div>
-                </div>
-            </div>
-        }
-        else if (NeedsLocation(workflow))
-        {
-            <div class="rounded-md border p-3">
-                <div class="mb-3">
-                    <BbTypographyH4>Create Location</BbTypographyH4>
-                    <BbTypographyMuted>The selected warehouse has no locations yet.</BbTypographyMuted>
-                </div>
-                <div class="grid gap-3 md:grid-cols-[1fr_1fr_1fr_auto]">
-                    <BbFormFieldInput TValue="string" @bind-Value="_locationQuickForm.Code" Label="Code" Required="true" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_locationQuickForm.Name" Label="Name" Required="true" />
-                    <BbFormFieldSelect TValue="string" @bind-Value="_locationQuickForm.LocationType" Label="Type">
-                        @foreach (var type in Enum.GetValues<InventoryLocationType>())
-                        {
-                            <BbSelectItem Value="@type.ToString()">@type</BbSelectItem>
-                        }
-                    </BbFormFieldSelect>
-                    <div class="flex items-end">
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => CreateLocationForWorkflow(workflow))" Disabled="@_savingLocation">
-                            Create Location
-                        </BbButton>
-                    </div>
-                </div>
-            </div>
-        }
-    </div>;
-
     private bool IsSectionAvailable(string section) => section switch
     {
         "summary" => true,
@@ -1255,9 +1394,7 @@ else
         _savingMovement = true;
         try
         {
-            var lotId = await ResolveLotId(_movementForm.LotId, _movementForm.NewLotNumber);
-            if (!string.IsNullOrWhiteSpace(_movementForm.NewLotNumber) && lotId is null)
-                return;
+            var lotId = Guid.TryParse(_movementForm.LotId, out var parsedLotId) ? parsedLotId : (Guid?)null;
 
             var result = await Inventario.PostStockMovement(new PostStockMovementRequest
             {
@@ -1287,8 +1424,11 @@ else
         }
     }
 
-    private void OpenLotDialog()
+    private void OpenLotDialog() => OpenLotDialog(null);
+
+    private void OpenLotDialog(ProductWorkflow? target)
     {
+        _lotCreateTarget = target;
         _lotForm.Reset();
         _lotDialogOpen = true;
     }
@@ -1322,8 +1462,14 @@ else
             ToastService.Show(result.IsSuccess ? "Lot created." : $"Failed: {result.Message}");
             if (result.IsSuccess)
             {
+                var lotNumber = _lotForm.LotNumber.Trim();
+                var target = _lotCreateTarget;
                 _lotDialogOpen = false;
+                _lotCreateTarget = null;
                 await Reload();
+                var created = _lots.FirstOrDefault(x => string.Equals(x.LotNumber, lotNumber, StringComparison.OrdinalIgnoreCase));
+                if (created is not null && target is not null)
+                    ApplyWorkflowLot(target.Value, created.Id.ToString());
             }
         }
         finally
@@ -1378,10 +1524,7 @@ else
                         Quantity = quantity,
                         UnitCost = decimal.TryParse(_receiveForm.UnitCost, out var unitCost) ? unitCost : null,
                         UnitOfMeasure = NullIfEmpty(_receiveForm.UnitOfMeasure),
-                        LotId = Guid.TryParse(_receiveForm.LotId, out var lotId) ? lotId : null,
-                        LotNumber = NullIfEmpty(_receiveForm.LotNumber),
-                        ManufacturedAt = ParseDate(_receiveForm.ManufacturedAt),
-                        ExpiresAt = ParseDate(_receiveForm.ExpiresAt)
+                        LotId = Guid.TryParse(_receiveForm.LotId, out var lotId) ? lotId : null
                     }
                 ]
             });
@@ -1460,59 +1603,25 @@ else
         }
     }
 
-    private async Task<Guid?> ResolveLotId(string? selectedLotId, string? newLotNumber)
+    private void OpenWarehouseCreateDialog(ProductWorkflow workflow)
     {
-        if (!_traceabilityEnabled)
-            return null;
-
-        if (Guid.TryParse(selectedLotId, out var existingLotId))
-            return existingLotId;
-
-        if (_product is null || string.IsNullOrWhiteSpace(newLotNumber))
-            return null;
-
-        var result = await Inventario.CreateInventoryLot(new CreateInventoryLotRequest
-        {
-            Metadata = BuildMetadata(),
-            ProductId = _product.Id,
-            LotNumber = newLotNumber.Trim(),
-            ReceivedAt = DateTime.UtcNow,
-            Status = InventoryLotStatus.Available
-        });
-
-        if (!result.IsSuccess)
-        {
-            ToastService.Show($"Failed to create lot: {result.Message}");
-            return null;
-        }
-
-        await RefreshLots(_product.TenantId);
-        return _lots.FirstOrDefault(x => string.Equals(x.LotNumber, newLotNumber.Trim(), StringComparison.OrdinalIgnoreCase))?.Id;
+        _warehouseCreateTarget = workflow;
+        _warehouseForm.Reset();
+        _warehouseForm.IsDefault = _warehouses.Count == 0;
+        _warehouseCreateDialogOpen = true;
     }
 
-    private async Task RefreshLots(Guid tenantId)
-    {
-        if (!_traceabilityEnabled) return;
-        _lots = await DataContext.Query<InventoryLot>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && x.ProductId == Id && !x.IsDeleted)
-            .OrderBy(x => x.ExpiresAt)
-            .ThenBy(x => x.LotNumber)
-            .Take(500)
-            .ToListAsync();
-    }
-
-    private async Task CreateWarehouseForWorkflow(ProductWorkflow workflow)
+    private async Task CreateWarehouseFromPicker()
     {
         if (_product is null) return;
-        if (string.IsNullOrWhiteSpace(_warehouseQuickForm.Code) || string.IsNullOrWhiteSpace(_warehouseQuickForm.Name))
+        if (string.IsNullOrWhiteSpace(_warehouseForm.Code) || string.IsNullOrWhiteSpace(_warehouseForm.Name))
         {
             ToastService.Show("Warehouse code and name are required.");
             return;
         }
 
-        var code = _warehouseQuickForm.Code.Trim();
+        var code = _warehouseForm.Code.Trim();
+        var target = _warehouseCreateTarget;
         _savingWarehouse = true;
         try
         {
@@ -1520,18 +1629,25 @@ else
             {
                 Metadata = BuildMetadata(),
                 Code = code,
-                Name = _warehouseQuickForm.Name.Trim(),
-                IsDefault = _warehouses.Count == 0
+                Name = _warehouseForm.Name.Trim(),
+                Description = NullIfEmpty(_warehouseForm.Description),
+                AddressLine = NullIfEmpty(_warehouseForm.AddressLine),
+                City = NullIfEmpty(_warehouseForm.City),
+                Region = NullIfEmpty(_warehouseForm.Region),
+                CountryCode = NullIfEmpty(_warehouseForm.CountryCode),
+                IsDefault = _warehouseForm.IsDefault
             });
 
             ToastService.Show(result.IsSuccess ? "Warehouse created." : $"Failed: {result.Message}");
             if (!result.IsSuccess) return;
 
-            _warehouseQuickForm.Reset();
+            _warehouseCreateDialogOpen = false;
+            _warehouseCreateTarget = null;
+            _warehouseForm.Reset();
             await LoadOperationalLookups(_product.TenantId);
             var created = _warehouses.FirstOrDefault(x => string.Equals(x.Code, code, StringComparison.OrdinalIgnoreCase));
-            if (created is not null)
-                ApplyWorkflowWarehouse(workflow, created.Id.ToString());
+            if (created is not null && target is not null)
+                ApplyWorkflowWarehouse(target.Value, created.Id.ToString());
         }
         finally
         {
@@ -1539,22 +1655,38 @@ else
         }
     }
 
-    private async Task CreateLocationForWorkflow(ProductWorkflow workflow)
+    private void OpenLocationCreateDialog(ProductWorkflow workflow)
+    {
+        var warehouseId = GetWorkflowWarehouseId(workflow);
+        if (!Guid.TryParse(warehouseId, out _))
+        {
+            ToastService.Show("Select or create a warehouse before creating a location.");
+            return;
+        }
+
+        _locationCreateTarget = workflow;
+        _locationForm.Reset();
+        _locationForm.WarehouseId = warehouseId;
+        _locationCreateDialogOpen = true;
+    }
+
+    private async Task CreateLocationFromPicker()
     {
         if (_product is null) return;
-        var warehouseIdText = GetWorkflowWarehouseId(workflow);
-        if (!Guid.TryParse(warehouseIdText, out var warehouseId))
+        if (!Guid.TryParse(_locationForm.WarehouseId, out var warehouseId))
         {
             ToastService.Show("Select a warehouse before creating a location.");
             return;
         }
-        if (string.IsNullOrWhiteSpace(_locationQuickForm.Code) || string.IsNullOrWhiteSpace(_locationQuickForm.Name))
+
+        if (string.IsNullOrWhiteSpace(_locationForm.Code) || string.IsNullOrWhiteSpace(_locationForm.Name))
         {
             ToastService.Show("Location code and name are required.");
             return;
         }
 
-        var code = _locationQuickForm.Code.Trim();
+        var code = _locationForm.Code.Trim();
+        var target = _locationCreateTarget;
         _savingLocation = true;
         try
         {
@@ -1563,23 +1695,75 @@ else
                 Metadata = BuildMetadata(),
                 WarehouseId = warehouseId,
                 Code = code,
-                Name = _locationQuickForm.Name.Trim(),
-                LocationType = Enum.TryParse<InventoryLocationType>(_locationQuickForm.LocationType, out var type) ? type : InventoryLocationType.Bin,
-                IsPickable = true
+                Name = _locationForm.Name.Trim(),
+                Description = NullIfEmpty(_locationForm.Description),
+                LocationType = Enum.TryParse<InventoryLocationType>(_locationForm.LocationType, out var type) ? type : InventoryLocationType.Bin,
+                IsPickable = _locationForm.IsPickable
             });
 
             ToastService.Show(result.IsSuccess ? "Location created." : $"Failed: {result.Message}");
             if (!result.IsSuccess) return;
 
-            _locationQuickForm.Reset();
+            _locationCreateDialogOpen = false;
+            _locationCreateTarget = null;
+            _locationForm.Reset();
             await LoadOperationalLookups(_product.TenantId);
             var created = _locations.FirstOrDefault(x => x.WarehouseId == warehouseId && string.Equals(x.Code, code, StringComparison.OrdinalIgnoreCase));
-            if (created is not null)
-                ApplyWorkflowLocation(workflow, created.Id.ToString());
+            if (created is not null && target is not null)
+                ApplyWorkflowLocation(target.Value, created.Id.ToString());
         }
         finally
         {
             _savingLocation = false;
+        }
+    }
+
+    private void OpenSupplierCreateDialog(ProductWorkflow workflow)
+    {
+        _supplierCreateTarget = workflow;
+        _supplierForm.Reset();
+        _supplierCreateDialogOpen = true;
+    }
+
+    private async Task CreateSupplierFromPicker()
+    {
+        if (_product is null) return;
+        if (string.IsNullOrWhiteSpace(_supplierForm.Code) || string.IsNullOrWhiteSpace(_supplierForm.Name))
+        {
+            ToastService.Show("Supplier code and name are required.");
+            return;
+        }
+
+        var code = _supplierForm.Code.Trim();
+        var target = _supplierCreateTarget;
+        _savingSupplier = true;
+        try
+        {
+            var result = await Inventario.CreateSupplier(new CreateSupplierRequest
+            {
+                Metadata = BuildMetadata(),
+                Code = code,
+                Name = _supplierForm.Name.Trim(),
+                ContactName = NullIfEmpty(_supplierForm.ContactName),
+                Email = NullIfEmpty(_supplierForm.Email),
+                Phone = NullIfEmpty(_supplierForm.Phone),
+                IsActive = _supplierForm.IsActive
+            });
+
+            ToastService.Show(result.IsSuccess ? "Supplier created." : $"Failed: {result.Message}");
+            if (!result.IsSuccess) return;
+
+            _supplierCreateDialogOpen = false;
+            _supplierCreateTarget = null;
+            _supplierForm.Reset();
+            await LoadOperationalLookups(_product.TenantId);
+            var created = _suppliers.FirstOrDefault(x => string.Equals(x.Code, code, StringComparison.OrdinalIgnoreCase));
+            if (created is not null && target is not null)
+                ApplyWorkflowSupplier(target.Value, created);
+        }
+        finally
+        {
+            _savingSupplier = false;
         }
     }
 
@@ -1621,6 +1805,32 @@ else
         }
     }
 
+    private void ApplyWorkflowLot(ProductWorkflow workflow, string lotId)
+    {
+        switch (workflow)
+        {
+            case ProductWorkflow.Movement:
+                _movementForm.LotId = lotId;
+                break;
+            case ProductWorkflow.Receiving:
+                _receiveForm.LotId = lotId;
+                break;
+        }
+    }
+
+    private void ApplyWorkflowSupplier(ProductWorkflow workflow, Supplier supplier)
+    {
+        switch (workflow)
+        {
+            case ProductWorkflow.Receiving:
+                _receiveForm.SupplierId = supplier.Id.ToString();
+                break;
+            case ProductWorkflow.Replenishment:
+                _ruleForm.PreferredSupplier = GetSupplierPreferredValue(supplier);
+                break;
+        }
+    }
+
     private string GetWorkflowWarehouseId(ProductWorkflow workflow) => workflow switch
     {
         ProductWorkflow.Movement => _movementForm.WarehouseId,
@@ -1628,13 +1838,6 @@ else
         ProductWorkflow.Replenishment => _ruleForm.WarehouseId,
         _ => ""
     };
-
-    private bool NeedsLocation(ProductWorkflow workflow)
-    {
-        var warehouseId = GetWorkflowWarehouseId(workflow);
-        return Guid.TryParse(warehouseId, out var parsedWarehouseId)
-            && !_locations.Any(x => x.WarehouseId == parsedWarehouseId);
-    }
 
     private void ApplyWorkflowDefaults()
     {
@@ -1683,6 +1886,24 @@ else
     private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
     private static string GetLotLabel(InventoryLot lot) =>
         string.IsNullOrWhiteSpace(lot.LotNumber) ? lot.Id.ToString()[..8] : lot.LotNumber;
+    private static string GetSupplierLabel(Supplier supplier) => $"{supplier.Code} - {supplier.Name}";
+    private static string GetPurchaseOrderLabel(PurchaseOrder order) => $"{order.OrderNumber} ({order.Status})";
+    private static string GetWarehousePickerValue(Warehouse warehouse) => warehouse.Id.ToString();
+    private static string GetLocationPickerValue(InventoryLocation location) => location.Id.ToString();
+    private static string GetLotPickerValue(InventoryLot lot) => lot.Id.ToString();
+    private static string GetSupplierPickerValue(Supplier supplier) => supplier.Id.ToString();
+    private static string GetSupplierPreferredValue(Supplier supplier) => GetSupplierLabel(supplier);
+    private static string GetPurchaseOrderPickerValue(PurchaseOrder order) => order.Id.ToString();
+    private static string GetWarehouseSearchText(Warehouse warehouse) =>
+        $"{warehouse.Code} {warehouse.Name} {warehouse.City} {warehouse.Region} {warehouse.CountryCode}";
+    private static string GetLocationSearchText(InventoryLocation location) =>
+        $"{location.Code} {location.Name} {location.LocationType} {location.Description}";
+    private static string GetLotSearchText(InventoryLot lot) =>
+        $"{lot.LotNumber} {lot.SupplierReference} {lot.SourceReferenceType} {lot.Status}";
+    private static string GetSupplierSearchText(Supplier supplier) =>
+        $"{supplier.Code} {supplier.Name} {supplier.ContactName} {supplier.Email} {supplier.Phone}";
+    private static string GetPurchaseOrderSearchText(PurchaseOrder order) =>
+        $"{order.OrderNumber} {order.Status} {order.OrderDate:g} {order.ExpectedDate:g} {order.Notes}";
 
     private RequestMetadata BuildMetadata() => new()
     {
@@ -1741,7 +1962,6 @@ else
         public string WarehouseId { get; set; } = "";
         public string LocationId { get; set; } = "";
         public string LotId { get; set; } = "";
-        public string NewLotNumber { get; set; } = "";
         public string MovementType { get; set; } = InventoryMovementType.Adjustment.ToString();
         public string Quantity { get; set; } = "0";
         public string UnitOfMeasure { get; set; } = "each";
@@ -1755,7 +1975,6 @@ else
             WarehouseId = "";
             LocationId = "";
             LotId = "";
-            NewLotNumber = "";
             MovementType = InventoryMovementType.Adjustment.ToString();
             Quantity = "0";
             UnitOfMeasure = "each";
@@ -1803,9 +2022,6 @@ else
         public string UnitCost { get; set; } = "";
         public string UnitOfMeasure { get; set; } = "each";
         public string LotId { get; set; } = "";
-        public string LotNumber { get; set; } = "";
-        public string ManufacturedAt { get; set; } = "";
-        public string ExpiresAt { get; set; } = "";
 
         public void Reset()
         {
@@ -1821,9 +2037,6 @@ else
             UnitCost = "";
             UnitOfMeasure = "each";
             LotId = "";
-            LotNumber = "";
-            ManufacturedAt = "";
-            ExpiresAt = "";
         }
     }
 
@@ -1851,29 +2064,67 @@ else
         }
     }
 
-    private sealed class WarehouseQuickForm
+    private sealed class WarehouseForm
     {
         public string Code { get; set; } = "";
         public string Name { get; set; } = "";
+        public string Description { get; set; } = "";
+        public string AddressLine { get; set; } = "";
+        public string City { get; set; } = "";
+        public string Region { get; set; } = "";
+        public string CountryCode { get; set; } = "";
+        public bool IsDefault { get; set; }
 
         public void Reset()
         {
             Code = "";
             Name = "";
+            Description = "";
+            AddressLine = "";
+            City = "";
+            Region = "";
+            CountryCode = "";
+            IsDefault = false;
         }
     }
 
-    private sealed class LocationQuickForm
+    private sealed class LocationForm
+    {
+        public string WarehouseId { get; set; } = "";
+        public string Code { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string Description { get; set; } = "";
+        public string LocationType { get; set; } = InventoryLocationType.Bin.ToString();
+        public bool IsPickable { get; set; } = true;
+
+        public void Reset()
+        {
+            WarehouseId = "";
+            Code = "";
+            Name = "";
+            Description = "";
+            LocationType = InventoryLocationType.Bin.ToString();
+            IsPickable = true;
+        }
+    }
+
+    private sealed class SupplierForm
     {
         public string Code { get; set; } = "";
         public string Name { get; set; } = "";
-        public string LocationType { get; set; } = InventoryLocationType.Bin.ToString();
+        public string ContactName { get; set; } = "";
+        public string Email { get; set; } = "";
+        public string Phone { get; set; } = "";
+        public bool IsActive { get; set; } = true;
 
         public void Reset()
         {
             Code = "";
             Name = "";
-            LocationType = InventoryLocationType.Bin.ToString();
+            ContactName = "";
+            Email = "";
+            Phone = "";
+            IsActive = true;
         }
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPicker.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPicker.razor
@@ -1,0 +1,263 @@
+@typeparam TItem
+
+<div class="xf-form-field xf-entity-picker">
+    @if (!string.IsNullOrWhiteSpace(Label))
+    {
+        <BbLabel>@Label</BbLabel>
+    }
+
+    <BbPopover Open="@_open" OpenChanged="@OnOpenChanged" RestoreFocusOnClose="true">
+        <BbPopoverTrigger AsChild="false">
+            <button type="button"
+                    class="xf-entity-picker-trigger"
+                    disabled="@Disabled"
+                    aria-label="@AriaLabel">
+                <span class="xf-entity-picker-trigger-text">@SelectedText</span>
+                <LucideIcon Name="chevrons-up-down" class="xf-entity-picker-trigger-icon" />
+            </button>
+        </BbPopoverTrigger>
+        <BbPopoverContent Class="xf-entity-picker-popover"
+                          MatchTriggerWidth="true"
+                          CloseOnClickOutside="true"
+                          CloseOnEscape="true"
+                          ZIndex="90">
+            <BbCommand SearchQuery="@_searchQuery"
+                       SearchQueryChanged="@OnSearchQueryChanged"
+                       CloseOnSelect="false"
+                       Class="xf-entity-picker-command">
+                <BbCommandInput Placeholder="@SearchPlaceholder" />
+                <BbCommandList Class="xf-entity-picker-list">
+                    @if (AllowClear)
+                    {
+                        <BbCommandItem Value="@($"{_instanceId}-clear")"
+                                       SearchText="@ClearText"
+                                       OnSelect="@ClearSelection">
+                            <div class="xf-entity-picker-action-row">
+                                <LucideIcon Name="x" class="xf-entity-picker-row-icon" />
+                                <span>@ClearText</span>
+                            </div>
+                        </BbCommandItem>
+                    }
+
+                    @if (!FilteredItems.Any())
+                    {
+                        <BbCommandEmpty>@EmptyMessage</BbCommandEmpty>
+                    }
+                    else
+                    {
+                        @foreach (var item in FilteredItems)
+                        {
+                            <BbCommandItem Value="@GetValue(item)"
+                                           SearchText="@GetSearchText(item)"
+                                           OnSelect="@(() => SelectItem(item))">
+                                @RenderItem(item)
+                            </BbCommandItem>
+                        }
+                    }
+
+                    @if (ShowAdvancedSearch || ShowCreate)
+                    {
+                        <BbCommandSeparator />
+                    }
+
+                    @if (ShowAdvancedSearch)
+                    {
+                        <BbCommandItem Value="@($"{_instanceId}-advanced")"
+                                       SearchText="@AdvancedSearchLabel"
+                                       OnSelect="@OpenAdvancedSearch">
+                            <div class="xf-entity-picker-action-row">
+                                <LucideIcon Name="search" class="xf-entity-picker-row-icon" />
+                                <span>@AdvancedSearchLabel</span>
+                            </div>
+                        </BbCommandItem>
+                    }
+
+                    @if (ShowCreate)
+                    {
+                        <BbCommandItem Value="@($"{_instanceId}-create")"
+                                       SearchText="@CreateLabel"
+                                       OnSelect="@OpenCreate">
+                            <div class="xf-entity-picker-action-row">
+                                <LucideIcon Name="plus" class="xf-entity-picker-row-icon" />
+                                <span>@CreateLabel</span>
+                            </div>
+                        </BbCommandItem>
+                    }
+                </BbCommandList>
+            </BbCommand>
+        </BbPopoverContent>
+    </BbPopover>
+
+    @if (!string.IsNullOrWhiteSpace(HelpText))
+    {
+        <BbTypographyMuted>@HelpText</BbTypographyMuted>
+    }
+</div>
+
+<BbDialog Open="@_advancedOpen" OpenChanged="@(value => _advancedOpen = value)">
+    <BbDialogContent TrapFocus="false" class="max-w-3xl">
+        <BbDialogHeader>
+            <BbDialogTitle>@AdvancedSearchTitle</BbDialogTitle>
+            <BbDialogDescription>@AdvancedSearchDescription</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <BbFormFieldInput TValue="string"
+                              @bind-Value="_advancedSearchQuery"
+                              Label="Search"
+                              Placeholder="@SearchPlaceholder" />
+
+            <div class="xf-entity-picker-advanced-list">
+                @if (!AdvancedFilteredItems.Any())
+                {
+                    <div class="xf-entity-picker-empty">@EmptyMessage</div>
+                }
+                else
+                {
+                    @foreach (var item in AdvancedFilteredItems)
+                    {
+                        <button type="button"
+                                class="xf-entity-picker-advanced-row"
+                                @onclick="@(() => SelectItemFromAdvanced(item))">
+                            @RenderItem(item)
+                        </button>
+                    }
+                }
+            </div>
+        </div>
+        <BbDialogFooter>
+            @if (ShowCreate)
+            {
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@OpenCreateFromAdvanced">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    @CreateLabel
+                </BbButton>
+            }
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _advancedOpen = false)">Close</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+@code {
+    private readonly string _instanceId = $"entity-picker-{Guid.NewGuid():N}";
+    private bool _open;
+    private bool _advancedOpen;
+    private string _searchQuery = "";
+    private string _advancedSearchQuery = "";
+
+    [Parameter] public string? Label { get; set; }
+    [Parameter] public string? Value { get; set; }
+    [Parameter] public EventCallback<string?> ValueChanged { get; set; }
+    [Parameter] public IReadOnlyList<TItem> Items { get; set; } = [];
+    [Parameter, EditorRequired] public Func<TItem, string> ValueSelector { get; set; } = default!;
+    [Parameter, EditorRequired] public Func<TItem, string> TextSelector { get; set; } = default!;
+    [Parameter] public Func<TItem, string>? SearchTextSelector { get; set; }
+    [Parameter] public RenderFragment<TItem>? ItemTemplate { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool AllowClear { get; set; }
+    [Parameter] public bool ShowAdvancedSearch { get; set; } = true;
+    [Parameter] public bool ShowCreate { get; set; }
+    [Parameter] public EventCallback OnCreate { get; set; }
+    [Parameter] public string Placeholder { get; set; } = "Select item";
+    [Parameter] public string SearchPlaceholder { get; set; } = "Search...";
+    [Parameter] public string EmptyMessage { get; set; } = "No results found.";
+    [Parameter] public string ClearText { get; set; } = "Clear selection";
+    [Parameter] public string AdvancedSearchLabel { get; set; } = "Advanced Search";
+    [Parameter] public string CreateLabel { get; set; } = "Create New";
+    [Parameter] public string? AdvancedSearchTitle { get; set; }
+    [Parameter] public string? AdvancedSearchDescription { get; set; }
+    [Parameter] public string? HelpText { get; set; }
+
+    private string AriaLabel => string.IsNullOrWhiteSpace(Label) ? Placeholder : Label;
+
+    private string SelectedText =>
+        Items.FirstOrDefault(item => string.Equals(GetValue(item), Value, StringComparison.OrdinalIgnoreCase)) is { } selected
+            ? TextSelector(selected)
+            : Placeholder;
+
+    private IReadOnlyList<TItem> FilteredItems => FilterItems(_searchQuery).ToList();
+    private IReadOnlyList<TItem> AdvancedFilteredItems => FilterItems(_advancedSearchQuery).ToList();
+
+    private IEnumerable<TItem> FilterItems(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return Items;
+
+        return Items.Where(item => GetSearchText(item).Contains(query, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private RenderFragment RenderItem(TItem item) => builder =>
+    {
+        if (ItemTemplate is not null)
+        {
+            builder.AddContent(0, ItemTemplate(item));
+            return;
+        }
+
+        builder.OpenElement(1, "div");
+        builder.AddAttribute(2, "class", "xf-entity-picker-default-row");
+        builder.AddContent(3, TextSelector(item));
+        builder.CloseElement();
+    };
+
+    private string GetValue(TItem item) => ValueSelector(item);
+    private string GetSearchText(TItem item) => SearchTextSelector?.Invoke(item) ?? TextSelector(item);
+
+    private Task OnSearchQueryChanged(string value)
+    {
+        _searchQuery = value;
+        return Task.CompletedTask;
+    }
+
+    private Task OnOpenChanged(bool value)
+    {
+        _open = value;
+        if (!value)
+            _searchQuery = "";
+
+        return Task.CompletedTask;
+    }
+
+    private async Task SelectItem(TItem item)
+    {
+        _open = false;
+        _searchQuery = "";
+        await ValueChanged.InvokeAsync(GetValue(item));
+    }
+
+    private async Task SelectItemFromAdvanced(TItem item)
+    {
+        _advancedOpen = false;
+        _advancedSearchQuery = "";
+        await ValueChanged.InvokeAsync(GetValue(item));
+    }
+
+    private async Task ClearSelection()
+    {
+        _open = false;
+        _searchQuery = "";
+        await ValueChanged.InvokeAsync("");
+    }
+
+    private Task OpenAdvancedSearch()
+    {
+        _open = false;
+        _advancedOpen = true;
+        _advancedSearchQuery = _searchQuery;
+        _searchQuery = "";
+        return Task.CompletedTask;
+    }
+
+    private async Task OpenCreate()
+    {
+        _open = false;
+        _searchQuery = "";
+        await OnCreate.InvokeAsync();
+    }
+
+    private async Task OpenCreateFromAdvanced()
+    {
+        _advancedOpen = false;
+        _advancedSearchQuery = "";
+        await OnCreate.InvokeAsync();
+    }
+}

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -135,6 +135,147 @@
     white-space: nowrap;
 }
 
+.xf-entity-picker {
+    min-width: 0;
+}
+
+.xf-entity-picker-trigger {
+    display: flex;
+    width: 100%;
+    min-height: 2.5rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border: 1px solid var(--input);
+    border-radius: calc(var(--radius) - 2px);
+    background: var(--background);
+    color: var(--foreground);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    transition: border-color 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
+}
+
+.xf-entity-picker-trigger:hover {
+    background: color-mix(in oklab, var(--muted) 45%, transparent);
+}
+
+.xf-entity-picker-trigger:focus-visible {
+    outline: none;
+    border-color: var(--ring);
+    box-shadow: 0 0 0 1px var(--ring);
+}
+
+.xf-entity-picker-trigger:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.xf-entity-picker-trigger-text {
+    min-width: 0;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.xf-entity-picker-trigger-icon {
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+    color: var(--muted-foreground);
+}
+
+.xf-entity-picker-popover {
+    z-index: 90;
+    min-width: 18rem;
+    max-width: min(42rem, calc(100vw - 2rem));
+    padding: 0;
+}
+
+.xf-entity-picker-command {
+    width: 100%;
+}
+
+.xf-entity-picker-list {
+    max-height: 20rem;
+    overflow-y: auto;
+}
+
+.xf-entity-picker-row,
+.xf-entity-picker-default-row,
+.xf-entity-picker-action-row {
+    display: flex;
+    min-width: 0;
+    width: 100%;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.xf-entity-picker-row-main {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.xf-entity-picker-row-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+}
+
+.xf-entity-picker-row-subtitle {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--muted-foreground);
+    font-size: 0.75rem;
+    line-height: 1rem;
+}
+
+.xf-entity-picker-row-icon {
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+    color: var(--muted-foreground);
+}
+
+.xf-entity-picker-advanced-list {
+    display: grid;
+    gap: 0.5rem;
+    max-height: 28rem;
+    overflow-y: auto;
+}
+
+.xf-entity-picker-advanced-row {
+    display: block;
+    width: 100%;
+    border: 1px solid var(--border);
+    border-radius: calc(var(--radius) - 2px);
+    background: var(--background);
+    padding: 0.75rem;
+    text-align: left;
+    transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.xf-entity-picker-advanced-row:hover {
+    background: color-mix(in oklab, var(--muted) 45%, transparent);
+}
+
+.xf-entity-picker-advanced-row:focus-visible {
+    outline: none;
+    border-color: var(--ring);
+    box-shadow: 0 0 0 1px var(--ring);
+}
+
+.xf-entity-picker-empty {
+    border: 1px dashed var(--border);
+    border-radius: calc(var(--radius) - 2px);
+    color: var(--muted-foreground);
+    padding: 1rem;
+    text-align: center;
+}
+
 .xf-form-field {
     display: flex;
     flex-direction: column;

--- a/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
@@ -166,6 +166,7 @@ public sealed class CatalogTests : InventarioTestBase
             Id = Guid.NewGuid(),
             TenantId = InventarioIntegrationTestFixture.TestTenantId,
             ProductId = product.Id,
+            VariationType = "Size",
             Name = $"Variation {Guid.NewGuid():N}",
             AdditionalPrice = 2.5m,
             IsEnabled = true,
@@ -181,6 +182,7 @@ public sealed class CatalogTests : InventarioTestBase
             .FirstOrDefaultAsync(x => x.Id == variation.Id);
         persisted.Should().NotBeNull();
         persisted!.ProductId.Should().Be(product.Id);
+        persisted.VariationType.Should().Be("Size");
     }
 
     [Test]
@@ -194,6 +196,7 @@ public sealed class CatalogTests : InventarioTestBase
             Id = Guid.NewGuid(),
             TenantId = InventarioIntegrationTestFixture.TestTenantId,
             ProductId = product.Id,
+            VariationType = "Size",
             Name = $"Variation {Guid.NewGuid():N}",
             AdditionalPrice = 2m,
             IsEnabled = true,
@@ -205,6 +208,7 @@ public sealed class CatalogTests : InventarioTestBase
         var ctx = InventarioIntegrationTestFixture.DataContext;
 
         variation.Name = $"Updated Variation {Guid.NewGuid():N}";
+        variation.VariationType = "Color";
         variation.AdditionalPrice = 4m;
         ctx.Update(variation);
         var save = await ctx.SaveChangesAsync();
@@ -216,6 +220,7 @@ public sealed class CatalogTests : InventarioTestBase
             .AsNoTracking()
             .FirstAsync(x => x.Id == variation.Id);
         persisted.Name.Should().Be(variation.Name);
+        persisted.VariationType.Should().Be("Color");
         persisted.AdditionalPrice.Should().Be(4m);
     }
 

--- a/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -53,6 +53,32 @@ public sealed class ControlPanelContractTests
         offenders.Should().BeEmpty("business workflow entities must go through IInventarioServiceWrapper endpoints");
     }
 
+    [Test]
+    public void ProductDetail_DependencyCreation_UsesEntityPickerOwnedDialogs()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var productDetailPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario",
+            "ProductDetail.razor");
+
+        var text = File.ReadAllText(productDetailPath);
+
+        text.Should().Contain("<XfEntityPicker", "product workflows should select dependency entities through the shared picker");
+        text.Should().NotContain("PrerequisiteCreateBlock", "dependency creation belongs to picker-owned dialogs, not embedded parent form sections");
+        text.Should().NotContain("CreateWarehouseForWorkflow", "warehouse creation must be launched from the picker action, not inline in the stock form");
+        text.Should().NotContain("CreateLocationForWorkflow", "location creation must be launched from the picker action, not inline in the stock form");
+        text.Should().NotContain("WarehouseQuickForm", "quick prerequisite forms should not be embedded in product workflow dialogs");
+        text.Should().NotContain("LocationQuickForm", "quick prerequisite forms should not be embedded in product workflow dialogs");
+        text.Should().NotContain("Create the first warehouse without leaving this product workflow.");
+        text.Should().NotContain("The selected warehouse has no locations yet.");
+    }
+
     private static IEnumerable<string> FindDirectMutations(
         DirectoryInfo repositoryRoot,
         string path,


### PR DESCRIPTION
## Summary
- Refactors Inventario product detail into a sectioned product hub with product-specific sidebar routes for summary, stock, lots/batches, replenishment, variations, and transactions.
- Adds product-preselected stock movement, receiving, lot creation, and reorder-rule dialogs using Inventario service wrappers; leaves direct IDataContext writes to allowlisted product/variation CRUD.
- Adds nullable ProductVariation.VariationType with EF migration, updates variation UI/tests, and documents the product-centric ControlPanel convention.

## Verification
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false
- dotnet build XFramework.slnx -m:1 /nr:false
- dotnet test src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj --filter "FullyQualifiedName~CatalogTests|FullyQualifiedName~ControlPanelContractTests" -m:1 /nr:false using xeon-dev Testcontainers loopback SSH+socat tunnel
