### PR TITLE
Enable native Inventario data grid filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,4 +11,9 @@ Primary route:
 - [docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md](docs/solutions/developer-experience/controlpanel-service-wrapper-and-integration-test-contract.md) - ControlPanel wrapper vs `IDataContext` rules and integration-test coverage tiers.
 - [docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md](docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md) - BlazorBlueprint ControlPanel usage, docs lookup, and visual verification rules.
 
+ControlPanel table rule:
+
+- Use BlazorBlueprint `BbDataGrid` for list, report, and data-heavy tabular UI as much as possible. Do not create raw HTML tables or custom table components unless the BlazorBlueprint grid cannot support the workflow, and document that exception in the change.
+- Enable native `BbDataGrid` column filtering on useful user-facing data columns. Use `Filterable="true"` on property columns and set `FilterBy` on template columns; leave command/action columns unfiltered.
+
 Task-specific OpenCode skills live under `.opencode/skills/`; use them as workflow helpers, not as the primary documentation authority.

--- a/docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md
+++ b/docs/solutions/tooling-decisions/blazor-blueprint-controlpanel-agent-guide.md
@@ -62,7 +62,9 @@ Use these common styled components first:
 - `BbDropdownMenu` for command/profile menus.
 - `BbDialog` for modal forms.
 - `BbTabs` only when the tab count is small and does not cause horizontal scrolling.
-- `BbDataGrid` for data-heavy tables that need paging, search, row click, or column templates.
+- `BbDataGrid` for list, report, and data-heavy tabular UI that needs paging, search, row click, sorting, filtering, or column templates. Prefer it over raw `<table>` markup and custom table components.
+
+For `BbDataGrid`, enable native column filtering on useful user-facing data columns. Set `Filterable="true"` on property columns. For template columns, set both `Filterable="true"` and a `FilterBy` expression that matches the rendered business value. Do not make action/command columns filterable.
 
 For icons, use Lucide components from `BlazorBlueprint.Icons.Lucide.Components`. Do not hand-draw common UI icons.
 
@@ -118,13 +120,14 @@ For `BbCombobox`, prefer typed `SelectOption<TValue>` options when the selection
 
 For parent dependency entities, use the shared `XfEntityPicker<TItem>` pattern instead of embedding prerequisite forms in the parent workflow. The picker trigger should provide quick search/select, an `Advanced Search` dialog, and a `Create New` dialog. For example, a product stock dialog should pick a warehouse/location/lot through entity pickers; warehouse and location creation belongs to the picker-owned create dialogs, not directly inside the stock form.
 
-`Advanced Search` must be meaningfully advanced. Do not implement it as a larger copy of the quick dropdown. Configure entity-specific `AdvancedColumns`, `AdvancedFilters`, and `AdvancedSearchScope` so the dialog shows a sortable multi-column finder with explicit filter controls. The operator should be able to tell what is being searched and filtered, for example warehouse code/name/location/default status, lot number/status/expiry/on-hand quantity, or supplier code/name/contact/active status.
+`Advanced Search` must be meaningfully advanced. Do not implement it as a larger copy of the quick dropdown. Configure entity-specific `AdvancedColumns` and `AdvancedSearchScope` so the dialog shows a sortable multi-column `BbDataGrid` finder. Use the grid's native column filters (`Filterable` and `FilterBy`) instead of redundant top-of-dialog filter bands. The operator should be able to tell what is being searched and filtered, for example warehouse code/name/location/default status, lot number/status/expiry/on-hand quantity, or supplier code/name/contact/active status.
 
 ## Operational Page Layout
 
 For module admin surfaces such as Inventario, keep list and detail workflows distinct:
 
 - List pages are for scanning, filtering, creating small records, and navigating to detail pages.
+- List and report pages should use `BbDataGrid` for tabular records and should enable native filters on the business columns users naturally search by. Keep command/action columns unfiltered.
 - Viewing and editing existing records should happen on the detail page with a clear edit mode, not in list-page edit modals.
 - Detail pages should show the operational context users need for that entity. For example, product detail should include catalog fields, replenishment rules, stock balances by warehouse/location/lot, and traceability records when those features are enabled.
 - Header actions belong on the far right of the page header. Use the shared `xf-page-header` and `xf-page-actions` classes instead of hand-assembling inconsistent flex utility combinations.

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
@@ -43,12 +43,12 @@ else
                                 OnRowClick="@((ProductCategory item) => Navigation.NavigateTo($"/inventario/categories/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" />
