### PR TITLE
Remove duplicate Inventario product back navigation

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Inventario/ProductDetail.razor
@@ -27,16 +27,10 @@ else if (!_moduleEnabled)
 }
 else if (_outsideTenantContext)
 {
-    <div class="space-y-4">
-        <BbButton Variant="ButtonVariant.Ghost" OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
-            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
-            Back to Products
-        </BbButton>
-        <BbAlert>
-            <BbAlertTitle>Product Outside Active Tenant</BbAlertTitle>
-            <BbAlertDescription>Switch to this product's tenant to view its details.</BbAlertDescription>
-        </BbAlert>
-    </div>
+    <BbAlert>
+        <BbAlertTitle>Product Outside Active Tenant</BbAlertTitle>
+        <BbAlertDescription>Switch to this product's tenant to view its details.</BbAlertDescription>
+    </BbAlert>
 }
 else if (_product is null)
 {
@@ -1093,10 +1087,6 @@ else
     }
 
     private RenderFragment ProductHeader => @<div class="xf-detail-header">
-        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" AriaLabel="Back to products"
-                  OnClick="@(() => Navigation.NavigateTo("/inventario/products"))">
-            <LucideIcon Name="arrow-left" class="h-4 w-4" />
-        </BbButton>
         <div class="xf-detail-header-main">
             <div class="xf-detail-header-title">
                 <BbTypographyH3>@(_product?.Name ?? "Unnamed Product")</BbTypographyH3>

--- a/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -288,7 +288,12 @@ public sealed class ControlPanelContractTests
         productDetailText.Should().NotContain("ProductSectionHref");
         productDetailText.Should().NotContain("ProductSectionNavClass");
         productDetailText.Should().NotContain("xf-detail-sidebar");
+        productDetailText.Should().NotContain("Back to Products");
+        productDetailText.Should().NotContain("Back to products");
+        productDetailText.Should().NotContain("AriaLabel=\"Back to products\"");
 
+        productSidebarText.Should().Contain("Label=\"Product List\"");
+        productSidebarText.Should().Contain("Href=\"/inventario/products\"");
         productSidebarText.Should().Contain("Product Detail");
         productSidebarText.Should().Contain("Label=\"Summary\"");
         productSidebarText.Should().Contain("Label=\"Stock\"");


### PR DESCRIPTION
## Summary
- removes the redundant in-page product detail back button because `ProductDetailSidebar` already provides `Product List` navigation
- removes the duplicate outside-tenant product detail back button
- extends the ControlPanel contract test to keep product detail navigation owned by the shell/sidebar

## Verification
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false` passed
- `dotnet build src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj -m:1 /nr:false` passed
- `dotnet test src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj --no-build --filter "FullyQualifiedName~ControlPanelContractTests" -m:1 /nr:false --logger "console;verbosity=minimal"` passed: 12/12
- `dotnet test src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj --no-build -m:1 /nr:false --logger "console;verbosity=minimal"` passed: 56/56

## Notes
- Other Inventario detail pages still have page-level back buttons because they do not have a dedicated shell detail sidebar like product detail does.
- Testcontainers ran through the documented xeon-dev loopback Docker tunnel.
