### PR TITLE
Use DataGrid in entity picker advanced search

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -106,7 +106,6 @@ else
         <BbDialogContent TrapFocus="false" class="max-w-4xl">
             <BbDialogHeader>
                 <BbDialogTitle>Post Stock Movement</BbDialogTitle>
-                <BbDialogDescription>Post movement for @_product.Name. The product is fixed by the open detail page.</BbDialogDescription>
             </BbDialogHeader>
             <div class="grid gap-4 py-4">
                 @FixedProductField

--- a/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPicker.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPicker.razor
@@ -1,4 +1,4 @@
-@typeparam TItem
+@typeparam TItem where TItem : class
 
 <div class="xf-form-field xf-entity-picker">
     @if (!string.IsNullOrWhiteSpace(Label))
@@ -99,114 +99,46 @@
         <BbDialogHeader>
             <BbDialogTitle>@AdvancedSearchTitle</BbDialogTitle>
             <BbDialogDescription>@AdvancedSearchDescription</BbDialogDescription>
-        </BbDialogHeader>
-        <div class="grid gap-4 py-4">
-            <div class="xf-entity-picker-advanced-tools">
-                <BbFormFieldInput TValue="string"
-                                  @bind-Value="_advancedSearchQuery"
-                                  Label="Search"
-                                  Placeholder="@AdvancedSearchPlaceholder" />
-                @if (!string.IsNullOrWhiteSpace(AdvancedSearchScopeText))
-                {
-                    <BbTypographyMuted>@AdvancedSearchScopeText</BbTypographyMuted>
-                }
-            </div>
-
-            @if (AdvancedFilters.Count > 0)
+            @if (ShowAdvancedColumnFilters)
             {
-                <div class="xf-entity-picker-advanced-filters">
-                    @foreach (var filter in AdvancedFilters)
-                    {
-                        <BbFormFieldSelect TValue="string"
-                                           Value="@GetAdvancedFilterValue(filter)"
-                                           ValueChanged="@(value => SetAdvancedFilter(filter, value))"
-                                           Label="@filter.Label">
-                            <BbSelectItem Value="@GetAllFilterValue(filter)">@GetAllFilterLabel(filter)</BbSelectItem>
-                            @foreach (var option in filter.Options)
-                            {
-                                <BbSelectItem Value="@option.Value">@option.Label</BbSelectItem>
-                            }
-                        </BbFormFieldSelect>
-                    }
-                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ResetAdvancedFilters">
-                        <LucideIcon Name="rotate-ccw" class="mr-2 h-4 w-4" />
-                        Reset
-                    </BbButton>
-                </div>
+                <p class="xf-entity-picker-advanced-hint">Hover over a column header to reveal its filter.</p>
             }
