### PR TITLE
Enhance ControlPanel entity picker advanced search

### DIFF
--- a/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
+++ b/docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md
@@ -54,6 +54,7 @@ Inventario product detail is the operational hub for product-specific inventory 
 - Use product-preselected dialogs for product-specific stock movements, receiving, lot creation, and reorder rules.
 - Use shared entity pickers for dependency entities such as warehouse, location, lot, supplier, and purchase order.
 - Dependency creation belongs to picker-owned `Create New` dialogs and picker-owned `Advanced Search` dialogs. Do not embed warehouse/location/supplier create forms directly inside product stock, receiving, or replenishment forms.
+- Picker `Advanced Search` dialogs must expose domain-specific columns, filters, and sorting. A plain single text search in a modal is not enough; the dialog should state what it searches and provide useful finder columns such as code, name, status, warehouse/location scope, expiry, supplier, active/default flags, and created dates where applicable.
 - Do not put existing-record edit workflows into list-page modals. List pages should navigate to detail pages; detail pages are the edit/operation surface.
 - Keep wrapper calls authoritative for stock, receiving, lots, reservations, planning, purchasing, reporting, and other advanced workflows.
 - Keep direct `IDataContext` mutations limited to the explicit Inventario catalog allowlist unless the contract is deliberately expanded and covered by tests.

--- a/docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md
+++ b/docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md
@@ -116,7 +116,9 @@ ControlPanel forms should use framework controls that match the data type:
 
 For `BbCombobox`, prefer typed `SelectOption<TValue>` options when the selection is simple. Use compositional `BbComboboxItem` only when the option rows need rich custom markup.
 
-For parent dependency entities, use the shared `XfEntityPicker<TItem>` pattern instead of embedding prerequisite forms in the parent workflow. The picker trigger should provide search/select, an `Advanced Search` dialog, and a `Create New` dialog. For example, a product stock dialog should pick a warehouse/location/lot through entity pickers; warehouse and location creation belongs to the picker-owned create dialogs, not directly inside the stock form.
+For parent dependency entities, use the shared `XfEntityPicker<TItem>` pattern instead of embedding prerequisite forms in the parent workflow. The picker trigger should provide quick search/select, an `Advanced Search` dialog, and a `Create New` dialog. For example, a product stock dialog should pick a warehouse/location/lot through entity pickers; warehouse and location creation belongs to the picker-owned create dialogs, not directly inside the stock form.
+
+`Advanced Search` must be meaningfully advanced. Do not implement it as a larger copy of the quick dropdown. Configure entity-specific `AdvancedColumns`, `AdvancedFilters`, and `AdvancedSearchScope` so the dialog shows a sortable multi-column finder with explicit filter controls. The operator should be able to tell what is being searched and filtered, for example warehouse code/name/location/default status, lot number/status/expiry/on-hand quantity, or supplier code/name/contact/active status.
 
 ## Operational Page Layout
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -120,6 +120,9 @@ else
                                     ValueSelector="@GetWarehousePickerValue"
                                     TextSelector="@GetWarehouseLabel"
                                     SearchTextSelector="@GetWarehouseSearchText"
+                                    AdvancedColumns="@WarehouseAdvancedColumns"
+                                    AdvancedFilters="@WarehouseAdvancedFilters"
+                                    AdvancedSearchScope="Searches warehouse code, name, city, region, country, default flag, and created date."
                                     Placeholder="Select warehouse"
                                     SearchPlaceholder="Search warehouses..."
                                     EmptyMessage="No warehouses found."
@@ -136,6 +139,9 @@ else
                                     ValueSelector="@GetLocationPickerValue"
                                     TextSelector="@GetLocationLabel"
                                     SearchTextSelector="@GetLocationSearchText"
+                                    AdvancedColumns="@LocationAdvancedColumns"
+                                    AdvancedFilters="@LocationAdvancedFilters"
+                                    AdvancedSearchScope="Searches location code, name, warehouse, type, pickable flag, and description."
                                     Placeholder="Select location"
                                     SearchPlaceholder="Search locations..."
                                     EmptyMessage="No locations found."
@@ -156,6 +162,9 @@ else
                                         ValueSelector="@GetLotPickerValue"
                                         TextSelector="@GetLotLabel"
                                         SearchTextSelector="@GetLotSearchText"
