### PR TITLE
Update IdentityServer ControlPanel pickers

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Addresses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Addresses.razor
@@ -51,7 +51,7 @@
 </div>
 
 <BbDialog Open="@_dialogOpen" OpenChanged="@(v => _dialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
             <BbDialogTitle>@(_isEditing ? "Edit Address" : "Add Address")</BbDialogTitle>
             <BbDialogDescription>
@@ -59,11 +59,23 @@
             </BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_formIdentityInfoId"
-                              Label="User ID (IdentityInfoId)"
-                              Placeholder="Enter user GUID"
-                              Required="true" />
+            <XfEntityPicker TItem="IdentityInformation"
+                            Label="User"
+                            Value="@_formIdentityInfoId"
+                            ValueChanged="@(value => _formIdentityInfoId = value ?? "")"
+                            Items="@_users"
+                            ValueSelector="@GetUserPickerValue"
+                            TextSelector="@GetUserLabel"
+                            SearchTextSelector="@GetUserSearchText"
+                            AdvancedColumns="@UserAdvancedColumns"
+                            AdvancedFilters="@UserAdvancedFilters"
+                            AdvancedSearchScope="Searches full name, identity name, gender, civil status, verified state, enabled state, and created date."
+                            Placeholder="Select user"
+                            SearchPlaceholder="Search users..."
+                            EmptyMessage="No users found."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find User"
+                            AdvancedSearchDescription="Search identity information records in the active tenant." />
             <div class="grid grid-cols-2 gap-4">
                 <BbFormFieldInput TValue="string"
                                   @bind-Value="_formUnitNumber"
@@ -106,6 +118,7 @@
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<IdentityAddress> _addresses = [];
+    private List<IdentityInformation> _users = [];
     private bool _loading = true;
     private bool _dialogOpen;
     private bool _deleteDialogOpen;
@@ -146,6 +159,18 @@
             _addresses = (await query.Take(100).ToListAsync())
                 .OrderByDescending(x => x.CreatedAt)
                 .ToList();
+
+            var userQuery = DataContext.Query<IdentityInformation>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .OrderBy(x => x.LastName)
+                .ThenBy(x => x.FirstName);
+            if (TenantFilter.SelectedTenantId is { } userTenantId)
+            {
+                userQuery = userQuery.Where(x => x.TenantId == userTenantId);
+            }
+
+            _users = await userQuery.Take(500).ToListAsync();
         }
         catch { /* query may fail */ }
     }
@@ -263,4 +288,53 @@
             }
         }
     }
