### PR TITLE
Align Inventario ControlPanel UI guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,4 +15,9 @@ ControlPanel UI rule:
 
 - Read [rules/UiGuidelines.md](rules/UiGuidelines.md) before changing ControlPanel or Blazor UI.
 
+ControlPanel table rule:
+
+- Use BlazorBlueprint `BbDataGrid` for list, report, and data-heavy tabular UI as much as possible. Do not create raw HTML tables or custom table components unless the BlazorBlueprint grid cannot support the workflow, and document that exception in the change.
+- Enable native `BbDataGrid` column filtering on useful user-facing data columns. Use `Filterable="true"` on property columns and set `FilterBy` on template columns; leave command/action columns unfiltered.
+
 Task-specific OpenCode skills live under `.opencode/skills/`; use them as workflow helpers, not as the primary documentation authority.

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Create/CreateProductValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Create/CreateProductValidator.cs
@@ -1,5 +1,5 @@
 using FluentValidation;
-using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
 
 namespace Inventario.Api.Features.Products.Create;
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/Endpoint.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Http.HttpResults;
 using XFramework.Core.Patterns;
 using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
 
 namespace Inventario.Api.Features.Products.Update;
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/UpdateProductValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/UpdateProductValidator.cs
@@ -1,5 +1,5 @@
 using FluentValidation;
-using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
 
 namespace Inventario.Api.Features.Products.Update;
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/UpdateProductWrapperEndpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Update/UpdateProductWrapperEndpoint.cs
@@ -3,20 +3,20 @@ using XFramework.Integration.Attributes;
 using XFramework.Inventario.Api.Services;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
 
-namespace Inventario.Api.Features.Products.Create;
+namespace Inventario.Api.Features.Products.Update;
 
-public static class CreateProductEndpoint
+public static class UpdateProductWrapperEndpoint
 {
     [BoltHandler]
-    [MapPost("/api/products", Tags = ["Products"],
-        Summary = "Create a new product",
-        Description = "Creates a new product in the inventory system")]
+    [MapPut("/api/products", Tags = ["Products"],
+        Summary = "Update an existing product",
+        Description = "Updates catalog fields for a product and invalidates the cache")]
     public static async Task<Result<ProductResponse>> Handle(
-        CreateProductRequest request,
+        UpdateProductRequest request,
         ProductService productService,
         CancellationToken ct)
     {
-        var result = await productService.CreateAsync(request, ct);
+        var result = await productService.UpdateAsync(request.ProductId, request, ct);
 
         if (!result.IsSuccess)
             return Result<ProductResponse>.Failure(result.Message!, result.StatusCode);

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
@@ -4,8 +4,10 @@ using XFramework.Core.Loggers;
 using XFramework.Core.Observability;
 using XFramework.Core.Patterns;
 using XFramework.Core.Services.Caching;
+using XFramework.Domain.Shared.Contracts.Requests;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
 using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace XFramework.Inventario.Api.Services;
@@ -37,7 +39,7 @@ public class ProductService
     /// </summary>
     public async Task<Result<Product>> CreateAsync(CreateProductRequest request, CancellationToken ct = default)
     {
-        var tenantResult = GetCurrentTenantId();
+        var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<Product>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
@@ -286,7 +288,7 @@ public class ProductService
     /// </summary>
     public async Task<Result<Product>> UpdateAsync(Guid id, UpdateProductRequest request, CancellationToken ct = default)
     {
-        var tenantResult = GetCurrentTenantId();
+        var tenantResult = GetCurrentTenantId(request);
         if (!tenantResult.IsSuccess)
             return Result<Product>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
@@ -412,8 +414,11 @@ public class ProductService
         }
     }
 
-    private Result<Guid> GetCurrentTenantId()
+    private Result<Guid> GetCurrentTenantId(RequestBase? request = null)
     {
+        if (request?.Metadata?.TenantId is { } metadataTenantId && metadataTenantId != Guid.Empty)
+            return Result<Guid>.Success(metadataTenantId);
+
         var user = _httpContextAccessor.HttpContext?.User;
         if (user?.Identity?.IsAuthenticated != true)
             return Result<Guid>.Unauthorized("Authentication is required for product catalog operations");
@@ -436,39 +441,6 @@ public class ProductService
 
     private static string? NormalizeSku(string? sku) =>
         string.IsNullOrWhiteSpace(sku) ? null : sku.Trim();
-}
-
-/// <summary>
-/// Request for creating a product
-/// </summary>
-public record CreateProductRequest
-{
-    public required string Name { get; init; }
-    public string? Description { get; init; }
-    public decimal Price { get; init; }
-    public int StockQuantity { get; init; }
-    public Guid CategoryId { get; init; }
-    public string? SKU { get; init; }
-    public string? Brand { get; init; }
-    public decimal? Weight { get; init; }
-    public string? Image { get; init; }
-    public bool? IsAvailable { get; init; }
-}
-
-/// <summary>
-/// Request for updating a product
-/// </summary>
-public record UpdateProductRequest
-{
-    public required string Name { get; init; }
-    public string? Description { get; init; }
-    public decimal Price { get; init; }
-    public Guid CategoryId { get; init; }
-    public string? SKU { get; init; }
-    public string? Brand { get; init; }
-    public decimal? Weight { get; init; }
-    public string? Image { get; init; }
-    public bool? IsAvailable { get; init; }
 }
 
 /// <summary>

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/CreateProductRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/CreateProductRequest.cs
@@ -1,0 +1,25 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+
+using TRequest = CreateProductRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreateProductRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public required string Name { get; init; }
+    public string? Description { get; init; }
+    public decimal Price { get; init; }
+    public int StockQuantity { get; init; }
+    public Guid CategoryId { get; init; }
+    public string? SKU { get; init; }
+    public string? Brand { get; init; }
+    public decimal? Weight { get; init; }
+    public string? Image { get; init; }
+    public bool? IsAvailable { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/UpdateProductRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/UpdateProductRequest.cs
@@ -1,0 +1,25 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+
+using TRequest = UpdateProductRequest;
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record UpdateProductRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid ProductId { get; init; }
+    public required string Name { get; init; }
+    public string? Description { get; init; }
+    public decimal Price { get; init; }
+    public Guid CategoryId { get; init; }
+    public string? SKU { get; init; }
+    public string? Brand { get; init; }
+    public decimal? Weight { get; init; }
+    public string? Image { get; init; }
+    public bool? IsAvailable { get; init; }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -3,6 +3,7 @@
 @using System.Text.Json
 @using ControlPanel.Server.Services
 @using XFramework.Domain.Shared.DataContext
+@using XFramework.Inventario.Domain.Shared.Contracts
 
 <div class="control-panel-shell flex h-screen overflow-hidden bg-background text-foreground">
     @* Fixed left sidebar - always visible *@
@@ -186,6 +187,8 @@
     private string _displayName = "Administrator";
     private string _userName = "";
     private string _userInitials = "A";
+    private Guid? _breadcrumbProductId;
+    private string? _breadcrumbProductLabel;
     private bool _profileMenuOpen;
 
     private string _selectedTenantName => TenantFilter.SelectedTenantName ?? "";
@@ -212,13 +215,64 @@
 
     private List<string> GetBreadcrumbs()
     {
+        if (TryGetInventarioProductDetailRoute(out var productId, out var section))
+        {
+            return BuildInventarioProductBreadcrumbs(productId, section);
+        }
+
         var path = new Uri(Nav.Uri).AbsolutePath.Trim('/');
         if (string.IsNullOrEmpty(path)) return [];
 
         return path.Split('/')
-            .Select(s => System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(s.Replace("-", " ")))
+            .Select(HumanizeSegment)
             .ToList();
     }
+
+    private List<string> BuildInventarioProductBreadcrumbs(Guid productId, string section)
+    {
+        var normalizedSection = NormalizeProductDetailSection(section);
+
+        return
+        [
+            "Inventario",
+            "Products",
+            GetProductBreadcrumbLabel(productId),
+            ProductSectionLabel(normalizedSection)
+        ];
+    }
+
+    private string GetProductBreadcrumbLabel(Guid productId) =>
+        _breadcrumbProductId == productId && !string.IsNullOrWhiteSpace(_breadcrumbProductLabel)
+            ? _breadcrumbProductLabel
+            : ShortId(productId);
+
+    private static string NormalizeProductDetailSection(string? section) =>
+        string.IsNullOrWhiteSpace(section)
+            ? "summary"
+            : section.ToLowerInvariant() switch
+            {
+                "batches" => "lots",
+                "lots-batches" => "lots",
+                "reorder" => "replenishment",
+                "rules" => "replenishment",
+                _ => section.ToLowerInvariant()
+            };
+
+    private static string ProductSectionLabel(string section) => section switch
+    {
+        "summary" => "Summary",
+        "stock" => "Stock",
+        "lots" => "Lots / Batches",
+        "replenishment" => "Replenishment",
+        "variations" => "Variations",
+        "transactions" => "Transactions",
+        _ => HumanizeSegment(section)
+    };
+
+    private static string HumanizeSegment(string segment) =>
+        System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(segment.Replace("-", " "));
+
+    private static string ShortId(Guid id) => id.ToString("N")[..8];
 
     protected override void OnInitialized()
     {
@@ -249,6 +303,8 @@
             ?? user.Identity.Name
             ?? "Administrator";
         _userInitials = BuildInitials(_displayName);
+
+        await RefreshBreadcrumbEntityLabels();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -574,6 +630,47 @@
         return true;
     }
 
+    private async Task RefreshBreadcrumbEntityLabels()
+    {
+        if (!TryGetInventarioProductDetailRoute(out var productId, out _))
+        {
+            _breadcrumbProductId = null;
+            _breadcrumbProductLabel = null;
+            return;
+        }
+
+        if (_breadcrumbProductId == productId && !string.IsNullOrWhiteSpace(_breadcrumbProductLabel))
+        {
+            return;
+        }
+
+        _breadcrumbProductId = productId;
+        _breadcrumbProductLabel = ShortId(productId);
+
+        try
+        {
+            var product = (await DataContext.Query<Product>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == productId && !x.IsDeleted)
+                .Take(1)
+                .ToListAsync())
+                .FirstOrDefault();
+
+            _breadcrumbProductLabel = product is null
+                ? ShortId(productId)
+                : !string.IsNullOrWhiteSpace(product.Name)
+                    ? product.Name
+                    : !string.IsNullOrWhiteSpace(product.SKU)
+                        ? product.SKU
+                        : ShortId(productId);
+        }
+        catch
+        {
+            _breadcrumbProductLabel = ShortId(productId);
+        }
+    }
+
     private bool TryGetWalletDetailRoute(out Guid walletId, out string section)
     {
         walletId = Guid.Empty;
@@ -613,15 +710,23 @@
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
     {
-        UpdateActiveSidebarGroup();
-        _contentRenderKey++;
-        InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(async () =>
+        {
+            UpdateActiveSidebarGroup();
+            _contentRenderKey++;
+            await RefreshBreadcrumbEntityLabels();
+            StateHasChanged();
+        });
     }
 
     private void OnTenantFilterChanged()
     {
-        _contentRenderKey++;
-        InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(async () =>
+        {
+            _contentRenderKey++;
+            await RefreshBreadcrumbEntityLabels();
+            StateHasChanged();
+        });
     }
 
     private void OnTenantsChanged()

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Categories.razor
@@ -151,9 +151,9 @@ else
                 .ToListAsync();
             _productCounts = products.GroupBy(x => x.CategoryId).ToDictionary(x => x.Key, x => x.Count());
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load categories: {ex.Message}");
+            ToastService.Show("Could not load categories.");
         }
         finally
         {
@@ -209,12 +209,12 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to save category: {result.Message}");
+                ToastService.Show("Could not save category.");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error saving category: {ex.Message}");
+            ToastService.Show("Could not save category.");
         }
         finally
         {
@@ -232,14 +232,14 @@ else
             _deletingCategory.ModifiedAt = DateTime.UtcNow;
             DataContext.Update(_deletingCategory);
             var result = await DataContext.SaveChangesAsync();
-            ToastService.Show(result.IsSuccess ? "Category deleted." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Category deleted." : "Could not delete category.");
             _deleteDialogOpen = false;
             _deletingCategory = null;
             await Reload();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error deleting category: {ex.Message}");
+            ToastService.Show("Could not delete category.");
         }
     }
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/CategoryDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/CategoryDetail.razor
@@ -127,25 +127,25 @@ else
                                 OnRowClick="@((Product item) => Navigation.NavigateTo($"/inventario/products/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="SKU">
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="SKU" Filterable="true" FilterBy="@(item => item.SKU ?? string.Empty)">
                                 <ChildContent Context="item">
                                     <span class="font-mono text-xs">@(item.SKU ?? "N/A")</span>
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Price" Sortable="true">
+                            <BbDataGridTemplateColumn Title="Price" Sortable="true" Filterable="true" FilterBy="@(item => item.Price)">
                                 <ChildContent Context="item">@item.Price.ToString("N2")</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Stock" Sortable="true">
+                            <BbDataGridTemplateColumn Title="Stock" Sortable="true" Filterable="true" FilterBy="@(item => item.StockQuantity)">
                                 <ChildContent Context="item">@item.StockQuantity</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Status">
+                            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.IsAvailable ? "Available" : "Unavailable")">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@(item.IsAvailable ? "Available" : "Unavailable")"
                                                  Status="@(item.IsAvailable ? "active" : "inactive")" />
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -225,9 +225,9 @@ else
             if (!_editMode)
                 LoadForm();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load category: {ex.Message}");
+            ToastService.Show("Could not load category.");
         }
         finally
         {
@@ -294,12 +294,12 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to save category: {result.Message}");
+                ToastService.Show("Could not save category.");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error saving category: {ex.Message}");
+            ToastService.Show("Could not save category.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/InventoryMovementDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/InventoryMovementDetail.razor
@@ -231,9 +231,9 @@ else
                     .FirstOrDefaultAsync();
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load movement: {ex.Message}");
+            ToastService.Show("Could not load movement.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LocationDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LocationDetail.razor
@@ -133,12 +133,12 @@ else
                                 OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -154,13 +154,13 @@ else
                                 OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -176,16 +176,16 @@ else
                                 OnRowClick="@((Reservation item) => Navigation.NavigateTo($"/inventario/reservations/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Status">
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status.ToString())">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@item.Status.ToString()" Status="@(item.Status == ReservationStatus.Active ? "active" : "inactive")" />
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -315,9 +315,9 @@ else
                 _productNames = products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]);
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load location: {ex.Message}");
+            ToastService.Show("Could not load location.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LotDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/LotDetail.razor
@@ -136,15 +136,15 @@ else
                                 OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Warehouse">
+                            <BbDataGridTemplateColumn Title="Warehouse" Filterable="true" FilterBy="@(item => GetWarehouseName(item.WarehouseId))">
                                 <ChildContent Context="item">@GetWarehouseName(item.WarehouseId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Location">
+                            <BbDataGridTemplateColumn Title="Location" Filterable="true" FilterBy="@(item => GetLocationName(item.LocationId))">
                                 <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -160,11 +160,11 @@ else
                                 OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceType)" Title="Reference" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceType)" Title="Reference" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -277,9 +277,9 @@ else
                 .Take(500)
                 .ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load lot: {ex.Message}");
+            ToastService.Show("Could not load lot.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Lots.razor
@@ -80,23 +80,24 @@ else
 }
 
 <BbDialog Open="@_createDialogOpen" OpenChanged="@(v => _createDialogOpen = v)">
-    <BbDialogContent TrapFocus="false">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Create Lot</BbDialogTitle>
             <BbDialogDescription>Lot numbers are unique per product inside the selected tenant.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <div class="xf-form-field">
-                <BbLabel>Product</BbLabel>
-                <BbCombobox TValue="string"
-                             @bind-Value="_form.ProductId"
-                             Options="@ProductOptions"
-                             Placeholder="Select product"
-                             SearchPlaceholder="Search products..."
-                             EmptyMessage="No products found."
-                             Class="xf-entity-combobox"
-                             MatchTriggerWidth="true" />
-            </div>
+            <XfEntityPicker TItem="Product"
+                            @bind-Value="_form.ProductId"
+                            Items="@_products"
+                            Label="Product"
+                            Placeholder="Select product"
+                            SearchPlaceholder="Search products..."
+                            EmptyMessage="No products found."
+                            ValueSelector="@GetProductPickerValue"
+                            TextSelector="@GetProductLabel"
+                            SearchTextSelector="@GetProductSearchText"
+                            AdvancedSearchTitle="Find Product"
+                            AdvancedSearchDescription="Search products in the active tenant." />
             <div class="grid gap-3 md:grid-cols-2">
                 <BbFormFieldInput TValue="string" @bind-Value="_form.LotNumber" Label="Lot / Batch Number" Required="true" />
                 <BbFormFieldSelect TValue="string" @bind-Value="_form.Status" Label="Status">
@@ -108,12 +109,15 @@ else
             </div>
             <div class="grid gap-3 md:grid-cols-2">
                 <BbFormFieldInput TValue="string" @bind-Value="_form.SupplierReference" Label="Supplier / Source Ref" />
-                <BbFormFieldInput TValue="string" @bind-Value="_form.UnitCost" Label="Unit Cost" />
+                <BbFormFieldCurrencyInput @bind-Value="_form.UnitCost"
+                                          Label="Unit Cost"
+                                          Min="0"
+                                          ShowSymbol="false" />
             </div>
             <div class="grid gap-3 md:grid-cols-3">
-                <BbFormFieldInput TValue="string" @bind-Value="_form.ReceivedAt" Label="Received Date" />
-                <BbFormFieldInput TValue="string" @bind-Value="_form.ManufacturedAt" Label="Manufacture Date" />
-                <BbFormFieldInput TValue="string" @bind-Value="_form.ExpiresAt" Label="Expiration Date" />
+                <BbFormFieldDatePicker @bind-Value="_form.ReceivedAt" Label="Received Date" />
+                <BbFormFieldDatePicker @bind-Value="_form.ManufacturedAt" Label="Manufacture Date" />
+                <BbFormFieldDatePicker @bind-Value="_form.ExpiresAt" Label="Expiration Date" />
             </div>
             <div class="grid gap-3 md:grid-cols-2">
                 <BbFormFieldInput TValue="string" @bind-Value="_form.SourceReferenceType" Label="Source Type" />
@@ -145,9 +149,6 @@ else
     private bool _saving;
     private bool _createDialogOpen;
     private bool IsCreateDisabled => _saving || _products.Count == 0 || string.IsNullOrWhiteSpace(_form.ProductId) || string.IsNullOrWhiteSpace(_form.LotNumber);
-
-    private List<SelectOption<string>> ProductOptions =>
-        _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
 
     protected override void OnInitialized()
     {
@@ -199,9 +200,9 @@ else
 
             _form.ProductId = _products.FirstOrDefault()?.Id.ToString() ?? "";
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load lots: {ex.Message}");
+            ToastService.Show("Could not load lots.");
         }
         finally
         {
@@ -235,14 +236,14 @@ else
                 SupplierReference = NullIfEmpty(_form.SupplierReference),
                 SourceReferenceType = NullIfEmpty(_form.SourceReferenceType),
                 SourceReferenceId = Guid.TryParse(_form.SourceReferenceId, out var sourceId) ? sourceId : null,
-                ReceivedAt = ParseDate(_form.ReceivedAt),
-                ManufacturedAt = ParseDate(_form.ManufacturedAt),
-                ExpiresAt = ParseDate(_form.ExpiresAt),
-                UnitCost = decimal.TryParse(_form.UnitCost, out var unitCost) ? unitCost : null,
+                ReceivedAt = _form.ReceivedAt,
+                ManufacturedAt = _form.ManufacturedAt,
+                ExpiresAt = _form.ExpiresAt,
+                UnitCost = _form.UnitCost > 0 ? _form.UnitCost : null,
                 Status = Enum.TryParse<InventoryLotStatus>(_form.Status, out var status) ? status : InventoryLotStatus.Available
             });
 
-            ToastService.Show(result.IsSuccess ? "Lot created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Lot created." : "Could not create lot.");
             if (result.IsSuccess)
             {
                 _createDialogOpen = false;
@@ -268,14 +269,16 @@ else
     private static string GetProductLabel(Product product) =>
         string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
 
+    private static string GetProductPickerValue(Product product) => product.Id.ToString();
+
+    private static string GetProductSearchText(Product product) =>
+        $"{product.Name} {product.SKU} {product.Brand} {product.Description}";
+
     private decimal GetLotOnHand(Guid lotId) =>
         _balances.Where(x => x.LotId == lotId).Sum(x => x.OnHandQuantity);
 
     private static string GetStatusBadge(InventoryLotStatus status) =>
         status is InventoryLotStatus.Available ? "active" : "inactive";
-
-    private static DateTime? ParseDate(string? value) =>
-        DateTime.TryParse(value, out var parsed) ? parsed : null;
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
@@ -293,10 +296,10 @@ else
         public string SupplierReference { get; set; } = "";
         public string SourceReferenceType { get; set; } = "";
         public string SourceReferenceId { get; set; } = "";
-        public string ReceivedAt { get; set; } = "";
-        public string ManufacturedAt { get; set; } = "";
-        public string ExpiresAt { get; set; } = "";
-        public string UnitCost { get; set; } = "";
+        public DateTime? ReceivedAt { get; set; }
+        public DateTime? ManufacturedAt { get; set; }
+        public DateTime? ExpiresAt { get; set; }
+        public decimal UnitCost { get; set; }
         public string Status { get; set; } = InventoryLotStatus.Available.ToString();
 
         public void Reset(string productId)
@@ -306,10 +309,10 @@ else
             SupplierReference = "";
             SourceReferenceType = "";
             SourceReferenceId = "";
-            ReceivedAt = DateTime.Today.ToString("yyyy-MM-dd");
-            ManufacturedAt = "";
-            ExpiresAt = "";
-            UnitCost = "";
+            ReceivedAt = DateTime.Today;
+            ManufacturedAt = null;
+            ExpiresAt = null;
+            UnitCost = 0m;
             Status = InventoryLotStatus.Available.ToString();
         }
     }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Planning.razor
@@ -118,54 +118,81 @@ else
 }
 
 <BbDialog Open="@_ruleDialogOpen" OpenChanged="@(v => _ruleDialogOpen = v)">
-    <BbDialogContent TrapFocus="false">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Add Reorder Rule</BbDialogTitle>
             <BbDialogDescription>Rules can apply tenant-wide for a product or be scoped to a warehouse/location.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
             <div class="grid gap-3 md:grid-cols-2">