-
-            <div class="xf-entity-picker-advanced-meta">
-                <span>@AdvancedResultText</span>
-                @if (!string.IsNullOrWhiteSpace(_advancedSortColumnKey))
-                {
-                    <span>Sorted by @CurrentSortTitle @(_advancedSortDescending ? "descending" : "ascending")</span>
-                }
-            </div>
-
-            <div class="xf-entity-picker-advanced-table-wrap">
+        </BbDialogHeader>
+        <div class="grid gap-3 py-4">
+            <div class="xf-entity-picker-advanced-grid-wrap">
                 @if (!AdvancedFilteredItems.Any())
                 {
                     <div class="xf-entity-picker-empty">@EmptyMessage</div>
                 }
                 else
                 {
-                    <table class="xf-entity-picker-advanced-table">
-                        <thead>
-                            <tr>
-                                @foreach (var column in EffectiveAdvancedColumns)
-                                {
-                                    <th class="@column.CssClass">
-                                        @if (column.Sortable)
-                                        {
-                                            <button type="button"
-                                                    class="xf-entity-picker-sort"
-                                                    @onclick="@(() => ToggleAdvancedSort(column))">
-                                                <span>@column.Title</span>
-                                                @if (string.Equals(_advancedSortColumnKey, column.Title, StringComparison.Ordinal))
-                                                {
-                                                    <LucideIcon Name="@(_advancedSortDescending ? "arrow-down" : "arrow-up")" class="h-3 w-3" />
-                                                }
-                                            </button>
-                                        }
-                                        else
-                                        {
-                                            @column.Title
-                                        }
-                                    </th>
-                                }
-                            </tr>
-                            @if (ShowAdvancedColumnFilters)
+                    <BbDataGrid Items="@AdvancedFilteredItems"
+                                ShowPagination="true"
+                                InitialPageSize="10"
+                                ShowSearch="false"
+                                Resizable="true"
+                                Reorderable="false"
+                                OnRowClick="@((TItem item) => SelectItemFromAdvanced(item))"
+                                Class="xf-entity-picker-advanced-grid cursor-pointer">
+                        <Columns>
+                            @foreach (var column in EffectiveAdvancedColumns)
                             {
-                                <tr class="xf-entity-picker-advanced-filter-row">
-                                    @foreach (var column in EffectiveAdvancedColumns)
-                                    {
-                                        <th class="@column.CssClass">
-                                            <input type="search"
-                                                   class="xf-entity-picker-column-filter"
-                                                   value="@GetAdvancedColumnFilterValue(column)"
-                                                   @oninput="@(args => SetAdvancedColumnFilter(column, args.Value?.ToString()))"
-                                                   placeholder="@($"Filter {column.Title}")"
-                                                   aria-label="@($"Filter {column.Title}")" />
-                                        </th>
-                                    }
-                                </tr>
+                                <BbDataGridTemplateColumn Id="@GetAdvancedColumnKey(column)"
+                                                          Title="@column.Title"
+                                                          Sortable="@column.Sortable"
+                                                          SortBy="@(item => FormatAdvancedCell(column.ValueSelector(item)))"
+                                                          Filterable="@ShowAdvancedColumnFilters"
+                                                          FilterBy="@(item => FormatAdvancedCell(column.ValueSelector(item)))"
+                                                          CellClass="@column.CssClass"
+                                                          HeaderClass="@column.CssClass"
+                                                          NoWrap="true">
+                                    <ChildContent Context="item">
+                                        @FormatAdvancedCell(column.ValueSelector(item))
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
                             }
-                        </thead>
-                        <tbody>
-                            @foreach (var item in AdvancedFilteredItems)
-                            {
-                                <tr class="xf-entity-picker-advanced-row"
-                                    tabindex="0"
-                                    @onclick="@(() => SelectItemFromAdvanced(item))"
-                                    @onkeydown="@((KeyboardEventArgs args) => SelectItemFromAdvancedOnKeyDown(args, item))">
-                                    @foreach (var column in EffectiveAdvancedColumns)
-                                    {
-                                        <td class="@column.CssClass">@FormatAdvancedCell(column.ValueSelector(item))</td>
-                                    }
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
+                        </Columns>
+                    </BbDataGrid>
                 }
             </div>
         </div>
@@ -228,11 +160,6 @@
     private bool _open;
     private bool _advancedOpen;
     private string _searchQuery = "";
-    private string _advancedSearchQuery = "";
-    private readonly Dictionary<string, string> _advancedFilterValues = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, string> _advancedColumnFilterValues = new(StringComparer.Ordinal);
-    private string? _advancedSortColumnKey;
-    private bool _advancedSortDescending;
 
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Value { get; set; }
@@ -280,16 +207,7 @@
                 new("Identifier", GetValue)
             ];
 