+
+    private static string GetUserPickerValue(IdentityInformation user) => user.Id.ToString();
+    private static string GetUserLabel(IdentityInformation user) =>
+        !string.IsNullOrWhiteSpace(user.FullName)
+            ? user.FullName
+            : !string.IsNullOrWhiteSpace(user.IdentityName)
+                ? user.IdentityName
+                : user.Id.ToString()[..8];
+
+    private static string GetUserSearchText(IdentityInformation user) =>
+        $"{user.FullName} {user.IdentityName} {user.Gender} {user.CivilStatus}";
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityInformation>> UserAdvancedColumns =>
+    [
+        new("Full Name", GetUserLabel),
+        new("Identity Name", x => x.IdentityName),
+        new("Gender", x => x.Gender?.ToString()),
+        new("Civil Status", x => x.CivilStatus?.ToString()),
+        new("Verified", x => FormatBoolean(x.IsVerified)),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityInformation>> UserAdvancedFilters =>
+    [
+        new("verified", "Verified", YesNoFilterOptions, x => x.IsVerified ? "true" : "false", "All users"),
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses"),
+        new("gender", "Gender", BuildDistinctFilterOptions(_users, x => x.Gender?.ToString()), x => x.Gender?.ToString(), "All genders")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private static IReadOnlyList<XfEntityPickerFilterOption> BuildDistinctFilterOptions<TItem>(
+        IEnumerable<TItem> items,
+        Func<TItem, string?> valueSelector) =>
+        items
+            .Select(valueSelector)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .Select(value => new XfEntityPickerFilterOption(value!, value!))
+            .ToArray();
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDateTime(DateTime value) => value == default ? "N/A" : value.ToString("g");
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Contacts.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Contacts.razor
@@ -48,7 +48,7 @@
 </div>
 
 <BbDialog Open="@_dialogOpen" OpenChanged="@(v => _dialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
             <BbDialogTitle>@(_isEditing ? "Edit Contact" : "Add Contact")</BbDialogTitle>
             <BbDialogDescription>
@@ -61,20 +61,59 @@
                               Label="Value"
                               Placeholder="Contact value"
                               Required="true" />
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_formCredentialId"
-                              Label="Credential ID"
-                              Placeholder="Enter credential GUID"
-                              Required="true" />
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_formTypeId"
-                              Label="Type ID"
-                              Placeholder="Contact type GUID" />
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_formGroupId"
-                              Label="Group ID"
-                              Placeholder="Group GUID"
-                              Required="true" />
+            <XfEntityPicker TItem="IdentityCredential"
+                            Label="Credential"
+                            Value="@_formCredentialId"
+                            ValueChanged="@(value => _formCredentialId = value ?? "")"
+                            Items="@_credentials"
+                            ValueSelector="@GetCredentialPickerValue"
+                            TextSelector="@GetCredentialLabel"
+                            SearchTextSelector="@GetCredentialSearchText"
+                            AdvancedColumns="@CredentialAdvancedColumns"
+                            AdvancedFilters="@CredentialAdvancedFilters"
+                            AdvancedSearchScope="Searches username, alias, owning identity, online state, device, location, last seen, and created date."
+                            Placeholder="Select credential"
+                            SearchPlaceholder="Search credentials..."
+                            EmptyMessage="No credentials found."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Credential"
+                            AdvancedSearchDescription="Search credentials in the active tenant." />
+            <XfEntityPicker TItem="IdentityContactType"
+                            Label="Contact Type"
+                            Value="@_formTypeId"
+                            ValueChanged="@(value => _formTypeId = value ?? "")"
+                            Items="@_contactTypes"
+                            ValueSelector="@GetContactTypePickerValue"
+                            TextSelector="@GetContactTypeLabel"
+                            SearchTextSelector="@GetContactTypeSearchText"
+                            AdvancedColumns="@ContactTypeAdvancedColumns"
+                            AdvancedFilters="@ContactTypeAdvancedFilters"
+                            AdvancedSearchScope="Searches contact type name, enabled state, system reference, and created date."
+                            Placeholder="No contact type"
+                            SearchPlaceholder="Search contact types..."
+                            EmptyMessage="No contact types found."
+                            AllowClear="true"
+                            ClearText="No contact type"
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Contact Type"
+                            AdvancedSearchDescription="Search contact classification types." />
+            <XfEntityPicker TItem="IdentityContactGroup"
+                            Label="Contact Group"
+                            Value="@_formGroupId"
+                            ValueChanged="@(value => _formGroupId = value ?? "")"
+                            Items="@_contactGroups"
+                            ValueSelector="@GetContactGroupPickerValue"
+                            TextSelector="@GetContactGroupLabel"
+                            SearchTextSelector="@GetContactGroupSearchText"
+                            AdvancedColumns="@ContactGroupAdvancedColumns"
+                            AdvancedFilters="@ContactGroupAdvancedFilters"
+                            AdvancedSearchScope="Searches contact group name, enabled state, system reference, contact count, and created date."
+                            Placeholder="Select contact group"
+                            SearchPlaceholder="Search contact groups..."
+                            EmptyMessage="No contact groups found."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Contact Group"
+                            AdvancedSearchDescription="Search contact groups in the active tenant." />
         </div>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _dialogOpen = false)">Cancel</BbButton>
@@ -93,6 +132,9 @@
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
     private List<IdentityContact> _contacts = [];
+    private List<IdentityCredential> _credentials = [];
+    private List<IdentityContactType> _contactTypes = [];
+    private List<IdentityContactGroup> _contactGroups = [];
     private bool _loading = true;
     private bool _dialogOpen;
     private bool _deleteDialogOpen;
@@ -132,6 +174,31 @@
             _contacts = (await query.Take(100).ToListAsync())
                 .OrderByDescending(x => x.CreatedAt)
                 .ToList();
+
+            var credentialQuery = DataContext.Query<IdentityCredential>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.IdentityInfo)
+                .OrderBy(x => x.UserName);
+            var typeQuery = DataContext.Query<IdentityContactType>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .OrderBy(x => x.Name);
+            var groupQuery = DataContext.Query<IdentityContactGroup>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .OrderBy(x => x.Name);
+
+            if (TenantFilter.SelectedTenantId is { } lookupTenantId)
+            {
+                credentialQuery = credentialQuery.Where(x => x.TenantId == lookupTenantId);
+                typeQuery = typeQuery.Where(x => x.TenantId == lookupTenantId);
+                groupQuery = groupQuery.Where(x => x.TenantId == lookupTenantId);
+            }
+
+            _credentials = await credentialQuery.Take(500).ToListAsync();
+            _contactTypes = await typeQuery.Take(100).ToListAsync();
+            _contactGroups = await groupQuery.Take(100).ToListAsync();
         }
         catch { /* query may fail */ }
     }
@@ -143,6 +210,10 @@
         _formCredentialId = "";
         _formTypeId = "";
         _formGroupId = "";
+        if (_contactGroups.Count == 1)
+        {
+            _formGroupId = _contactGroups[0].Id.ToString();
+        }
         _dialogOpen = true;
     }
 
@@ -173,13 +244,13 @@
 
         if (!Guid.TryParse(_formCredentialId, out var credentialId))
         {
-            ToastService.Show("Invalid Credential ID.");
+            ToastService.Show("Invalid selected credential.");
             return;
         }
 
         if (!Guid.TryParse(_formGroupId, out var groupId))
         {
-            ToastService.Show("Invalid Group ID.");
+            ToastService.Show("Invalid selected contact group.");
             return;
         }
 