-                <div class="xf-form-field">
-                    <BbLabel>Product</BbLabel>
-                    <BbCombobox TValue="string"
-                                 @bind-Value="_form.ProductId"
-                                 Options="@ProductOptions"
-                                 Placeholder="Select product"
-                                 SearchPlaceholder="Search products..."
-                                 EmptyMessage="No products found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
-                <div class="xf-form-field">
-                    <BbLabel>Warehouse</BbLabel>
-                    <BbCombobox TValue="string"
-                                 Value="@_form.WarehouseId"
-                                 ValueChanged="@OnWarehouseChanged"
-                                 Options="@WarehouseOptions"
-                                 Placeholder="Any warehouse"
-                                 SearchPlaceholder="Search warehouses..."
-                                 EmptyMessage="No warehouses found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
-                <div class="xf-form-field">
-                    <BbLabel>Location</BbLabel>
-                    <BbCombobox TValue="string"
-                                 @bind-Value="_form.LocationId"
-                                 Options="@LocationOptions"
-                                 Placeholder="Any location"
-                                 SearchPlaceholder="Search locations..."
-                                 EmptyMessage="No locations found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
+                <XfEntityPicker TItem="Product"
+                                @bind-Value="_form.ProductId"
+                                Items="@_products"
+                                Label="Product"
+                                Placeholder="Select product"
+                                SearchPlaceholder="Search products..."
+                                EmptyMessage="No products found."
+                                ValueSelector="@GetProductPickerValue"
+                                TextSelector="@GetProductLabel"
+                                SearchTextSelector="@GetProductSearchText"
+                                AdvancedSearchTitle="Find Product"
+                                AdvancedSearchDescription="Search products in the active tenant." />
+                <XfEntityPicker TItem="Warehouse"
+                                Value="@_form.WarehouseId"
+                                ValueChanged="@OnWarehouseChanged"
+                                Items="@_warehouses"
+                                Label="Warehouse"
+                                Placeholder="Any warehouse"
+                                SearchPlaceholder="Search warehouses..."
+                                EmptyMessage="No warehouses found."
+                                ValueSelector="@GetWarehousePickerValue"
+                                TextSelector="@GetWarehouseLabel"
+                                SearchTextSelector="@GetWarehouseSearchText"
+                                AllowClear="true"
+                                ClearText="Any warehouse"
+                                AdvancedSearchTitle="Find Warehouse"
+                                AdvancedSearchDescription="Search warehouses in the active tenant." />
+                <XfEntityPicker TItem="InventoryLocation"
+                                @bind-Value="_form.LocationId"
+                                Items="@LocationsForSelectedWarehouse().ToList()"
+                                Label="Location"
+                                Placeholder="Any location"
+                                SearchPlaceholder="Search locations..."
+                                EmptyMessage="No locations found."
+                                ValueSelector="@GetLocationPickerValue"
+                                TextSelector="@GetLocationLabel"
+                                SearchTextSelector="@GetLocationSearchText"
+                                AllowClear="true"
+                                ClearText="Any location"
+                                AdvancedSearchTitle="Find Location"
+                                AdvancedSearchDescription="Search locations for the selected warehouse." />
                 <BbFormFieldInput TValue="string" @bind-Value="_form.PreferredSupplier" Label="Preferred Supplier" />
             </div>
             <div class="grid gap-3 md:grid-cols-4">
-                <BbFormFieldInput TValue="string" @bind-Value="_form.MinimumQuantity" Label="Minimum" />
-                <BbFormFieldInput TValue="string" @bind-Value="_form.MaximumQuantity" Label="Maximum" />
-                <BbFormFieldInput TValue="string" @bind-Value="_form.ReorderPoint" Label="Reorder Point" />
-                <BbFormFieldInput TValue="string" @bind-Value="_form.ReorderQuantity" Label="Reorder Qty" />
+                <BbFormFieldNumericInput TValue="decimal"
+                                         @bind-Value="_form.MinimumQuantity"
+                                         Label="Minimum"
+                                         Min="0"
+                                         DecimalPlaces="2"
+                                         Step="1" />
+                <BbFormFieldNumericInput TValue="decimal"
+                                         @bind-Value="_form.MaximumQuantity"
+                                         Label="Maximum"
+                                         Min="0"
+                                         DecimalPlaces="2"
+                                         Step="1" />
+                <BbFormFieldNumericInput TValue="decimal"
+                                         @bind-Value="_form.ReorderPoint"
+                                         Label="Reorder Point"
+                                         Min="0"
+                                         DecimalPlaces="2"
+                                         Step="1" />
+                <BbFormFieldNumericInput TValue="decimal"
+                                         @bind-Value="_form.ReorderQuantity"
+                                         Label="Reorder Qty"
+                                         Min="0"
+                                         DecimalPlaces="2"
+                                         Step="1" />
             </div>
             <BbFormFieldSwitch Checked="@_form.IsActive"
                                CheckedChanged="@((bool value) => _form.IsActive = value)"
@@ -198,27 +225,6 @@ else
     private bool _planningEnabled;
     private bool _ruleDialogOpen;
     private bool _savingRule;
-
-    private List<SelectOption<string>> ProductOptions =>
-        _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
-    private List<SelectOption<string>> WarehouseOptions
-    {
-        get
-        {
-            var options = new List<SelectOption<string>> { new("", "Any warehouse") };
-            options.AddRange(_warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))));
-            return options;
-        }
-    }
-    private List<SelectOption<string>> LocationOptions
-    {
-        get
-        {
-            var options = new List<SelectOption<string>> { new("", "Any location") };
-            options.AddRange(LocationsForSelectedWarehouse().Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))));
-            return options;
-        }
-    }
 
     protected override void OnInitialized()
     {
@@ -263,9 +269,9 @@ else
             BuildSuggestions();
             ApplyDefaults();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load planning: {ex.Message}");
+            ToastService.Show("Could not load planning.");
         }
         finally
         {
@@ -310,24 +316,16 @@ else
             return;
         }
 
-        if (!decimal.TryParse(_form.MinimumQuantity, out var min) ||
-            !decimal.TryParse(_form.ReorderPoint, out var point) ||
-            !decimal.TryParse(_form.ReorderQuantity, out var qty) ||
-            min < 0 || point < 0 || qty <= 0)
+        if (_form.MinimumQuantity < 0 || _form.ReorderPoint < 0 || _form.ReorderQuantity <= 0)
         {
             ToastService.Show("Quantities must be valid.");
             return;
         }
 
-        decimal? max = null;
-        if (!string.IsNullOrWhiteSpace(_form.MaximumQuantity))
+        if (_form.MaximumQuantity > 0 && _form.MaximumQuantity < _form.MinimumQuantity)
         {
-            if (!decimal.TryParse(_form.MaximumQuantity, out var parsedMax) || parsedMax < min)
-            {
-                ToastService.Show("Maximum must be greater than or equal to minimum.");
-                return;
-            }
-            max = parsedMax;
+            ToastService.Show("Maximum must be greater than or equal to minimum.");
+            return;
         }
 
         _savingRule = true;
@@ -339,14 +337,14 @@ else
                 ProductId = productId,
                 WarehouseId = Guid.TryParse(_form.WarehouseId, out var warehouseId) ? warehouseId : null,
                 LocationId = Guid.TryParse(_form.LocationId, out var locationId) ? locationId : null,
-                MinimumQuantity = min,
-                MaximumQuantity = max,
-                ReorderPoint = point,
-                ReorderQuantity = qty,
+                MinimumQuantity = _form.MinimumQuantity,
+                MaximumQuantity = _form.MaximumQuantity > 0 ? _form.MaximumQuantity : null,
+                ReorderPoint = _form.ReorderPoint,
+                ReorderQuantity = _form.ReorderQuantity,
                 PreferredSupplier = NullIfEmpty(_form.PreferredSupplier),
                 IsActive = _form.IsActive
             });
-            ToastService.Show(result.IsSuccess ? "Reorder rule created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Reorder rule created." : "Could not create reorder rule.");
             if (result.IsSuccess)
             {
                 _ruleDialogOpen = false;
@@ -387,10 +385,10 @@ else
         _form.ProductId = "";
         _form.WarehouseId = "";
         _form.LocationId = "";
-        _form.MinimumQuantity = "0";
-        _form.MaximumQuantity = "";
-        _form.ReorderPoint = "0";
-        _form.ReorderQuantity = "1";
+        _form.MinimumQuantity = 0m;
+        _form.MaximumQuantity = 0m;
+        _form.ReorderPoint = 0m;
+        _form.ReorderQuantity = 1m;
         _form.PreferredSupplier = "";
         _form.IsActive = true;
     }
@@ -400,6 +398,11 @@ else
 
     private string GetProductLabel(Product product) =>
         string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
+
+    private static string GetProductPickerValue(Product product) => product.Id.ToString();
+
+    private static string GetProductSearchText(Product product) =>
+        $"{product.Name} {product.SKU} {product.Brand} {product.Description}";
 
     private string GetWarehouseName(Guid? warehouseId) =>
         warehouseId is { } id ? _warehouses.FirstOrDefault(x => x.Id == id) is { } warehouse ? GetWarehouseLabel(warehouse) : id.ToString()[..8] : "Any warehouse";
@@ -419,6 +422,10 @@ else
 
     private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
     private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
+    private static string GetWarehousePickerValue(Warehouse warehouse) => warehouse.Id.ToString();
+    private static string GetWarehouseSearchText(Warehouse warehouse) => $"{warehouse.Code} {warehouse.Name} {warehouse.City} {warehouse.Region} {warehouse.CountryCode}";
+    private static string GetLocationPickerValue(InventoryLocation location) => location.Id.ToString();
+    private string GetLocationSearchText(InventoryLocation location) => $"{location.Code} {location.Name} {GetWarehouseName(location.WarehouseId)} {location.LocationType} {location.Description}";
     private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     public void Dispose()
@@ -441,10 +448,10 @@ else
         public string ProductId { get; set; } = "";
         public string WarehouseId { get; set; } = "";
         public string LocationId { get; set; } = "";
-        public string MinimumQuantity { get; set; } = "0";
-        public string MaximumQuantity { get; set; } = "";
-        public string ReorderPoint { get; set; } = "0";
-        public string ReorderQuantity { get; set; } = "1";
+        public decimal MinimumQuantity { get; set; }
+        public decimal MaximumQuantity { get; set; }
+        public decimal ReorderPoint { get; set; }
+        public decimal ReorderQuantity { get; set; } = 1m;
         public string PreferredSupplier { get; set; } = "";
         public bool IsActive { get; set; } = true;
     }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -86,20 +86,29 @@ else
 @if (_product is not null)
 {
     <BbDialog Open="@_variationDialogOpen" OpenChanged="@(value => _variationDialogOpen = value)">
-        <BbDialogContent TrapFocus="false">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
             <BbDialogHeader>
                 <BbDialogTitle>@(_variationForm.IsEditing ? "Edit Variant" : "Add Variant")</BbDialogTitle>
                 <BbDialogDescription>Configure a sellable variant for @_product.Name.</BbDialogDescription>
             </BbDialogHeader>
             <div class="grid gap-4 py-4">
-                <BbFormFieldCombobox TValue="string"
-                                     @bind-Value="_variationForm.ProductVariationTypeId"
-                                     Options="@VariationTypeOptions"
-                                     Label="Variation Type"
-                                     Placeholder="Select a variation type"
-                                     SearchPlaceholder="Search variation types..."
-                                     EmptyMessage="No variation types found."
-                                     MatchTriggerWidth="true" />
+                <XfEntityPicker TItem="ProductVariationType"
+                                Label="Variation Type"
+                                Value="@_variationForm.ProductVariationTypeId"
+                                ValueChanged="@(value => _variationForm.ProductVariationTypeId = value ?? "")"
+                                Items="@_variationTypes"
+                                ValueSelector="@GetVariationTypePickerValue"
+                                TextSelector="@GetVariationTypeLabel"
+                                SearchTextSelector="@GetVariationTypeSearchText"
+                                AdvancedColumns="@VariationTypeAdvancedColumns"
+                                AdvancedFilters="@VariationTypeAdvancedFilters"
+                                AdvancedSearchScope="Searches variation type name, code, scope, and created date."
+                                Placeholder="Select a variation type"
+                                SearchPlaceholder="Search variation types..."
+                                EmptyMessage="No variation types found."
+                                ShowCreate="false"
+                                AdvancedSearchTitle="Find Variation Type"
+                                AdvancedSearchDescription="Select the variation type for this variant." />
                 @if (_variationTypes.Count == 0)
                 {
                     <BbAlert>
@@ -109,7 +118,11 @@ else
                 }
                 <div class="grid gap-3 md:grid-cols-2">
                     <BbFormFieldInput TValue="string" @bind-Value="_variationForm.Name" Label="Variant" Required="true" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_variationForm.Price" Label="Variant Price" />
+                    <BbFormFieldCurrencyInput @bind-Value="_variationForm.Price"
+                                              Label="Variant Price"
+                                              Min="0"
+                                              Required="true"
+                                              ShowSymbol="false" />
                 </div>
             </div>
             <BbDialogFooter>
@@ -120,7 +133,7 @@ else
     </BbDialog>
 
     <BbDialog Open="@_variationTypeDialogOpen" OpenChanged="@(value => _variationTypeDialogOpen = value)">
-        <BbDialogContent TrapFocus="false">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
             <BbDialogHeader>
                 <BbDialogTitle>Create Variation Type</BbDialogTitle>
                 <BbDialogDescription>Add a reusable tenant-wide type or limit it to @_product.Name.</BbDialogDescription>
@@ -140,7 +153,7 @@ else
     </BbDialog>
 
     <BbDialog Open="@_movementDialogOpen" OpenChanged="@(value => _movementDialogOpen = value)">
-        <BbDialogContent TrapFocus="false" class="max-w-4xl">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
             <BbDialogHeader>
                 <BbDialogTitle>Post Stock Movement</BbDialogTitle>
             </BbDialogHeader>
@@ -148,14 +161,25 @@ else
                 @FixedProductField
                 @if (CanPickVariant)
                 {
-                    <BbFormFieldCombobox TValue="string"
-                                         @bind-Value="_movementForm.ProductVariationId"
-                                         Options="@VariantOptions"
-                                         Label="Variant"
-                                         Placeholder="Base product"
-                                         SearchPlaceholder="Search variants..."
-                                         EmptyMessage="No variants found."
-                                         MatchTriggerWidth="true" />
+                    <XfEntityPicker TItem="ProductVariation"
+                                    Label="Variant"
+                                    Value="@_movementForm.ProductVariationId"
+                                    ValueChanged="@(value => _movementForm.ProductVariationId = value ?? "")"
+                                    Items="@_variations"
+                                    ValueSelector="@GetVariantPickerValue"
+                                    TextSelector="@GetVariantLabel"
+                                    SearchTextSelector="@GetVariantSearchText"
+                                    AdvancedColumns="@VariantAdvancedColumns"
+                                    AdvancedFilters="@VariantAdvancedFilters"
+                                    AdvancedSearchScope="Searches variant name, type, price, price delta, and created date."
+                                    Placeholder="Base product"
+                                    SearchPlaceholder="Search variants..."
+                                    EmptyMessage="No variants found."
+                                    AllowClear="true"
+                                    ClearText="Base product"
+                                    ShowCreate="false"
+                                    AdvancedSearchTitle="Find Variant"
+                                    AdvancedSearchDescription="Select a variant for this stock movement." />
                 }
 
                 <div class="grid gap-3 md:grid-cols-2">
@@ -232,7 +256,12 @@ else
                 </div>
 
                 <div class="grid gap-3 md:grid-cols-3">
-                    <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Quantity" Label="Quantity" />
+                    <BbFormFieldNumericInput TValue="decimal"
+                                             @bind-Value="_movementForm.Quantity"
+                                             Label="Quantity"
+                                             DecimalPlaces="2"
+                                             Step="1"
+                                             AllowNegative="true" />
                     <BbFormFieldInput TValue="string" @bind-Value="_movementForm.UnitOfMeasure" Label="Unit" />
                     <BbFormFieldInput TValue="string" @bind-Value="_movementForm.ReferenceType" Label="Reference Type" />
                 </div>
@@ -252,7 +281,7 @@ else
     </BbDialog>
 
     <BbDialog Open="@_lotDialogOpen" OpenChanged="@(value => _lotDialogOpen = value)">
-        <BbDialogContent TrapFocus="false">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
             <BbDialogHeader>
                 <BbDialogTitle>Create Lot / Batch</BbDialogTitle>
                 <BbDialogDescription>Create a traceability lot for @_product.Name.</BbDialogDescription>
@@ -261,14 +290,25 @@ else
                 @FixedProductField
                 @if (CanPickVariant)
                 {
-                    <BbFormFieldCombobox TValue="string"
-                                         @bind-Value="_lotForm.ProductVariationId"
-                                         Options="@VariantOptions"
-                                         Label="Variant"
-                                         Placeholder="Base product"
-                                         SearchPlaceholder="Search variants..."
-                                         EmptyMessage="No variants found."
-                                         MatchTriggerWidth="true" />
+                    <XfEntityPicker TItem="ProductVariation"
+                                    Label="Variant"
+                                    Value="@_lotForm.ProductVariationId"
+                                    ValueChanged="@(value => _lotForm.ProductVariationId = value ?? "")"
+                                    Items="@_variations"
+                                    ValueSelector="@GetVariantPickerValue"
+                                    TextSelector="@GetVariantLabel"
+                                    SearchTextSelector="@GetVariantSearchText"
+                                    AdvancedColumns="@VariantAdvancedColumns"
+                                    AdvancedFilters="@VariantAdvancedFilters"
+                                    AdvancedSearchScope="Searches variant name, type, price, price delta, and created date."
+                                    Placeholder="Base product"
+                                    SearchPlaceholder="Search variants..."
+                                    EmptyMessage="No variants found."
+                                    AllowClear="true"
+                                    ClearText="Base product"
+                                    ShowCreate="false"
+                                    AdvancedSearchTitle="Find Variant"
+                                    AdvancedSearchDescription="Select a variant for this lot." />
                 }
                 <div class="grid gap-3 md:grid-cols-2">
                     <BbFormFieldInput TValue="string" @bind-Value="_lotForm.LotNumber" Label="Lot / Batch Number" Required="true" />
@@ -279,10 +319,13 @@ else
                         }
                     </BbFormFieldSelect>
                     <BbFormFieldInput TValue="string" @bind-Value="_lotForm.SupplierReference" Label="Supplier / Source Reference" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.UnitCost" Label="Unit Cost" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.ReceivedAt" Label="Received Date" Placeholder="YYYY-MM-DD" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.ManufacturedAt" Label="Manufacture Date" Placeholder="YYYY-MM-DD" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_lotForm.ExpiresAt" Label="Expiration Date" Placeholder="YYYY-MM-DD" />
+                    <BbFormFieldCurrencyInput @bind-Value="_lotForm.UnitCost"
+                                              Label="Unit Cost"
+                                              Min="0"
+                                              ShowSymbol="false" />
+                    <BbFormFieldDatePicker @bind-Value="_lotForm.ReceivedAt" Label="Received Date" />
+                    <BbFormFieldDatePicker @bind-Value="_lotForm.ManufacturedAt" Label="Manufacture Date" />
+                    <BbFormFieldDatePicker @bind-Value="_lotForm.ExpiresAt" Label="Expiration Date" />
                     <BbFormFieldInput TValue="string" @bind-Value="_lotForm.SourceReferenceType" Label="Source Type" />
                 </div>
             </div>
@@ -294,7 +337,7 @@ else
     </BbDialog>
 
     <BbDialog Open="@_receiveDialogOpen" OpenChanged="@(value => _receiveDialogOpen = value)">
-        <BbDialogContent TrapFocus="false" class="max-w-4xl">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-extra-wide">
             <BbDialogHeader>
                 <BbDialogTitle>Receive Batch / Stock</BbDialogTitle>
                 <BbDialogDescription>Receive stock for @_product.Name into a warehouse location.</BbDialogDescription>
@@ -303,14 +346,25 @@ else
                 @FixedProductField
                 @if (CanPickVariant)
                 {
-                    <BbFormFieldCombobox TValue="string"
-                                         @bind-Value="_receiveForm.ProductVariationId"
-                                         Options="@VariantOptions"
-                                         Label="Variant"
-                                         Placeholder="Base product"
-                                         SearchPlaceholder="Search variants..."
-                                         EmptyMessage="No variants found."
-                                         MatchTriggerWidth="true" />
+                    <XfEntityPicker TItem="ProductVariation"
+                                    Label="Variant"
+                                    Value="@_receiveForm.ProductVariationId"
+                                    ValueChanged="@(value => _receiveForm.ProductVariationId = value ?? "")"
+                                    Items="@_variations"
+                                    ValueSelector="@GetVariantPickerValue"
+                                    TextSelector="@GetVariantLabel"
+                                    SearchTextSelector="@GetVariantSearchText"
+                                    AdvancedColumns="@VariantAdvancedColumns"
+                                    AdvancedFilters="@VariantAdvancedFilters"
+                                    AdvancedSearchScope="Searches variant name, type, price, price delta, and created date."
+                                    Placeholder="Base product"
+                                    SearchPlaceholder="Search variants..."
+                                    EmptyMessage="No variants found."
+                                    AllowClear="true"
+                                    ClearText="Base product"
+                                    ShowCreate="false"
+                                    AdvancedSearchTitle="Find Variant"
+                                    AdvancedSearchDescription="Select a variant for this receiving line." />
                 }
 
                 <div class="grid gap-3 md:grid-cols-3">
@@ -402,8 +456,16 @@ else
                 </div>
 
                 <div class="grid gap-3 md:grid-cols-3">
-                    <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.Quantity" Label="Quantity" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.UnitCost" Label="Unit Cost" />
+                    <BbFormFieldNumericInput TValue="decimal"
+                                             @bind-Value="_receiveForm.Quantity"
+                                             Label="Quantity"
+                                             Min="0"
+                                             DecimalPlaces="2"
+                                             Step="1" />
+                    <BbFormFieldCurrencyInput @bind-Value="_receiveForm.UnitCost"
+                                              Label="Unit Cost"
+                                              Min="0"
+                                              ShowSymbol="false" />
                     <BbFormFieldInput TValue="string" @bind-Value="_receiveForm.UnitOfMeasure" Label="Unit" />
                 </div>
 
@@ -440,7 +502,7 @@ else
     </BbDialog>
 
     <BbDialog Open="@_ruleDialogOpen" OpenChanged="@(value => _ruleDialogOpen = value)">
-        <BbDialogContent TrapFocus="false">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
             <BbDialogHeader>
                 <BbDialogTitle>Add Reorder Rule</BbDialogTitle>
                 <BbDialogDescription>Add min/max/reorder rules for @_product.Name.</BbDialogDescription>
@@ -449,14 +511,25 @@ else
                 @FixedProductField
                 @if (CanPickVariant)
                 {
-                    <BbFormFieldCombobox TValue="string"
-                                         @bind-Value="_ruleForm.ProductVariationId"
-                                         Options="@VariantOptions"
-                                         Label="Variant"
-                                         Placeholder="All variants and base product"
-                                         SearchPlaceholder="Search variants..."
-                                         EmptyMessage="No variants found."
-                                         MatchTriggerWidth="true" />
+                    <XfEntityPicker TItem="ProductVariation"
+                                    Label="Variant"
+                                    Value="@_ruleForm.ProductVariationId"
+                                    ValueChanged="@(value => _ruleForm.ProductVariationId = value ?? "")"
+                                    Items="@_variations"
+                                    ValueSelector="@GetVariantPickerValue"
+                                    TextSelector="@GetVariantLabel"
+                                    SearchTextSelector="@GetVariantSearchText"
+                                    AdvancedColumns="@VariantAdvancedColumns"
+                                    AdvancedFilters="@VariantAdvancedFilters"
+                                    AdvancedSearchScope="Searches variant name, type, price, price delta, and created date."
+                                    Placeholder="All variants and base product"
+                                    SearchPlaceholder="Search variants..."
+                                    EmptyMessage="No variants found."
+                                    AllowClear="true"
+                                    ClearText="All variants and base product"
+                                    ShowCreate="false"
+                                    AdvancedSearchTitle="Find Variant"
+                                    AdvancedSearchDescription="Select the variant scope for this reorder rule." />
                 }
 
                 <div class="grid gap-3 md:grid-cols-2">
@@ -534,10 +607,30 @@ else
                     }
                 </div>
                 <div class="grid gap-3 md:grid-cols-4">