+                                        AdvancedColumns="@LotAdvancedColumns"
+                                        AdvancedFilters="@LotAdvancedFilters"
+                                        AdvancedSearchScope="Searches lot number, status, expiry, received date, supplier/source reference, and on-hand quantity."
                                         Placeholder="No lot / untracked"
                                         SearchPlaceholder="Search lots..."
                                         EmptyMessage="No lots found."
@@ -245,6 +254,9 @@ else
                                     ValueSelector="@GetPurchaseOrderPickerValue"
                                     TextSelector="@GetPurchaseOrderLabel"
                                     SearchTextSelector="@GetPurchaseOrderSearchText"
+                                    AdvancedColumns="@PurchaseOrderAdvancedColumns"
+                                    AdvancedFilters="@PurchaseOrderAdvancedFilters"
+                                    AdvancedSearchScope="Searches purchase order number, status, supplier, order date, expected date, and notes."
                                     Placeholder="No purchase order"
                                     SearchPlaceholder="Search purchase orders..."
                                     EmptyMessage="No purchase orders found."
@@ -261,6 +273,9 @@ else
                                     ValueSelector="@GetSupplierPickerValue"
                                     TextSelector="@GetSupplierLabel"
                                     SearchTextSelector="@GetSupplierSearchText"
+                                    AdvancedColumns="@SupplierAdvancedColumns"
+                                    AdvancedFilters="@SupplierAdvancedFilters"
+                                    AdvancedSearchScope="Searches supplier code, name, contact, email, phone, active flag, and created date."
                                     Placeholder="No supplier"
                                     SearchPlaceholder="Search suppliers..."
                                     EmptyMessage="No suppliers found."
@@ -282,6 +297,9 @@ else
                                     ValueSelector="@GetWarehousePickerValue"
                                     TextSelector="@GetWarehouseLabel"
                                     SearchTextSelector="@GetWarehouseSearchText"
+                                    AdvancedColumns="@WarehouseAdvancedColumns"
+                                    AdvancedFilters="@WarehouseAdvancedFilters"
+                                    AdvancedSearchScope="Searches warehouse code, name, city, region, country, default flag, and created date."
                                     Placeholder="Select warehouse"
                                     SearchPlaceholder="Search warehouses..."
                                     EmptyMessage="No warehouses found."
@@ -298,6 +316,9 @@ else
                                     ValueSelector="@GetLocationPickerValue"
                                     TextSelector="@GetLocationLabel"
                                     SearchTextSelector="@GetLocationSearchText"
+                                    AdvancedColumns="@LocationAdvancedColumns"
+                                    AdvancedFilters="@LocationAdvancedFilters"
+                                    AdvancedSearchScope="Searches location code, name, warehouse, type, pickable flag, and description."
                                     Placeholder="Select location"
                                     SearchPlaceholder="Search locations..."
                                     EmptyMessage="No locations found."
@@ -327,6 +348,9 @@ else
                                     ValueSelector="@GetLotPickerValue"
                                     TextSelector="@GetLotLabel"
                                     SearchTextSelector="@GetLotSearchText"
+                                    AdvancedColumns="@LotAdvancedColumns"
+                                    AdvancedFilters="@LotAdvancedFilters"
+                                    AdvancedSearchScope="Searches lot number, status, expiry, received date, supplier/source reference, and on-hand quantity."
                                     Placeholder="No lot / untracked"
                                     SearchPlaceholder="Search lots..."
                                     EmptyMessage="No lots found."
@@ -364,6 +388,9 @@ else
                                     ValueSelector="@GetWarehousePickerValue"
                                     TextSelector="@GetWarehouseLabel"
                                     SearchTextSelector="@GetWarehouseSearchText"
+                                    AdvancedColumns="@WarehouseAdvancedColumns"
+                                    AdvancedFilters="@WarehouseAdvancedFilters"
+                                    AdvancedSearchScope="Searches warehouse code, name, city, region, country, default flag, and created date."
                                     Placeholder="Any warehouse"
                                     SearchPlaceholder="Search warehouses..."
                                     EmptyMessage="No warehouses found."
@@ -382,6 +409,9 @@ else
                                     ValueSelector="@GetLocationPickerValue"
                                     TextSelector="@GetLocationLabel"
                                     SearchTextSelector="@GetLocationSearchText"
