### PR TITLE
Fix Inventario API test service setup

### DIFF
--- a/src/Tests/Inventario.Api.Tests/InventoryPlanningReportingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/InventoryPlanningReportingServiceTests.cs
@@ -186,8 +186,14 @@ public sealed class InventoryPlanningReportingServiceTests
         return dataContext;
     }
 
-    private static InventoryPlanningService CreatePlanningService(FakeDataContext dataContext, Guid tenantId) =>
-        new(dataContext, CreateHttpContextAccessor(tenantId), new FakeTenantModuleFeatureService());
+    private static InventoryPlanningService CreatePlanningService(FakeDataContext dataContext, Guid tenantId)
+    {
+        var httpContextAccessor = CreateHttpContextAccessor(tenantId);
+        var featureService = new FakeTenantModuleFeatureService();
+        var productVariationService = new ProductVariationService(dataContext, httpContextAccessor, featureService);
+
+        return new InventoryPlanningService(dataContext, httpContextAccessor, featureService, productVariationService);
+    }
 
     private static InventoryReportingService CreateReportingService(
         FakeDataContext dataContext,

--- a/src/Tests/Inventario.Api.Tests/PurchasingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/PurchasingServiceTests.cs
@@ -227,11 +227,13 @@ public sealed class PurchasingServiceTests
             }
         };
         var featureService = new FakeTenantModuleFeatureService();
+        var productVariationService = new ProductVariationService(dataContext, httpContextAccessor, featureService);
         var stockPostingService = new StockPostingService(
             dataContext,
             httpContextAccessor,
-            featureService);
-        return new PurchasingService(dataContext, httpContextAccessor, stockPostingService, featureService);
+            featureService,
+            productVariationService);
+        return new PurchasingService(dataContext, httpContextAccessor, stockPostingService, productVariationService, featureService);
     }
 
     private sealed class FakeTenantModuleFeatureService : ITenantModuleFeatureService

--- a/src/Tests/Inventario.Api.Tests/ReservationServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ReservationServiceTests.cs
@@ -365,10 +365,13 @@ public sealed class ReservationServiceTests
             }
         };
 
+        var featureService = new FakeTenantModuleFeatureService();
+        var productVariationService = new ProductVariationService(dataContext, httpContextAccessor, featureService);
         var stockPostingService = new StockPostingService(
             dataContext,
             httpContextAccessor,
-            new FakeTenantModuleFeatureService());
+            featureService,
+            productVariationService);
         var allocationService = new InventoryAllocationService(dataContext, httpContextAccessor, stockPostingService);
         return new ReservationService(dataContext, httpContextAccessor, allocationService);
     }

--- a/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
@@ -371,10 +371,14 @@ public sealed class StockPostingServiceTests
             }
         };
 
+        var featureService = new FakeTenantModuleFeatureService(negativeStockEnabled);
+        var productVariationService = new ProductVariationService(dataContext, httpContextAccessor, featureService);
+
         return new StockPostingService(
             dataContext,
             httpContextAccessor,
-            new FakeTenantModuleFeatureService(negativeStockEnabled));
+            featureService,
+            productVariationService);
     }
 
     private sealed class FakeTenantModuleFeatureService(bool negativeStockEnabled) : ITenantModuleFeatureService


### PR DESCRIPTION
## Summary
- Updates Inventario API unit-test service setup helpers for the new ProductVariationService constructor dependency.
- Fixes the Publish NuGet Packages build failure introduced after the variant-aware Inventario merge.

## Verification
- dotnet build src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj -m:1 /nr:false --no-restore
- dotnet test src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj -m:1 /nr:false --no-build --logger "console;verbosity=minimal"
- dotnet build XFramework.slnx -c Release -p:XFrameworkVersion=1.0.1-dev.local -p:BoltVersion=1.0.0-dev.local -m:1 /nr:false --no-restore