-                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.MinimumQuantity" Label="Minimum" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.MaximumQuantity" Label="Maximum" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.ReorderPoint" Label="Reorder Point" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_ruleForm.ReorderQuantity" Label="Reorder Qty" />
+                    <BbFormFieldNumericInput TValue="decimal"
+                                             @bind-Value="_ruleForm.MinimumQuantity"
+                                             Label="Minimum"
+                                             Min="0"
+                                             DecimalPlaces="2"
+                                             Step="1" />
+                    <BbFormFieldNumericInput TValue="decimal"
+                                             @bind-Value="_ruleForm.MaximumQuantity"
+                                             Label="Maximum"
+                                             Min="0"
+                                             DecimalPlaces="2"
+                                             Step="1" />
+                    <BbFormFieldNumericInput TValue="decimal"
+                                             @bind-Value="_ruleForm.ReorderPoint"
+                                             Label="Reorder Point"
+                                             Min="0"
+                                             DecimalPlaces="2"
+                                             Step="1" />
+                    <BbFormFieldNumericInput TValue="decimal"
+                                             @bind-Value="_ruleForm.ReorderQuantity"
+                                             Label="Reorder Qty"
+                                             Min="0"
+                                             DecimalPlaces="2"
+                                             Step="1" />
                 </div>
                 <BbFormFieldSwitch Checked="@_ruleForm.IsActive"
                                    CheckedChanged="@((bool value) => _ruleForm.IsActive = value)"
@@ -551,7 +644,7 @@ else
     </BbDialog>
 
     <BbDialog Open="@_warehouseCreateDialogOpen" OpenChanged="@(value => _warehouseCreateDialogOpen = value)">
-        <BbDialogContent TrapFocus="false">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
             <BbDialogHeader>
                 <BbDialogTitle>Create Warehouse</BbDialogTitle>
                 <BbDialogDescription>Create a warehouse, then return to the product workflow with it selected.</BbDialogDescription>
@@ -580,7 +673,7 @@ else
     </BbDialog>
 
     <BbDialog Open="@_locationCreateDialogOpen" OpenChanged="@(value => _locationCreateDialogOpen = value)">
-        <BbDialogContent TrapFocus="false">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
             <BbDialogHeader>
                 <BbDialogTitle>Create Location</BbDialogTitle>
                 <BbDialogDescription>Create a location for the selected warehouse, then return to the product workflow.</BbDialogDescription>
@@ -626,7 +719,7 @@ else
     </BbDialog>
 
     <BbDialog Open="@_supplierCreateDialogOpen" OpenChanged="@(value => _supplierCreateDialogOpen = value)">
-        <BbDialogContent TrapFocus="false">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
             <BbDialogHeader>
                 <BbDialogTitle>Create Supplier</BbDialogTitle>
                 <BbDialogDescription>Create a supplier, then return to the product workflow with it selected.</BbDialogDescription>
@@ -771,18 +864,6 @@ else
     private string? RuleLocationHelpText => CanCreateRuleLocation ? null : "Select a warehouse before scoping this rule to a location.";
     private bool CanPickVariant => _variationsEnabled && _variations.Count > 0;
 
-    private List<SelectOption<string>> CategoryOptions =>
-        _categories.Select(category => new SelectOption<string>(category.Id.ToString(), category.Name ?? category.Id.ToString()[..8])).ToList();
-    private List<SelectOption<string>> VariationTypeOptions =>
-        _variationTypes
-            .Select(type => new SelectOption<string>(type.Id.ToString(), GetVariationTypeLabel(type)))
-            .ToList();
-    private List<SelectOption<string>> VariantOptions =>
-    [
-        new("", "Base product"),
-        .. _variations.Select(variation => new SelectOption<string>(variation.Id.ToString(), GetVariantLabel(variation)))
-    ];
-
     protected override void OnInitialized()
     {
         TenantFilter.OnChanged += OnTenantChanged;
@@ -822,9 +903,9 @@ else
             if (!_editMode)
                 LoadProductForm();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load product: {ex.Message}");
+            ToastService.Show("Could not load product.");
         }
         finally
         {
@@ -1007,7 +1088,7 @@ else
             return;
         }
 
-        ToastService.Show($"Failed to load variation types: {result.Message}");
+        ToastService.Show("Could not load variation types.");
         _variationTypes = [];
     }
 
@@ -1071,17 +1152,29 @@ else
                             <BbFormFieldInput TValue="string" @bind-Value="_productForm.Name" Label="Name" Required="true" />
                             <BbFormFieldInput TValue="string" @bind-Value="_productForm.Sku" Label="SKU" />
                         </div>
-                        <BbFormFieldCombobox TValue="string"
-                                             @bind-Value="_productForm.CategoryId"
-                                             Options="@CategoryOptions"
-                                             Label="Category"
-                                             Placeholder="Select category"
-                                             SearchPlaceholder="Search categories..."
-                                             EmptyMessage="No categories found."
-                                             MatchTriggerWidth="true"
-                                             Required="true" />
+                        <XfEntityPicker TItem="ProductCategory"
+                                        Label="Category"
+                                        Value="@_productForm.CategoryId"
+                                        ValueChanged="@(value => _productForm.CategoryId = value ?? "")"
+                                        Items="@_categories"
+                                        ValueSelector="@GetCategoryPickerValue"
+                                        TextSelector="@GetCategoryLabel"
+                                        SearchTextSelector="@GetCategorySearchText"
+                                        AdvancedColumns="@CategoryAdvancedColumns"
+                                        AdvancedFilters="@CategoryAdvancedFilters"
+                                        AdvancedSearchScope="Searches category name, description, and created date."
+                                        Placeholder="Select category"
+                                        SearchPlaceholder="Search categories..."
+                                        EmptyMessage="No categories found."
+                                        ShowCreate="false"
+                                        AdvancedSearchTitle="Find Category"
+                                        AdvancedSearchDescription="Select the category for this product." />
                         <div class="xf-detail-field-grid">
-                            <BbFormFieldInput TValue="string" @bind-Value="_productForm.Price" Label="Price" />
+                            <BbFormFieldCurrencyInput @bind-Value="_productForm.Price"
+                                                      Label="Price"
+                                                      Min="0"
+                                                      Required="true"
+                                                      ShowSymbol="false" />
                             <BbFormFieldInput TValue="string" @bind-Value="_productForm.Brand" Label="Brand" />
                         </div>
                         <BbFormFieldInput TValue="string" @bind-Value="_productForm.Description" Label="Description" />
@@ -1458,7 +1551,7 @@ else
         _productForm.Name = _product.Name ?? "";
         _productForm.Sku = _product.SKU ?? "";
         _productForm.CategoryId = _product.CategoryId.ToString();
-        _productForm.Price = _product.Price.ToString("0.##");
+        _productForm.Price = _product.Price;
         _productForm.Brand = _product.Brand ?? "";
         _productForm.Description = _product.Description ?? "";
         _productForm.IsAvailable = _product.IsAvailable;
@@ -1477,37 +1570,27 @@ else
             ToastService.Show("Select a category.");
             return;
         }
-        if (!decimal.TryParse(_productForm.Price, out var price) || price < 0)
+        if (_productForm.Price < 0)
         {
-            ToastService.Show("Price must be a non-negative number.");
+            ToastService.Show("Price must be zero or greater.");
             return;
         }
 
         _saving = true;
         try
         {
-            var fresh = await DataContext.Query<Product>()
-                .IgnoreQueryFilters()
-                .NoCache()
-                .Where(x => x.Id == _product.Id && x.TenantId == tenantId && !x.IsDeleted)
-                .FirstOrDefaultAsync();
-            if (fresh is null)
+            var result = await Inventario.UpdateProduct(new UpdateProductRequest
             {
-                ToastService.Show("Product not found.");
-                return;
-            }
-
-            fresh.Name = _productForm.Name.Trim();
-            fresh.SKU = NullIfEmpty(_productForm.Sku);
-            fresh.CategoryId = categoryId;
-            fresh.Price = price;
-            fresh.Brand = NullIfEmpty(_productForm.Brand);
-            fresh.Description = NullIfEmpty(_productForm.Description);
-            fresh.IsAvailable = _productForm.IsAvailable;
-            fresh.ModifiedAt = DateTime.UtcNow;
-            DataContext.Update(fresh);
-
-            var result = await DataContext.SaveChangesAsync();
+                Metadata = BuildMetadata(),
+                ProductId = _product.Id,
+                Name = _productForm.Name.Trim(),
+                SKU = NullIfEmpty(_productForm.Sku),
+                CategoryId = categoryId,
+                Price = _productForm.Price,
+                Brand = NullIfEmpty(_productForm.Brand),
+                Description = NullIfEmpty(_productForm.Description),
+                IsAvailable = _productForm.IsAvailable
+            });
             if (result.IsSuccess)
             {
                 ToastService.Show("Product updated.");
@@ -1516,12 +1599,12 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to save product: {result.Message}");
+                ToastService.Show("Could not save product.");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error saving product: {ex.Message}");
+            ToastService.Show("Could not save product.");
         }
         finally
         {
@@ -1532,7 +1615,7 @@ else
     private void OpenVariationDialog()
     {
         _variationForm.Reset();
-        _variationForm.Price = (_product?.Price ?? 0m).ToString("0.##");
+        _variationForm.Price = _product?.Price ?? 0m;
         _variationDialogOpen = true;
     }
 
@@ -1542,7 +1625,7 @@ else
         _variationForm.ProductVariationId = variation.Id.ToString();
         _variationForm.ProductVariationTypeId = variation.ProductVariationTypeId?.ToString() ?? "";
         _variationForm.Name = variation.Name ?? "";
-        _variationForm.Price = GetVariantPrice(variation).ToString("0.##");
+        _variationForm.Price = GetVariantPrice(variation);
         _variationDialogOpen = true;
     }
 
@@ -1580,12 +1663,12 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to create variation type: {result.Message}");
+                ToastService.Show("Could not create variation type.");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error creating variation type: {ex.Message}");
+            ToastService.Show("Could not create variation type.");
         }
         finally
         {
@@ -1602,11 +1685,13 @@ else
             return;
         }
 
-        if (!decimal.TryParse(_variationForm.Price, out var price) || price < 0)
+        if (_variationForm.Price < 0)
         {
             ToastService.Show("Variant price must be a non-negative number.");
             return;
         }
+
+        var price = _variationForm.Price;
 
         _saving = true;
         try
@@ -1642,12 +1727,12 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to save variant: {result.Message}");
+                ToastService.Show("Could not save variant.");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error saving variant: {ex.Message}");
+            ToastService.Show("Could not save variant.");
         }
         finally
         {
@@ -1683,7 +1768,7 @@ else
             return;
         }
 
-        if (!decimal.TryParse(_movementForm.Quantity, out var quantity) || quantity == 0)
+        if (_movementForm.Quantity == 0)
         {
             ToastService.Show("Quantity must not be zero.");
             return;
@@ -1706,14 +1791,14 @@ else
                 LocationId = locationId,
                 LotId = lotId,
                 MovementType = Enum.TryParse<InventoryMovementType>(_movementForm.MovementType, out var type) ? type : InventoryMovementType.Adjustment,
-                Quantity = quantity,
+                Quantity = _movementForm.Quantity,
                 UnitOfMeasure = NullIfEmpty(_movementForm.UnitOfMeasure),
                 ReferenceType = NullIfEmpty(_movementForm.ReferenceType),
                 Reason = NullIfEmpty(_movementForm.Reason),
                 AllowNegativeStock = _negativeStockEnabled && _movementForm.AllowNegativeStock
             });
 
-            ToastService.Show(result.IsSuccess ? "Stock movement posted." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Stock movement posted." : "Could not post stock movement.");
             if (result.IsSuccess)
             {
                 _movementDialogOpen = false;
@@ -1761,14 +1846,14 @@ else
                 LotNumber = _lotForm.LotNumber.Trim(),
                 SupplierReference = NullIfEmpty(_lotForm.SupplierReference),
                 SourceReferenceType = NullIfEmpty(_lotForm.SourceReferenceType),
-                ReceivedAt = ParseDate(_lotForm.ReceivedAt),
-                ManufacturedAt = ParseDate(_lotForm.ManufacturedAt),
-                ExpiresAt = ParseDate(_lotForm.ExpiresAt),
-                UnitCost = decimal.TryParse(_lotForm.UnitCost, out var cost) ? cost : null,
+                ReceivedAt = _lotForm.ReceivedAt,
+                ManufacturedAt = _lotForm.ManufacturedAt,
+                ExpiresAt = _lotForm.ExpiresAt,
+                UnitCost = _lotForm.UnitCost > 0 ? _lotForm.UnitCost : null,
                 Status = Enum.TryParse<InventoryLotStatus>(_lotForm.Status, out var status) ? status : InventoryLotStatus.Available
             });
 
-            ToastService.Show(result.IsSuccess ? "Lot created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Lot created." : "Could not create lot.");
             if (result.IsSuccess)
             {
                 var lotNumber = _lotForm.LotNumber.Trim();
@@ -1810,7 +1895,7 @@ else
             return;
         }
 
-        if (!decimal.TryParse(_receiveForm.Quantity, out var quantity) || quantity <= 0)
+        if (_receiveForm.Quantity <= 0)
         {
             ToastService.Show("Quantity must be greater than zero.");
             return;
@@ -1836,15 +1921,15 @@ else
                         PurchaseOrderLineId = Guid.TryParse(_receiveForm.PurchaseOrderLineId, out var lineId) ? lineId : null,
                         ProductId = _product.Id,
                         ProductVariationId = Guid.TryParse(_receiveForm.ProductVariationId, out var variationId) ? variationId : null,
-                        Quantity = quantity,
-                        UnitCost = decimal.TryParse(_receiveForm.UnitCost, out var unitCost) ? unitCost : null,
+                        Quantity = _receiveForm.Quantity,
+                        UnitCost = _receiveForm.UnitCost > 0 ? _receiveForm.UnitCost : null,
                         UnitOfMeasure = NullIfEmpty(_receiveForm.UnitOfMeasure),
                         LotId = Guid.TryParse(_receiveForm.LotId, out var lotId) ? lotId : null
                     }
                 ]
             });
 
-            ToastService.Show(result.IsSuccess ? "Receiving posted." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Receiving posted." : "Could not post receiving.");
             if (result.IsSuccess)
             {
                 _receiveDialogOpen = false;
@@ -1866,26 +1951,23 @@ else
     private async Task CreateRule()
     {
         if (_product is null) return;
-        if (!decimal.TryParse(_ruleForm.MinimumQuantity, out var min) ||
-            !decimal.TryParse(_ruleForm.ReorderPoint, out var point) ||
-            !decimal.TryParse(_ruleForm.ReorderQuantity, out var qty) ||
-            min < 0 ||
-            point < 0 ||
-            qty <= 0)
+        if (_ruleForm.MinimumQuantity < 0 ||
+            _ruleForm.ReorderPoint < 0 ||
+            _ruleForm.ReorderQuantity <= 0)
         {
             ToastService.Show("Quantities must be valid.");
             return;
         }
 
         decimal? max = null;
-        if (!string.IsNullOrWhiteSpace(_ruleForm.MaximumQuantity))
+        if (_ruleForm.MaximumQuantity > 0)
         {
-            if (!decimal.TryParse(_ruleForm.MaximumQuantity, out var parsedMax) || parsedMax < min)
+            if (_ruleForm.MaximumQuantity < _ruleForm.MinimumQuantity)
             {
                 ToastService.Show("Maximum must be greater than or equal to minimum.");
                 return;
             }
-            max = parsedMax;
+            max = _ruleForm.MaximumQuantity;
         }
 
         _savingRule = true;
@@ -1898,15 +1980,15 @@ else
                 ProductVariationId = Guid.TryParse(_ruleForm.ProductVariationId, out var variationId) ? variationId : null,
                 WarehouseId = Guid.TryParse(_ruleForm.WarehouseId, out var warehouseId) ? warehouseId : null,
                 LocationId = Guid.TryParse(_ruleForm.LocationId, out var locationId) ? locationId : null,
-                MinimumQuantity = min,
+                MinimumQuantity = _ruleForm.MinimumQuantity,
                 MaximumQuantity = max,
-                ReorderPoint = point,
-                ReorderQuantity = qty,
+                ReorderPoint = _ruleForm.ReorderPoint,
+                ReorderQuantity = _ruleForm.ReorderQuantity,
                 PreferredSupplier = NullIfEmpty(_ruleForm.PreferredSupplier),
                 IsActive = _ruleForm.IsActive
             });
 
-            ToastService.Show(result.IsSuccess ? "Reorder rule created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Reorder rule created." : "Could not create reorder rule.");
             if (result.IsSuccess)
             {
                 _ruleDialogOpen = false;
@@ -1954,7 +2036,7 @@ else
                 IsDefault = _warehouseForm.IsDefault
             });
 
-            ToastService.Show(result.IsSuccess ? "Warehouse created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Warehouse created." : "Could not create warehouse.");
             if (!result.IsSuccess) return;
 
             _warehouseCreateDialogOpen = false;
@@ -2017,7 +2099,7 @@ else
                 IsPickable = _locationForm.IsPickable
             });
 
-            ToastService.Show(result.IsSuccess ? "Location created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Location created." : "Could not create location.");
             if (!result.IsSuccess) return;
 
             _locationCreateDialogOpen = false;
@@ -2066,7 +2148,7 @@ else
                 IsActive = _supplierForm.IsActive
             });
 
-            ToastService.Show(result.IsSuccess ? "Supplier created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Supplier created." : "Could not create supplier.");
             if (!result.IsSuccess) return;
 
             _supplierCreateDialogOpen = false;
@@ -2185,6 +2267,12 @@ else
     private string GetCategoryName(Guid categoryId) =>
         _categories.FirstOrDefault(x => x.Id == categoryId)?.Name ?? "Uncategorized";
 
+    private static string GetCategoryPickerValue(ProductCategory category) => category.Id.ToString();
+    private static string GetCategoryLabel(ProductCategory category) =>
+        string.IsNullOrWhiteSpace(category.Name) ? category.Id.ToString()[..8] : category.Name;
+    private static string GetCategorySearchText(ProductCategory category) =>
+        $"{category.Name} {category.Description}";
+
     private string GetRuleScope(InventoryReorderRule rule) =>
         $"{GetWarehouseName(rule.WarehouseId)} / {GetLocationName(rule.LocationId)}";
 
@@ -2214,6 +2302,10 @@ else
         return string.IsNullOrWhiteSpace(typeName) ? name : $"{typeName}: {name}";
     }
 
+    private static string GetVariantPickerValue(ProductVariation variation) => variation.Id.ToString();
+    private string GetVariantSearchText(ProductVariation variation) =>
+        $"{variation.Name} {GetVariationTypeName(variation)} {GetVariantPrice(variation):0.##} {GetVariantDelta(variation):+0.##;-0.##;0}";
+
     private string GetVariationTypeName(ProductVariation variation)
     {
         if (variation.ProductVariationTypeId is { } typeId &&
@@ -2231,6 +2323,10 @@ else
         var name = string.IsNullOrWhiteSpace(type.Name) ? type.Id.ToString()[..8] : type.Name;
         return $"{name} ({scope})";
     }
+
+    private static string GetVariationTypePickerValue(ProductVariationType type) => type.Id.ToString();
+    private static string GetVariationTypeSearchText(ProductVariationType type) =>
+        $"{type.Name} {type.Code} {GetVariationTypeScope(type)}";
 
     private static string GetVariationTypeScope(ProductVariationType type) =>
         type.ProductId is null ? "Tenant-wide" : "Product";
@@ -2287,6 +2383,15 @@ else
         new("Created", x => FormatDate(x.CreatedAt))
     ];
 