-                            <BbDataGridTemplateColumn Title="Products">
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Products" Filterable="true" FilterBy="@(item => GetProductCount(item.Id))">
                                 <ChildContent Context="item">@GetProductCount(item.Id)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
                                     <div class="flex items-center gap-1" @onclick:stopPropagation="true">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
@@ -49,20 +49,20 @@ else
                                 OnRowClick="@((InventoryLot item) => Navigation.NavigateTo($"/inventario/lots/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot / Batch" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot / Batch" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Status">
+                            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status)">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@item.Status.ToString()" Status="@GetStatusBadge(item.Status)" />
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="On Hand">
+                            <BbDataGridTemplateColumn Title="On Hand" Filterable="true" FilterBy="@(item => GetLotOnHand(item.Id))">
                                 <ChildContent Context="item">@GetLotOnHand(item.Id).ToString("N2")</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
                                     <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View lot"

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
@@ -73,13 +73,13 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_suggestions" ShowPagination="true" InitialPageSize="20">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.WarehouseName)" Title="Warehouse" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LocationName)" Title="Location" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.SuggestedQuantity)" Title="Suggested Qty" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Preferred Supplier" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.WarehouseName)" Title="Warehouse" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LocationName)" Title="Location" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.SuggestedQuantity)" Title="Suggested Qty" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Preferred Supplier" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -93,18 +93,18 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_rules" ShowPagination="true" InitialPageSize="20">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Scope">
+                            <BbDataGridTemplateColumn Title="Scope" Filterable="true" FilterBy="@(item => GetScopeLabel(item))">
                                 <ChildContent Context="item">@GetScopeLabel(item)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.MinimumQuantity)" Title="Min" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MaximumQuantity)" Title="Max" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Point" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReorderQuantity)" Title="Qty" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Supplier" />
-                            <BbDataGridTemplateColumn Title="Status">
+                            <BbDataGridPropertyColumn Property="@(x => x.MinimumQuantity)" Title="Min" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MaximumQuantity)" Title="Max" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Point" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReorderQuantity)" Title="Qty" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.PreferredSupplier)" Title="Supplier" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.IsActive)">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@(item.IsActive ? "Active" : "Inactive")" Status="@(item.IsActive ? "active" : "inactive")" />
                                 </ChildContent>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
@@ -73,32 +73,32 @@ else
                                 OnRowClick="@((Product item) => Navigation.NavigateTo($"/inventario/products/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="SKU">
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="SKU" Filterable="true" FilterBy="@(item => item.SKU ?? string.Empty)">
                                 <ChildContent Context="item">
                                     <span class="font-mono text-xs">@(item.SKU ?? "N/A")</span>
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Category">
+                            <BbDataGridTemplateColumn Title="Category" Filterable="true" FilterBy="@(item => GetCategoryName(item.CategoryId))">
                                 <ChildContent Context="item">@GetCategoryName(item.CategoryId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Price" Sortable="true">
+                            <BbDataGridTemplateColumn Title="Price" Sortable="true" Filterable="true" FilterBy="@(item => item.Price)">
                                 <ChildContent Context="item">@item.Price.ToString("N2")</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Stock" Sortable="true">
+                            <BbDataGridTemplateColumn Title="Stock" Sortable="true" Filterable="true" FilterBy="@(item => item.StockQuantity)">
                                 <ChildContent Context="item">
                                     <span class="@(item.StockQuantity <= _lowStockThreshold ? "font-semibold text-yellow-600" : "")">
                                         @item.StockQuantity
                                     </span>
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Status">
+                            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.IsAvailable)">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@(item.IsAvailable ? "Available" : "Unavailable")"
                                                  Status="@(item.IsAvailable ? "active" : "inactive")" />
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
                                     <div class="flex items-center gap-1">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
