### PR TITLE
docs: prevent duplicate detail navigation

### DIFF
--- a/rules/UiGuidelines.md
+++ b/rules/UiGuidelines.md
@@ -122,8 +122,10 @@ Before creating custom UI, check the installed BlazorBlueprint component surface
 - List pages must not embed create or update forms as cards/sections above, below, or beside the grid. Provide a visible create action button that opens a focused dialog/sheet or navigates to a dedicated create page.
 - Existing-record edit workflows belong on detail pages with a clear edit mode, not list-page edit modals.
 - Detail pages should show the operational context needed for the entity.
-- If a detail page grows beyond a few scannable sections, add a local detail sidebar/navigation and split major sections into dedicated detail subpages or routes. Do not force many unrelated sections into one long scrolling page.
+- Detail pages should have only one section-navigation surface. If the app shell or left sidebar already exposes entity detail navigation, use that navigation and do not render a second in-page detail sidebar.
+- If a detail page grows beyond a few scannable sections, split major sections into dedicated detail subpages or routes. Add an in-page detail sidebar/navigation only when the shell has no suitable detail navigation. Do not force many unrelated sections into one long scrolling page.
 - Product-specific inventory workflows should keep operators on `/inventario/products/{id}` or a detail-sidebar route when practical.
+- Breadcrumbs and detail navigation labels should use human-readable entity names or shortened identifiers where possible; avoid raw full GUIDs in primary navigation chrome.
 - Use shared layout classes instead of ad hoc flex/responsive utility combinations:
   - `xf-page-header`
   - `xf-page-actions`
@@ -135,7 +137,7 @@ Before creating custom UI, check the installed BlazorBlueprint component surface
 ## Standard Page Recipes
 
 - List page: `xf-page-header` with title and `xf-page-actions`, optional `xf-filter-actions`, `BbDataGrid` with useful `Filterable` columns, pagination, row click when detail exists, and visible create/action buttons. Do not render create/update forms inline on the list page; launch create from a button and route updates to detail/edit surfaces.
-- Detail page: stable header, summary/metrics in `xf-summary-grid`, inline edit through `EditableForm` when suitable, operational sections in grids/tabs, and wrapper-backed commands for business actions. When sections become too many or too tall, use a detail sidebar/nav and move sections to subpages/routes.
+- Detail page: stable header, summary/metrics in `xf-summary-grid`, inline edit through `EditableForm` when suitable, operational sections in grids/tabs, and wrapper-backed commands for business actions. When sections become too many or too tall, move sections to subpages/routes and use the existing shell/sidebar detail navigation when available.
 - Report page: date/range and entity filters using Blueprint controls or `XfEntityPicker`, optional `BbFilterBuilder` for complex conditions, `BbDataGrid` or `BbDataView`, export/actions in the header, and explicit empty/loading states.
 - Picker dialog: quick search in the trigger popover, advanced search in a `BbDialog` with `BbDataGrid`, domain-specific columns, `Filterable`/`FilterBy`, and optional picker-owned create dialog.
 - Destructive action: use `DialogService.Confirm` or `BbAlertDialog`, use destructive button styling, describe the exact consequence, then call the wrapper/service and show a semantic toast.
@@ -150,6 +152,7 @@ Before creating custom UI, check the installed BlazorBlueprint component surface
 - Do not show GUIDs as primary user-facing labels.
 - Do not invent schema/configuration models when BlazorBlueprint already provides `FormSchema`, `FormFieldDefinition`, `FilterDefinition`, `FilterField`, `ToastData`, or dialog option models.
 - Do not place create or update forms in cards above list grids. Lists should expose actions, not permanently embedded mutation forms.
+- Do not create duplicate detail navigation. If the shell/sidebar already has detail-section links, do not add another stack of in-page section buttons.
 - Do not put existing-record edits in list-page modals.
 - Do not put required information behind hover-only UI.
 - Do not hard-code third-party component chrome text when `IBbLocalizer` can override it.


### PR DESCRIPTION
## Summary
- clarify that detail pages should have only one section navigation surface
- prefer existing shell/sidebar detail navigation over duplicate in-page sidebars
- require human-readable or shortened labels in breadcrumb/detail nav where possible

## Testing
- Not run; documentation-only change.