+    private IReadOnlyList<XfEntityPickerColumn<ProductCategory>> CategoryAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Description", x => x.Description),
+        new("Created", x => FormatDate(x.CreatedAt))
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilter<ProductCategory>> CategoryAdvancedFilters = [];
+
     private IReadOnlyList<XfEntityPickerFilter<Warehouse>> WarehouseAdvancedFilters =>
     [
         new("default", "Default warehouse", YesNoFilterOptions, x => x.IsDefault ? "true" : "false", "All warehouses"),
@@ -2307,6 +2412,41 @@ else
     [
         new("type", "Location type", BuildEnumFilterOptions<InventoryLocationType>(), x => x.LocationType.ToString(), "All types"),
         new("pickable", "Pickable", YesNoFilterOptions, x => x.IsPickable ? "true" : "false", "All locations")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<ProductVariationType>> VariationTypeAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Code", x => x.Code),
+        new("Scope", GetVariationTypeScope),
+        new("Created", x => FormatDate(x.CreatedAt))
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilter<ProductVariationType>> VariationTypeAdvancedFilters =
+    [
+        new(
+            "scope",
+            "Scope",
+            [
+                new XfEntityPickerFilterOption("Tenant-wide", "Tenant-wide"),
+                new XfEntityPickerFilterOption("Product", "Product")
+            ],
+            GetVariationTypeScope,
+            "All scopes")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<ProductVariation>> VariantAdvancedColumns =>
+    [
+        new("Variant", x => x.Name),
+        new("Type", GetVariationTypeName),
+        new("Price", x => GetVariantPrice(x).ToString("0.##")),
+        new("Delta", x => GetVariantDelta(x).ToString("+0.##;-0.##;0")),
+        new("Created", x => FormatDate(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<ProductVariation>> VariantAdvancedFilters =>
+    [
+        new("type", "Variation type", BuildDistinctFilterOptions(_variations, GetVariationTypeName), GetVariationTypeName, "All types")
     ];
 
     private IReadOnlyList<XfEntityPickerColumn<InventoryLot>> LotAdvancedColumns =>
@@ -2437,9 +2577,6 @@ else
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
-    private static DateTime? ParseDate(string? value) =>
-        DateTime.TryParse(value, out var date) ? date : null;
-
     public void Dispose()
     {
         TenantFilter.OnChanged -= OnTenantChanged;
@@ -2458,7 +2595,7 @@ else
         public string Name { get; set; } = "";
         public string Sku { get; set; } = "";
         public string CategoryId { get; set; } = "";
-        public string Price { get; set; } = "0";
+        public decimal Price { get; set; }
         public string Brand { get; set; } = "";
         public string Description { get; set; } = "";
         public bool IsAvailable { get; set; } = true;
@@ -2469,7 +2606,7 @@ else
         public string ProductVariationId { get; set; } = "";
         public string ProductVariationTypeId { get; set; } = "";
         public string Name { get; set; } = "";
-        public string Price { get; set; } = "0";
+        public decimal Price { get; set; }
         public bool IsEditing => !string.IsNullOrWhiteSpace(ProductVariationId);
 
         public void Reset()
@@ -2477,7 +2614,7 @@ else
             ProductVariationId = "";
             ProductVariationTypeId = "";
             Name = "";
-            Price = "0";
+            Price = 0m;
         }
     }
 
@@ -2503,7 +2640,7 @@ else
         public string LocationId { get; set; } = "";
         public string LotId { get; set; } = "";
         public string MovementType { get; set; } = InventoryMovementType.Adjustment.ToString();
-        public string Quantity { get; set; } = "0";
+        public decimal Quantity { get; set; }
         public string UnitOfMeasure { get; set; } = "each";
         public string ReferenceType { get; set; } = "";
         public string Reason { get; set; } = "";
@@ -2517,7 +2654,7 @@ else
             LocationId = "";
             LotId = "";
             MovementType = InventoryMovementType.Adjustment.ToString();
-            Quantity = "0";
+            Quantity = 0m;
             UnitOfMeasure = "each";
             ReferenceType = "";
             Reason = "";
@@ -2531,10 +2668,10 @@ else
         public string LotNumber { get; set; } = "";
         public string SupplierReference { get; set; } = "";
         public string SourceReferenceType { get; set; } = "";
-        public string ReceivedAt { get; set; } = "";
-        public string ManufacturedAt { get; set; } = "";
-        public string ExpiresAt { get; set; } = "";
-        public string UnitCost { get; set; } = "";
+        public DateTime? ReceivedAt { get; set; }
+        public DateTime? ManufacturedAt { get; set; }
+        public DateTime? ExpiresAt { get; set; }
+        public decimal UnitCost { get; set; }
         public string Status { get; set; } = InventoryLotStatus.Available.ToString();
 
         public void Reset()
@@ -2543,10 +2680,10 @@ else
             LotNumber = "";
             SupplierReference = "";
             SourceReferenceType = "";
-            ReceivedAt = "";
-            ManufacturedAt = "";
-            ExpiresAt = "";
-            UnitCost = "";
+            ReceivedAt = DateTime.Today;
+            ManufacturedAt = null;
+            ExpiresAt = null;
+            UnitCost = 0m;
             Status = InventoryLotStatus.Available.ToString();
         }
     }
@@ -2562,8 +2699,8 @@ else
         public string LocationId { get; set; } = "";
         public string ReferenceNumber { get; set; } = "";
         public string IdempotencyKey { get; set; } = "";
-        public string Quantity { get; set; } = "1";
-        public string UnitCost { get; set; } = "";
+        public decimal Quantity { get; set; } = 1m;
+        public decimal UnitCost { get; set; }
         public string UnitOfMeasure { get; set; } = "each";
         public string LotId { get; set; } = "";
 
@@ -2578,8 +2715,8 @@ else
             LocationId = "";
             ReferenceNumber = "";
             IdempotencyKey = "";
-            Quantity = "1";
-            UnitCost = "";
+            Quantity = 1m;
+            UnitCost = 0m;
             UnitOfMeasure = "each";
             LotId = "";
         }
@@ -2590,10 +2727,10 @@ else
         public string ProductVariationId { get; set; } = "";
         public string WarehouseId { get; set; } = "";
         public string LocationId { get; set; } = "";
-        public string MinimumQuantity { get; set; } = "0";
-        public string MaximumQuantity { get; set; } = "";
-        public string ReorderPoint { get; set; } = "0";
-        public string ReorderQuantity { get; set; } = "1";
+        public decimal MinimumQuantity { get; set; }
+        public decimal MaximumQuantity { get; set; }
+        public decimal ReorderPoint { get; set; }
+        public decimal ReorderQuantity { get; set; } = 1m;
         public string PreferredSupplier { get; set; } = "";
         public bool IsActive { get; set; } = true;
 
@@ -2602,10 +2739,10 @@ else
             ProductVariationId = "";
             WarehouseId = "";
             LocationId = "";
-            MinimumQuantity = "0";
-            MaximumQuantity = "";
-            ReorderPoint = "0";
-            ReorderQuantity = "1";
+            MinimumQuantity = 0m;
+            MaximumQuantity = 0m;
+            ReorderPoint = 0m;
+            ReorderQuantity = 1m;
             PreferredSupplier = "";
             IsActive = true;
         }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductTransactionDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductTransactionDetail.razor
@@ -170,9 +170,9 @@ else
                 .Where(x => x.TenantId == _transaction.TenantId && x.Id == _transaction.ProductId && !x.IsDeleted)
                 .FirstOrDefaultAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load transaction: {ex.Message}");
+            ToastService.Show("Could not load transaction.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Products.razor
@@ -1,5 +1,6 @@
 @page "/inventario/products"
 @using XFramework.Domain.Shared.DataContext
+@using XFramework.Domain.Shared.BusinessObjects
 @implements IDisposable
 
 <PageTitle>Inventario Products - Control Panel</PageTitle>
@@ -118,25 +119,39 @@ else
 }
 
 <BbDialog Open="@_productDialogOpen" OpenChanged="@(v => _productDialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Create Product</BbDialogTitle>
             <BbDialogDescription>Catalog data belongs to the selected tenant.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <BbFormFieldInput TValue="string" @bind-Value="_form.Name" Label="Name" Required="true" />
-            <BbFormFieldInput TValue="string" @bind-Value="_form.Sku" Label="SKU" />
-            <BbFormFieldCombobox TValue="string"
-                                  @bind-Value="_form.CategoryId"
-                                  Options="@CategoryOptions"
-                                  Label="Category"
-                                  Placeholder="Select category"
-                                  SearchPlaceholder="Search categories..."
-                                  EmptyMessage="No categories found."
-                                  MatchTriggerWidth="true"
-                                  Required="true" />
             <div class="grid gap-4 md:grid-cols-2">
-                <BbFormFieldInput TValue="string" @bind-Value="_form.Price" Label="Price" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Name" Label="Name" Required="true" />
+                <BbFormFieldInput TValue="string" @bind-Value="_form.Sku" Label="SKU" />
+            </div>
+            <XfEntityPicker TItem="ProductCategory"
+                            Label="Category"
+                            Value="@_form.CategoryId"
+                            ValueChanged="@(value => _form.CategoryId = value ?? "")"
+                            Items="@_categories"
+                            ValueSelector="@GetCategoryPickerValue"
+                            TextSelector="@GetCategoryLabel"
+                            SearchTextSelector="@GetCategorySearchText"
+                            AdvancedColumns="@CategoryAdvancedColumns"
+                            AdvancedFilters="@CategoryAdvancedFilters"
+                            AdvancedSearchScope="Searches category name, description, product count, and created date."
+                            Placeholder="Select category"
+                            SearchPlaceholder="Search categories..."
+                            EmptyMessage="No categories found."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Category"
+                            AdvancedSearchDescription="Select the category for this product." />
+            <div class="grid gap-4 md:grid-cols-2">
+                <BbFormFieldCurrencyInput @bind-Value="_form.Price"
+                                           Label="Price"
+                                           Min="0"
+                                          Required="true"
+                                          ShowSymbol="false" />
                 <BbFormFieldInput TValue="string" @bind-Value="_form.Brand" Label="Brand" />
             </div>
             <BbFormFieldInput TValue="string" @bind-Value="_form.Description" Label="Description" />
@@ -155,6 +170,7 @@ else
 
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
+    [Inject] private IInventarioServiceWrapper Inventario { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
@@ -225,9 +241,9 @@ else
             await LoadSettings();
             ApplySearch();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load products: {ex.Message}");
+            ToastService.Show("Could not load products.");
         }
         finally
         {
@@ -273,10 +289,21 @@ else
     private string GetCategoryName(Guid categoryId) =>
         _categories.FirstOrDefault(x => x.Id == categoryId)?.Name ?? "Uncategorized";
 
-    private List<SelectOption<string>> CategoryOptions =>
-        _categories
-            .Select(category => new SelectOption<string>(category.Id.ToString(), category.Name ?? category.Id.ToString()[..8]))
-            .ToList();
+    private static string GetCategoryPickerValue(ProductCategory category) => category.Id.ToString();
+    private static string GetCategoryLabel(ProductCategory category) =>
+        string.IsNullOrWhiteSpace(category.Name) ? category.Id.ToString()[..8] : category.Name;
+    private static string GetCategorySearchText(ProductCategory category) =>
+        $"{category.Name} {category.Description}";
+
+    private IReadOnlyList<XfEntityPickerColumn<ProductCategory>> CategoryAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Description", x => x.Description),
+        new("Products", x => _products.Count(product => product.CategoryId == x.Id).ToString()),
+        new("Created", x => x.CreatedAt.ToString("yyyy-MM-dd"))
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilter<ProductCategory>> CategoryAdvancedFilters = [];
 
     private void OpenCreateDialog()
     {
@@ -288,7 +315,7 @@ else
 
     private async Task SaveProduct()
     {
-        if (TenantFilter.SelectedTenantId is not Guid tenantId)
+        if (TenantFilter.SelectedTenantId is not Guid)
         {
             ToastService.Show("Select a tenant before saving products.");
             return;
@@ -306,32 +333,28 @@ else
             return;
         }
 
-        if (!decimal.TryParse(_form.Price, out var price) || price < 0)
+        if (_form.Price < 0)
         {
-            ToastService.Show("Price must be a non-negative number.");
+            ToastService.Show("Price must be zero or greater.");
             return;
         }
 
         _saving = true;
         try
         {
-            DataContext.Add(new Product
+            var result = await Inventario.CreateProduct(new CreateProductRequest
             {
-                Id = Guid.NewGuid(),
-                TenantId = tenantId,
+                Metadata = BuildMetadata(),
                 Name = _form.Name.Trim(),
                 SKU = NullIfEmpty(_form.Sku),
                 CategoryId = categoryId,
-                Price = price,
+                Price = _form.Price,
                 StockQuantity = 0,
                 Brand = NullIfEmpty(_form.Brand),
                 Description = NullIfEmpty(_form.Description),
-                IsAvailable = _form.IsAvailable,
-                CreatedAt = DateTime.UtcNow,
-                IsEnabled = true
+                IsAvailable = _form.IsAvailable
             });
 
-            var result = await DataContext.SaveChangesAsync();
             if (result.IsSuccess)
             {
                 ToastService.Show("Product created.");
@@ -340,12 +363,12 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to save product: {result.Message}");
+                ToastService.Show("Could not save product.");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error saving product: {ex.Message}");
+            ToastService.Show("Could not save product.");
         }
         finally
         {
@@ -355,6 +378,13 @@ else
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private RequestMetadata BuildMetadata() => new()
+    {
+        TenantId = TenantFilter.SelectedTenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "ControlPanel"
+    };
 
     public void Dispose()
     {
@@ -367,7 +397,7 @@ else
         public string Name { get; set; } = "";
         public string Sku { get; set; } = "";
         public string CategoryId { get; set; } = "";
-        public string Price { get; set; } = "0";
+        public decimal Price { get; set; }
         public string Brand { get; set; } = "";
         public string Description { get; set; } = "";
         public bool IsAvailable { get; set; } = true;
@@ -377,7 +407,7 @@ else
             Name = "";
             Sku = "";
             CategoryId = "";
-            Price = "0";
+            Price = 0m;
             Brand = "";
             Description = "";
             IsAvailable = true;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrderDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrderDetail.razor
@@ -79,16 +79,16 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_lines" ShowPagination="true" InitialPageSize="20">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.OrderedQuantity)" Title="Ordered" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedQuantity)" Title="Received" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Remaining">
+                            <BbDataGridPropertyColumn Property="@(x => x.OrderedQuantity)" Title="Ordered" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedQuantity)" Title="Received" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Remaining" Filterable="true" FilterBy="@(item => Math.Max(0, item.OrderedQuantity - item.ReceivedQuantity))">
                                 <ChildContent Context="item">@Math.Max(0, item.OrderedQuantity - item.ReceivedQuantity).ToString("N2")</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.UnitCost)" Title="Unit Cost" />
-                            <BbDataGridPropertyColumn Property="@(x => x.UnitOfMeasure)" Title="Unit" />
+                            <BbDataGridPropertyColumn Property="@(x => x.UnitCost)" Title="Unit Cost" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.UnitOfMeasure)" Title="Unit" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -104,10 +104,10 @@ else
                                 OnRowClick="@((ReceivingDocument item) => Navigation.NavigateTo($"/inventario/receiving/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ReceiptNumber)" Title="Receipt" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceiptNumber)" Title="Receipt" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -192,9 +192,9 @@ else
                 .Take(500)
                 .ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load purchase order: {ex.Message}");
+            ToastService.Show("Could not load purchase order.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/PurchaseOrders.razor
@@ -80,7 +80,7 @@ else
 }
 
 <BbDialog Open="@_createDialogOpen" OpenChanged="@(v => _createDialogOpen = v)">
-    <BbDialogContent TrapFocus="false" class="max-w-4xl">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Create Purchase Order</BbDialogTitle>
             <BbDialogDescription>Add one or more product lines. Receiving will update line quantities later.</BbDialogDescription>
@@ -88,24 +88,27 @@ else
         <div class="grid gap-4 py-4">
             <div class="grid gap-3 md:grid-cols-3">
                 <BbFormFieldInput TValue="string" @bind-Value="_form.OrderNumber" Label="Order Number" />
-                <div class="xf-form-field">
-                    <BbLabel>Supplier</BbLabel>
-                    <BbCombobox TValue="string"
-                                 @bind-Value="_form.SupplierId"
-                                 Options="@SupplierOptions"
-                                 Placeholder="No supplier"
-                                 SearchPlaceholder="Search suppliers..."
-                                 EmptyMessage="No suppliers found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
+                <XfEntityPicker TItem="Supplier"
+                                @bind-Value="_form.SupplierId"
+                                Items="@_suppliers"
+                                Label="Supplier"
+                                Placeholder="No supplier"
+                                SearchPlaceholder="Search suppliers..."
+                                EmptyMessage="No suppliers found."
+                                ValueSelector="@GetSupplierPickerValue"
+                                TextSelector="@GetSupplierLabel"
+                                SearchTextSelector="@GetSupplierSearchText"
+                                AllowClear="true"
+                                ClearText="No supplier"
+                                AdvancedSearchTitle="Find Supplier"
+                                AdvancedSearchDescription="Search suppliers in the active tenant." />
                 <BbFormFieldSelect TValue="string" @bind-Value="_form.Status" Label="Status">
                     <BbSelectItem Value="@PurchaseOrderStatus.Open.ToString()">Open</BbSelectItem>
                     <BbSelectItem Value="@PurchaseOrderStatus.Draft.ToString()">Draft</BbSelectItem>
                 </BbFormFieldSelect>
             </div>
             <div class="grid gap-3 md:grid-cols-2">
-                <BbFormFieldInput TValue="string" @bind-Value="_form.ExpectedDate" Label="Expected Date" />
+                <BbFormFieldDatePicker @bind-Value="_form.ExpectedDate" Label="Expected Date" />
                 <BbFormFieldInput TValue="string" @bind-Value="_form.Notes" Label="Notes" />
             </div>
 
@@ -123,19 +126,28 @@ else
                         var index = i;
                         var line = _form.Lines[index];
                         <div class="grid gap-3 rounded-md border p-3 md:grid-cols-[2fr_1fr_1fr_auto]">
-                            <div class="xf-form-field">
-                                <BbLabel>Product</BbLabel>
-                                <BbCombobox TValue="string"
-                                             @bind-Value="line.ProductId"
-                                             Options="@ProductOptions"
-                                             Placeholder="Select product"
-                                             SearchPlaceholder="Search products..."
-                                             EmptyMessage="No products found."
-                                             Class="xf-entity-combobox"
-                                             MatchTriggerWidth="true" />
-                            </div>
-                            <BbFormFieldInput TValue="string" @bind-Value="line.Quantity" Label="Quantity" />
-                            <BbFormFieldInput TValue="string" @bind-Value="line.UnitCost" Label="Unit Cost" />
+                            <XfEntityPicker TItem="Product"
+                                            @bind-Value="line.ProductId"
+                                            Items="@_products"
+                                            Label="Product"
+                                            Placeholder="Select product"
+                                            SearchPlaceholder="Search products..."
+                                            EmptyMessage="No products found."
+                                            ValueSelector="@GetProductPickerValue"
+                                            TextSelector="@GetProductLabel"
+                                            SearchTextSelector="@GetProductSearchText"
+                                            AdvancedSearchTitle="Find Product"
+                                            AdvancedSearchDescription="Search products in the active tenant." />
+                            <BbFormFieldNumericInput TValue="decimal"
+                                                     @bind-Value="line.Quantity"
+                                                     Label="Quantity"
+                                                     Min="0"
+                                                     DecimalPlaces="2"
+                                                     Step="1" />
+                            <BbFormFieldCurrencyInput @bind-Value="line.UnitCost"
+                                                      Label="Unit Cost"
+                                                      Min="0"
+                                                      ShowSymbol="false" />
                             <div class="flex items-end">
                                 <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Remove line"
                                           Disabled="@(_form.Lines.Count == 1)"
@@ -173,10 +185,7 @@ else
     private bool _purchasingEnabled;
     private bool _saving;
     private bool _createDialogOpen;
-    private bool IsCreateDisabled => _saving || _products.Count == 0 || _form.Lines.Any(x => string.IsNullOrWhiteSpace(x.ProductId) || !decimal.TryParse(x.Quantity, out var quantity) || quantity <= 0);
-
-    private List<SelectOption<string>> SupplierOptions => [new("", "No supplier"), .. _suppliers.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Code} - {x.Name}"))];
-    private List<SelectOption<string>> ProductOptions => _products.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Name} ({x.SKU ?? x.Id.ToString()[..8]})")).ToList();
+    private bool IsCreateDisabled => _saving || _products.Count == 0 || _form.Lines.Any(x => string.IsNullOrWhiteSpace(x.ProductId) || x.Quantity <= 0);
 
     protected override void OnInitialized()
     {
@@ -232,9 +241,9 @@ else
                 .Take(1000)
                 .ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load purchase orders: {ex.Message}");
+            ToastService.Show("Could not load purchase orders.");
         }
         finally
         {
@@ -249,7 +258,7 @@ else
         _createDialogOpen = true;
     }
 
-    private void AddLine() => _form.Lines.Add(new PurchaseOrderLineForm { ProductId = _products.FirstOrDefault()?.Id.ToString() ?? "", Quantity = "1" });
+    private void AddLine() => _form.Lines.Add(new PurchaseOrderLineForm { ProductId = _products.FirstOrDefault()?.Id.ToString() ?? "", Quantity = 1m });
 
     private void RemoveLine(int index)
     {
@@ -268,21 +277,21 @@ else
                 OrderNumber = NullIfEmpty(_form.OrderNumber),
                 SupplierId = Guid.TryParse(_form.SupplierId, out var supplierId) ? supplierId : null,
                 Status = Enum.TryParse<PurchaseOrderStatus>(_form.Status, out var status) ? status : PurchaseOrderStatus.Open,
-                ExpectedDate = ParseDate(_form.ExpectedDate),
+                ExpectedDate = _form.ExpectedDate,
                 Notes = NullIfEmpty(_form.Notes),
                 Lines = _form.Lines
-                    .Where(x => Guid.TryParse(x.ProductId, out _) && decimal.TryParse(x.Quantity, out var quantity) && quantity > 0)
+                    .Where(x => Guid.TryParse(x.ProductId, out _) && x.Quantity > 0)
                     .Select(x => new PurchaseOrderLineRequest
                     {
                         ProductId = Guid.Parse(x.ProductId),
-                        OrderedQuantity = decimal.Parse(x.Quantity),
-                        UnitCost = decimal.TryParse(x.UnitCost, out var unitCost) ? unitCost : null,
+                        OrderedQuantity = x.Quantity,
+                        UnitCost = x.UnitCost > 0 ? x.UnitCost : null,
                         UnitOfMeasure = NullIfEmpty(x.UnitOfMeasure)
                     })
                     .ToList()
             });
 
-            ToastService.Show(result.IsSuccess ? "Purchase order created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Purchase order created." : "Could not create purchase order.");
             if (result.IsSuccess)
             {
                 _createDialogOpen = false;
@@ -298,6 +307,22 @@ else
     private string GetSupplierName(Guid? supplierId) =>
         supplierId is { } id ? _suppliers.FirstOrDefault(x => x.Id == id)?.Name ?? id.ToString()[..8] : "No supplier";
 
+    private static string GetSupplierPickerValue(Supplier supplier) => supplier.Id.ToString();
+
+    private static string GetSupplierLabel(Supplier supplier) =>
+        string.IsNullOrWhiteSpace(supplier.Code) ? supplier.Name ?? supplier.Id.ToString()[..8] : $"{supplier.Code} - {supplier.Name}";
+
+    private static string GetSupplierSearchText(Supplier supplier) =>
+        $"{supplier.Code} {supplier.Name} {supplier.ContactName} {supplier.Email} {supplier.Phone}";
+
+    private static string GetProductPickerValue(Product product) => product.Id.ToString();
+
+    private static string GetProductLabel(Product product) =>
+        string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
+
+    private static string GetProductSearchText(Product product) =>
+        $"{product.Name} {product.SKU} {product.Brand} {product.Description}";
+
     private static string GetStatusBadge(PurchaseOrderStatus status) =>
         status switch
         {
@@ -309,8 +334,6 @@ else
 
     private RequestMetadata BuildMetadata() => new() { TenantId = TenantFilter.SelectedTenantId };
     private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-    private static DateTime? ParseDate(string? value) => DateTime.TryParse(value, out var date) ? date : null;
-
     public void Dispose()
     {
         TenantFilter.OnChanged -= OnTenantChanged;
@@ -322,7 +345,7 @@ else
         public string OrderNumber { get; set; } = "";
         public string SupplierId { get; set; } = "";
         public string Status { get; set; } = PurchaseOrderStatus.Open.ToString();
-        public string ExpectedDate { get; set; } = "";
+        public DateTime? ExpectedDate { get; set; }
         public string Notes { get; set; } = "";
         public List<PurchaseOrderLineForm> Lines { get; } = [];
 
@@ -331,18 +354,18 @@ else
             OrderNumber = "";
             SupplierId = "";
             Status = PurchaseOrderStatus.Open.ToString();
-            ExpectedDate = "";
+            ExpectedDate = null;
             Notes = "";
             Lines.Clear();
-            Lines.Add(new PurchaseOrderLineForm { ProductId = productId, Quantity = "1" });
+            Lines.Add(new PurchaseOrderLineForm { ProductId = productId, Quantity = 1m });
         }
     }
 
     private sealed class PurchaseOrderLineForm
     {
         public string ProductId { get; set; } = "";
-        public string Quantity { get; set; } = "1";
-        public string UnitCost { get; set; } = "";
+        public decimal Quantity { get; set; } = 1m;
+        public decimal UnitCost { get; set; }
         public string UnitOfMeasure { get; set; } = "";
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Receiving.razor
@@ -81,7 +81,7 @@ else
 }
 
 <BbDialog Open="@_receiveDialogOpen" OpenChanged="@(v => _receiveDialogOpen = v)">
-    <BbDialogContent TrapFocus="false" class="max-w-5xl">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-extra-wide">
         <BbDialogHeader>
             <BbDialogTitle>Receive Stock</BbDialogTitle>
             <BbDialogDescription>Receiving posts receipt movements and updates balances in one save.</BbDialogDescription>
@@ -89,53 +89,61 @@ else
         <div class="grid gap-4 py-4">
             <div class="grid gap-3 md:grid-cols-3">
                 <BbFormFieldInput TValue="string" @bind-Value="_form.ReceiptNumber" Label="Receipt Number" />
-                <div class="xf-form-field">
-                    <BbLabel>Purchase Order</BbLabel>
-                    <BbCombobox TValue="string"
-                                 @bind-Value="_form.PurchaseOrderId"
-                                 Options="@PurchaseOrderOptions"
-                                 Placeholder="No purchase order"
-                                 SearchPlaceholder="Search purchase orders..."
-                                 EmptyMessage="No purchase orders found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
-                <div class="xf-form-field">
-                    <BbLabel>Supplier</BbLabel>
-                    <BbCombobox TValue="string"
-                                 @bind-Value="_form.SupplierId"
-                                 Options="@SupplierOptions"
-                                 Placeholder="No supplier"
-                                 SearchPlaceholder="Search suppliers..."
-                                 EmptyMessage="No suppliers found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
+                <XfEntityPicker TItem="PurchaseOrder"
+                                @bind-Value="_form.PurchaseOrderId"
+                                Items="@OpenPurchaseOrders"
+                                Label="Purchase Order"
+                                Placeholder="No purchase order"
+                                SearchPlaceholder="Search purchase orders..."
+                                EmptyMessage="No purchase orders found."
+                                ValueSelector="@GetPurchaseOrderPickerValue"
+                                TextSelector="@GetPurchaseOrderLabel"
+                                SearchTextSelector="@GetPurchaseOrderSearchText"
+                                AllowClear="true"
+                                ClearText="No purchase order"
+                                AdvancedSearchTitle="Find Purchase Order"
+                                AdvancedSearchDescription="Search open purchase orders in the active tenant." />
+                <XfEntityPicker TItem="Supplier"
+                                @bind-Value="_form.SupplierId"
+                                Items="@_suppliers"
+                                Label="Supplier"
+                                Placeholder="No supplier"
+                                SearchPlaceholder="Search suppliers..."
+                                EmptyMessage="No suppliers found."
+                                ValueSelector="@GetSupplierPickerValue"
+                                TextSelector="@GetSupplierLabel"
+                                SearchTextSelector="@GetSupplierSearchText"
+                                AllowClear="true"
+                                ClearText="No supplier"
+                                AdvancedSearchTitle="Find Supplier"
+                                AdvancedSearchDescription="Search suppliers in the active tenant." />
             </div>
             <div class="grid gap-3 md:grid-cols-3">
-                <div class="xf-form-field">
-                    <BbLabel>Warehouse</BbLabel>
-                    <BbCombobox TValue="string"
-                                 Value="@_form.WarehouseId"
-                                 ValueChanged="@OnWarehouseChanged"
-                                 Options="@WarehouseOptions"
-                                 Placeholder="Select warehouse"
-                                 SearchPlaceholder="Search warehouses..."
-                                 EmptyMessage="No warehouses found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
-                <div class="xf-form-field">
-                    <BbLabel>Location</BbLabel>
-                    <BbCombobox TValue="string"
-                                 @bind-Value="_form.LocationId"
-                                 Options="@LocationOptions"
-                                 Placeholder="Select location"
-                                 SearchPlaceholder="Search locations..."
-                                 EmptyMessage="No locations found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
+                <XfEntityPicker TItem="Warehouse"
+                                Value="@_form.WarehouseId"
+                                ValueChanged="@OnWarehouseChanged"
+                                Items="@_warehouses"
+                                Label="Warehouse"
+                                Placeholder="Select warehouse"
+                                SearchPlaceholder="Search warehouses..."
+                                EmptyMessage="No warehouses found."
+                                ValueSelector="@GetWarehousePickerValue"
+                                TextSelector="@GetWarehouseLabel"
+                                SearchTextSelector="@GetWarehouseSearchText"
+                                AdvancedSearchTitle="Find Warehouse"
+                                AdvancedSearchDescription="Search warehouses in the active tenant." />
+                <XfEntityPicker TItem="InventoryLocation"
+                                @bind-Value="_form.LocationId"
+                                Items="@FilteredLocations"
+                                Label="Location"
+                                Placeholder="Select location"
+                                SearchPlaceholder="Search locations..."
+                                EmptyMessage="No locations found."
+                                ValueSelector="@GetLocationPickerValue"
+                                TextSelector="@GetLocationLabel"
+                                SearchTextSelector="@GetLocationSearchText"
+                                AdvancedSearchTitle="Find Location"
+                                AdvancedSearchDescription="Search locations for the selected warehouse." />
                 <BbFormFieldInput TValue="string" @bind-Value="_form.ReferenceNumber" Label="Reference" />
             </div>
 
@@ -154,30 +162,42 @@ else
                         var line = _form.Lines[index];
                         <div class="grid gap-3 rounded-md border p-3">
                             <div class="grid gap-3 md:grid-cols-[1.2fr_1.4fr_0.8fr_0.8fr_auto]">
-                                <div class="xf-form-field">
-                                    <BbLabel>PO Line</BbLabel>
-                                    <BbCombobox TValue="string"
-                                                 @bind-Value="line.PurchaseOrderLineId"
-                                                 Options="@PurchaseOrderLineOptions"
-                                                 Placeholder="No PO line"
-                                                 SearchPlaceholder="Search PO lines..."
-                                                 EmptyMessage="No open PO lines."
-                                                 Class="xf-entity-combobox"
-                                                 MatchTriggerWidth="true" />
-                                </div>
-                                <div class="xf-form-field">
-                                    <BbLabel>Product</BbLabel>
-                                    <BbCombobox TValue="string"
-                                                 @bind-Value="line.ProductId"
-                                                 Options="@ProductOptions"
-                                                 Placeholder="Select product"
-                                                 SearchPlaceholder="Search products..."
-                                                 EmptyMessage="No products found."
-                                                 Class="xf-entity-combobox"
-                                                 MatchTriggerWidth="true" />
-                                </div>
-                                <BbFormFieldInput TValue="string" @bind-Value="line.Quantity" Label="Quantity" />
-                                <BbFormFieldInput TValue="string" @bind-Value="line.UnitCost" Label="Unit Cost" />
+                                <XfEntityPicker TItem="PurchaseOrderLine"
+                                                @bind-Value="line.PurchaseOrderLineId"
+                                                Items="@OpenPurchaseOrderLines"
+                                                Label="PO Line"
+                                                Placeholder="No PO line"
+                                                SearchPlaceholder="Search PO lines..."
+                                                EmptyMessage="No open PO lines."
+                                                ValueSelector="@GetPurchaseOrderLinePickerValue"
+                                                TextSelector="@GetPurchaseOrderLineLabel"
+                                                SearchTextSelector="@GetPurchaseOrderLineSearchText"
+                                                AllowClear="true"
+                                                ClearText="No PO line"
+                                                AdvancedSearchTitle="Find Purchase Order Line"
+                                                AdvancedSearchDescription="Search open purchase order lines." />
+                                <XfEntityPicker TItem="Product"
+                                                @bind-Value="line.ProductId"
+                                                Items="@_products"
+                                                Label="Product"
+                                                Placeholder="Select product"
+                                                SearchPlaceholder="Search products..."
+                                                EmptyMessage="No products found."
+                                                ValueSelector="@GetProductPickerValue"
+                                                TextSelector="@GetProductLabel"
+                                                SearchTextSelector="@GetProductSearchText"
+                                                AdvancedSearchTitle="Find Product"
+                                                AdvancedSearchDescription="Search products in the active tenant." />
+                                <BbFormFieldNumericInput TValue="decimal"
+                                                         @bind-Value="line.Quantity"
+                                                         Label="Quantity"
+                                                         Min="0"
+                                                         DecimalPlaces="2"
+                                                         Step="1" />
+                                <BbFormFieldCurrencyInput @bind-Value="line.UnitCost"
+                                                          Label="Unit Cost"
+                                                          Min="0"
+                                                          ShowSymbol="false" />
                                 <div class="flex items-end">
                                     <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Remove line"
                                               Disabled="@(_form.Lines.Count == 1)"
@@ -187,20 +207,23 @@ else
                                 </div>
                             </div>
                             <div class="grid gap-3 md:grid-cols-4">
-                                <div class="xf-form-field">
-                                    <BbLabel>Existing Lot</BbLabel>
-                                    <BbCombobox TValue="string"
-                                                 @bind-Value="line.LotId"
-                                                 Options="@LotOptions"
-                                                 Placeholder="Create/no lot"
-                                                 SearchPlaceholder="Search lots..."
-                                                 EmptyMessage="No lots found."
-                                                 Class="xf-entity-combobox"
-                                                 MatchTriggerWidth="true" />
-                                </div>
+                                <XfEntityPicker TItem="InventoryLot"
+                                                @bind-Value="line.LotId"
+                                                Items="@_lots"
+                                                Label="Existing Lot"
+                                                Placeholder="Create/no lot"
+                                                SearchPlaceholder="Search lots..."
+                                                EmptyMessage="No lots found."
+                                                ValueSelector="@GetLotPickerValue"
+                                                TextSelector="@GetLotLabel"
+                                                SearchTextSelector="@GetLotSearchText"
+                                                AllowClear="true"
+                                                ClearText="Create/no lot"
+                                                AdvancedSearchTitle="Find Lot / Batch"
+                                                AdvancedSearchDescription="Search lots in the active tenant." />
                                 <BbFormFieldInput TValue="string" @bind-Value="line.LotNumber" Label="New Lot Number" />
-                                <BbFormFieldInput TValue="string" @bind-Value="line.ManufacturedAt" Label="Manufacture Date" />
-                                <BbFormFieldInput TValue="string" @bind-Value="line.ExpiresAt" Label="Expiration Date" />
+                                <BbFormFieldDatePicker @bind-Value="line.ManufacturedAt" Label="Manufacture Date" />
+                                <BbFormFieldDatePicker @bind-Value="line.ExpiresAt" Label="Expiration Date" />
                             </div>
                         </div>
                     }
@@ -241,15 +264,16 @@ else
         _saving ||
         string.IsNullOrWhiteSpace(_form.WarehouseId) ||
         string.IsNullOrWhiteSpace(_form.LocationId) ||
-        _form.Lines.Any(x => string.IsNullOrWhiteSpace(x.ProductId) || !decimal.TryParse(x.Quantity, out var quantity) || quantity <= 0);
+        _form.Lines.Any(x => string.IsNullOrWhiteSpace(x.ProductId) || x.Quantity <= 0);
 
-    private List<SelectOption<string>> PurchaseOrderOptions => [new("", "No purchase order"), .. _orders.Where(x => x.Status is PurchaseOrderStatus.Open or PurchaseOrderStatus.PartiallyReceived).Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.OrderNumber} ({x.Status})"))];
-    private List<SelectOption<string>> PurchaseOrderLineOptions => [new("", "No PO line"), .. _orderLines.Where(x => x.ReceivedQuantity < x.OrderedQuantity).Select(x => new SelectOption<string>(x.Id.ToString(), $"{GetPurchaseOrderNumber(x.PurchaseOrderId)} - {GetProductName(x.ProductId)} ({x.OrderedQuantity - x.ReceivedQuantity:N2} remaining)"))];
-    private List<SelectOption<string>> SupplierOptions => [new("", "No supplier"), .. _suppliers.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Code} - {x.Name}"))];
-    private List<SelectOption<string>> ProductOptions => _products.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Name} ({x.SKU ?? x.Id.ToString()[..8]})")).ToList();
-    private List<SelectOption<string>> WarehouseOptions => _warehouses.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Code} - {x.Name}")).ToList();
-    private List<SelectOption<string>> LocationOptions => _locations.Where(x => x.WarehouseId.ToString() == _form.WarehouseId).Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.Code} - {x.Name}")).ToList();
-    private List<SelectOption<string>> LotOptions => [new("", "Create/no lot"), .. _lots.Select(x => new SelectOption<string>(x.Id.ToString(), $"{x.LotNumber} - {GetProductName(x.ProductId)}"))];
+    private IReadOnlyList<PurchaseOrder> OpenPurchaseOrders =>
+        _orders.Where(x => x.Status is PurchaseOrderStatus.Open or PurchaseOrderStatus.PartiallyReceived).ToList();
+
+    private IReadOnlyList<PurchaseOrderLine> OpenPurchaseOrderLines =>
+        _orderLines.Where(x => x.ReceivedQuantity < x.OrderedQuantity).ToList();
+
+    private IReadOnlyList<InventoryLocation> FilteredLocations =>
+        _locations.Where(x => x.WarehouseId.ToString() == _form.WarehouseId).ToList();
 
     protected override void OnInitialized()
     {
@@ -292,9 +316,9 @@ else
             _locations = await DataContext.Query<InventoryLocation>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.Code).Take(500).ToListAsync();
             _lots = await DataContext.Query<InventoryLot>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).OrderBy(x => x.LotNumber).Take(500).ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load receiving: {ex.Message}");