@@ -49,18 +49,18 @@ else
                                 OnRowClick="@((PurchaseOrder item) => Navigation.NavigateTo($"/inventario/purchase-orders/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.OrderNumber)" Title="Order" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Supplier">
+                            <BbDataGridPropertyColumn Property="@(x => x.OrderNumber)" Title="Order" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Supplier" Filterable="true" FilterBy="@(item => GetSupplierName(item.SupplierId))">
                                 <ChildContent Context="item">@GetSupplierName(item.SupplierId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Status">
+                            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status)">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@item.Status.ToString()" Status="@GetStatusBadge(item.Status)" />
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.OrderDate)" Title="Order Date" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ExpectedDate)" Title="Expected" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Lines">
+                            <BbDataGridPropertyColumn Property="@(x => x.OrderDate)" Title="Order Date" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpectedDate)" Title="Expected" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Lines" Filterable="true" FilterBy="@(item => _lines.Count(x => x.PurchaseOrderId == item.Id))">
                                 <ChildContent Context="item">@_lines.Count(x => x.PurchaseOrderId == item.Id)</ChildContent>
                             </BbDataGridTemplateColumn>
                             <BbDataGridTemplateColumn Title="Actions">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
@@ -49,19 +49,19 @@ else
                                 OnRowClick="@((ReceivingDocument item) => Navigation.NavigateTo($"/inventario/receiving/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ReceiptNumber)" Title="Receipt" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Purchase Order">
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceiptNumber)" Title="Receipt" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Purchase Order" Filterable="true" FilterBy="@(item => GetPurchaseOrderNumber(item.PurchaseOrderId))">
                                 <ChildContent Context="item">@GetPurchaseOrderNumber(item.PurchaseOrderId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Supplier">
+                            <BbDataGridTemplateColumn Title="Supplier" Filterable="true" FilterBy="@(item => GetSupplierName(item.SupplierId))">
                                 <ChildContent Context="item">@GetSupplierName(item.SupplierId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Warehouse">
+                            <BbDataGridTemplateColumn Title="Warehouse" Filterable="true" FilterBy="@(item => GetWarehouseName(item.WarehouseId))">
                                 <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
-                            <BbDataGridTemplateColumn Title="Lines">
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Lines" Filterable="true" FilterBy="@(item => _lines.Count(x => x.ReceivingDocumentId == item.Id))">
                                 <ChildContent Context="item">@_lines.Count(x => x.ReceivingDocumentId == item.Id)</ChildContent>
                             </BbDataGridTemplateColumn>
                             <BbDataGridTemplateColumn Title="Actions">

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reports.razor
@@ -47,10 +47,10 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_lowStock" ShowPagination="true" InitialPageSize="10">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Scope" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Scope" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -64,11 +64,11 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_nearExpiry" ShowPagination="true" InitialPageSize="10">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -82,11 +82,11 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_expired" ShowPagination="true" InitialPageSize="10">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expired" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expired" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -100,12 +100,12 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_stockPositions" ShowPagination="true" InitialPageSize="20">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" />
-                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -119,11 +119,11 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="20">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Reference)" Title="Reference" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Reference)" Title="Reference" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Date" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -137,11 +137,11 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_allocations" ShowPagination="true" InitialPageSize="20">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
@@ -56,21 +56,21 @@ else
                                 OnRowClick="@((Reservation item) => Navigation.NavigateTo($"/inventario/reservations/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Location">
+                            <BbDataGridTemplateColumn Title="Location" Filterable="true" FilterBy="@(item => GetLocationName(item.LocationId))">
                                 <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Status">
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status)">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@item.Status.ToString()" Status="@GetStatusBadge(item.Status)" />
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceType)" Title="Reference" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceType)" Title="Reference" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
                                     @if (item.Status == ReservationStatus.Active)

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -57,25 +57,25 @@ else
                                     OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
                                     Class="cursor-pointer">
                             <Columns>
-                                <BbDataGridTemplateColumn Title="Product">
+                                <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                     <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Warehouse">
+                                <BbDataGridTemplateColumn Title="Warehouse" Filterable="true" FilterBy="@(item => GetWarehouseName(item.WarehouseId))">
                                     <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Location">
