### PR TITLE
Fix Inventario product service tests namespace

### DIFF
--- a/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
@@ -13,6 +13,7 @@ using XFramework.Domain.Contexts;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Api.Services;
 using XFramework.Inventario.Domain.Shared.Contracts;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
 using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace Inventario.Api.Tests;


### PR DESCRIPTION
## Summary
- fixes the post-merge Publish build failure from PR #299
- imports the moved shared product request namespace in `Inventario.Api.Tests/ProductServiceTests.cs`

## Verification
- `dotnet build src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj -m:1 /nr:false` passed
- `dotnet test src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj --no-build -m:1 /nr:false --logger "console;verbosity=minimal"` passed: 29/29
- `dotnet build XFramework.slnx -c Release -m:1 /nr:false` passed