+            ToastService.Show("Could not load receiving.");
         }
         finally
         {
@@ -315,7 +339,7 @@ else
         _form.LocationId = _locations.FirstOrDefault(x => x.WarehouseId.ToString() == _form.WarehouseId)?.Id.ToString() ?? "";
     }
 
-    private void AddLine() => _form.Lines.Add(new ReceivingLineForm { ProductId = _products.FirstOrDefault()?.Id.ToString() ?? "", Quantity = "1" });
+    private void AddLine() => _form.Lines.Add(new ReceivingLineForm { ProductId = _products.FirstOrDefault()?.Id.ToString() ?? "", Quantity = 1m });
 
     private void RemoveLine(int index)
     {
@@ -339,22 +363,22 @@ else
                 ReferenceNumber = NullIfEmpty(_form.ReferenceNumber),
                 IdempotencyKey = NullIfEmpty(_form.IdempotencyKey),
                 Lines = _form.Lines
-                    .Where(x => Guid.TryParse(x.ProductId, out _) && decimal.TryParse(x.Quantity, out var quantity) && quantity > 0)
+                    .Where(x => Guid.TryParse(x.ProductId, out _) && x.Quantity > 0)
                     .Select(x => new ReceivingLineRequest
                     {
                         PurchaseOrderLineId = Guid.TryParse(x.PurchaseOrderLineId, out var poLineId) ? poLineId : null,
                         ProductId = Guid.Parse(x.ProductId),
-                        Quantity = decimal.Parse(x.Quantity),
-                        UnitCost = decimal.TryParse(x.UnitCost, out var unitCost) ? unitCost : null,
+                        Quantity = x.Quantity,
+                        UnitCost = x.UnitCost > 0 ? x.UnitCost : null,
                         LotId = Guid.TryParse(x.LotId, out var lotId) ? lotId : null,
                         LotNumber = NullIfEmpty(x.LotNumber),
-                        ManufacturedAt = ParseDate(x.ManufacturedAt),
-                        ExpiresAt = ParseDate(x.ExpiresAt)
+                        ManufacturedAt = x.ManufacturedAt,
+                        ExpiresAt = x.ExpiresAt
                     })
                     .ToList()
             });
 