+                                    AdvancedColumns="@LocationAdvancedColumns"
+                                    AdvancedFilters="@LocationAdvancedFilters"
+                                    AdvancedSearchScope="Searches location code, name, warehouse, type, pickable flag, and description."
                                     Placeholder="Any location"
                                     SearchPlaceholder="Search locations..."
                                     EmptyMessage="No locations found."
@@ -404,6 +434,9 @@ else
                                         ValueSelector="@GetSupplierPreferredValue"
                                         TextSelector="@GetSupplierLabel"
                                         SearchTextSelector="@GetSupplierSearchText"
+                                        AdvancedColumns="@SupplierAdvancedColumns"
+                                        AdvancedFilters="@SupplierAdvancedFilters"
+                                        AdvancedSearchScope="Searches supplier code, name, contact, email, phone, active flag, and created date."
                                         Placeholder="No preferred supplier"
                                         SearchPlaceholder="Search suppliers..."
                                         EmptyMessage="No suppliers found."
@@ -481,6 +514,9 @@ else
                                 ValueSelector="@GetWarehousePickerValue"
                                 TextSelector="@GetWarehouseLabel"
                                 SearchTextSelector="@GetWarehouseSearchText"
+                                AdvancedColumns="@WarehouseAdvancedColumns"
+                                AdvancedFilters="@WarehouseAdvancedFilters"
+                                AdvancedSearchScope="Searches warehouse code, name, city, region, country, default flag, and created date."
                                 Placeholder="Select warehouse"
                                 SearchPlaceholder="Search warehouses..."
                                 EmptyMessage="No warehouses found."
@@ -1904,6 +1940,157 @@ else
         $"{supplier.Code} {supplier.Name} {supplier.ContactName} {supplier.Email} {supplier.Phone}";
     private static string GetPurchaseOrderSearchText(PurchaseOrder order) =>
         $"{order.OrderNumber} {order.Status} {order.OrderDate:g} {order.ExpectedDate:g} {order.Notes}";