-    private string AdvancedSearchScopeText =>
-        AdvancedSearchScope ?? $"Searches {string.Join(", ", EffectiveAdvancedColumns.Select(x => x.Title))}.";
-
-    private IReadOnlyList<TItem> AdvancedFilteredItems => SortAdvancedItems(FilterAdvancedItems()).ToList();
-
-    private string AdvancedResultText =>
-        AdvancedFilteredItems.Count == 1 ? "1 result" : $"{AdvancedFilteredItems.Count} results";
-
-    private string CurrentSortTitle =>
-        EffectiveAdvancedColumns.FirstOrDefault(x => string.Equals(x.Title, _advancedSortColumnKey, StringComparison.Ordinal))?.Title ?? "";
+    private IReadOnlyList<TItem> AdvancedFilteredItems => Items;
 
     private IEnumerable<TItem> FilterItems(string query)
     {
@@ -297,65 +215,6 @@
             return Items;
 
         return Items.Where(item => GetSearchText(item).Contains(query, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private IEnumerable<TItem> FilterAdvancedItems()
-    {
-        var query = _advancedSearchQuery.Trim();
-
-        return Items.Where(item =>
-        {
-            if (!string.IsNullOrWhiteSpace(query) &&
-                !GetAdvancedSearchText(item).Contains(query, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            foreach (var filter in AdvancedFilters)
-            {
-                if (!_advancedFilterValues.TryGetValue(filter.Key, out var selected) ||
-                    string.IsNullOrWhiteSpace(selected))
-                {
-                    continue;
-                }
-
-                if (!string.Equals(filter.ValueSelector(item), selected, StringComparison.OrdinalIgnoreCase))
-                    return false;
-            }
-
-            foreach (var column in EffectiveAdvancedColumns)
-            {
-                if (!_advancedColumnFilterValues.TryGetValue(GetAdvancedColumnKey(column), out var columnFilter) ||
-                    string.IsNullOrWhiteSpace(columnFilter))
-                {
-                    continue;
-                }
-
-                if (!FormatAdvancedCell(column.ValueSelector(item))
-                    .Contains(columnFilter.Trim(), StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        });
-    }
-
-    private IEnumerable<TItem> SortAdvancedItems(IEnumerable<TItem> items)
-    {
-        if (string.IsNullOrWhiteSpace(_advancedSortColumnKey))
-            return items;
-
-        var column = EffectiveAdvancedColumns.FirstOrDefault(x =>
-            string.Equals(x.Title, _advancedSortColumnKey, StringComparison.Ordinal));
-
-        if (column is null)
-            return items;
-
-        return _advancedSortDescending
-            ? items.OrderByDescending(item => FormatAdvancedCell(column.ValueSelector(item)), StringComparer.CurrentCultureIgnoreCase)
-            : items.OrderBy(item => FormatAdvancedCell(column.ValueSelector(item)), StringComparer.CurrentCultureIgnoreCase);
     }
 
     private RenderFragment RenderItem(TItem item) => builder =>
@@ -374,78 +233,8 @@
 
     private string GetValue(TItem item) => ValueSelector(item);
     private string GetSearchText(TItem item) => SearchTextSelector?.Invoke(item) ?? TextSelector(item);
-    private string GetAdvancedSearchText(TItem item)
-    {
-        if (AdvancedSearchTextSelector is not null)
-            return AdvancedSearchTextSelector(item);
-
-        var values = EffectiveAdvancedColumns.Select(column => FormatAdvancedCell(column.ValueSelector(item)));
-        return $"{GetSearchText(item)} {string.Join(' ', values)}";
-    }
 
     private static string GetAdvancedColumnKey(XfEntityPickerColumn<TItem> column) => column.Title;
-
-    private string GetAdvancedColumnFilterValue(XfEntityPickerColumn<TItem> column) =>
-        _advancedColumnFilterValues.TryGetValue(GetAdvancedColumnKey(column), out var value) ? value : "";
-
-    private Task SetAdvancedColumnFilter(XfEntityPickerColumn<TItem> column, string? value)
-    {
-        var columnKey = GetAdvancedColumnKey(column);
-        if (string.IsNullOrWhiteSpace(value))
-            _advancedColumnFilterValues.Remove(columnKey);
-        else
-            _advancedColumnFilterValues[columnKey] = value;
-
-        return Task.CompletedTask;
-    }
-
-    private static string GetAllFilterLabel(XfEntityPickerFilter<TItem> filter) =>
-        string.IsNullOrWhiteSpace(filter.AllLabel) ? "All" : filter.AllLabel;
-
-    private static string GetAllFilterValue(XfEntityPickerFilter<TItem> filter) => GetAllFilterLabel(filter);
-
-    private string GetAdvancedFilterValue(XfEntityPickerFilter<TItem> filter) =>
-        _advancedFilterValues.TryGetValue(filter.Key, out var value) ? value : GetAllFilterValue(filter);
-
-    private Task SetAdvancedFilter(XfEntityPickerFilter<TItem> filter, string value)
-    {
-        if (string.IsNullOrWhiteSpace(value) ||
-            string.Equals(value, GetAllFilterValue(filter), StringComparison.Ordinal))
-        {
-            _advancedFilterValues.Remove(filter.Key);
-        }
-        else
-        {
-            _advancedFilterValues[filter.Key] = value;
-        }
-
-        return Task.CompletedTask;
-    }
-
-    private Task ResetAdvancedFilters()
-    {
-        _advancedFilterValues.Clear();
-        _advancedColumnFilterValues.Clear();
-        _advancedSearchQuery = "";
-        _advancedSortColumnKey = null;
-        _advancedSortDescending = false;
-        return Task.CompletedTask;
-    }
-
-    private Task ToggleAdvancedSort(XfEntityPickerColumn<TItem> column)
-    {
-        if (string.Equals(_advancedSortColumnKey, column.Title, StringComparison.Ordinal))
-        {
-            _advancedSortDescending = !_advancedSortDescending;
-        }
-        else
-        {
-            _advancedSortColumnKey = column.Title;
-            _advancedSortDescending = false;
-        }
-
-        return Task.CompletedTask;
-    }
 
     private static string FormatAdvancedCell(string? value) =>
         string.IsNullOrWhiteSpace(value) ? "N/A" : value;
@@ -475,14 +264,7 @@
     private async Task SelectItemFromAdvanced(TItem item)
     {
         _advancedOpen = false;
-        _advancedSearchQuery = "";
         await ValueChanged.InvokeAsync(GetValue(item));
-    }
-
-    private async Task SelectItemFromAdvancedOnKeyDown(KeyboardEventArgs args, TItem item)
-    {
-        if (args.Key is "Enter" or " ")
-            await SelectItemFromAdvanced(item);
     }
 
     private async Task ClearSelection()
@@ -496,10 +278,7 @@
     {
         _open = false;
         _advancedOpen = true;
-        _advancedSearchQuery = _searchQuery;
         _searchQuery = "";
-        if (string.IsNullOrWhiteSpace(_advancedSortColumnKey) && EffectiveAdvancedColumns.FirstOrDefault(x => x.Sortable) is { } firstSortable)
-            _advancedSortColumnKey = firstSortable.Title;
 
         return Task.CompletedTask;
     }
@@ -514,7 +293,6 @@
     private async Task OpenCreateFromAdvanced()
     {
         _advancedOpen = false;
-        _advancedSearchQuery = "";
         await OnCreate.InvokeAsync();
     }
 }

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -240,125 +240,25 @@
     color: var(--muted-foreground);
 }
 
-.xf-entity-picker-advanced-tools {
-    display: grid;
-    gap: 0.35rem;
-}
-
 .xf-entity-picker-advanced-dialog {
     width: min(74rem, calc(100vw - 2rem));
     max-width: min(74rem, calc(100vw - 2rem));
 }
 
-.xf-entity-picker-advanced-filters {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
-    gap: 0.75rem;
-    align-items: end;
-}
-
-.xf-entity-picker-advanced-meta {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 0.75rem;
+.xf-entity-picker-advanced-hint {
     color: var(--muted-foreground);
-    font-size: 0.75rem;
-    line-height: 1rem;
-}
-
-.xf-entity-picker-advanced-table-wrap {
-    max-height: min(32rem, 60vh);
-    overflow: auto;
-    border: 1px solid var(--border);
-    border-radius: calc(var(--radius) - 2px);
-}
-
-.xf-entity-picker-advanced-table {
-    width: 100%;
-    min-width: 58rem;
-    border-collapse: collapse;
-    font-size: 0.875rem;
+    font-size: 0.8125rem;
     line-height: 1.25rem;
+    margin: 0.25rem 0 0;
 }
 
-.xf-entity-picker-advanced-table th {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    border-bottom: 1px solid var(--border);
-    background: var(--muted);
-    color: var(--muted-foreground);
-    font-weight: 500;
-    padding: 0.625rem 0.75rem;
-    text-align: left;
-    white-space: nowrap;
+.xf-entity-picker-advanced-grid-wrap {
+    max-height: min(34rem, 62vh);
+    overflow: auto;
 }
 
-.xf-entity-picker-advanced-filter-row th {
-    top: 2.5rem;
-    z-index: 2;
-    background: color-mix(in oklab, var(--muted) 72%, var(--background));
-    padding: 0.45rem 0.5rem;
-}
-
-.xf-entity-picker-advanced-table td {
-    border-bottom: 1px solid var(--border);
-    padding: 0.625rem 0.75rem;
-    vertical-align: top;
-}
-
-.xf-entity-picker-advanced-row {
-    cursor: pointer;
-    transition: background-color 150ms ease, box-shadow 150ms ease;
-}
-
-.xf-entity-picker-advanced-row:hover {
-    background: color-mix(in oklab, var(--muted) 45%, transparent);
-}
-
-.xf-entity-picker-advanced-row:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 1px var(--ring);
-}
-
-.xf-entity-picker-sort {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    border: 0;
-    background: transparent;
-    color: inherit;
-    cursor: pointer;
-    font: inherit;
-    padding: 0;
-}
-
-.xf-entity-picker-column-filter {
-    width: 100%;
-    min-width: 7rem;
-    height: 2rem;
-    border-radius: calc(var(--radius) - 4px);
-    border: 1px solid var(--input);
-    background: var(--background);
-    color: var(--foreground);
-    font-size: 0.75rem;
-    line-height: 1rem;
-    padding: 0.35rem 0.5rem;
-    outline: none;
-}
-
-.xf-entity-picker-column-filter::placeholder {
-    color: var(--muted-foreground);
-}
-
-.xf-entity-picker-column-filter:focus {
-    border-color: var(--ring);
-    box-shadow: 0 0 0 1px var(--ring);
-}
-
-.xf-entity-picker-sort:hover {
-    color: var(--foreground);
+.xf-entity-picker-advanced-grid {
+    min-width: 58rem;
 }
 
 .xf-entity-picker-empty {

--- a/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -115,12 +115,17 @@ public sealed class ControlPanelContractTests
         productDetailText.Should().Contain("AdvancedColumns=\"@PurchaseOrderAdvancedColumns\"");
         productDetailText.Should().Contain("AdvancedFilters=\"@PurchaseOrderAdvancedFilters\"");
 
-        pickerText.Should().Contain("xf-entity-picker-advanced-table", "advanced search must render a multi-column finder, not the same single-column command list");
-        pickerText.Should().Contain("ToggleAdvancedSort", "advanced search columns should be sortable");
-        pickerText.Should().Contain("AdvancedFilters", "advanced search should support explicit filters");
+        pickerText.Should().Contain("<BbDataGrid", "advanced search must use the shared BlazorBlueprint data grid instead of a custom table");
+        pickerText.Should().Contain("BbDataGridTemplateColumn", "advanced search must render a multi-column finder, not the same single-column command list");
+        pickerText.Should().Contain("SortBy", "advanced search columns should use native data grid sorting");
         pickerText.Should().Contain("xf-entity-picker-advanced-dialog", "advanced search dialogs should be wide enough for multi-column finder tables");
+        pickerText.Should().Contain("Hover over a column header to reveal its filter.", "advanced search should make native column filters discoverable");
         pickerText.Should().Contain("ShowAdvancedColumnFilters", "advanced finder tables should support per-column filtering");
-        pickerText.Should().Contain("xf-entity-picker-column-filter", "advanced finder tables should render column filter inputs");
+        pickerText.Should().Contain("FilterBy", "advanced finder tables should use native data grid column filtering");
+        pickerText.Should().NotContain("xf-entity-picker-advanced-tools", "advanced search should not render a redundant search band above the data grid");
+        pickerText.Should().NotContain("xf-entity-picker-advanced-filters", "advanced search should use native data grid filters instead of duplicate select filters above the grid");
+        pickerText.Should().NotContain("xf-entity-picker-column-filter", "advanced finder tables should not render custom filter inputs");
+        pickerText.Should().NotContain("<table class=\"xf-entity-picker-advanced-table\"", "advanced finder tables should not use a custom table implementation");
         pickerText.Should().NotContain("__all__", "filter sentinels must not leak into selected filter labels");
     }
 


### PR DESCRIPTION
## Summary
- Replaced the custom XfEntityPicker advanced-search table with BlazorBlueprint BbDataGrid.
- Removed the redundant advanced-search search/select filter band so filtering lives in the DataGrid columns.
- Added a short hint explaining that column filters appear from the headers.
- Removed the awkward Post Stock Movement dialog description.

## Verification
- dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false
- dotnet test src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj --filter FullyQualifiedName~ControlPanelContractTests -m:1 /nr:false --logger console;verbosity=minimal
- Local browser smoke on http://127.0.0.1:5005/inventario/products/1312c5f2-4248-4afb-9cd9-0ac0b454a45d/stock