-            ToastService.Show(result.IsSuccess ? "Receiving posted." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Receiving posted." : "Could not post receiving.");
             if (result.IsSuccess)
             {
                 _receiveDialogOpen = false;
@@ -371,10 +395,30 @@ else
     private string GetProductName(Guid productId) => _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
     private string GetSupplierName(Guid? supplierId) => supplierId is { } id ? _suppliers.FirstOrDefault(x => x.Id == id)?.Name ?? id.ToString()[..8] : "No supplier";
     private string GetWarehouseName(Guid warehouseId) => _warehouses.FirstOrDefault(x => x.Id == warehouseId)?.Name ?? warehouseId.ToString()[..8];
+    private static string GetPurchaseOrderPickerValue(PurchaseOrder order) => order.Id.ToString();
+    private string GetPurchaseOrderLabel(PurchaseOrder order) => $"{order.OrderNumber} ({order.Status})";
+    private string GetPurchaseOrderSearchText(PurchaseOrder order) => $"{order.OrderNumber} {order.Status} {GetSupplierName(order.SupplierId)} {order.Notes}";
+    private static string GetPurchaseOrderLinePickerValue(PurchaseOrderLine line) => line.Id.ToString();
+    private string GetPurchaseOrderLineLabel(PurchaseOrderLine line) => $"{GetPurchaseOrderNumber(line.PurchaseOrderId)} - {GetProductName(line.ProductId)} ({line.OrderedQuantity - line.ReceivedQuantity:N2} remaining)";
+    private string GetPurchaseOrderLineSearchText(PurchaseOrderLine line) => $"{GetPurchaseOrderLineLabel(line)} {line.UnitOfMeasure}";
+    private static string GetSupplierPickerValue(Supplier supplier) => supplier.Id.ToString();
+    private static string GetSupplierLabel(Supplier supplier) => string.IsNullOrWhiteSpace(supplier.Code) ? supplier.Name ?? supplier.Id.ToString()[..8] : $"{supplier.Code} - {supplier.Name}";
+    private static string GetSupplierSearchText(Supplier supplier) => $"{supplier.Code} {supplier.Name} {supplier.ContactName} {supplier.Email} {supplier.Phone}";
+    private static string GetProductPickerValue(Product product) => product.Id.ToString();
+    private static string GetProductLabel(Product product) => string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
+    private static string GetProductSearchText(Product product) => $"{product.Name} {product.SKU} {product.Brand} {product.Description}";
+    private static string GetWarehousePickerValue(Warehouse warehouse) => warehouse.Id.ToString();
+    private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+    private static string GetWarehouseSearchText(Warehouse warehouse) => $"{warehouse.Code} {warehouse.Name} {warehouse.City} {warehouse.Region} {warehouse.CountryCode}";
+    private static string GetLocationPickerValue(InventoryLocation location) => location.Id.ToString();
+    private string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
+    private string GetLocationSearchText(InventoryLocation location) => $"{location.Code} {location.Name} {GetWarehouseName(location.WarehouseId)} {location.LocationType} {location.Description}";
+    private static string GetLotPickerValue(InventoryLot lot) => lot.Id.ToString();
+    private string GetLotLabel(InventoryLot lot) => string.IsNullOrWhiteSpace(lot.LotNumber) ? lot.Id.ToString()[..8] : $"{lot.LotNumber} - {GetProductName(lot.ProductId)}";
+    private string GetLotSearchText(InventoryLot lot) => $"{lot.LotNumber} {lot.Status} {GetProductName(lot.ProductId)} {lot.SupplierReference}";
 
     private RequestMetadata BuildMetadata() => new() { TenantId = TenantFilter.SelectedTenantId };
     private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-    private static DateTime? ParseDate(string? value) => DateTime.TryParse(value, out var date) ? date : null;
 
     public void Dispose()
     {
@@ -403,7 +447,7 @@ else
             ReferenceNumber = "";
             IdempotencyKey = "";
             Lines.Clear();
-            Lines.Add(new ReceivingLineForm { ProductId = productId, Quantity = "1" });
+            Lines.Add(new ReceivingLineForm { ProductId = productId, Quantity = 1m });
         }
     }
 
@@ -411,11 +455,11 @@ else
     {
         public string PurchaseOrderLineId { get; set; } = "";
         public string ProductId { get; set; } = "";
-        public string Quantity { get; set; } = "1";
-        public string UnitCost { get; set; } = "";
+        public decimal Quantity { get; set; } = 1m;
+        public decimal UnitCost { get; set; }
         public string LotId { get; set; } = "";
         public string LotNumber { get; set; } = "";
-        public string ManufacturedAt { get; set; } = "";
-        public string ExpiresAt { get; set; } = "";
+        public DateTime? ManufacturedAt { get; set; }
+        public DateTime? ExpiresAt { get; set; }
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReceivingDocumentDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReceivingDocumentDetail.razor
@@ -90,15 +90,15 @@ else
                 <BbCardContent>
                     <BbDataGrid Items="@_lines" ShowPagination="true" InitialPageSize="20">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Lot">
+                            <BbDataGridTemplateColumn Title="Lot" Filterable="true" FilterBy="@(item => GetLotLabel(item.LotId, item.LotNumber))">
                                 <ChildContent Context="item">@GetLotLabel(item.LotId, item.LotNumber)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Quantity" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.UnitCost)" Title="Unit Cost" />
-                            <BbDataGridTemplateColumn Title="Stock Balance">
+                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Quantity" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.UnitCost)" Title="Unit Cost" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Stock Balance" Filterable="true" FilterBy="@(item => GetStockBalanceFilterText(item))">
                                 <ChildContent Context="item">
                                     @if (item.StockBalanceId is { } balanceId)
                                     {
@@ -181,9 +181,9 @@ else
             _locations = await DataContext.Query<InventoryLocation>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(500).ToListAsync();
             _lots = await DataContext.Query<InventoryLot>().IgnoreQueryFilters().NoCache().Where(x => x.TenantId == tenantId && !x.IsDeleted).Take(500).ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load receiving document: {ex.Message}");
+            ToastService.Show("Could not load receiving document.");
         }
         finally
         {
@@ -199,6 +199,7 @@ else
     private string GetWarehouseName(Guid warehouseId) => _warehouses.FirstOrDefault(x => x.Id == warehouseId)?.Name ?? warehouseId.ToString()[..8];
     private string GetLocationName(Guid locationId) => _locations.FirstOrDefault(x => x.Id == locationId)?.Name ?? locationId.ToString()[..8];
     private string GetLotLabel(Guid? lotId, string? fallback) => lotId is { } id ? _lots.FirstOrDefault(x => x.Id == id)?.LotNumber ?? id.ToString()[..8] : fallback ?? "Untracked";
+    private static string GetStockBalanceFilterText(ReceivingLine line) => line.StockBalanceId is { } id ? id.ToString()[..8] : "N/A";
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reports.razor
@@ -36,8 +36,79 @@ else
                 <ReportMetric Title="Low Stock" Value="@_lowStock.Count.ToString()" />
                 <ReportMetric Title="Near Expiry" Value="@_nearExpiry.Count.ToString()" />
                 <ReportMetric Title="Expired Lots" Value="@_expired.Count.ToString()" />
-                <ReportMetric Title="Stock Positions" Value="@_balances.Count.ToString()" />
+                <ReportMetric Title="Stock Positions" Value="@_stockPositions.Count.ToString()" />
             </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Report Filters</BbCardTitle>
+                    <BbCardDescription>Scope the report cards before using column filters inside each grid.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        <XfEntityPicker TItem="Product"
+                                        @bind-Value="_filterProductId"
+                                        Items="@_products"
+                                        Label="Product"
+                                        Placeholder="All products"
+                                        SearchPlaceholder="Search products..."
+                                        EmptyMessage="No products found."
+                                        ValueSelector="@GetProductPickerValue"
+                                        TextSelector="@GetProductLabel"
+                                        SearchTextSelector="@GetProductSearchText"
+                                        AllowClear="true"
+                                        ClearText="All products"
+                                        AdvancedSearchTitle="Find Product"
+                                        AdvancedSearchDescription="Search products in the active tenant." />
+                        <XfEntityPicker TItem="Warehouse"
+                                        Value="@_filterWarehouseId"
+                                        ValueChanged="@OnFilterWarehouseChanged"
+                                        Items="@_warehouses"
+                                        Label="Warehouse"
+                                        Placeholder="All warehouses"
+                                        SearchPlaceholder="Search warehouses..."
+                                        EmptyMessage="No warehouses found."
+                                        ValueSelector="@GetWarehousePickerValue"
+                                        TextSelector="@GetWarehouseLabel"
+                                        SearchTextSelector="@GetWarehouseSearchText"
+                                        AllowClear="true"
+                                        ClearText="All warehouses"
+                                        AdvancedSearchTitle="Find Warehouse"
+                                        AdvancedSearchDescription="Search warehouses in the active tenant." />
+                        <XfEntityPicker TItem="InventoryLocation"
+                                        @bind-Value="_filterLocationId"
+                                        Items="@LocationsForSelectedWarehouse().ToList()"
+                                        Label="Location"
+                                        Placeholder="All locations"
+                                        SearchPlaceholder="Search locations..."
+                                        EmptyMessage="No locations found."
+                                        ValueSelector="@GetLocationPickerValue"
+                                        TextSelector="@GetLocationLabel"
+                                        SearchTextSelector="@GetLocationSearchText"
+                                        AllowClear="true"
+                                        ClearText="All locations"
+                                        AdvancedSearchTitle="Find Location"
+                                        AdvancedSearchDescription="Search locations in the selected warehouse." />
+                        <BbFormFieldNumericInput TValue="int"
+                                                 @bind-Value="_nearExpiryWindowDays"
+                                                 Label="Near Expiry Window"
+                                                 Min="1"
+                                                 Max="365"
+                                                 Step="1" />
+                        <BbFormFieldDatePicker @bind-Value="_movementFrom" Label="Movement From" />
+                        <BbFormFieldDatePicker @bind-Value="_movementTo" Label="Movement To" />
+                    </div>
+                    <div class="mt-4 flex flex-wrap justify-end gap-2">
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@ResetReportFilters">
+                            <LucideIcon Name="rotate-ccw" class="mr-2 h-4 w-4" />
+                            Reset
+                        </BbButton>
+                        <BbButton OnClick="@ApplyReportFilters">
+                            Apply Filters
+                        </BbButton>
+                    </div>
+                </BbCardContent>
+            </BbCard>
 
             <BbCard>
                 <BbCardHeader>
@@ -45,32 +116,46 @@ else
                     <BbCardDescription>@_lowStock.Count scoped rule(s) at or below reorder point</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_lowStock" ShowPagination="true" InitialPageSize="10">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Scope" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" Filterable="true" />
-                        </Columns>
-                    </BbDataGrid>
+                    @if (_lowStock.Count == 0)
+                    {
+                        <BbEmpty Title="No low-stock rows" Description="Adjust filters or configure active reorder rules." />
+                    }
+                    else
+                    {
+                        <BbDataGrid Items="@_lowStock" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Scope" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReorderPoint)" Title="Reorder Point" Sortable="true" Filterable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    }
                 </BbCardContent>
             </BbCard>
 
             <BbCard>
                 <BbCardHeader>
                     <BbCardTitle>Near Expiry</BbCardTitle>
-                    <BbCardDescription>Lots expiring in the next 30 days with on-hand stock</BbCardDescription>
+                    <BbCardDescription>Lots expiring in the next @_nearExpiryWindowDays day(s) with on-hand stock</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_nearExpiry" ShowPagination="true" InitialPageSize="10">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
-                        </Columns>
-                    </BbDataGrid>
+                    @if (_nearExpiry.Count == 0)
+                    {
+                        <BbEmpty Title="No near-expiry stock" Description="Adjust filters or expand the expiry window." />
+                    }
+                    else
+                    {
+                        <BbDataGrid Items="@_nearExpiry" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    }
                 </BbCardContent>
             </BbCard>
 
@@ -80,15 +165,22 @@ else
                     <BbCardDescription>Expired or expired-status lots that still have on-hand stock</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_expired" ShowPagination="true" InitialPageSize="10">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expired" Sortable="true" Filterable="true" />
-                        </Columns>
-                    </BbDataGrid>
+                    @if (_expired.Count == 0)
+                    {
+                        <BbEmpty Title="No expired stock" Description="No expired lots match the current filters." />
+                    }
+                    else
+                    {
+                        <BbDataGrid Items="@_expired" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expired" Sortable="true" Filterable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    }
                 </BbCardContent>
             </BbCard>
 
@@ -98,16 +190,23 @@ else
                     <BbCardDescription>@_stockPositions.Count balance row(s)</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_stockPositions" ShowPagination="true" InitialPageSize="20">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
-                        </Columns>
-                    </BbDataGrid>
+                    @if (_stockPositions.Count == 0)
+                    {
+                        <BbEmpty Title="No stock positions" Description="No balances match the current filters." />
+                    }
+                    else
+                    {
+                        <BbDataGrid Items="@_stockPositions" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Scope)" Title="Location" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Filterable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    }
                 </BbCardContent>
             </BbCard>
 
@@ -117,15 +216,22 @@ else
                     <BbCardDescription>@_movements.Count latest movement(s)</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="20">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Reference)" Title="Reference" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Date" Sortable="true" Filterable="true" />
-                        </Columns>
-                    </BbDataGrid>
+                    @if (_movements.Count == 0)
+                    {
+                        <BbEmpty Title="No movements" Description="No movement rows match the current filters." />
+                    }
+                    else
+                    {
+                        <BbDataGrid Items="@_movements" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Reference)" Title="Reference" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Date" Sortable="true" Filterable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    }
                 </BbCardContent>
             </BbCard>
 
@@ -135,15 +241,22 @@ else
                     <BbCardDescription>@_allocations.Count allocation row(s)</BbCardDescription>
                 </BbCardHeader>
                 <BbCardContent>
-                    <BbDataGrid Items="@_allocations" ShowPagination="true" InitialPageSize="20">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Filterable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" Filterable="true" />
-                        </Columns>
-                    </BbDataGrid>
+                    @if (_allocations.Count == 0)
+                    {
+                        <BbEmpty Title="No allocations" Description="No reservation allocations match the current filters." />
+                    }
+                    else
+                    {
+                        <BbDataGrid Items="@_allocations" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ProductName)" Title="Product" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.LotNumber)" Title="Lot" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" Filterable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    }
                 </BbCardContent>
             </BbCard>
         </div>
@@ -170,6 +283,12 @@ else
     private List<StockRow> _stockPositions = [];
     private List<MovementRow> _movements = [];
     private List<AllocationRow> _allocations = [];
+    private string? _filterProductId;
+    private string? _filterWarehouseId;
+    private string? _filterLocationId;
+    private int _nearExpiryWindowDays = 30;
+    private DateTime? _movementFrom;
+    private DateTime? _movementTo;
     private bool _loading = true;
     private bool _hasTenant;
     private bool _reportingEnabled;
@@ -207,9 +326,9 @@ else
 
             BuildRows();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load inventory reports: {ex.Message}");
+            ToastService.Show("Could not load inventory reports.");
         }
         finally
         {
@@ -238,9 +357,34 @@ else
 
     private void BuildRows()
     {
-        _lowStock = _rules.Select(rule =>
+        var productId = ParseFilterGuid(_filterProductId);
+        var warehouseId = ParseFilterGuid(_filterWarehouseId);
+        var locationId = ParseFilterGuid(_filterLocationId);
+        var balances = _balances
+            .Where(x => MatchesProduct(productId, x.ProductId))
+            .Where(x => MatchesWarehouse(warehouseId, x.WarehouseId))
+            .Where(x => MatchesLocation(locationId, x.LocationId))
+            .ToList();
+        var rules = _rules
+            .Where(x => MatchesProduct(productId, x.ProductId))
+            .Where(x => MatchesNullableScope(warehouseId, x.WarehouseId))
+            .Where(x => MatchesNullableScope(locationId, x.LocationId))
+            .ToList();
+        var movements = _rawMovements
+            .Where(x => MatchesProduct(productId, x.ProductId))
+            .Where(x => MatchesWarehouse(warehouseId, x.WarehouseId))
+            .Where(x => MatchesLocation(locationId, x.LocationId))
+            .Where(MatchesMovementDateRange)
+            .ToList();
+        var allocations = _rawAllocations
+            .Where(x => MatchesProduct(productId, x.ProductId))
+            .Where(x => MatchesWarehouse(warehouseId, x.WarehouseId))
+            .Where(x => MatchesLocation(locationId, x.LocationId))
+            .ToList();
+
+        _lowStock = rules.Select(rule =>
             {
-                var available = _balances.Where(x =>
+                var available = balances.Where(x =>
                         x.ProductId == rule.ProductId &&
                         (rule.WarehouseId is null || x.WarehouseId == rule.WarehouseId) &&
                         (rule.LocationId is null || x.LocationId == rule.LocationId))
@@ -252,9 +396,18 @@ else
             .ToList();
 
         var now = DateTime.UtcNow;
-        _nearExpiry = BuildExpiryRows(lot => lot.ExpiresAt is not null && lot.ExpiresAt > now && lot.ExpiresAt <= now.AddDays(30));
-        _expired = BuildExpiryRows(lot => lot.Status == InventoryLotStatus.Expired || lot.ExpiresAt is not null && lot.ExpiresAt <= now);
-        _stockPositions = _balances.Select(balance => new StockRow(
+        var expiryWindow = Math.Clamp(_nearExpiryWindowDays, 1, 365);
+        _nearExpiry = BuildExpiryRows(
+            balances,
+            lot => MatchesProduct(productId, lot.ProductId) &&
+                   lot.ExpiresAt is not null &&
+                   lot.ExpiresAt > now &&
+                   lot.ExpiresAt <= now.AddDays(expiryWindow));
+        _expired = BuildExpiryRows(
+            balances,
+            lot => MatchesProduct(productId, lot.ProductId) &&
+                   (lot.Status == InventoryLotStatus.Expired || lot.ExpiresAt is not null && lot.ExpiresAt <= now));
+        _stockPositions = balances.Select(balance => new StockRow(
                 GetProductName(balance.ProductId),
                 GetScope(balance.WarehouseId, balance.LocationId),
                 GetLotNumber(balance.LotId),
@@ -262,14 +415,14 @@ else
                 balance.ReservedQuantity,
                 balance.AvailableQuantity))
             .ToList();
-        _movements = _rawMovements.Select(movement => new MovementRow(
+        _movements = movements.Select(movement => new MovementRow(
                 GetProductName(movement.ProductId),
                 movement.MovementType,
                 movement.QuantityDelta,
                 FormatReference(movement.ReferenceType, movement.ReferenceId),
                 movement.MovementDate))
             .ToList();
-        _allocations = _rawAllocations.Select(allocation => new AllocationRow(
+        _allocations = allocations.Select(allocation => new AllocationRow(
                 GetProductName(allocation.ProductId),
                 GetLotNumber(allocation.LotId),
                 allocation.Quantity,
@@ -278,12 +431,14 @@ else
             .ToList();
     }
 
-    private List<ExpiryRow> BuildExpiryRows(Func<InventoryLot, bool> lotFilter)
+    private List<ExpiryRow> BuildExpiryRows(
+        IReadOnlyCollection<StockBalance> balances,
+        Func<InventoryLot, bool> lotFilter)
     {
         var lots = _lots.Where(lotFilter).ToDictionary(x => x.Id);
         if (lots.Count == 0) return [];
 
-        return _balances
+        return balances
             .Where(x => x.LotId is { } lotId && lots.ContainsKey(lotId) && x.OnHandQuantity > 0)
             .Select(balance =>
             {
@@ -297,6 +452,70 @@ else
             })
             .OrderBy(x => x.ExpiresAt)
             .ToList();
+    }
+
+    private void ApplyReportFilters()
+    {
+        _nearExpiryWindowDays = Math.Clamp(_nearExpiryWindowDays, 1, 365);
+        BuildRows();
+    }
+
+    private void ResetReportFilters()
+    {
+        _filterProductId = null;
+        _filterWarehouseId = null;
+        _filterLocationId = null;
+        _nearExpiryWindowDays = 30;
+        _movementFrom = null;
+        _movementTo = null;
+        BuildRows();
+    }
+
+    private Task OnFilterWarehouseChanged(string? value)
+    {
+        _filterWarehouseId = value;
+        _filterLocationId = null;
+        return Task.CompletedTask;
+    }
+
+    private IEnumerable<InventoryLocation> LocationsForSelectedWarehouse()
+    {
+        var warehouseId = ParseFilterGuid(_filterWarehouseId);
+        return warehouseId is null
+            ? _locations
+            : _locations.Where(x => x.WarehouseId == warehouseId.Value);
+    }
+
+    private static Guid? ParseFilterGuid(string? value) =>
+        Guid.TryParse(value, out var parsed) ? parsed : null;
+
+    private static bool MatchesProduct(Guid? filterProductId, Guid productId) =>
+        filterProductId is null || productId == filterProductId.Value;
+
+    private static bool MatchesWarehouse(Guid? filterWarehouseId, Guid warehouseId) =>
+        filterWarehouseId is null || warehouseId == filterWarehouseId.Value;
+
+    private static bool MatchesWarehouse(Guid? filterWarehouseId, Guid? warehouseId) =>
+        filterWarehouseId is null || warehouseId == filterWarehouseId.Value;
+
+    private static bool MatchesLocation(Guid? filterLocationId, Guid locationId) =>
+        filterLocationId is null || locationId == filterLocationId.Value;
+
+    private static bool MatchesLocation(Guid? filterLocationId, Guid? locationId) =>
+        filterLocationId is null || locationId == filterLocationId.Value;
+
+    private static bool MatchesNullableScope(Guid? filterId, Guid? scopeId) =>
+        filterId is null || scopeId is null || scopeId == filterId.Value;
+
+    private bool MatchesMovementDateRange(InventoryMovement movement)
+    {
+        if (_movementFrom is { } from && movement.MovementDate.Date < from.Date)
+            return false;
+
+        if (_movementTo is { } to && movement.MovementDate.Date > to.Date)
+            return false;
+
+        return true;
     }
 
     private string GetProductName(Guid productId) =>
@@ -316,6 +535,31 @@ else
 
     private static string FormatReference(string? type, Guid? id) =>
         string.IsNullOrWhiteSpace(type) ? "N/A" : id is { } value ? $"{type} / {value.ToString()[..8]}" : type;
+
+    private static string GetProductPickerValue(Product product) => product.Id.ToString();
+
+    private static string GetWarehousePickerValue(Warehouse warehouse) => warehouse.Id.ToString();
+
+    private static string GetLocationPickerValue(InventoryLocation location) => location.Id.ToString();
+
+    private static string GetProductLabel(Product product) =>
+        string.IsNullOrWhiteSpace(product.SKU)
+            ? product.Name ?? product.Id.ToString()[..8]
+            : $"{product.SKU} - {product.Name ?? product.Id.ToString()[..8]}";
+
+    private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+
+    private string GetLocationLabel(InventoryLocation location) =>
+        $"{location.Code} - {location.Name} ({GetWarehouseName(location.WarehouseId)})";
+
+    private static string GetProductSearchText(Product product) =>
+        $"{product.SKU} {product.Name} {product.Description}";
+
+    private static string GetWarehouseSearchText(Warehouse warehouse) =>
+        $"{warehouse.Code} {warehouse.Name} {warehouse.City} {warehouse.Region} {warehouse.CountryCode}";
+
+    private string GetLocationSearchText(InventoryLocation location) =>
+        $"{location.Code} {location.Name} {GetWarehouseName(location.WarehouseId)}";
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReservationDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ReservationDetail.razor
@@ -160,19 +160,19 @@ else
                     {
                         <BbDataGrid Items="@_allocations" ShowPagination="true" InitialPageSize="10">
                             <Columns>
-                                <BbDataGridTemplateColumn Title="Lot">
+                                <BbDataGridTemplateColumn Title="Lot" Filterable="true" FilterBy="@(item => GetLotLabel(item.LotId))">
                                     <ChildContent Context="item">@GetLotLabel(item.LotId)</ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="Status">
+                                <BbDataGridPropertyColumn Property="@(x => x.Quantity)" Title="Qty" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status.ToString())">
                                     <ChildContent Context="item">
                                         <StatusBadge Text="@item.Status.ToString()" Status="@GetAllocationStatusBadge(item.Status)" />
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReleasedAt)" Title="Released" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.FulfilledAt)" Title="Fulfilled" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="Balance">
+                                <BbDataGridPropertyColumn Property="@(x => x.ReservedAt)" Title="Reserved" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReleasedAt)" Title="Released" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.FulfilledAt)" Title="Fulfilled" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Balance" Filterable="true" FilterBy="@(item => ShortId(item.StockBalanceId))">
                                     <ChildContent Context="item">
                                         <span class="font-mono text-xs">@ShortId(item.StockBalanceId)</span>
                                     </ChildContent>
@@ -308,9 +308,9 @@ else
                     .ToListAsync();
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load reservation: {ex.Message}");
+            ToastService.Show("Could not load reservation.");
         }
         finally
         {
@@ -352,7 +352,7 @@ else
         try
         {
             var result = await action();
-            ToastService.Show(result.IsSuccess ? successMessage : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? successMessage : "Could not update reservation.");
             if (result.IsSuccess)
                 await Reload();
         }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Reservations.razor
@@ -101,63 +101,69 @@ else
 }
 
 <BbDialog Open="@_reservationDialogOpen" OpenChanged="@(v => _reservationDialogOpen = v)">
-    <BbDialogContent TrapFocus="false">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Reserve Inventory</BbDialogTitle>
             <BbDialogDescription>Reservations reduce available quantity without changing on-hand stock.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
             <div class="grid gap-3 xl:grid-cols-3">
-                <div class="xf-form-field">
-                    <BbLabel>Product</BbLabel>
-                    <BbCombobox TValue="string"
-                                 Value="@_form.ProductId"
-                                 ValueChanged="@OnReservationProductChanged"
-                                 Options="@ProductOptions"
-                                 Placeholder="Select product"
-                                 SearchPlaceholder="Search products..."
-                                 EmptyMessage="No products found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
-                <div class="xf-form-field">
-                    <BbLabel>Warehouse</BbLabel>
-                    <BbCombobox TValue="string"
-                                 Value="@_form.WarehouseId"
-                                 ValueChanged="@OnReservationWarehouseChanged"
-                                 Options="@WarehouseOptions"
-                                 Placeholder="Select warehouse"
-                                 SearchPlaceholder="Search warehouses..."
-                                 EmptyMessage="No warehouses found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
-                <div class="xf-form-field">
-                    <BbLabel>Location</BbLabel>
-                    <BbCombobox TValue="string"
-                                 @bind-Value="_form.LocationId"
-                                 Options="@ReservationLocationOptions"
-                                 Placeholder="Select location"
-                                 SearchPlaceholder="Search locations..."
-                                 EmptyMessage="No locations found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
+                <XfEntityPicker TItem="Product"
+                                Value="@_form.ProductId"
+                                ValueChanged="@OnReservationProductChanged"
+                                Items="@_products"
+                                Label="Product"
+                                Placeholder="Select product"
+                                SearchPlaceholder="Search products..."
+                                EmptyMessage="No products found."
+                                ValueSelector="@GetProductPickerValue"
+                                TextSelector="@GetProductLabel"
+                                SearchTextSelector="@GetProductSearchText"
+                                AdvancedSearchTitle="Find Product"
+                                AdvancedSearchDescription="Search products in the active tenant." />
+                <XfEntityPicker TItem="Warehouse"
+                                Value="@_form.WarehouseId"
+                                ValueChanged="@OnReservationWarehouseChanged"
+                                Items="@_warehouses"
+                                Label="Warehouse"
+                                Placeholder="Select warehouse"
+                                SearchPlaceholder="Search warehouses..."
+                                EmptyMessage="No warehouses found."
+                                ValueSelector="@GetWarehousePickerValue"
+                                TextSelector="@GetWarehouseLabel"
+                                SearchTextSelector="@GetWarehouseSearchText"
+                                AdvancedSearchTitle="Find Warehouse"
+                                AdvancedSearchDescription="Search warehouses in the active tenant." />
+                <XfEntityPicker TItem="InventoryLocation"
+                                @bind-Value="_form.LocationId"
+                                Items="@LocationsForSelectedWarehouse().ToList()"
+                                Label="Location"
+                                Placeholder="Select location"
+                                SearchPlaceholder="Search locations..."
+                                EmptyMessage="No locations found."
+                                ValueSelector="@GetLocationPickerValue"
+                                TextSelector="@GetLocationLabel"
+                                SearchTextSelector="@GetLocationSearchText"
+                                AdvancedSearchTitle="Find Location"
+                                AdvancedSearchDescription="Search locations for the selected warehouse." />
             </div>
             @if (_traceabilityEnabled)
             {
                 <div class="grid gap-3 md:grid-cols-2">
-                    <div class="xf-form-field">
-                        <BbLabel>Lot / Batch</BbLabel>
-                        <BbCombobox TValue="string"
-                                     @bind-Value="_form.LotId"
-                                     Options="@ReservationLotOptions"
-                                     Placeholder="Auto FEFO allocation"
-                                     SearchPlaceholder="Search lots..."
-                                     EmptyMessage="No lots found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
+                    <XfEntityPicker TItem="InventoryLot"
+                                    @bind-Value="_form.LotId"
+                                    Items="@LotsForSelectedProduct().ToList()"
+                                    Label="Lot / Batch"
+                                    Placeholder="Auto FEFO allocation"
+                                    SearchPlaceholder="Search lots..."
+                                    EmptyMessage="No lots found."
+                                    ValueSelector="@GetLotPickerValue"
+                                    TextSelector="@GetLotLabel"
+                                    SearchTextSelector="@GetLotSearchText"
+                                    AllowClear="true"
+                                    ClearText="Auto FEFO allocation"
+                                    AdvancedSearchTitle="Find Lot / Batch"
+                                    AdvancedSearchDescription="Search lots for the selected product." />
                     <BbFormFieldSwitch Checked="@_form.AllowExpiredLotOverride"
                                        CheckedChanged="@((bool value) => _form.AllowExpiredLotOverride = value)"
                                        Label="Allow expired lot override" />
@@ -168,14 +174,13 @@ else
                 }
             }
             <div class="grid gap-3 md:grid-cols-3">
-                <BbFormFieldInput TValue="string" @bind-Value="_form.Quantity" Label="Quantity" />
-                <div class="xf-form-field">
-                    <BbLabel>Expires At</BbLabel>
-                    <input type="datetime-local"
-                           class="xf-datetime-input"
-                           value="@_form.ExpiresAt"
-                           @oninput="@((ChangeEventArgs e) => _form.ExpiresAt = e.Value?.ToString() ?? string.Empty)" />
-                </div>
+                <BbFormFieldNumericInput TValue="decimal"
+                                         @bind-Value="_form.Quantity"
+                                         Label="Quantity"
+                                         Min="0"
+                                         DecimalPlaces="2"
+                                         Step="1" />
+                <BbFormFieldDatePicker @bind-Value="_form.ExpiresAt" Label="Expires At" />
                 <BbFormFieldInput TValue="string" @bind-Value="_form.ReferenceType" Label="Reference Type" />
             </div>
             <div class="grid gap-3 md:grid-cols-2">
@@ -214,25 +219,6 @@ else
     private bool _expiring;
     private bool _reservationDialogOpen;
     private bool IsReserveDisabled => _reserving || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
-    private List<SelectOption<string>> ProductOptions =>
-        _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
-    private List<SelectOption<string>> WarehouseOptions =>
-        _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
-    private List<SelectOption<string>> ReservationLocationOptions =>
-        LocationsForSelectedWarehouse().Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
-    private List<SelectOption<string>> ReservationLotOptions
-    {
-        get
-        {
-            var options = new List<SelectOption<string>>
-            {
-                new("", "Auto FEFO allocation")
-            };
-            options.AddRange(LotsForSelectedProduct()
-                .Select(lot => new SelectOption<string>(lot.Id.ToString(), GetLotLabel(lot))));
-            return options;
-        }
-    }
 
     protected override void OnInitialized()
     {
@@ -308,9 +294,9 @@ else
 
             ApplyDefaultSelections();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load reservations: {ex.Message}");
+            ToastService.Show("Could not load reservations.");
         }
         finally
         {
@@ -329,15 +315,9 @@ else
             return;
         }
 
-        if (!decimal.TryParse(_form.Quantity, out var quantity) || quantity <= 0)
+        if (_form.Quantity <= 0)
         {
             ToastService.Show("Quantity must be greater than zero.");
-            return;
-        }
-
-        if (!TryParseOptionalDate(_form.ExpiresAt, out var expiresAt))
-        {
-            ToastService.Show("Expiration date is invalid.");
             return;
         }
 
@@ -350,9 +330,9 @@ else
                 ProductId = productId,
                 WarehouseId = warehouseId,
                 LocationId = locationId,
-                Quantity = quantity,
+                Quantity = _form.Quantity,
                 LotId = Guid.TryParse(_form.LotId, out var lotId) ? lotId : null,
-                ExpiresAt = expiresAt,
+                ExpiresAt = _form.ExpiresAt,
                 ReferenceType = NullIfEmpty(_form.ReferenceType),
                 ReferenceId = Guid.TryParse(_form.ReferenceId, out var referenceId) ? referenceId : (Guid?)null,
                 Reason = NullIfEmpty(_form.Reason),
@@ -360,11 +340,11 @@ else
                 ExpiredLotOverrideReason = NullIfEmpty(_form.ExpiredLotOverrideReason)
             });
 
-            ToastService.Show(result.IsSuccess ? "Inventory reserved." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Inventory reserved." : "Could not reserve inventory.");
             if (result.IsSuccess)
             {
-                _form.Quantity = "0";
-                _form.ExpiresAt = "";
+                _form.Quantity = 0m;
+                _form.ExpiresAt = null;
                 _form.LotId = "";
                 _form.AllowExpiredLotOverride = false;
                 _form.ExpiredLotOverrideReason = "";
@@ -434,7 +414,7 @@ else
     private async Task RunReservationAction(Func<Task<CmdResponse>> action, string successMessage)
     {
         var result = await action();
-        ToastService.Show(result.IsSuccess ? successMessage : $"Failed: {result.Message}");
+        ToastService.Show(result.IsSuccess ? successMessage : "Could not update reservation.");
         if (result.IsSuccess)
             await Reload();
     }
@@ -486,6 +466,11 @@ else
     private string GetProductLabel(Product product) =>
         string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
 
+    private static string GetProductPickerValue(Product product) => product.Id.ToString();
+
+    private static string GetProductSearchText(Product product) =>
+        $"{product.Name} {product.SKU} {product.Brand} {product.Description}";
+
     private string GetProductName(Guid productId) =>
         _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
 
@@ -498,8 +483,13 @@ else
     }
 
     private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+    private static string GetWarehousePickerValue(Warehouse warehouse) => warehouse.Id.ToString();
+    private static string GetWarehouseSearchText(Warehouse warehouse) => $"{warehouse.Code} {warehouse.Name} {warehouse.City} {warehouse.Region} {warehouse.CountryCode}";
+    private string GetWarehouseName(Guid warehouseId) => _warehouses.FirstOrDefault(x => x.Id == warehouseId) is { } warehouse ? GetWarehouseLabel(warehouse) : warehouseId.ToString()[..8];
 
     private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
+    private static string GetLocationPickerValue(InventoryLocation location) => location.Id.ToString();
+    private string GetLocationSearchText(InventoryLocation location) => $"{location.Code} {location.Name} {GetWarehouseName(location.WarehouseId)} {location.LocationType} {location.Description}";
 
     private static string GetLotLabel(InventoryLot lot)
     {
@@ -507,21 +497,13 @@ else
         return $"{lot.LotNumber} - {expiry}";
     }
 
+    private static string GetLotPickerValue(InventoryLot lot) => lot.Id.ToString();
+
+    private string GetLotSearchText(InventoryLot lot) =>
+        $"{lot.LotNumber} {lot.Status} {GetProductName(lot.ProductId)} {lot.SupplierReference}";
+
     private static string GetStatusBadge(ReservationStatus status) =>
         status == ReservationStatus.Active ? "active" : "inactive";
-
-    private static bool TryParseOptionalDate(string? value, out DateTime? date)
-    {
-        date = null;
-        if (string.IsNullOrWhiteSpace(value))
-            return true;
-
-        if (!DateTime.TryParse(value, out var parsed))
-            return false;
-
-        date = parsed.ToUniversalTime();
-        return true;
-    }
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
@@ -538,8 +520,8 @@ else
         public string WarehouseId { get; set; } = "";
         public string LocationId { get; set; } = "";
         public string LotId { get; set; } = "";
-        public string Quantity { get; set; } = "0";
-        public string ExpiresAt { get; set; } = "";
+        public decimal Quantity { get; set; }
+        public DateTime? ExpiresAt { get; set; }
         public string ReferenceType { get; set; } = "";
         public string ReferenceId { get; set; } = "";
         public string Reason { get; set; } = "";

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Settings.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Settings.razor
@@ -111,9 +111,9 @@ else
             _skuRequired = bool.TryParse(GetValue(configs, SkuRequiredKey, "true"), out var skuRequired) && skuRequired;
             _allowNegativeStock = bool.TryParse(GetValue(configs, AllowNegativeStockKey, "false"), out var allowNegative) && allowNegative;
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load Inventario settings: {ex.Message}");
+            ToastService.Show("Could not load Inventario settings.");
         }
         finally
         {
@@ -141,11 +141,11 @@ else
             await UpsertSetting(tenantId, AllowNegativeStockKey, _allowNegativeStock.ToString(), "boolean");
 
             var result = await DataContext.SaveChangesAsync();
-            ToastService.Show(result.IsSuccess ? "Inventario settings saved." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Inventario settings saved." : "Could not save Inventario settings.");
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error saving Inventario settings: {ex.Message}");
+            ToastService.Show("Could not save Inventario settings.");
         }
         finally
         {
@@ -186,7 +186,7 @@ else
         var result = await DataContext.SaveChangesAsync();
         if (!result.IsSuccess)
         {
-            throw new InvalidOperationException(result.Message ?? "Unable to create settings group.");
+            throw new InvalidOperationException("Unable to create settings group.");
         }
 
         return created.Id;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Stock.razor
@@ -135,62 +135,68 @@ else
 }
 
 <BbDialog Open="@_movementDialogOpen" OpenChanged="@(v => _movementDialogOpen = v)">
-    <BbDialogContent TrapFocus="false">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Post Movement</BbDialogTitle>
             <BbDialogDescription>Movements are append-only and update stock balances through Inventario services.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
             <div class="grid gap-3 xl:grid-cols-2">
-                <div class="xf-form-field">
-                    <BbLabel>Product</BbLabel>
-                    <BbCombobox TValue="string"
-                                 Value="@_movementForm.ProductId"
-                                 ValueChanged="@OnMovementProductChanged"
-                                 Options="@ProductOptions"
-                                 Placeholder="Select product"
-                                 SearchPlaceholder="Search products..."
-                                 EmptyMessage="No products found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
+                <XfEntityPicker TItem="Product"
+                                Value="@_movementForm.ProductId"
+                                ValueChanged="@OnMovementProductChanged"
+                                Items="@_products"
+                                Label="Product"
+                                Placeholder="Select product"
+                                SearchPlaceholder="Search products..."
+                                EmptyMessage="No products found."
+                                ValueSelector="@GetProductPickerValue"
+                                TextSelector="@GetProductLabel"
+                                SearchTextSelector="@GetProductSearchText"
+                                AdvancedSearchTitle="Find Product"
+                                AdvancedSearchDescription="Search products in the active tenant." />
                 @if (_traceabilityEnabled)
                 {
-                    <div class="xf-form-field">
-                        <BbLabel>Lot / Batch</BbLabel>
-                        <BbCombobox TValue="string"
-                                     @bind-Value="_movementForm.LotId"
-                                     Options="@MovementLotOptions"
-                                     Placeholder="No lot"
-                                     SearchPlaceholder="Search lots..."
-                                     EmptyMessage="No lots found."
-                                     Class="xf-entity-combobox"
-                                     MatchTriggerWidth="true" />
-                    </div>
+                    <XfEntityPicker TItem="InventoryLot"
+                                    @bind-Value="_movementForm.LotId"
+                                    Items="@LotsForSelectedProduct().ToList()"
+                                    Label="Lot / Batch"
+                                    Placeholder="No lot"
+                                    SearchPlaceholder="Search lots..."
+                                    EmptyMessage="No lots found."
+                                    ValueSelector="@GetLotPickerValue"
+                                    TextSelector="@GetLotLabel"
+                                    SearchTextSelector="@GetLotSearchText"
+                                    AllowClear="true"
+                                    ClearText="No lot / untracked"
+                                    AdvancedSearchTitle="Find Lot / Batch"
+                                    AdvancedSearchDescription="Search lots for the selected product." />
                 }
-                <div class="xf-form-field">
-                    <BbLabel>Warehouse</BbLabel>
-                    <BbCombobox TValue="string"
-                                 Value="@_movementForm.WarehouseId"
-                                 ValueChanged="@OnMovementWarehouseChanged"
-                                 Options="@WarehouseOptions"
-                                 Placeholder="Select warehouse"
-                                 SearchPlaceholder="Search warehouses..."
-                                 EmptyMessage="No warehouses found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
-                <div class="xf-form-field">
-                    <BbLabel>Location</BbLabel>
-                    <BbCombobox TValue="string"
-                                 @bind-Value="_movementForm.LocationId"
-                                 Options="@MovementLocationOptions"
-                                 Placeholder="Select location"
-                                 SearchPlaceholder="Search locations..."
-                                 EmptyMessage="No locations found."
-                                 Class="xf-entity-combobox"
-                                 MatchTriggerWidth="true" />
-                </div>
+                <XfEntityPicker TItem="Warehouse"
+                                Value="@_movementForm.WarehouseId"
+                                ValueChanged="@OnMovementWarehouseChanged"
+                                Items="@_warehouses"
+                                Label="Warehouse"
+                                Placeholder="Select warehouse"
+                                SearchPlaceholder="Search warehouses..."
+                                EmptyMessage="No warehouses found."
+                                ValueSelector="@GetWarehousePickerValue"
+                                TextSelector="@GetWarehouseLabel"
+                                SearchTextSelector="@GetWarehouseSearchText"
+                                AdvancedSearchTitle="Find Warehouse"
+                                AdvancedSearchDescription="Search warehouses in the active tenant." />
+                <XfEntityPicker TItem="InventoryLocation"
+                                @bind-Value="_movementForm.LocationId"
+                                Items="@LocationsForSelectedWarehouse().ToList()"
+                                Label="Location"
+                                Placeholder="Select location"
+                                SearchPlaceholder="Search locations..."
+                                EmptyMessage="No locations found."
+                                ValueSelector="@GetLocationPickerValue"
+                                TextSelector="@GetLocationLabel"
+                                SearchTextSelector="@GetLocationSearchText"
+                                AdvancedSearchTitle="Find Location"
+                                AdvancedSearchDescription="Search locations for the selected warehouse." />
                 <BbFormFieldSelect TValue="string" @bind-Value="_movementForm.MovementType" Label="Movement Type">
                     @foreach (var type in Enum.GetValues<InventoryMovementType>())
                     {
@@ -199,7 +205,11 @@ else
                 </BbFormFieldSelect>
             </div>
             <div class="grid gap-3 md:grid-cols-3">
-                <BbFormFieldInput TValue="string" @bind-Value="_movementForm.Quantity" Label="Quantity" />
+                <BbFormFieldNumericInput TValue="decimal"
+                                         @bind-Value="_movementForm.Quantity"
+                                         Label="Quantity"
+                                         DecimalPlaces="2"
+                                         Step="1" />
                 <BbFormFieldInput TValue="string" @bind-Value="_movementForm.UnitOfMeasure" Label="Unit" />
                 <BbFormFieldInput TValue="string" @bind-Value="_movementForm.ReferenceType" Label="Reference Type" />
             </div>
@@ -244,26 +254,6 @@ else
     private bool _postingMovement;
     private bool _movementDialogOpen;
     private bool IsPostMovementDisabled => _postingMovement || _products.Count == 0 || _warehouses.Count == 0 || _locations.Count == 0;
-    private List<SelectOption<string>> ProductOptions =>
-        _products.Select(product => new SelectOption<string>(product.Id.ToString(), GetProductLabel(product))).ToList();
-    private List<SelectOption<string>> WarehouseOptions =>
-        _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
-    private List<SelectOption<string>> MovementLocationOptions =>
-        LocationsForSelectedWarehouse().Select(location => new SelectOption<string>(location.Id.ToString(), GetLocationLabel(location))).ToList();
-    private List<SelectOption<string>> MovementLotOptions
-    {
-        get
-        {
-            var options = new List<SelectOption<string>>
-            {
-                new("", "No lot / untracked")
-            };
-            options.AddRange(LotsForSelectedProduct()
-                .Select(lot => new SelectOption<string>(lot.Id.ToString(), GetLotLabel(lot))));
-            return options;
-        }
-    }
-
     protected override void OnInitialized()
     {
         TenantFilter.OnChanged += OnTenantChanged;
@@ -350,9 +340,9 @@ else
 
             ApplyDefaultMovementSelections();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load stock control: {ex.Message}");
+            ToastService.Show("Could not load stock control.");
         }
         finally
         {
@@ -371,7 +361,7 @@ else
             return;
         }
 
-        if (!decimal.TryParse(_movementForm.Quantity, out var quantity) || quantity == 0)
+        if (_movementForm.Quantity == 0)
         {
             ToastService.Show("Quantity must not be zero.");
             return;
@@ -388,17 +378,17 @@ else
                 LocationId = locationId,
                 LotId = Guid.TryParse(_movementForm.LotId, out var lotId) ? lotId : null,
                 MovementType = Enum.TryParse<InventoryMovementType>(_movementForm.MovementType, out var type) ? type : InventoryMovementType.Adjustment,
-                Quantity = quantity,
+                Quantity = _movementForm.Quantity,
                 UnitOfMeasure = NullIfEmpty(_movementForm.UnitOfMeasure),
                 ReferenceType = NullIfEmpty(_movementForm.ReferenceType),
                 Reason = NullIfEmpty(_movementForm.Reason),
                 AllowNegativeStock = _negativeStockEnabled && _movementForm.AllowNegativeStock
             });
 
-            ToastService.Show(result.IsSuccess ? "Stock movement posted." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Stock movement posted." : "Could not post stock movement.");
             if (result.IsSuccess)
             {
-                _movementForm.Quantity = "0";
+                _movementForm.Quantity = 0m;
                 _movementForm.Reason = "";
                 _movementDialogOpen = false;
                 await Reload();
@@ -463,10 +453,20 @@ else
     private string GetProductLabel(Product product) =>
         string.IsNullOrWhiteSpace(product.SKU) ? product.Name ?? product.Id.ToString()[..8] : $"{product.Name} ({product.SKU})";
 
+    private static string GetProductPickerValue(Product product) => product.Id.ToString();
+
+    private static string GetProductSearchText(Product product) =>
+        $"{product.Name} {product.SKU} {product.Brand} {product.Description}";
+
     private string GetProductName(Guid productId) =>
         _products.FirstOrDefault(x => x.Id == productId)?.Name ?? productId.ToString()[..8];
 
     private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+
+    private static string GetWarehousePickerValue(Warehouse warehouse) => warehouse.Id.ToString();
+
+    private static string GetWarehouseSearchText(Warehouse warehouse) =>
+        $"{warehouse.Code} {warehouse.Name} {warehouse.City} {warehouse.Region} {warehouse.CountryCode}";
 
     private string GetWarehouseName(Guid warehouseId) =>
         _warehouses.FirstOrDefault(x => x.Id == warehouseId)?.Name ?? warehouseId.ToString()[..8];
@@ -476,6 +476,11 @@ else
 
     private static string GetLocationLabel(InventoryLocation location) => $"{location.Code} - {location.Name}";
 
+    private static string GetLocationPickerValue(InventoryLocation location) => location.Id.ToString();
+
+    private string GetLocationSearchText(InventoryLocation location) =>
+        $"{location.Code} {location.Name} {GetWarehouseName(location.WarehouseId)} {location.LocationType} {location.Description}";
+
     private string GetLotLabel(Guid? lotId) =>
         lotId is { } id
             ? _lots.FirstOrDefault(x => x.Id == id)?.LotNumber ?? id.ToString()[..8]
@@ -483,6 +488,11 @@ else
 
     private string GetLotLabel(InventoryLot lot) =>
         string.IsNullOrWhiteSpace(lot.LotNumber) ? lot.Id.ToString()[..8] : lot.LotNumber;
+
+    private static string GetLotPickerValue(InventoryLot lot) => lot.Id.ToString();
+
+    private string GetLotSearchText(InventoryLot lot) =>
+        $"{lot.LotNumber} {lot.Status} {GetProductName(lot.ProductId)} {lot.SupplierReference} {lot.SourceReferenceType}";
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
@@ -500,7 +510,7 @@ else
         public string LocationId { get; set; } = "";
         public string LotId { get; set; } = "";
         public string MovementType { get; set; } = InventoryMovementType.Adjustment.ToString();
-        public string Quantity { get; set; } = "0";
+        public decimal Quantity { get; set; }
         public string UnitOfMeasure { get; set; } = "each";
         public string ReferenceType { get; set; } = "";
         public string Reason { get; set; } = "";

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/StockBalanceDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/StockBalanceDetail.razor
@@ -124,11 +124,11 @@ else
                                 OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityBefore)" Title="Before" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityBefore)" Title="Before" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -222,9 +222,9 @@ else
                 .Take(100)
                 .ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load stock balance: {ex.Message}");
+            ToastService.Show("Could not load stock balance.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Suppliers.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Suppliers.razor
@@ -64,7 +64,7 @@ else
 }
 
 <BbDialog Open="@_createDialogOpen" OpenChanged="@(v => _createDialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Create Supplier</BbDialogTitle>
             <BbDialogDescription>Supplier codes are unique inside the selected tenant.</BbDialogDescription>
@@ -137,9 +137,9 @@ else
                 .Take(500)
                 .ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load suppliers: {ex.Message}");
+            ToastService.Show("Could not load suppliers.");
         }
         finally
         {
@@ -170,7 +170,7 @@ else
                 IsActive = _form.IsActive
             });
 
-            ToastService.Show(result.IsSuccess ? "Supplier created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Supplier created." : "Could not create supplier.");
             if (result.IsSuccess)
             {
                 _createDialogOpen = false;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Transactions.razor
@@ -118,9 +118,9 @@ else
                 .Take(250)
                 .ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load inventory transactions: {ex.Message}");
+            ToastService.Show("Could not load inventory transactions.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/WarehouseDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/WarehouseDetail.razor
@@ -124,10 +124,10 @@ else
                                 OnRowClick="@((InventoryLocation item) => Navigation.NavigateTo($"/inventario/locations/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.LocationType)" Title="Type" Sortable="true" />
-                            <BbDataGridTemplateColumn Title="Pickable">
+                            <BbDataGridPropertyColumn Property="@(x => x.Code)" Title="Code" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.LocationType)" Title="Type" Sortable="true" Filterable="true" />
+                            <BbDataGridTemplateColumn Title="Pickable" Filterable="true" FilterBy="@(item => item.IsPickable ? "Pickable" : "Storage")">
                                 <ChildContent Context="item">
                                     <StatusBadge Text="@(item.IsPickable ? "Pickable" : "Storage")" Status="@(item.IsPickable ? "active" : "inactive")" />
                                 </ChildContent>
@@ -147,15 +147,15 @@ else
                                 OnRowClick="@((StockBalance item) => Navigation.NavigateTo($"/inventario/stock/balances/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridTemplateColumn Title="Location">
+                            <BbDataGridTemplateColumn Title="Location" Filterable="true" FilterBy="@(item => GetLocationName(item.LocationId))">
                                 <ChildContent Context="item">@GetLocationName(item.LocationId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.OnHandQuantity)" Title="On Hand" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.ReservedQuantity)" Title="Reserved" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.AvailableQuantity)" Title="Available" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -171,13 +171,13 @@ else
                                 OnRowClick="@((InventoryMovement item) => Navigation.NavigateTo($"/inventario/stock/movements/{item.Id}"))"
                                 Class="cursor-pointer">
                         <Columns>
-                            <BbDataGridTemplateColumn Title="Product">
+                            <BbDataGridTemplateColumn Title="Product" Filterable="true" FilterBy="@(item => GetProductName(item.ProductId))">
                                 <ChildContent Context="item">@GetProductName(item.ProductId)</ChildContent>
                             </BbDataGridTemplateColumn>
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementType)" Title="Type" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityDelta)" Title="Delta" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.QuantityAfter)" Title="After" Sortable="true" Filterable="true" />
+                            <BbDataGridPropertyColumn Property="@(x => x.MovementDate)" Title="Movement Date" Sortable="true" Filterable="true" />
                         </Columns>
                     </BbDataGrid>
                 </BbCardContent>
@@ -284,9 +284,9 @@ else
                 _productNames = products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]);
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load warehouse: {ex.Message}");
+            ToastService.Show("Could not load warehouse.");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/Warehouses.razor
@@ -116,7 +116,7 @@ else
 }
 
 <BbDialog Open="@_warehouseDialogOpen" OpenChanged="@(v => _warehouseDialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Create Warehouse</BbDialogTitle>
             <BbDialogDescription>Warehouse codes are unique inside the selected tenant.</BbDialogDescription>
@@ -147,23 +147,29 @@ else
 </BbDialog>
 
 <BbDialog Open="@_locationDialogOpen" OpenChanged="@(v => _locationDialogOpen = v)">
-    <BbDialogContent TrapFocus="false">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
         <BbDialogHeader>
             <BbDialogTitle>Create Location</BbDialogTitle>
             <BbDialogDescription>Locations belong to a warehouse and represent bins, shelves, or zones.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <div class="xf-form-field">
-                <BbLabel>Warehouse</BbLabel>
-                <BbCombobox TValue="string"
-                             @bind-Value="_locationForm.WarehouseId"
-                             Options="@WarehouseOptions"
-                             Placeholder="Select warehouse"
-                             SearchPlaceholder="Search warehouses..."
-                             EmptyMessage="No warehouses found."
-                             Class="xf-entity-combobox"
-                             MatchTriggerWidth="true" />
-            </div>
+            <XfEntityPicker TItem="Warehouse"
+                            Label="Warehouse"
+                            Value="@_locationForm.WarehouseId"
+                            ValueChanged="@(value => _locationForm.WarehouseId = value ?? "")"
+                            Items="@_warehouses"
+                            ValueSelector="@GetWarehousePickerValue"
+                            TextSelector="@GetWarehouseLabel"
+                            SearchTextSelector="@GetWarehouseSearchText"
+                            AdvancedColumns="@WarehouseAdvancedColumns"
+                            AdvancedFilters="@WarehouseAdvancedFilters"
+                            AdvancedSearchScope="Searches warehouse code, name, city, region, country, default flag, and created date."
+                            Placeholder="Select warehouse"
+                            SearchPlaceholder="Search warehouses..."
+                            EmptyMessage="No warehouses found."
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Warehouse"
+                            AdvancedSearchDescription="Select the warehouse that owns this location." />
             <div class="grid gap-3 md:grid-cols-2">
                 <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Code" Label="Code" Required="true" />
                 <BbFormFieldInput TValue="string" @bind-Value="_locationForm.Name" Label="Name" Required="true" />
@@ -208,8 +214,6 @@ else
     private bool _warehouseDialogOpen;
     private bool _locationDialogOpen;
     private bool IsCreateLocationDisabled => _savingLocation || _warehouses.Count == 0;
-    private List<SelectOption<string>> WarehouseOptions =>
-        _warehouses.Select(warehouse => new SelectOption<string>(warehouse.Id.ToString(), GetWarehouseLabel(warehouse))).ToList();
 
     protected override void OnInitialized()
     {
@@ -252,9 +256,9 @@ else
                 .Take(500)
                 .ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load warehouses: {ex.Message}");
+            ToastService.Show("Could not load warehouses.");
         }
         finally
         {
@@ -305,7 +309,7 @@ else
                 CountryCode = NullIfEmpty(_warehouseForm.CountryCode),
                 IsDefault = _warehouseForm.IsDefault
             });
-            ToastService.Show(result.IsSuccess ? "Warehouse created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Warehouse created." : "Could not create warehouse.");
             if (result.IsSuccess)
             {
                 _warehouseForm.Reset();
@@ -346,7 +350,7 @@ else
                 LocationType = Enum.TryParse<InventoryLocationType>(_locationForm.LocationType, out var type) ? type : InventoryLocationType.Bin,
                 IsPickable = _locationForm.IsPickable
             });