+                                <BbDataGridTemplateColumn Title="Location" Filterable="true" FilterBy="@(item => GetLocationName(item.LocationId))">
                                     <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
                                 </BbDataGridTemplateColumn>
                                 @if (_traceabilityEnabled)
                                 {
-                                    <BbDataGridTemplateColumn Title="Lot">
+                                    <BbDataGridTemplateColumn Title="Lot" Filterable="true" FilterBy="@(item => GetLotLabel(item.LotId))">
                                         <ChildContent Context="item">@GetLotLabel(item.LotId)</ChildContent>
                                     </BbDataGridTemplateColumn>
                                 }
-                                <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.LastMovementAt)" Title="Last Movement" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.LastMovementAt)" Title="Last Movement" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View stock balance"
@@ -102,21 +102,21 @@ else
                                     OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
                                     Class="cursor-pointer">
                             <Columns>
-                                <BbDataGridTemplateColumn Title="Product">
+                                <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                     <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                                 </BbDataGridTemplateColumn>
                                 @if (_traceabilityEnabled)
                                 {
-                                    <BbDataGridTemplateColumn Title="Lot">
+                                    <BbDataGridTemplateColumn Title="Lot" Filterable="true" FilterBy="@(item => GetLotLabel(item.LotId))">
                                         <ChildContent Context="item">@GetLotLabel(item.LotId)</ChildContent>
                                     </BbDataGridTemplateColumn>
                                 }
-                                <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.QuantityBefore)" Title="Before" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" />
-                                <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.QuantityBefore)" Title="Before" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View movement"

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Suppliers.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Suppliers.razor
@@ -46,11 +46,11 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_suppliers" ShowPagination="true" InitialPageSize="20">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ContactName)" Title="Contact" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Email)" Title="Email" />
-                            <BbDataGridTemplateColumn Title="Status">
+                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ContactName)" Title="Contact" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Email)" Title="Email" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.IsActive)">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@(item.IsActive ? "Active" : "Inactive")" Status="@(item.IsActive ? "active" : "inactive")" />
                                 </ChildContent>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
@@ -41,15 +41,15 @@ else
                                 OnRowClick="@((ProductTransaction item) => Navigation.NavigateTo($"/inventario/transactions/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Quantity" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Total">
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Quantity" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Total" Filterable="true" FilterBy="@(item => item.TotalPrice)">
                                 <ChildContent Context="item">@item.TotalPrice.ToString("N2")</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.TransactionDate)" Title="Transaction Date" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                             <BbDataGridTemplateColumn Title="Actions">
                                 <ChildContent Context="item">
                                     <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="View transaction"

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
@@ -54,15 +54,15 @@ else
                                 OnRowClick="@((Warehouse item) => Navigation.NavigateTo($"/inventario/warehouses/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.City)" Title="City" />
-                            <BbDataGridTemplateColumn Title="Default">
+                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.City)" Title="City" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Default" Filterable="true" FilterBy="@(item => item.IsDefault)">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@(item.IsDefault ? "Default" : "Standard")" Status="@(item.IsDefault ? "active" : "inactive")" />
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Locations">
+                            <BbDataGridTemplateColumn Title="Locations" Filterable="true" FilterBy="@(item => _locations.Count(x => x.WarehouseId == item.Id))">
                                 <ChildContent Context="item">@_locations.Count(x => x.WarehouseId == item.Id)</ChildContent>
                             </BbDataGridTemplateColumn>
                             <BbDataGridTemplateColumn Title="Actions">
@@ -88,13 +88,13 @@ else
                                 OnRowClick="@((InventoryLocation item) => Navigation.NavigateTo($"/inventario/locations/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Warehouse">
+                            <BbDataGridTemplateColumn Title="Warehouse" Filterable="true" FilterBy="@(item => GetWarehouseName(item.WarehouseId))">
                                 <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LocationType)" Title="Type" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Pickable">
+                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LocationType)" Title="Type" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Pickable" Filterable="true" FilterBy="@(item => item.IsPickable)">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@(item.IsPickable ? "Pickable" : "Storage")" Status="@(item.IsPickable ? "active" : "inactive")" />
                                 </ChildContent>

--- a/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -28,6 +28,22 @@ public sealed class ControlPanelContractTests
         "ReceivingLine"
     ];
 