+
+    private IReadOnlyList<XfEntityPickerColumn<Warehouse>> WarehouseAdvancedColumns =>
+    [
+        new("Code", x => x.Code),
+        new("Name", x => x.Name),
+        new("City", x => x.City),
+        new("Region", x => x.Region),
+        new("Country", x => x.CountryCode),
+        new("Default", x => FormatBoolean(x.IsDefault)),
+        new("Locations", x => _locations.Count(location => location.WarehouseId == x.Id).ToString()),
+        new("Created", x => FormatDate(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<Warehouse>> WarehouseAdvancedFilters =>
+    [
+        new("default", "Default warehouse", YesNoFilterOptions, x => x.IsDefault ? "true" : "false", "All warehouses"),
+        new("country", "Country", BuildDistinctFilterOptions(_warehouses, x => x.CountryCode), x => x.CountryCode, "All countries")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<InventoryLocation>> LocationAdvancedColumns =>
+    [
+        new("Warehouse", x => GetWarehouseName(x.WarehouseId)),
+        new("Code", x => x.Code),
+        new("Name", x => x.Name),
+        new("Type", x => x.LocationType.ToString()),
+        new("Pickable", x => FormatBoolean(x.IsPickable)),
+        new("Description", x => x.Description)
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<InventoryLocation>> LocationAdvancedFilters =>
+    [
+        new("type", "Location type", BuildEnumFilterOptions<InventoryLocationType>(), x => x.LocationType.ToString(), "All types"),
+        new("pickable", "Pickable", YesNoFilterOptions, x => x.IsPickable ? "true" : "false", "All locations")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<InventoryLot>> LotAdvancedColumns =>
+    [
+        new("Lot / Batch", x => GetLotLabel(x)),
+        new("Status", x => x.Status.ToString()),
+        new("Expiry", x => FormatDate(x.ExpiresAt)),
+        new("Received", x => FormatDate(x.ReceivedAt)),
+        new("Supplier Ref", x => x.SupplierReference),
+        new("Source", x => x.SourceReferenceType),
+        new("Unit Cost", x => FormatDecimal(x.UnitCost)),
+        new("On Hand", x => GetLotOnHand(x.Id).ToString("0.##"))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<InventoryLot>> LotAdvancedFilters =>
+    [
+        new("status", "Lot status", BuildEnumFilterOptions<InventoryLotStatus>(), x => x.Status.ToString(), "All statuses"),
+        new("expiry", "Expiry", LotExpiryFilterOptions, GetLotExpiryState, "All expiry states")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<Supplier>> SupplierAdvancedColumns =>
+    [
+        new("Code", x => x.Code),
+        new("Name", x => x.Name),
+        new("Contact", x => x.ContactName),
+        new("Email", x => x.Email),
+        new("Phone", x => x.Phone),
+        new("Active", x => FormatBoolean(x.IsActive)),
+        new("Created", x => FormatDate(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<Supplier>> SupplierAdvancedFilters =>
+    [
+        new("active", "Active", YesNoFilterOptions, x => x.IsActive ? "true" : "false", "All suppliers")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<PurchaseOrder>> PurchaseOrderAdvancedColumns =>
+    [
+        new("Order #", x => x.OrderNumber),
+        new("Status", x => x.Status.ToString()),
+        new("Supplier", GetPurchaseOrderSupplierLabel),
+        new("Order Date", x => FormatDate(x.OrderDate)),
+        new("Expected", x => FormatDate(x.ExpectedDate)),
+        new("Lines", x => x.Lines.Count.ToString()),
+        new("Notes", x => x.Notes)
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<PurchaseOrder>> PurchaseOrderAdvancedFilters =>
+    [
+        new("status", "Status", BuildEnumFilterOptions<PurchaseOrderStatus>(), x => x.Status.ToString(), "All statuses"),
+        new("supplier", "Supplier", BuildSupplierFilterOptions(), x => x.SupplierId?.ToString(), "All suppliers")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> LotExpiryFilterOptions =
+    [
+        new("valid", "Valid"),
+        new("near-expiry", "Near expiry"),
+        new("expired", "Expired"),
+        new("no-expiry", "No expiry")
+    ];
+
+    private static IReadOnlyList<XfEntityPickerFilterOption> BuildEnumFilterOptions<TEnum>()
+        where TEnum : struct, Enum =>
+        Enum.GetValues<TEnum>()
+            .Select(value => new XfEntityPickerFilterOption(value.ToString(), value.ToString()))
+            .ToArray();
+
+    private static IReadOnlyList<XfEntityPickerFilterOption> BuildDistinctFilterOptions<TItem>(
+        IEnumerable<TItem> items,
+        Func<TItem, string?> valueSelector) =>
+        items
+            .Select(valueSelector)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .Select(value => new XfEntityPickerFilterOption(value!, value!))
+            .ToArray();
+
+    private IReadOnlyList<XfEntityPickerFilterOption> BuildSupplierFilterOptions() =>
+        _suppliers
+            .OrderBy(x => x.Name)
+            .Select(x => new XfEntityPickerFilterOption(x.Id.ToString(), GetSupplierLabel(x)))
+            .ToArray();
+
+    private string GetPurchaseOrderSupplierLabel(PurchaseOrder order)
+    {
+        if (order.Supplier is not null)
+            return GetSupplierLabel(order.Supplier);
+
+        return order.SupplierId is { } supplierId
+            ? _suppliers.FirstOrDefault(x => x.Id == supplierId) is { } supplier ? GetSupplierLabel(supplier) : supplierId.ToString()[..8]
+            : "No supplier";
+    }
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDate(DateTime value) => value == default ? "N/A" : value.ToString("yyyy-MM-dd");
+    private static string FormatDate(DateTime? value) => value is { } date ? FormatDate(date) : "N/A";
+    private static string FormatDecimal(decimal? value) => value is { } amount ? amount.ToString("0.####") : "N/A";
+
+    private static string GetLotExpiryState(InventoryLot lot)
+    {
+        if (lot.ExpiresAt is null)
+            return "no-expiry";
+
+        var expiryDate = lot.ExpiresAt.Value.Date;
+        var today = DateTime.UtcNow.Date;
+
+        if (expiryDate < today)
+            return "expired";
+
+        return expiryDate <= today.AddDays(30) ? "near-expiry" : "valid";
+    }
 
     private RequestMetadata BuildMetadata() => new()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPicker.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPicker.razor
@@ -101,26 +101,96 @@
             <BbDialogDescription>@AdvancedSearchDescription</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_advancedSearchQuery"
-                              Label="Search"
-                              Placeholder="@SearchPlaceholder" />
+            <div class="xf-entity-picker-advanced-tools">
+                <BbFormFieldInput TValue="string"
+                                  @bind-Value="_advancedSearchQuery"
+                                  Label="Search"
+                                  Placeholder="@AdvancedSearchPlaceholder" />
+                @if (!string.IsNullOrWhiteSpace(AdvancedSearchScopeText))
+                {
+                    <BbTypographyMuted>@AdvancedSearchScopeText</BbTypographyMuted>
+                }
+            </div>
 
-            <div class="xf-entity-picker-advanced-list">
+            @if (AdvancedFilters.Count > 0)
+            {
+                <div class="xf-entity-picker-advanced-filters">
+                    @foreach (var filter in AdvancedFilters)
+                    {
+                        <BbFormFieldSelect TValue="string"
+                                           Value="@GetAdvancedFilterValue(filter)"
+                                           ValueChanged="@(value => SetAdvancedFilter(filter, value))"
+                                           Label="@filter.Label">
+                            <BbSelectItem Value="@AllFilterValue">@filter.AllLabel</BbSelectItem>
+                            @foreach (var option in filter.Options)
+                            {
+                                <BbSelectItem Value="@option.Value">@option.Label</BbSelectItem>
+                            }
+                        </BbFormFieldSelect>
+                    }
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ResetAdvancedFilters">
+                        <LucideIcon Name="rotate-ccw" class="mr-2 h-4 w-4" />
+                        Reset
+                    </BbButton>
+                </div>
+            }
+
+            <div class="xf-entity-picker-advanced-meta">
+                <span>@AdvancedResultText</span>
+                @if (!string.IsNullOrWhiteSpace(_advancedSortColumnKey))
+                {
+                    <span>Sorted by @CurrentSortTitle @(_advancedSortDescending ? "descending" : "ascending")</span>
+                }
+            </div>
+
+            <div class="xf-entity-picker-advanced-table-wrap">
                 @if (!AdvancedFilteredItems.Any())
                 {
                     <div class="xf-entity-picker-empty">@EmptyMessage</div>
                 }
                 else
                 {
-                    @foreach (var item in AdvancedFilteredItems)
-                    {
-                        <button type="button"
-                                class="xf-entity-picker-advanced-row"
-                                @onclick="@(() => SelectItemFromAdvanced(item))">
-                            @RenderItem(item)
-                        </button>
-                    }
+                    <table class="xf-entity-picker-advanced-table">
+                        <thead>
+                            <tr>
+                                @foreach (var column in EffectiveAdvancedColumns)
+                                {
+                                    <th class="@column.CssClass">
+                                        @if (column.Sortable)
+                                        {
+                                            <button type="button"
+                                                    class="xf-entity-picker-sort"
+                                                    @onclick="@(() => ToggleAdvancedSort(column))">
+                                                <span>@column.Title</span>
+                                                @if (string.Equals(_advancedSortColumnKey, column.Title, StringComparison.Ordinal))
+                                                {
+                                                    <LucideIcon Name="@(_advancedSortDescending ? "arrow-down" : "arrow-up")" class="h-3 w-3" />
+                                                }
+                                            </button>
+                                        }
+                                        else
+                                        {
+                                            @column.Title
+                                        }
+                                    </th>
+                                }
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var item in AdvancedFilteredItems)
+                            {
+                                <tr class="xf-entity-picker-advanced-row"
+                                    tabindex="0"
+                                    @onclick="@(() => SelectItemFromAdvanced(item))"
+                                    @onkeydown="@((KeyboardEventArgs args) => SelectItemFromAdvancedOnKeyDown(args, item))">
+                                    @foreach (var column in EffectiveAdvancedColumns)
+                                    {
+                                        <td class="@column.CssClass">@FormatAdvancedCell(column.ValueSelector(item))</td>
+                                    }
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
                 }
             </div>
         </div>
@@ -139,10 +209,14 @@
 
 @code {
     private readonly string _instanceId = $"entity-picker-{Guid.NewGuid():N}";
+    private const string AllFilterValue = "__all__";
     private bool _open;
     private bool _advancedOpen;
     private string _searchQuery = "";
     private string _advancedSearchQuery = "";
+    private readonly Dictionary<string, string> _advancedFilterValues = new(StringComparer.Ordinal);
+    private string? _advancedSortColumnKey;
+    private bool _advancedSortDescending;
 
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Value { get; set; }
@@ -151,7 +225,10 @@
     [Parameter, EditorRequired] public Func<TItem, string> ValueSelector { get; set; } = default!;
     [Parameter, EditorRequired] public Func<TItem, string> TextSelector { get; set; } = default!;
     [Parameter] public Func<TItem, string>? SearchTextSelector { get; set; }
+    [Parameter] public Func<TItem, string>? AdvancedSearchTextSelector { get; set; }
     [Parameter] public RenderFragment<TItem>? ItemTemplate { get; set; }
+    [Parameter] public IReadOnlyList<XfEntityPickerColumn<TItem>> AdvancedColumns { get; set; } = [];
+    [Parameter] public IReadOnlyList<XfEntityPickerFilter<TItem>> AdvancedFilters { get; set; } = [];
     [Parameter] public bool Disabled { get; set; }
     [Parameter] public bool AllowClear { get; set; }
     [Parameter] public bool ShowAdvancedSearch { get; set; } = true;
@@ -159,6 +236,8 @@
     [Parameter] public EventCallback OnCreate { get; set; }
     [Parameter] public string Placeholder { get; set; } = "Select item";
     [Parameter] public string SearchPlaceholder { get; set; } = "Search...";
+    [Parameter] public string AdvancedSearchPlaceholder { get; set; } = "Search visible columns...";
+    [Parameter] public string? AdvancedSearchScope { get; set; }
     [Parameter] public string EmptyMessage { get; set; } = "No results found.";
     [Parameter] public string ClearText { get; set; } = "Clear selection";
     [Parameter] public string AdvancedSearchLabel { get; set; } = "Advanced Search";
@@ -175,7 +254,25 @@
             : Placeholder;
 
     private IReadOnlyList<TItem> FilteredItems => FilterItems(_searchQuery).ToList();
-    private IReadOnlyList<TItem> AdvancedFilteredItems => FilterItems(_advancedSearchQuery).ToList();
+    private IReadOnlyList<XfEntityPickerColumn<TItem>> EffectiveAdvancedColumns =>
+        AdvancedColumns.Count > 0
+            ? AdvancedColumns
+            :
+            [
+                new("Name", TextSelector),
+                new("Identifier", GetValue)
+            ];
+
+    private string AdvancedSearchScopeText =>
+        AdvancedSearchScope ?? $"Searches {string.Join(", ", EffectiveAdvancedColumns.Select(x => x.Title))}.";
+
+    private IReadOnlyList<TItem> AdvancedFilteredItems => SortAdvancedItems(FilterAdvancedItems()).ToList();
+
+    private string AdvancedResultText =>
+        AdvancedFilteredItems.Count == 1 ? "1 result" : $"{AdvancedFilteredItems.Count} results";
+
+    private string CurrentSortTitle =>
+        EffectiveAdvancedColumns.FirstOrDefault(x => string.Equals(x.Title, _advancedSortColumnKey, StringComparison.Ordinal))?.Title ?? "";
 
     private IEnumerable<TItem> FilterItems(string query)
     {
@@ -183,6 +280,50 @@
             return Items;
 
         return Items.Where(item => GetSearchText(item).Contains(query, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private IEnumerable<TItem> FilterAdvancedItems()
+    {
+        var query = _advancedSearchQuery.Trim();
+
+        return Items.Where(item =>
+        {
+            if (!string.IsNullOrWhiteSpace(query) &&
+                !GetAdvancedSearchText(item).Contains(query, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            foreach (var filter in AdvancedFilters)
+            {
+                if (!_advancedFilterValues.TryGetValue(filter.Key, out var selected) ||
+                    string.IsNullOrWhiteSpace(selected))
+                {
+                    continue;
+                }
+
+                if (!string.Equals(filter.ValueSelector(item), selected, StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+
+            return true;
+        });
+    }
+
+    private IEnumerable<TItem> SortAdvancedItems(IEnumerable<TItem> items)
+    {
+        if (string.IsNullOrWhiteSpace(_advancedSortColumnKey))
+            return items;
+
+        var column = EffectiveAdvancedColumns.FirstOrDefault(x =>
+            string.Equals(x.Title, _advancedSortColumnKey, StringComparison.Ordinal));
+
+        if (column is null)
+            return items;
+
+        return _advancedSortDescending
+            ? items.OrderByDescending(item => FormatAdvancedCell(column.ValueSelector(item)), StringComparer.CurrentCultureIgnoreCase)
+            : items.OrderBy(item => FormatAdvancedCell(column.ValueSelector(item)), StringComparer.CurrentCultureIgnoreCase);
     }
 
     private RenderFragment RenderItem(TItem item) => builder =>
@@ -201,6 +342,54 @@
 
     private string GetValue(TItem item) => ValueSelector(item);
     private string GetSearchText(TItem item) => SearchTextSelector?.Invoke(item) ?? TextSelector(item);
+    private string GetAdvancedSearchText(TItem item)
+    {
+        if (AdvancedSearchTextSelector is not null)
+            return AdvancedSearchTextSelector(item);
+
+        var values = EffectiveAdvancedColumns.Select(column => FormatAdvancedCell(column.ValueSelector(item)));
+        return $"{GetSearchText(item)} {string.Join(' ', values)}";
+    }
+
+    private string GetAdvancedFilterValue(XfEntityPickerFilter<TItem> filter) =>
+        _advancedFilterValues.TryGetValue(filter.Key, out var value) ? value : AllFilterValue;
+
+    private Task SetAdvancedFilter(XfEntityPickerFilter<TItem> filter, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || string.Equals(value, AllFilterValue, StringComparison.Ordinal))
+            _advancedFilterValues.Remove(filter.Key);
+        else
+            _advancedFilterValues[filter.Key] = value;
+
+        return Task.CompletedTask;
+    }
+
+    private Task ResetAdvancedFilters()
+    {
+        _advancedFilterValues.Clear();
+        _advancedSearchQuery = "";
+        _advancedSortColumnKey = null;
+        _advancedSortDescending = false;
+        return Task.CompletedTask;
+    }
+
+    private Task ToggleAdvancedSort(XfEntityPickerColumn<TItem> column)
+    {
+        if (string.Equals(_advancedSortColumnKey, column.Title, StringComparison.Ordinal))
+        {
+            _advancedSortDescending = !_advancedSortDescending;
+        }
+        else
+        {
+            _advancedSortColumnKey = column.Title;
+            _advancedSortDescending = false;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static string FormatAdvancedCell(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "N/A" : value;
 
     private Task OnSearchQueryChanged(string value)
     {
@@ -231,6 +420,12 @@
         await ValueChanged.InvokeAsync(GetValue(item));
     }
 
+    private async Task SelectItemFromAdvancedOnKeyDown(KeyboardEventArgs args, TItem item)
+    {
+        if (args.Key is "Enter" or " ")
+            await SelectItemFromAdvanced(item);
+    }
+
     private async Task ClearSelection()
     {
         _open = false;
@@ -244,6 +439,9 @@
         _advancedOpen = true;
         _advancedSearchQuery = _searchQuery;
         _searchQuery = "";
+        if (string.IsNullOrWhiteSpace(_advancedSortColumnKey) && EffectiveAdvancedColumns.FirstOrDefault(x => x.Sortable) is { } firstSortable)
+            _advancedSortColumnKey = firstSortable.Title;
+
         return Task.CompletedTask;
     }
 

--- a/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPickerModels.cs
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPickerModels.cs
@@ -1,0 +1,18 @@
+namespace ControlPanel.Server.Components.Shared;
+
+public sealed record XfEntityPickerColumn<TItem>(
+    string Title,
+    Func<TItem, string?> ValueSelector,
+    bool Sortable = true,
+    string? CssClass = null);
+
+public sealed record XfEntityPickerFilterOption(
+    string Value,
+    string Label);
+
+public sealed record XfEntityPickerFilter<TItem>(
+    string Key,
+    string Label,
+    IReadOnlyList<XfEntityPickerFilterOption> Options,
+    Func<TItem, string?> ValueSelector,
+    string AllLabel = "All");

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -240,22 +240,65 @@
     color: var(--muted-foreground);
 }
 
-.xf-entity-picker-advanced-list {
+.xf-entity-picker-advanced-tools {
     display: grid;
-    gap: 0.5rem;
-    max-height: 28rem;
-    overflow-y: auto;
+    gap: 0.35rem;
+}
+
+.xf-entity-picker-advanced-filters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 0.75rem;
+    align-items: end;
+}
+
+.xf-entity-picker-advanced-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.75rem;
+    color: var(--muted-foreground);
+    font-size: 0.75rem;
+    line-height: 1rem;
+}
+
+.xf-entity-picker-advanced-table-wrap {
+    max-height: min(32rem, 60vh);
+    overflow: auto;
+    border: 1px solid var(--border);
+    border-radius: calc(var(--radius) - 2px);
+}
+
+.xf-entity-picker-advanced-table {
+    width: 100%;
+    min-width: 42rem;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+}
+
+.xf-entity-picker-advanced-table th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    border-bottom: 1px solid var(--border);
+    background: var(--muted);
+    color: var(--muted-foreground);
+    font-weight: 500;
+    padding: 0.625rem 0.75rem;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.xf-entity-picker-advanced-table td {
+    border-bottom: 1px solid var(--border);
+    padding: 0.625rem 0.75rem;
+    vertical-align: top;
 }
 
 .xf-entity-picker-advanced-row {
-    display: block;
-    width: 100%;
-    border: 1px solid var(--border);
-    border-radius: calc(var(--radius) - 2px);
-    background: var(--background);
-    padding: 0.75rem;
-    text-align: left;
-    transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+    cursor: pointer;
+    transition: background-color 150ms ease, box-shadow 150ms ease;
 }
 
 .xf-entity-picker-advanced-row:hover {
@@ -264,8 +307,23 @@
 
 .xf-entity-picker-advanced-row:focus-visible {
     outline: none;
-    border-color: var(--ring);
-    box-shadow: 0 0 0 1px var(--ring);
+    box-shadow: inset 0 0 0 1px var(--ring);
+}
+
+.xf-entity-picker-sort {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    padding: 0;
+}
+
+.xf-entity-picker-sort:hover {
+    color: var(--foreground);
 }
 
 .xf-entity-picker-empty {

--- a/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -79,6 +79,47 @@ public sealed class ControlPanelContractTests
         text.Should().NotContain("The selected warehouse has no locations yet.");
     }
 
+    [Test]
+    public void ProductDetail_EntityPickers_DefineAdvancedSearchColumnsAndFilters()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var productDetailPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario",
+            "ProductDetail.razor");
+        var pickerPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Shared",
+            "XfEntityPicker.razor");
+
+        var productDetailText = File.ReadAllText(productDetailPath);
+        var pickerText = File.ReadAllText(pickerPath);
+
+        productDetailText.Should().Contain("AdvancedColumns=\"@WarehouseAdvancedColumns\"");
+        productDetailText.Should().Contain("AdvancedFilters=\"@WarehouseAdvancedFilters\"");
+        productDetailText.Should().Contain("AdvancedColumns=\"@LocationAdvancedColumns\"");
+        productDetailText.Should().Contain("AdvancedFilters=\"@LocationAdvancedFilters\"");
+        productDetailText.Should().Contain("AdvancedColumns=\"@LotAdvancedColumns\"");
+        productDetailText.Should().Contain("AdvancedFilters=\"@LotAdvancedFilters\"");
+        productDetailText.Should().Contain("AdvancedColumns=\"@SupplierAdvancedColumns\"");
+        productDetailText.Should().Contain("AdvancedFilters=\"@SupplierAdvancedFilters\"");
+        productDetailText.Should().Contain("AdvancedColumns=\"@PurchaseOrderAdvancedColumns\"");
+        productDetailText.Should().Contain("AdvancedFilters=\"@PurchaseOrderAdvancedFilters\"");
+
+        pickerText.Should().Contain("xf-entity-picker-advanced-table", "advanced search must render a multi-column finder, not the same single-column command list");
+        pickerText.Should().Contain("ToggleAdvancedSort", "advanced search columns should be sortable");
+        pickerText.Should().Contain("AdvancedFilters", "advanced search should support explicit filters");
+    }
+
     private static IEnumerable<string> FindDirectMutations(
         DirectoryInfo repositoryRoot,
         string path,


### PR DESCRIPTION
## Summary
- upgrades shared `XfEntityPicker<TItem>` advanced search from a single text list into a sortable, filterable multi-column finder
- adds Inventario defaults for warehouse, location, lot, supplier, and purchase-order pickers
- updates ControlPanel docs and contract guardrails so Advanced Search cannot regress into a plain modal list

## Validation
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false`
- `dotnet build XFramework.slnx -m:1 /nr:false`
- `dotnet test src/Tests/Inventario.IntegrationTests/Inventario.IntegrationTests.csproj --filter TestCategory=Area:ControlPanelContract -m:1 /nr:false` via xeon-dev SSH+socat Testcontainers tunnel