-            ToastService.Show(result.IsSuccess ? "Location created." : $"Failed: {result.Message}");
+            ToastService.Show(result.IsSuccess ? "Location created." : "Could not create location.");
             if (result.IsSuccess)
             {
                 _locationForm.Reset();
@@ -374,6 +378,46 @@ else
             : warehouseId.ToString()[..8];
 
     private static string GetWarehouseLabel(Warehouse warehouse) => $"{warehouse.Code} - {warehouse.Name}";
+    private static string GetWarehousePickerValue(Warehouse warehouse) => warehouse.Id.ToString();
+    private static string GetWarehouseSearchText(Warehouse warehouse) =>
+        $"{warehouse.Code} {warehouse.Name} {warehouse.City} {warehouse.Region} {warehouse.CountryCode}";
+
+    private IReadOnlyList<XfEntityPickerColumn<Warehouse>> WarehouseAdvancedColumns =>
+    [
+        new("Code", x => x.Code),
+        new("Name", x => x.Name),
+        new("City", x => x.City),
+        new("Region", x => x.Region),
+        new("Country", x => x.CountryCode),
+        new("Default", x => FormatBoolean(x.IsDefault)),
+        new("Locations", x => _locations.Count(location => location.WarehouseId == x.Id).ToString()),
+        new("Created", x => x.CreatedAt.ToString("yyyy-MM-dd"))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<Warehouse>> WarehouseAdvancedFilters =>
+    [
+        new("default", "Default warehouse", YesNoFilterOptions, x => x.IsDefault ? "true" : "false", "All warehouses"),
+        new("country", "Country", BuildDistinctFilterOptions(_warehouses, x => x.CountryCode), x => x.CountryCode, "All countries")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private static IReadOnlyList<XfEntityPickerFilterOption> BuildDistinctFilterOptions<TItem>(
+        IEnumerable<TItem> items,
+        Func<TItem, string?> selector) =>
+        items
+            .Select(selector)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value)
+            .Select(value => new XfEntityPickerFilterOption(value!, value!))
+            .ToList();
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPicker.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/XfEntityPicker.razor
@@ -94,21 +94,50 @@
     }
 </div>
 
-<BbDialog Open="@_advancedOpen" OpenChanged="@(value => _advancedOpen = value)">
+<BbDialog Open="@_advancedOpen" OpenChanged="@OnAdvancedOpenChanged">
     <BbDialogContent TrapFocus="false" class="xf-entity-picker-advanced-dialog">
         <BbDialogHeader>
             <BbDialogTitle>@AdvancedSearchTitle</BbDialogTitle>
             <BbDialogDescription>@AdvancedSearchDescription</BbDialogDescription>
+            @if (!string.IsNullOrWhiteSpace(AdvancedSearchScope))
+            {
+                <BbTypographyMuted>@AdvancedSearchScope</BbTypographyMuted>
+            }
             @if (ShowAdvancedColumnFilters)
             {
                 <p class="xf-entity-picker-advanced-hint">Hover over a column header to reveal its filter.</p>
             }
         </BbDialogHeader>
         <div class="grid gap-3 py-4">
+            <BbFormFieldInput TValue="string"
+                              @bind-Value="_advancedSearchQuery"
+                              Label="Search"
+                              Placeholder="@AdvancedSearchPlaceholder" />
+
+            @if (HasAdvancedFilters)
+            {
+                <div class="grid gap-3 md:grid-cols-2">
+                    @foreach (var filter in AdvancedFilters)
+                    {
+                        <BbFormFieldSelect TValue="string"
+                                           Value="@GetAdvancedFilterValue(filter)"
+                                           ValueChanged="@((string value) => SetAdvancedFilterValue(filter, value))"
+                                           Label="@filter.Label">
+                            <BbSelectItem Value="@AdvancedFilterAllValue">@filter.AllLabel</BbSelectItem>
+                            @foreach (var option in filter.Options)
+                            {
+                                <BbSelectItem Value="@option.Value">@option.Label</BbSelectItem>
+                            }
+                        </BbFormFieldSelect>
+                    }
+                </div>
+            }
+
             <div class="xf-entity-picker-advanced-grid-wrap">
                 @if (!AdvancedFilteredItems.Any())
                 {
-                    <div class="xf-entity-picker-empty">@EmptyMessage</div>
+                    <BbEmpty Title="@EmptyMessage"
+                             Description="No records are available for this selection." />
                 }
                 else
                 {
@@ -150,16 +179,19 @@
                     @CreateLabel
                 </BbButton>
             }
-            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _advancedOpen = false)">Close</BbButton>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@CloseAdvancedSearch">Close</BbButton>
         </BbDialogFooter>
     </BbDialogContent>
 </BbDialog>
 
 @code {
+    private const string AdvancedFilterAllValue = "All";
     private readonly string _instanceId = $"entity-picker-{Guid.NewGuid():N}";
+    private readonly Dictionary<string, string> _advancedFilterValues = [];
     private bool _open;
     private bool _advancedOpen;
     private string _searchQuery = "";
+    private string _advancedSearchQuery = "";
 
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Value { get; set; }
@@ -198,16 +230,26 @@
             : Placeholder;
 
     private IReadOnlyList<TItem> FilteredItems => FilterItems(_searchQuery).ToList();
+    private bool HasAdvancedFilters => AdvancedFilters.Count > 0;
+    private IReadOnlyList<TItem> AdvancedFilteredItems =>
+        Items
+            .Where(AdvancedFiltersMatch)
+            .Where(AdvancedSearchMatches)
+            .ToList();
+
     private IReadOnlyList<XfEntityPickerColumn<TItem>> EffectiveAdvancedColumns =>
-        AdvancedColumns.Count > 0
-            ? AdvancedColumns
+        BuildEffectiveAdvancedColumns();
+
+    private IReadOnlyList<XfEntityPickerColumn<TItem>> BuildEffectiveAdvancedColumns()
+    {
+        return AdvancedColumns.Count > 0
+            ? AdvancedColumns.ToList()
             :
             [
-                new("Name", TextSelector),
-                new("Identifier", GetValue)
+                new XfEntityPickerColumn<TItem>("Name", TextSelector),
+                new XfEntityPickerColumn<TItem>("Identifier", GetValue)
             ];
-
-    private IReadOnlyList<TItem> AdvancedFilteredItems => Items;
+    }
 
     private IEnumerable<TItem> FilterItems(string query)
     {
@@ -239,6 +281,60 @@
     private static string FormatAdvancedCell(string? value) =>
         string.IsNullOrWhiteSpace(value) ? "N/A" : value;
 
+    private bool AdvancedFiltersMatch(TItem item)
+    {
+        foreach (var filter in AdvancedFilters)
+        {
+            var selected = GetAdvancedFilterValue(filter);
+            if (string.Equals(selected, AdvancedFilterAllValue, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = filter.ValueSelector(item);
+            if (!string.Equals(value, selected, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        return true;
+    }
+
+    private bool AdvancedSearchMatches(TItem item)
+    {
+        if (string.IsNullOrWhiteSpace(_advancedSearchQuery))
+            return true;
+
+        return GetAdvancedSearchText(item).Contains(_advancedSearchQuery, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string GetAdvancedSearchText(TItem item)
+    {
+        if (AdvancedSearchTextSelector is not null)
+            return AdvancedSearchTextSelector(item);
+
+        return string.Join(
+            " ",
+            EffectiveAdvancedColumns.Select(column => FormatAdvancedCell(column.ValueSelector(item))));
+    }
+
+    private string GetAdvancedFilterValue(XfEntityPickerFilter<TItem> filter) =>
+        _advancedFilterValues.TryGetValue(filter.Key, out var value)
+            ? value
+            : AdvancedFilterAllValue;
+
+    private Task SetAdvancedFilterValue(XfEntityPickerFilter<TItem> filter, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)
+            || string.Equals(value, AdvancedFilterAllValue, StringComparison.OrdinalIgnoreCase))
+        {
+            _advancedFilterValues.Remove(filter.Key);
+        }
+        else
+        {
+            _advancedFilterValues[filter.Key] = value;
+        }
+
+        return Task.CompletedTask;
+    }
+
     private Task OnSearchQueryChanged(string value)
     {
         _searchQuery = value;
@@ -254,16 +350,27 @@
         return Task.CompletedTask;
     }
 
+    private Task OnAdvancedOpenChanged(bool value)
+    {
+        _advancedOpen = value;
+        if (!value)
+            ResetAdvancedSearchState();
+
+        return Task.CompletedTask;
+    }
+
     private async Task SelectItem(TItem item)
     {
         _open = false;
         _searchQuery = "";
+        ResetAdvancedSearchState();
         await ValueChanged.InvokeAsync(GetValue(item));
     }
 
     private async Task SelectItemFromAdvanced(TItem item)
     {
         _advancedOpen = false;
+        ResetAdvancedSearchState();
         await ValueChanged.InvokeAsync(GetValue(item));
     }
 
@@ -271,6 +378,7 @@
     {
         _open = false;
         _searchQuery = "";
+        ResetAdvancedSearchState();
         await ValueChanged.InvokeAsync("");
     }
 
@@ -293,6 +401,20 @@
     private async Task OpenCreateFromAdvanced()
     {
         _advancedOpen = false;
+        ResetAdvancedSearchState();
         await OnCreate.InvokeAsync();
+    }
+
+    private Task CloseAdvancedSearch()
+    {
+        _advancedOpen = false;
+        ResetAdvancedSearchState();
+        return Task.CompletedTask;
+    }
+
+    private void ResetAdvancedSearchState()
+    {
+        _advancedSearchQuery = "";
+        _advancedFilterValues.Clear();
     }
 }

--- a/src/Presentation/ControlPanel.Server/Components/_Imports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/_Imports.razor
@@ -26,6 +26,7 @@
 @using IdentityServer.Domain.Shared.Contracts
 @using IdentityServer.Integration.Drivers
 @using XFramework.Inventario.Domain.Shared.Contracts
+@using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products
 @using global::Inventario.Integration.Drivers
 @using global::Messaging.Domain.Shared
 @using global::Messaging.Domain.Shared.Contracts

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -313,6 +313,16 @@
     max-width: min(74rem, calc(100vw - 2rem));
 }
 
+.xf-dialog-wide {
+    width: min(64rem, calc(100vw - 2rem));
+    max-width: min(64rem, calc(100vw - 2rem));
+}
+
+.xf-dialog-extra-wide {
+    width: min(74rem, calc(100vw - 2rem));
+    max-width: min(74rem, calc(100vw - 2rem));
+}
+
 .xf-entity-picker-advanced-hint {
     color: var(--muted-foreground);
     font-size: 0.8125rem;
@@ -459,6 +469,7 @@
     .xf-detail-field-grid-wide {
         grid-template-columns: repeat(3, minmax(0, 1fr));
     }
+
 }
 
 .login-shell {

--- a/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -12,6 +12,7 @@ public sealed class ControlPanelContractTests
 {
     private static readonly string[] BusinessWorkflowEntities =
     [
+        "Product",
         "InventoryReorderRule",
         "Warehouse",
         "InventoryLocation",
@@ -43,6 +44,31 @@ public sealed class ControlPanelContractTests
         "Stock.razor",
         "Suppliers.razor",
         "Transactions.razor",
+        "Warehouses.razor"
+    ];
+
+    private static readonly string[] InventarioDetailPagesRequiringFilteredDataGrids =
+    [
+        "CategoryDetail.razor",
+        "WarehouseDetail.razor",
+        "LocationDetail.razor",
+        "LotDetail.razor",
+        "StockBalanceDetail.razor",
+        "ReceivingDocumentDetail.razor",
+        "ReservationDetail.razor",
+        "PurchaseOrderDetail.razor"
+    ];
+
+    private static readonly string[] InventarioWorkflowPagesRequiringEntityPickers =
+    [
+        "Products.razor",
+        "ProductDetail.razor",
+        "Lots.razor",
+        "Stock.razor",
+        "Receiving.razor",
+        "PurchaseOrders.razor",
+        "Reservations.razor",
+        "Planning.razor",
         "Warehouses.razor"
     ];
 
@@ -148,6 +174,182 @@ public sealed class ControlPanelContractTests
     }
 
     [Test]
+    public void ProductPages_ProductWrites_UseInventarioServiceWrapper()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario");
+        var productsText = File.ReadAllText(Path.Combine(pagesRoot, "Products.razor"));
+        var productDetailText = File.ReadAllText(Path.Combine(pagesRoot, "ProductDetail.razor"));
+
+        productsText.Should().Contain("IInventarioServiceWrapper Inventario");
+        productsText.Should().Contain("Inventario.CreateProduct(");
+        productsText.Should().NotContain("DataContext.Add(new Product");
+
+        productDetailText.Should().Contain("IInventarioServiceWrapper Inventario");
+        productDetailText.Should().Contain("Inventario.UpdateProduct(");
+        productDetailText.Should().NotContain("DataContext.Update");
+    }
+
+    [Test]
+    public void ProductPages_CategorySelectors_UseEntityPicker()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario");
+        var productsText = File.ReadAllText(Path.Combine(pagesRoot, "Products.razor"));
+        var productDetailText = File.ReadAllText(Path.Combine(pagesRoot, "ProductDetail.razor"));
+
+        productsText.Should().Contain("XfEntityPicker TItem=\"ProductCategory\"");
+        productsText.Should().Contain("AdvancedColumns=\"@CategoryAdvancedColumns\"");
+        productsText.Should().NotContain("CategoryOptions");
+
+        productDetailText.Should().Contain("XfEntityPicker TItem=\"ProductCategory\"");
+        productDetailText.Should().Contain("AdvancedColumns=\"@CategoryAdvancedColumns\"");
+        productDetailText.Should().NotContain("Options=\"@CategoryOptions\"");
+    }
+
+    [Test]
+    public void ProductDetail_LongWorkflowDialogs_UseWideResponsiveLayoutsAndTypedInputs()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var productDetailPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario",
+            "ProductDetail.razor");
+        var text = File.ReadAllText(productDetailPath);
+
+        text.Should().Contain("Class=\"xf-dialog-wide\"");
+        text.Should().Contain("Class=\"xf-dialog-extra-wide\"");
+        text.Should().Contain("@page \"/inventario/products/{Id:guid}/{Section}\"");
+        text.Should().NotContain("xf-detail-layout");
+        text.Should().NotContain("xf-detail-sidebar");
+        text.Should().NotContain("xf-detail-nav");
+        text.Should().NotContain("ProductSectionNav");
+        text.Should().Contain("BbFormFieldNumericInput TValue=\"decimal\"");
+        text.Should().Contain("BbFormFieldCurrencyInput");
+        text.Should().Contain("BbFormFieldDatePicker");
+        text.Should().Contain("md:grid-cols-2");
+        text.Should().Contain("md:grid-cols-3");
+
+        text.Should().NotContain("TValue=\"string\" @bind-Value=\"_movementForm.Quantity\"");
+        text.Should().NotContain("TValue=\"string\" @bind-Value=\"_receiveForm.Quantity\"");
+        text.Should().NotContain("ParseDate(");
+    }
+
+    [Test]
+    public void ProductDetailNavigation_UsesShellSidebarAndHumanReadableBreadcrumbs()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var controlPanelRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components");
+        var productDetailPath = Path.Combine(
+            controlPanelRoot,
+            "Pages",
+            "Inventario",
+            "ProductDetail.razor");
+        var productSidebarPath = Path.Combine(
+            controlPanelRoot,
+            "Layout",
+            "ProductDetailSidebar.razor");
+        var mainLayoutPath = Path.Combine(
+            controlPanelRoot,
+            "Layout",
+            "MainLayout.razor");
+
+        var productDetailText = File.ReadAllText(productDetailPath);
+        var productSidebarText = File.ReadAllText(productSidebarPath);
+        var mainLayoutText = File.ReadAllText(mainLayoutPath);
+
+        productDetailText.Should().Contain("@page \"/inventario/products/{Id:guid}\"");
+        productDetailText.Should().Contain("@page \"/inventario/products/{Id:guid}/{Section}\"");
+        productDetailText.Should().NotContain("ProductSectionNav");
+        productDetailText.Should().NotContain("ProductSectionHref");
+        productDetailText.Should().NotContain("ProductSectionNavClass");
+        productDetailText.Should().NotContain("xf-detail-sidebar");
+
+        productSidebarText.Should().Contain("Product Detail");
+        productSidebarText.Should().Contain("Label=\"Summary\"");
+        productSidebarText.Should().Contain("Label=\"Stock\"");
+        productSidebarText.Should().Contain("Label=\"Lots / Batches\"");
+        productSidebarText.Should().Contain("Label=\"Replenishment\"");
+        productSidebarText.Should().Contain("Label=\"Variations\"");
+        productSidebarText.Should().Contain("Label=\"Transactions\"");
+
+        mainLayoutText.Should().Contain("BuildInventarioProductBreadcrumbs");
+        mainLayoutText.Should().Contain("RefreshBreadcrumbEntityLabels");
+        mainLayoutText.Should().Contain("GetProductBreadcrumbLabel");
+        mainLayoutText.Should().Contain("DataContext.Query<Product>()");
+        mainLayoutText.Should().Contain("ProductSectionLabel(normalizedSection)");
+        mainLayoutText.Should().Contain("ShortId(productId)");
+
+        var getBreadcrumbsBody = Regex.Match(
+            mainLayoutText,
+            @"private\s+List<string>\s+GetBreadcrumbs\(\)\s*\{(?<body>.*?)\n\s*\}",
+            RegexOptions.Singleline).Groups["body"].Value;
+
+        getBreadcrumbsBody.Should().Contain("TryGetInventarioProductDetailRoute");
+        getBreadcrumbsBody.Should().Contain("BuildInventarioProductBreadcrumbs");
+        getBreadcrumbsBody.Should().NotContain("TitleCase(s.Replace");
+    }
+
+    [Test]
+    public void InventarioPages_Toasts_DoNotExposeRawTechnicalDetails()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario");
+
+        var forbiddenPatterns = new[]
+        {
+            @"ToastService\.[A-Za-z]+\s*\([^;]*(?:ex|exception)\.Message",
+            @"ToastService\.[A-Za-z]+\s*\([^;]*result\.Message",
+            @"ToastService\.[A-Za-z]+\s*\([^;]*SqlException",
+            @"ToastService\.[A-Za-z]+\s*\([^;]*DbUpdateException",
+            @"ToastService\.[A-Za-z]+\s*\([^;]*stack trace"
+        };
+
+        var offenders = Directory.EnumerateFiles(pagesRoot, "*.razor", SearchOption.AllDirectories)
+            .SelectMany(path =>
+            {
+                var text = File.ReadAllText(path);
+                return forbiddenPatterns
+                    .Where(pattern => Regex.IsMatch(text, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline))
+                    .Select(pattern => $"{Path.GetRelativePath(repositoryRoot.FullName, path)} matched {pattern}");
+            })
+            .ToArray();
+
+        offenders.Should().BeEmpty("Inventario toasts should use semantic user-facing copy while logging technical details separately");
+    }
+
+    [Test]
     public void InventarioListPages_TabularSurfaces_UseFilteredBlazorBlueprintDataGrids()
     {
         var repositoryRoot = FindRepositoryRoot();
@@ -180,6 +382,66 @@ public sealed class ControlPanelContractTests
                     "Filterable=\"true\"",
                     $"{page} data grids should expose native column filtering on useful business columns");
             }