+    private static readonly string[] InventarioListPagesRequiringFilteredDataGrids =
+    [
+        "Categories.razor",
+        "Lots.razor",
+        "Planning.razor",
+        "Products.razor",
+        "PurchaseOrders.razor",
+        "Receiving.razor",
+        "Reports.razor",
+        "Reservations.razor",
+        "Stock.razor",
+        "Suppliers.razor",
+        "Transactions.razor",
+        "Warehouses.razor"
+    ];
+
     [Test]
     public void InventarioPages_BusinessWorkflowMutations_DoNotUseDirectRemoteDataContextMutation()
     {
@@ -127,6 +143,69 @@ public sealed class ControlPanelContractTests
         pickerText.Should().NotContain("xf-entity-picker-column-filter", "advanced finder tables should not render custom filter inputs");
         pickerText.Should().NotContain("<table class=\"xf-entity-picker-advanced-table\"", "advanced finder tables should not use a custom table implementation");
         pickerText.Should().NotContain("__all__", "filter sentinels must not leak into selected filter labels");
+    }
+
+    [Test]
+    public void InventarioListPages_TabularSurfaces_UseFilteredBlazorBlueprintDataGrids()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario");
+
+        foreach (var page in InventarioListPagesRequiringFilteredDataGrids)
+        {
+            var pagePath = Path.Combine(pagesRoot, page);
+            var text = File.ReadAllText(pagePath);
+
+            text.Should().NotContain("<table", $"{page} should use BlazorBlueprint data grids instead of raw tables");
+            text.Should().Contain("<BbDataGrid", $"{page} should use BbDataGrid for list/report tabular records");
+            text.Should().NotMatchRegex(
+                @"<BbDataGridTemplateColumn\b[^>]*Title=""Actions""[^>]*Filterable=""true""",
+                $"{page} should not expose filters on command/action columns");
+
+            var grids = Regex.Matches(text, @"<BbDataGrid\b[\s\S]*?</BbDataGrid>", RegexOptions.Multiline);
+            grids.Should().NotBeEmpty($"{page} should render at least one data grid");
+
+            foreach (Match grid in grids)
+            {
+                grid.Value.Should().Contain(
+                    "Filterable=\"true\"",
+                    $"{page} data grids should expose native column filtering on useful business columns");
+            }
+        }
+    }
+
+    [Test]
+    public void AgentGuidance_ControlPanelTables_PrefersFilteredBlazorBlueprintDataGrids()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var agentsPath = Path.Combine(repositoryRoot.FullName, "AGENTS.md");
+        var blazorGuidePath = Path.Combine(
+            repositoryRoot.FullName,
+            "docs",
+            "solutions",
+            "tooling-decisions",
+            "blazor-blueprint-controlpanel-agent-guide.md");
+
+        var agentsText = File.ReadAllText(agentsPath);
+        var guideText = File.ReadAllText(blazorGuidePath);
+
+        agentsText.Should().Contain("BbDataGrid");
+        agentsText.Should().Contain("Filterable=\"true\"");
+        agentsText.Should().Contain("FilterBy");
+        agentsText.Should().Contain("Do not create raw HTML tables");
+
+        guideText.Should().Contain("BbDataGrid");
+        guideText.Should().Contain("Filterable=\"true\"");
+        guideText.Should().Contain("FilterBy");
+        guideText.Should().Contain("Prefer it over raw `<table>` markup");
+        guideText.Should().Contain("Do not make action/command columns filterable");
     }
 
     private static IEnumerable<string> FindDirectMutations(


### PR DESCRIPTION
﻿## Summary
- Document that ControlPanel agents should prefer BlazorBlueprint `BbDataGrid` over custom/raw tables.
- Enable native `BbDataGrid` column filtering across Inventario list and report pages.
- Add ControlPanel contract coverage to guard filtered `BbDataGrid` usage and agent guidance.

## Validation
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false`
- `dotnet test src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj --filter "FullyQualifiedName~ControlPanelContractTests" -m:1 /nr:false --logger "console;verbosity=minimal"`
- Local browser smoke on `http://127.0.0.1:5005`: Products, Stock, and Reports native filters render/open; no console errors.