@@ -253,4 +324,92 @@
             }
         }
     }
+
+    private static string GetCredentialPickerValue(IdentityCredential credential) => credential.Id.ToString();
+    private static string GetContactTypePickerValue(IdentityContactType contactType) => contactType.Id.ToString();
+    private static string GetContactGroupPickerValue(IdentityContactGroup contactGroup) => contactGroup.Id.ToString();
+
+    private static string GetCredentialLabel(IdentityCredential credential)
+    {
+        if (!string.IsNullOrWhiteSpace(credential.UserName))
+            return credential.UserName;
+
+        if (!string.IsNullOrWhiteSpace(credential.UserAlias))
+            return credential.UserAlias;
+
+        return credential.Id.ToString()[..8];
+    }
+
+    private static string GetContactTypeLabel(IdentityContactType contactType) =>
+        string.IsNullOrWhiteSpace(contactType.Name)
+            ? contactType.Id.ToString()[..8]
+            : contactType.Name;
+
+    private static string GetContactGroupLabel(IdentityContactGroup contactGroup) =>
+        string.IsNullOrWhiteSpace(contactGroup.Name)
+            ? contactGroup.Id.ToString()[..8]
+            : contactGroup.Name;
+
+    private static string GetCredentialSearchText(IdentityCredential credential) =>
+        $"{credential.UserName} {credential.UserAlias} {credential.Device} {credential.Location} {credential.IdentityInfo?.FullName} {credential.IdentityInfo?.IdentityName}";
+
+    private static string GetContactTypeSearchText(IdentityContactType contactType) =>
+        $"{contactType.Name} {contactType.SystemReferenceId}";
+
+    private static string GetContactGroupSearchText(IdentityContactGroup contactGroup) =>
+        $"{contactGroup.Name} {contactGroup.SystemReferenceId}";
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityCredential>> CredentialAdvancedColumns =>
+    [
+        new("Username", x => x.UserName),
+        new("Alias", x => x.UserAlias),
+        new("Identity", x => x.IdentityInfo?.FullName ?? x.IdentityInfo?.IdentityName),
+        new("Online", x => FormatBoolean(x.IsOnline)),
+        new("Device", x => x.Device),
+        new("Location", x => x.Location),
+        new("Last Seen", x => FormatDateTime(x.LastSeen)),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityCredential>> CredentialAdvancedFilters =>
+    [
+        new("online", "Online", YesNoFilterOptions, x => x.IsOnline ? "true" : "false", "All credentials"),
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityContactType>> ContactTypeAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("System Ref", x => x.SystemReferenceId.ToString()[..8]),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityContactType>> ContactTypeAdvancedFilters =>
+    [
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityContactGroup>> ContactGroupAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("Contacts", x => _contacts.Count(contact => contact.GroupId == x.Id).ToString()),
+        new("System Ref", x => x.SystemReferenceId.ToString()[..8]),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityContactGroup>> ContactGroupAdvancedFilters =>
+    [
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDateTime(DateTime value) => value == default ? "N/A" : value.ToString("g");
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -339,7 +339,7 @@ else
 
 @* -- Add / Edit Configuration Dialog -- *@
 <BbDialog Open="@_configDialogOpen" OpenChanged="@(v => _configDialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
             <BbDialogTitle>@(_isEditingConfig ? "Edit Configuration" : "Add Configuration")</BbDialogTitle>
             <BbDialogDescription>
@@ -354,14 +354,23 @@ else
             <div class="grid grid-cols-2 gap-4">
                 <BbFormFieldInput TValue="string" @bind-Value="_configForm.Unit" Label="Unit"
                                   Placeholder="e.g. count, MB, boolean" />
-                <BbFormFieldNativeSelect TValue="string" @bind-Value="_configForm.GroupIdString" Label="Group"
-                                         Placeholder="-- Select Group --">
-                    <option value="">-- Select Group --</option>
-                    @foreach (var group in _configGroups)
-                    {
-                        <option value="@group.Id.ToString()">@(group.Name ?? group.Id.ToString()[..8])</option>
-                    }
-                </BbFormFieldNativeSelect>
+                <XfEntityPicker TItem="RegistryConfigurationGroup"
+                                Label="Group"
+                                Value="@_configForm.GroupIdString"
+                                ValueChanged="@(value => _configForm.GroupIdString = value ?? "")"
+                                Items="@_configGroups"
+                                ValueSelector="@GetConfigurationGroupPickerValue"
+                                TextSelector="@GetConfigurationGroupLabel"
+                                SearchTextSelector="@GetConfigurationGroupSearchText"
+                                AdvancedColumns="@ConfigurationGroupAdvancedColumns"
+                                AdvancedFilters="@ConfigurationGroupAdvancedFilters"
+                                AdvancedSearchScope="Searches configuration group name, description, enabled state, system reference, configuration count, and created date."
+                                Placeholder="Select group"
+                                SearchPlaceholder="Search configuration groups..."
+                                EmptyMessage="No configuration groups found."
+                                ShowCreate="false"
+                                AdvancedSearchTitle="Find Configuration Group"
+                                AdvancedSearchDescription="Search registry configuration groups before assigning this setting." />
             </div>
         </div>
         <BbDialogFooter>
@@ -935,6 +944,39 @@ else
         public string? Unit { get; set; }
         public string GroupIdString { get; set; } = "";
     }
+
+    private static string GetConfigurationGroupPickerValue(RegistryConfigurationGroup group) => group.Id.ToString();
+    private static string GetConfigurationGroupLabel(RegistryConfigurationGroup group) =>
+        string.IsNullOrWhiteSpace(group.Name)
+            ? group.Id.ToString()[..8]
+            : group.Name;
+
+    private static string GetConfigurationGroupSearchText(RegistryConfigurationGroup group) =>
+        $"{group.Name} {group.Description} {group.SystemReferenceId}";
+
+    private IReadOnlyList<XfEntityPickerColumn<RegistryConfigurationGroup>> ConfigurationGroupAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Description", x => x.Description),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("Configurations", x => _detailConfigs.Count(config => config.GroupId == x.Id).ToString()),
+        new("System Ref", x => x.SystemReferenceId.ToString()[..8]),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<RegistryConfigurationGroup>> ConfigurationGroupAdvancedFilters =>
+    [
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDateTime(DateTime value) => value == default ? "N/A" : value.ToString("g");
 
     private sealed class ModuleFeatureRow(
         Guid id,

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
@@ -105,7 +105,7 @@
 
 @* -- Create Tenant Dialog -- *@
 <BbDialog Open="@_tenantDialogOpen" OpenChanged="@(v => _tenantDialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
             <BbDialogTitle>Create Tenant</BbDialogTitle>
             <BbDialogDescription>Fill in the details for the new tenant.</BbDialogDescription>
@@ -144,10 +144,25 @@
                                   Label="Availability Date"
                                   Placeholder="YYYY-MM-DD" />
             </div>
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_tenantForm.ParentTenantIdString"
-                              Label="Parent Tenant ID"
-                              Placeholder="Optional — leave blank for root tenant" />
+            <XfEntityPicker TItem="Tenant"
+                              Value="@_tenantForm.ParentTenantIdString"
+                              ValueChanged="@(value => _tenantForm.ParentTenantIdString = value ?? "")"
+                              Label="Parent Tenant"
+                              Items="@_tenants"
+                              ValueSelector="@GetTenantPickerValue"
+                              TextSelector="@GetTenantLabel"
+                              SearchTextSelector="@GetTenantSearchText"
+                              AdvancedColumns="@TenantAdvancedColumns"
+                              AdvancedFilters="@TenantAdvancedFilters"
+                              AdvancedSearchScope="Searches tenant name, description, status, version, expiration, enabled state, and created date."
+                              SearchPlaceholder="Search tenants..."
+                              EmptyMessage="No tenants found."
+                              AllowClear="true"
+                              ClearText="No parent tenant"
+                              ShowCreate="false"
+                              AdvancedSearchTitle="Find Parent Tenant"
+                              AdvancedSearchDescription="Search existing tenants to use as the parent tenant."
+                              Placeholder="Optional - leave blank for root tenant" />
         </div>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _tenantDialogOpen = false)">Cancel</BbButton>
@@ -360,4 +375,57 @@
         public string AvailabilityString { get; set; } = "";
         public string ParentTenantIdString { get; set; } = "";
     }
+
+    private static string GetTenantPickerValue(Tenant tenant) => tenant.Id.ToString();
+    private static string GetTenantLabel(Tenant tenant) =>
+        string.IsNullOrWhiteSpace(tenant.Name)
+            ? tenant.Id.ToString()[..8]
+            : tenant.Name;
+
+    private static string GetTenantSearchText(Tenant tenant) =>
+        $"{tenant.Name} {tenant.Description} {GetTenantStatusText(tenant.Status)} {tenant.Version}";
+
+    private IReadOnlyList<XfEntityPickerColumn<Tenant>> TenantAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Description", x => x.Description),
+        new("Status", x => GetTenantStatusText(x.Status)),
+        new("Version", x => x.Version.ToString("0.##")),
+        new("Expiration", x => FormatDate(x.Expiration)),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<Tenant>> TenantAdvancedFilters =>
+    [
+        new("status", "Status", TenantStatusFilterOptions, x => x.Status?.ToString(), "All statuses"),
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All tenants")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> TenantStatusFilterOptions =
+    [
+        new("0", "Pending"),
+        new("1", "Active"),
+        new("2", "Suspended"),
+        new("3", "Inactive")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private static string GetTenantStatusText(short? status) => status switch
+    {
+        0 => "Pending",
+        1 => "Active",
+        2 => "Suspended",
+        3 => "Inactive",
+        _ => "Unknown"
+    };
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDate(DateTime? value) => value is { } date ? date.ToString("yyyy-MM-dd") : "N/A";
+    private static string FormatDateTime(DateTime value) => value == default ? "N/A" : value.ToString("g");
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/UserDetail.razor
@@ -516,22 +516,46 @@ else
 
 <!-- Assign Role Dialog -->
 <BbDialog Open="@_assignRoleDialogOpen" OpenChanged="@(v => _assignRoleDialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
             <BbDialogTitle>Assign Role</BbDialogTitle>
             <BbDialogDescription>Assign a role to one of this user's credentials.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <BbFormFieldSelect TValue="string"
-                               @bind-Value="_roleForm.CredentialId"
-                               Label="Credential"
-                               Placeholder="Select credential"
-                               Options="@CredentialOptions" />
-            <BbFormFieldSelect TValue="string"
-                               @bind-Value="_roleForm.RoleTypeId"
-                               Label="Role Type"
-                               Placeholder="Select role type"
-                               Options="@RoleTypeOptions" />
+            <XfEntityPicker TItem="IdentityCredential"
+                            Label="Credential"
+                            Value="@_roleForm.CredentialId"
+                            ValueChanged="@(value => _roleForm.CredentialId = value ?? "")"
+                            Items="@_credentials"
+                            ValueSelector="@GetCredentialPickerValue"
+                            TextSelector="@GetCredentialLabel"
+                            SearchTextSelector="@GetCredentialSearchText"
+                            AdvancedColumns="@CredentialAdvancedColumns"
+                            AdvancedFilters="@CredentialAdvancedFilters"
+                            AdvancedSearchScope="Searches username, alias, owning identity, online state, device, location, last seen, and created date."
+                            Placeholder="Select credential"
+                            SearchPlaceholder="Search credentials..."
+                            EmptyMessage="No credentials found for this user."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Credential"
+                            AdvancedSearchDescription="Search this user's credentials before assigning a role." />
+            <XfEntityPicker TItem="IdentityRoleType"
+                            Label="Role Type"
+                            Value="@_roleForm.RoleTypeId"
+                            ValueChanged="@(value => _roleForm.RoleTypeId = value ?? "")"
+                            Items="@_roleTypes"
+                            ValueSelector="@GetRoleTypePickerValue"
+                            TextSelector="@GetRoleTypeLabel"
+                            SearchTextSelector="@GetRoleTypeSearchText"
+                            AdvancedColumns="@RoleTypeAdvancedColumns"
+                            AdvancedFilters="@RoleTypeAdvancedFilters"
+                            AdvancedSearchScope="Searches role type name, role level, group, enabled state, system reference, and created date."
+                            Placeholder="Select role type"
+                            SearchPlaceholder="Search role types..."
+                            EmptyMessage="No role types found."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Role Type"
+                            AdvancedSearchDescription="Search available role types for the active tenant." />
             <div class="xf-form-field">
                 <BbLabel>Expiration Date</BbLabel>
                 <input type="datetime-local"
@@ -557,22 +581,65 @@ else
 
 <!-- Create/Edit Contact Dialog -->
 <BbDialog Open="@_contactDialogOpen" OpenChanged="@(v => _contactDialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
             <BbDialogTitle>@(_editingContact is not null ? "Edit Contact" : "Add Contact")</BbDialogTitle>
             <BbDialogDescription>@(_editingContact is not null ? "Update contact information." : "Add a new contact entry.")</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <BbFormFieldSelect TValue="string"
-                               @bind-Value="_contactForm.CredentialId"
-                               Label="Credential"
-                               Placeholder="Select credential"
-                               Options="@CredentialOptions" />
-            <BbFormFieldSelect TValue="string"
-                               @bind-Value="_contactForm.TypeId"
-                               Label="Contact Type"
-                               Placeholder="Select type"
-                               Options="@ContactTypeOptions" />
+            <XfEntityPicker TItem="IdentityCredential"
+                            Label="Credential"
+                            Value="@_contactForm.CredentialId"
+                            ValueChanged="@(value => _contactForm.CredentialId = value ?? "")"
+                            Items="@_credentials"
+                            ValueSelector="@GetCredentialPickerValue"
+                            TextSelector="@GetCredentialLabel"
+                            SearchTextSelector="@GetCredentialSearchText"
+                            AdvancedColumns="@CredentialAdvancedColumns"
+                            AdvancedFilters="@CredentialAdvancedFilters"
+                            AdvancedSearchScope="Searches username, alias, owning identity, online state, device, location, last seen, and created date."
+                            Placeholder="Select credential"
+                            SearchPlaceholder="Search credentials..."
+                            EmptyMessage="No credentials found for this user."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Credential"
+                            AdvancedSearchDescription="Search this user's credentials before adding contact information." />
+            <XfEntityPicker TItem="IdentityContactType"
+                            Label="Contact Type"
+                            Value="@_contactForm.TypeId"
+                            ValueChanged="@(value => _contactForm.TypeId = value ?? "")"
+                            Items="@_contactTypes"
+                            ValueSelector="@GetContactTypePickerValue"
+                            TextSelector="@GetContactTypeLabel"
+                            SearchTextSelector="@GetContactTypeSearchText"
+                            AdvancedColumns="@ContactTypeAdvancedColumns"
+                            AdvancedFilters="@ContactTypeAdvancedFilters"
+                            AdvancedSearchScope="Searches contact type name, enabled state, system reference, and created date."
+                            Placeholder="No contact type"
+                            SearchPlaceholder="Search contact types..."
+                            EmptyMessage="No contact types found."
+                            AllowClear="true"
+                            ClearText="No contact type"
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Contact Type"
+                            AdvancedSearchDescription="Search contact classification types." />
+            <XfEntityPicker TItem="IdentityContactGroup"
+                            Label="Contact Group"
+                            Value="@_contactForm.GroupId"
+                            ValueChanged="@(value => _contactForm.GroupId = value ?? "")"
+                            Items="@_contactGroups"
+                            ValueSelector="@GetContactGroupPickerValue"
+                            TextSelector="@GetContactGroupLabel"
+                            SearchTextSelector="@GetContactGroupSearchText"
+                            AdvancedColumns="@ContactGroupAdvancedColumns"
+                            AdvancedFilters="@ContactGroupAdvancedFilters"
+                            AdvancedSearchScope="Searches contact group name, enabled state, system reference, contact count, and created date."
+                            Placeholder="Select contact group"
+                            SearchPlaceholder="Search contact groups..."
+                            EmptyMessage="No contact groups found."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Contact Group"
+                            AdvancedSearchDescription="Search contact groups for the active tenant." />
             <BbFormFieldInput TValue="string"
                               @bind-Value="_contactForm.Value"
                               Label="Value"
@@ -652,6 +719,7 @@ else
     // Lookup data
     private List<IdentityRoleType> _roleTypes = [];
     private List<IdentityContactType> _contactTypes = [];
+    private List<IdentityContactGroup> _contactGroups = [];
 
     // State
     private bool _loading = true;
@@ -947,6 +1015,14 @@ else
                     .Take(100)
                     .ToListAsync())
                 .ToList();
+
+            _contactGroups = (await DataContext.Query<IdentityContactGroup>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .OrderBy(x => x.Name)
+                    .Take(100)
+                    .ToListAsync())
+                .ToList();
         }
         catch { /* lookups may fail */ }
     }
@@ -1200,6 +1276,10 @@ else
         {
             _contactForm.CredentialId = _credentials[0].Id.ToString();
         }
+        if (_contactGroups.Count == 1)
+        {
+            _contactForm.GroupId = _contactGroups[0].Id.ToString();
+        }
         _contactDialogOpen = true;
     }
 
@@ -1210,6 +1290,7 @@ else
         {
             CredentialId = contact.CredentialId.ToString(),
             TypeId = contact.TypeId?.ToString() ?? "",
+            GroupId = contact.GroupId.ToString(),
             Value = contact.Value
         };
         _contactDialogOpen = true;
@@ -1225,6 +1306,11 @@ else
         if (!Guid.TryParse(_contactForm.CredentialId, out var credId))
         {
             ToastService.Show("Please select a credential.");
+            return;
+        }
+        if (!Guid.TryParse(_contactForm.GroupId, out var groupId))
+        {
+            ToastService.Show("Please select a contact group.");
             return;
         }
 
@@ -1244,6 +1330,7 @@ else
                     fresh.Value = _contactForm.Value;
                     fresh.CredentialId = credId;
                     fresh.TypeId = Guid.TryParse(_contactForm.TypeId, out var tid) ? tid : null;
+                    fresh.GroupId = groupId;
                     fresh.ModifiedAt = DateTime.UtcNow;
 
                     DataContext.Update(fresh);
@@ -1259,6 +1346,7 @@ else
                     TenantId = _user!.TenantId,
                     CredentialId = credId,
                     TypeId = Guid.TryParse(_contactForm.TypeId, out var tid) ? tid : null,
+                    GroupId = groupId,
                     Value = _contactForm.Value,
                     IsEnabled = true,
                     CreatedAt = DateTime.UtcNow
@@ -1474,6 +1562,129 @@ else
             ? contactType.Id.ToString()[..8]
             : contactType.Name;
 
+    private static string GetCredentialPickerValue(IdentityCredential credential) => credential.Id.ToString();
+    private static string GetRoleTypePickerValue(IdentityRoleType roleType) => roleType.Id.ToString();
+    private static string GetContactTypePickerValue(IdentityContactType contactType) => contactType.Id.ToString();
+    private static string GetContactGroupPickerValue(IdentityContactGroup contactGroup) => contactGroup.Id.ToString();
+    private static string GetContactGroupLabel(IdentityContactGroup contactGroup) =>
+        string.IsNullOrWhiteSpace(contactGroup.Name)
+            ? contactGroup.Id.ToString()[..8]
+            : contactGroup.Name;
+
+    private string GetCredentialSearchText(IdentityCredential credential) =>
+        $"{credential.UserName} {credential.UserAlias} {credential.Device} {credential.Location} {GetIdentityLabel(credential.IdentityInfoId)}";
+
+    private string GetRoleTypeSearchText(IdentityRoleType roleType) =>
+        $"{roleType.Name} {roleType.RoleLevel} {GetRoleTypeGroupLabel(roleType.GroupId)} {roleType.SystemReferenceId}";
+
+    private static string GetContactTypeSearchText(IdentityContactType contactType) =>
+        $"{contactType.Name} {contactType.SystemReferenceId}";
+
+    private static string GetContactGroupSearchText(IdentityContactGroup contactGroup) =>
+        $"{contactGroup.Name} {contactGroup.SystemReferenceId}";
+
+    private string GetIdentityLabel(Guid identityInfoId)
+    {
+        if (_user?.Id == identityInfoId)
+            return _user.FullName ?? _user.IdentityName ?? identityInfoId.ToString()[..8];
+
+        return identityInfoId.ToString()[..8];
+    }
+
+    private string GetRoleTypeGroupLabel(Guid groupId) =>
+        _roleTypes.FirstOrDefault(x => x.GroupId == groupId)?.Group?.Name
+        ?? groupId.ToString()[..8];
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityCredential>> CredentialAdvancedColumns =>
+    [
+        new("Username", x => x.UserName),
+        new("Alias", x => x.UserAlias),
+        new("Identity", x => GetIdentityLabel(x.IdentityInfoId)),
+        new("Online", x => FormatBoolean(x.IsOnline)),
+        new("Device", x => x.Device),
+        new("Location", x => x.Location),
+        new("Last Seen", x => FormatDateTime(x.LastSeen)),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityCredential>> CredentialAdvancedFilters =>
+    [
+        new("online", "Online", YesNoFilterOptions, x => x.IsOnline ? "true" : "false", "All credentials"),
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityRoleType>> RoleTypeAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Level", x => x.RoleLevel?.ToString()),
+        new("Group", x => x.Group?.Name ?? GetRoleTypeGroupLabel(x.GroupId)),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("System Ref", x => x.SystemReferenceId.ToString()[..8]),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityRoleType>> RoleTypeAdvancedFilters =>
+    [
+        new("group", "Group", BuildRoleTypeGroupFilterOptions(), x => x.GroupId.ToString(), "All groups"),
+        new("level", "Level", BuildDistinctFilterOptions(_roleTypes, x => x.RoleLevel?.ToString()), x => x.RoleLevel?.ToString(), "All levels"),
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityContactType>> ContactTypeAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("System Ref", x => x.SystemReferenceId.ToString()[..8]),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityContactType>> ContactTypeAdvancedFilters =>
+    [
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityContactGroup>> ContactGroupAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("Contacts", x => _contacts.Count(contact => contact.GroupId == x.Id).ToString()),
+        new("System Ref", x => x.SystemReferenceId.ToString()[..8]),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityContactGroup>> ContactGroupAdvancedFilters =>
+    [
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilterOption> BuildRoleTypeGroupFilterOptions() =>
+        _roleTypes
+            .Select(x => new { x.GroupId, Label = x.Group?.Name ?? x.GroupId.ToString()[..8] })
+            .DistinctBy(x => x.GroupId)
+            .OrderBy(x => x.Label)
+            .Select(x => new XfEntityPickerFilterOption(x.GroupId.ToString(), x.Label))
+            .ToArray();
+
+    private static IReadOnlyList<XfEntityPickerFilterOption> BuildDistinctFilterOptions<TItem>(
+        IEnumerable<TItem> items,
+        Func<TItem, string?> valueSelector) =>
+        items
+            .Select(valueSelector)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .Select(value => new XfEntityPickerFilterOption(value!, value!))
+            .ToArray();
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDateTime(DateTime value) => value == default ? "N/A" : value.ToString("g");
+
     private static bool TryResolveRoleExpiration(string? value, out DateTime expiration)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -1523,6 +1734,7 @@ else
     {
         public string CredentialId { get; set; } = "";
         public string TypeId { get; set; } = "";
+        public string GroupId { get; set; } = "";
         public string Value { get; set; } = "";
     }
 

--- a/src/Tests/ControlPanel.E2ETests/IdentityServerControlPanelContractTests.cs
+++ b/src/Tests/ControlPanel.E2ETests/IdentityServerControlPanelContractTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+
+namespace ControlPanel.E2ETests;
+
+[TestFixture]
+[Category("Kind:Integration")]
+[Category("Module:IdentityServer")]
+[Category("Area:ControlPanelContract")]
+public sealed class IdentityServerControlPanelContractTests
+{
+    [Test]
+    public void IdentityServerEntityRelationshipDialogs_UseSharedEntityPickerAdvancedSearch()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Identity");
+
+        var userDetail = File.ReadAllText(Path.Combine(pagesRoot, "UserDetail.razor"));
+        var contacts = File.ReadAllText(Path.Combine(pagesRoot, "Contacts.razor"));
+        var addresses = File.ReadAllText(Path.Combine(pagesRoot, "Addresses.razor"));
+        var tenants = File.ReadAllText(Path.Combine(pagesRoot, "Tenants.razor"));
+        var tenantDetail = File.ReadAllText(Path.Combine(pagesRoot, "TenantDetail.razor"));
+
+        userDetail.Should().Contain("<XfEntityPicker TItem=\"IdentityCredential\"");
+        userDetail.Should().Contain("<XfEntityPicker TItem=\"IdentityRoleType\"");
+        userDetail.Should().Contain("<XfEntityPicker TItem=\"IdentityContactType\"");
+        userDetail.Should().Contain("<XfEntityPicker TItem=\"IdentityContactGroup\"");
+        userDetail.Should().Contain("AdvancedColumns=\"@CredentialAdvancedColumns\"");
+        userDetail.Should().Contain("AdvancedFilters=\"@CredentialAdvancedFilters\"");
+        userDetail.Should().Contain("AdvancedColumns=\"@RoleTypeAdvancedColumns\"");
+        userDetail.Should().Contain("AdvancedFilters=\"@RoleTypeAdvancedFilters\"");
+        userDetail.Should().Contain("AdvancedColumns=\"@ContactTypeAdvancedColumns\"");
+        userDetail.Should().Contain("AdvancedFilters=\"@ContactTypeAdvancedFilters\"");
+        userDetail.Should().Contain("AdvancedColumns=\"@ContactGroupAdvancedColumns\"");
+        userDetail.Should().Contain("AdvancedFilters=\"@ContactGroupAdvancedFilters\"");
+
+        contacts.Should().Contain("<XfEntityPicker TItem=\"IdentityCredential\"");
+        contacts.Should().Contain("<XfEntityPicker TItem=\"IdentityContactType\"");
+        contacts.Should().Contain("<XfEntityPicker TItem=\"IdentityContactGroup\"");
+        contacts.Should().Contain("AdvancedColumns=\"@CredentialAdvancedColumns\"");
+        contacts.Should().Contain("AdvancedFilters=\"@CredentialAdvancedFilters\"");
+        contacts.Should().Contain("AdvancedColumns=\"@ContactTypeAdvancedColumns\"");
+        contacts.Should().Contain("AdvancedFilters=\"@ContactTypeAdvancedFilters\"");
+        contacts.Should().Contain("AdvancedColumns=\"@ContactGroupAdvancedColumns\"");
+        contacts.Should().Contain("AdvancedFilters=\"@ContactGroupAdvancedFilters\"");
+        contacts.Should().NotContain("Label=\"Credential ID\"");
+        contacts.Should().NotContain("Label=\"Type ID\"");
+        contacts.Should().NotContain("Label=\"Group ID\"");
+
+        addresses.Should().Contain("<XfEntityPicker TItem=\"IdentityInformation\"");
+        addresses.Should().Contain("AdvancedColumns=\"@UserAdvancedColumns\"");
+        addresses.Should().Contain("AdvancedFilters=\"@UserAdvancedFilters\"");
+        addresses.Should().NotContain("Label=\"User ID (IdentityInfoId)\"");
+
+        tenants.Should().Contain("<XfEntityPicker TItem=\"Tenant\"");
+        tenants.Should().Contain("AdvancedColumns=\"@TenantAdvancedColumns\"");
+        tenants.Should().Contain("AdvancedFilters=\"@TenantAdvancedFilters\"");
+        tenants.Should().Contain("AdvancedSearchScope=\"Searches tenant name, description, status, version, expiration, enabled state, and created date.\"");
+        tenants.Should().NotContain("Label=\"Parent Tenant ID\"");
+
+        tenantDetail.Should().Contain("<XfEntityPicker TItem=\"RegistryConfigurationGroup\"");
+        tenantDetail.Should().Contain("AdvancedColumns=\"@ConfigurationGroupAdvancedColumns\"");
+        tenantDetail.Should().Contain("AdvancedFilters=\"@ConfigurationGroupAdvancedFilters\"");
+        tenantDetail.Should().NotContain("<BbFormFieldNativeSelect");
+    }
+
+    [Test]
+    public void SharedEntityPickerAdvancedSearch_RemainsMultiColumnAndFilterable()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pickerPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Shared",
+            "XfEntityPicker.razor");
+
+        var pickerText = File.ReadAllText(pickerPath);
+
+        pickerText.Should().Contain("xf-entity-picker-advanced-table");
+        pickerText.Should().Contain("ToggleAdvancedSort");
+        pickerText.Should().Contain("AdvancedFilters");
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "XFramework.slnx")))
+                return current;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate XFramework repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- migrated IdentityServer ControlPanel relationship selectors to the shared XfEntityPicker Advanced Search pattern
- added module-specific advanced columns, filters, and search scopes for users, credentials, role types, contact types/groups, tenants, and configuration groups
- added ControlPanel contract tests to guard IdentityServer picker usage and shared advanced-search behavior

## Verification
- dotnet build .\src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false --nologo -v:minimal
- dotnet test .\src\Tests\ControlPanel.E2ETests\ControlPanel.E2ETests.csproj --filter TestCategory=Area:ControlPanelContract --nologo -v:minimal

Note: ControlPanel build reports the existing NU1510 warning for System.Net.Http.Json in XFramework.Integration.