+        }
+    }
+
+    [Test]
+    public void InventarioDetailPages_TabularSurfaces_UseFilteredBlazorBlueprintDataGrids()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario");
+
+        foreach (var page in InventarioDetailPagesRequiringFilteredDataGrids)
+        {
+            var pagePath = Path.Combine(pagesRoot, page);
+            var text = File.ReadAllText(pagePath);
+
+            text.Should().NotContain("<table", $"{page} should use BlazorBlueprint data grids instead of raw tables");
+            text.Should().Contain("<BbDataGrid", $"{page} should use BbDataGrid for detail tabular records");
+            text.Should().NotMatchRegex(
+                @"<BbDataGridTemplateColumn\b[^>]*Title=""Actions""[^>]*Filterable=""true""",
+                $"{page} should not expose filters on command/action columns");
+
+            var grids = Regex.Matches(text, @"<BbDataGrid\b[\s\S]*?</BbDataGrid>", RegexOptions.Multiline);
+            grids.Should().NotBeEmpty($"{page} should render at least one data grid");
+
+            foreach (Match grid in grids)
+            {
+                grid.Value.Should().Contain(
+                    "Filterable=\"true\"",
+                    $"{page} detail grids should expose native column filtering on useful business columns");
+            }
+        }
+    }
+
+    [Test]
+    public void InventarioWorkflowPages_DomainEntitySelectors_UseSharedEntityPicker()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Inventario");
+
+        foreach (var page in InventarioWorkflowPagesRequiringEntityPickers)
+        {
+            var pagePath = Path.Combine(pagesRoot, page);
+            var text = File.ReadAllText(pagePath);
+
+            text.Should().Contain("<XfEntityPicker", $"{page} should use the shared entity picker for domain entity selectors");
+            text.Should().NotContain("<BbCombobox", $"{page} should not use plain comboboxes for product, warehouse, location, lot, supplier, or purchase-order selectors");
+            text.Should().NotContain("<BbFormFieldCombobox", $"{page} should not use form-field comboboxes for domain entity selectors");
         }
     }
 

--- a/src/Tests/Inventario.IntegrationTests/Tests/WrapperContractCoverageTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/WrapperContractCoverageTests.cs
@@ -4,6 +4,7 @@ using XFramework.Inventario.Domain.Shared.Contracts.Requests.Locations;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Lots;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Planning;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
@@ -19,6 +20,60 @@ namespace Inventario.IntegrationTests.Tests;
 [Category(TestCategories.Wrappers)]
 public sealed class WrapperContractCoverageTests : InventarioTestBase
 {
+    [Test]
+    [Category(TestCategories.Catalog)]
+    public async Task ProductWriteWrappers_CreateAndUpdateProduct_PersistChanges()
+    {
+        await using var setupDb = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(setupDb);
+        var sku = UniqueCode("SKU");
+
+        var create = await InventarioIntegrationTestFixture.ServiceWrapper.CreateProduct(
+            new CreateProductRequest
+            {
+                Metadata = CreateMetadata(),
+                Name = $"Wrapper Product {sku}",
+                SKU = sku,
+                CategoryId = category.Id,
+                Price = 25m,
+                StockQuantity = 0,
+                Brand = "Wrapper Brand",
+                IsAvailable = true
+            });
+        create.IsSuccess.Should().BeTrue(create.Message);
+
+        await using var createdDb = CreateDbContext();
+        var product = await createdDb.Set<Product>()
+            .IgnoreQueryFilters()
+            .SingleAsync(x => x.SKU == sku);
+
+        var update = await InventarioIntegrationTestFixture.ServiceWrapper.UpdateProduct(
+            new UpdateProductRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = product.Id,
+                Name = $"{product.Name} Updated",
+                SKU = sku,
+                CategoryId = category.Id,
+                Price = 31.50m,
+                Brand = "Updated Wrapper Brand",
+                Description = "Updated through wrapper coverage",
+                IsAvailable = false
+            });
+        update.IsSuccess.Should().BeTrue(update.Message);
+
+        await using var updatedDb = CreateDbContext();
+        var updated = await updatedDb.Set<Product>()
+            .IgnoreQueryFilters()
+            .SingleAsync(x => x.Id == product.Id);
+
+        updated.Name.Should().EndWith("Updated");
+        updated.Price.Should().Be(31.50m);
+        updated.Brand.Should().Be("Updated Wrapper Brand");
+        updated.Description.Should().Be("Updated through wrapper coverage");
+        updated.IsAvailable.Should().BeFalse();
+    }
+
     [Test]
     [Category(TestCategories.Warehousing)]
     public async Task GetWarehouseAndLocationWrappers_TenantScopedRecords_ReturnOnlyRequestTenant()


### PR DESCRIPTION
## Summary
- aligns Inventario ControlPanel pages with the updated UI guidelines
- routes product create/update through Inventario wrapper contracts and adds wrapper coverage
- removes duplicate in-page product detail navigation and uses product labels in breadcrumbs instead of raw GUIDs
- broadens BbDataGrid filtering, XfEntityPicker usage, semantic toast copy, typed Blueprint inputs, and reports filtering/empty states

## Verification
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false` passed
- `dotnet build src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj -m:1 /nr:false` passed
- `dotnet test src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj --no-build --filter "FullyQualifiedName~ControlPanelContractTests" -m:1 /nr:false --logger "console;verbosity=minimal"` passed: 12/12
- `dotnet test src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj --no-build -m:1 /nr:false --logger "console;verbosity=minimal"` passed: 56/56
- local ControlPanel browser smoke on `127.0.0.1:5005` passed for product detail sections and breadcrumb behavior

## Notes
- Testcontainers ran through the documented xeon-dev loopback Docker tunnel.
- Existing NU1510 package prune warnings remain unchanged.
