### PR TITLE
Fix IdentityServer ControlPanel UI guideline gaps

### DIFF
--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Credentials/Create/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Credentials/Create/Endpoint.cs
@@ -1,36 +1,58 @@
 using FluentValidation;
 using XFramework.Integration.Attributes;
-using CreateRequest = XFramework.Domain.Shared.Contracts.Requests.Create<IdentityServer.Domain.Shared.Contracts.IdentityCredential>;
 
 namespace IdentityServer.Api.Features.Credentials.Create;
 
 public static class CreateCredentialEndpoint
 {
+    [BoltHandler]
     [MapPost("/api/credentials", Tags = ["Credentials"],
         Summary = "Create a new identity credential",
         Description = "Creates a new identity credential with BCrypt password hashing (workFactor 11).",
         ExcludeFromOpenApi = true)]
     public static async Task<Result<IdentityCredential>> Handle(
-        CreateRequest request,
+        CreateCredentialRequest request,
         IAuthService authService,
         CancellationToken ct)
     {
-        return await authService.CreateCredentialAsync(request, ct);
+        if (request.Metadata.TenantId is not { } tenantId || tenantId == Guid.Empty)
+        {
+            return Result<IdentityCredential>.Failure("Tenant context is required.");
+        }
+
+        var credential = new IdentityCredential
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            IdentityInfoId = request.IdentityInfoId,
+            UserName = request.UserName,
+            UserAlias = request.UserAlias,
+            Password = request.Password,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        return await authService.CreateCredentialAsync(
+            new Create<IdentityCredential>(credential)
+            {
+                Metadata = request.Metadata
+            },
+            ct);
     }
 }
 
-public class CreateCredentialRequestValidator : AbstractValidator<CreateRequest>
+public class CreateCredentialRequestValidator : AbstractValidator<CreateCredentialRequest>
 {
     public CreateCredentialRequestValidator()
     {
-        RuleFor(x => x.Model.UserName)
+        RuleFor(x => x.UserName)
             .NotEmpty().WithMessage("Username is required");
 
-        RuleFor(x => x.Model.Password)
+        RuleFor(x => x.Password)
             .NotEmpty().WithMessage("Password is required")
             .MinimumLength(8).WithMessage("Password must be at least 8 characters");
 
-        RuleFor(x => x.Model.IdentityInfoId)
+        RuleFor(x => x.IdentityInfoId)
             .NotEmpty().WithMessage("Identity Info ID is required");
     }
 }

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Requests/CreateCredentialRequest.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Requests/CreateCredentialRequest.cs
@@ -1,0 +1,14 @@
+namespace IdentityServer.Domain.Shared.Contracts.Requests;
+
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreateCredentialRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<CreateCredentialRequest, TResponse>
+{
+    public Guid IdentityInfoId { get; set; }
+    public string? UserName { get; set; }
+    public string? UserAlias { get; set; }
+    public string? Password { get; set; }
+}

--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -42,6 +42,10 @@
                     {
                         <TenantDetailSidebar TenantId="@tenantRouteId" />
                     }
+                    else if (TryGetUserDetailRoute(out var userRouteId, out _))
+                    {
+                        <UserDetailSidebar UserId="@userRouteId" />
+                    }
                     else
                     {
                         <NavMenu />
@@ -421,6 +425,11 @@
             return "tenant-detail";
         }
 
+        if (TryGetUserDetailRoute(out _, out _))
+        {
+            return "user-detail";
+        }
+
         var segments = CurrentPath
             .Trim('/')
             .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -593,6 +602,31 @@
             || !string.Equals(segments[0], "identity", StringComparison.OrdinalIgnoreCase)
             || !string.Equals(segments[1], "tenants", StringComparison.OrdinalIgnoreCase)
             || !Guid.TryParse(segments[2], out tenantId))
+        {
+            return false;
+        }
+
+        if (segments.Length >= 4)
+        {
+            section = segments[3];
+        }
+
+        return true;
+    }
+
+    private bool TryGetUserDetailRoute(out Guid userId, out string section)
+    {
+        userId = Guid.Empty;
+        section = "summary";
+
+        var segments = CurrentPath
+            .Trim('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (segments.Length < 3
+            || !string.Equals(segments[0], "identity", StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(segments[1], "users", StringComparison.OrdinalIgnoreCase)
+            || !Guid.TryParse(segments[2], out userId))
         {
             return false;
         }

--- a/src/Presentation/ControlPanel.Server/Components/Layout/UserDetailSidebar.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/UserDetailSidebar.razor
@@ -1,0 +1,44 @@
+@* User detail section navigation *@
+@inject NavigationManager Navigation
+
+<SidebarNavItem Href="/identity/users"
+                Label="User List"
+                Icon="arrow-left"
+                Match="NavLinkMatch.All"
+                Strong="true" />
+
+<SidebarSection GroupId="user-detail" Title="User Detail" Icon="user">
+    <SidebarAnchorItem Href="@SectionHref("summary")" Label="Summary" Icon="file-text" Active="@(CurrentSection == "summary")" />
+    <SidebarAnchorItem Href="@SectionHref("credentials")" Label="Credentials" Icon="key-round" Active="@(CurrentSection == "credentials")" />
+    <SidebarAnchorItem Href="@SectionHref("roles")" Label="Roles" Icon="shield" Active="@(CurrentSection == "roles")" />
+    <SidebarAnchorItem Href="@SectionHref("contacts")" Label="Contacts" Icon="mail" Active="@(CurrentSection == "contacts")" />
+    <SidebarAnchorItem Href="@SectionHref("addresses")" Label="Addresses" Icon="map-pin" Active="@(CurrentSection == "addresses")" />
+    <SidebarAnchorItem Href="@SectionHref("sessions")" Label="Sessions" Icon="monitor" Active="@(CurrentSection == "sessions")" />
+    <SidebarAnchorItem Href="@SectionHref("auth-logs")" Label="Auth Logs" Icon="clipboard-list" Active="@(CurrentSection == "auth-logs")" />
+    <SidebarAnchorItem Href="@SectionHref("wallets")" Label="Wallets" Icon="wallet" Active="@(CurrentSection == "wallets")" />
+</SidebarSection>
+
+@code {
+    [Parameter] public Guid UserId { get; set; }
+
+    private string CurrentPath => new Uri(Navigation.Uri).AbsolutePath.TrimEnd('/');
+    private string BaseHref => $"/identity/users/{UserId}";
+
+    private string CurrentSection
+    {
+        get
+        {
+            var segments = CurrentPath
+                .Trim('/')
+                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            return segments.Length >= 4 ? NormalizeSection(segments[3]) : "summary";
+        }
+    }
+
+    private string SectionHref(string section) =>
+        section == "summary" ? BaseHref : $"{BaseHref}/{section}";
+
+    private static string NormalizeSection(string section) =>
+        section.Equals("info", StringComparison.OrdinalIgnoreCase) ? "summary" : section.ToLowerInvariant();
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/AddressDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/AddressDetail.razor
@@ -1,0 +1,436 @@
+@page "/identity/addresses/{Id:guid}"
+
+<PageTitle>Address Detail - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (_address is null)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@BackToAddresses">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Addresses
+        </BbButton>
+        <BbAlert Variant="AlertVariant.Danger">
+            <BbAlertTitle>Address Not Found</BbAlertTitle>
+            <BbAlertDescription>No address found with the specified ID.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@BackToAddresses">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Addresses
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Address Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to All Tenants or the address tenant to view this record.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="xf-page-header">
+                <div>
+                    <div class="flex items-center gap-2">
+                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" OnClick="@BackToAddresses">
+                            <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                        </BbButton>
+                        <div>
+                            <BbTypographyH3>@AddressTitle</BbTypographyH3>
+                            <BbTypographyMuted>@GetUserLabelById(_address.IdentityInfoId)</BbTypographyMuted>
+                        </div>
+                    </div>
+                </div>
+                <div class="xf-page-actions">
+                    <StatusBadge Text="@(_address.IsEnabled ? "Enabled" : "Disabled")"
+                                 Status="@(_address.IsEnabled ? "active" : "inactive")" />
+                    @if (_address.DefaultAddress == true)
+                    {
+                        <StatusBadge Text="Default" Status="active" />
+                    }
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ReloadData">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Destructive" OnClick="@OpenDeleteDialog">
+                        <LucideIcon Name="trash-2" class="mr-2 h-4 w-4" />
+                        Delete
+                    </BbButton>
+                </div>
+            </div>
+
+            <EditableForm @ref="_editableForm"
+                          TModel="IdentityAddress"
+                          Model="_address"
+                          OnSave="SaveAddress"
+                          OnDiscard="DiscardAddressEdit"
+                          Saving="_saving"
+                          RequireDirtyForSave="false"
+                          Title="Address Details">
+                @if (_editableForm?.IsEditing == true)
+                {
+                    <div class="xf-detail-field-grid">
+                        <XfEntityPicker TItem="IdentityInformation"
+                                        Label="User"
+                                        Value="@_formIdentityInfoId"
+                                        ValueChanged="@(value => _formIdentityInfoId = value ?? string.Empty)"
+                                        Items="@_users"
+                                        ValueSelector="@GetUserPickerValue"
+                                        TextSelector="@GetUserLabel"
+                                        SearchTextSelector="@GetUserSearchText"
+                                        AdvancedColumns="@UserAdvancedColumns"
+                                        AdvancedFilters="@UserAdvancedFilters"
+                                        AdvancedSearchScope="Searches full name, identity name, gender, civil status, verified state, enabled state, and created date."
+                                        Placeholder="Select user"
+                                        SearchPlaceholder="Search users..."
+                                        EmptyMessage="No users found."
+                                        ShowCreate="false"
+                                        AdvancedSearchTitle="Find User"
+                                        AdvancedSearchDescription="Search identity information records in the address tenant." />
+                        <BbFormFieldInput TValue="string"
+                                          @bind-Value="_formUnitNumber"
+                                          Label="Unit Number"
+                                          Placeholder="Unit or apartment number" />
+                        <BbFormFieldInput TValue="string"
+                                          @bind-Value="_formStreet"
+                                          Label="Street"
+                                          Placeholder="Street address" />
+                        <BbFormFieldInput TValue="string"
+                                          @bind-Value="_formBuilding"
+                                          Label="Building"
+                                          Placeholder="Building name" />
+                        <BbFormFieldInput TValue="string"
+                                          @bind-Value="_formSubdivision"
+                                          Label="Subdivision"
+                                          Placeholder="Subdivision or village" />
+                        <BbFormFieldInput TValue="string"
+                                          @bind-Value="_formConsolidatedName"
+                                          Label="Full Address"
+                                          Placeholder="Complete address line" />
+                        <BbFormFieldSwitch Checked="@_formIsDefault"
+                                           CheckedChanged="@((bool value) => _formIsDefault = value)"
+                                           Label="Default Address" />
+                    </div>
+                }
+                else
+                {
+                    <div class="xf-summary-grid">
+                        <div>
+                            <BbTypographyMuted>User</BbTypographyMuted>
+                            <div class="font-medium">@GetUserLabelById(_address.IdentityInfoId)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Unit</BbTypographyMuted>
+                            <div class="font-medium">@DisplayValue(_address.UnitNumber)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Street</BbTypographyMuted>
+                            <div class="font-medium">@DisplayValue(_address.Street)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Building</BbTypographyMuted>
+                            <div class="font-medium">@DisplayValue(_address.Building)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Subdivision</BbTypographyMuted>
+                            <div class="font-medium">@DisplayValue(_address.Subdivision)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Full Address</BbTypographyMuted>
+                            <div class="font-medium">@DisplayValue(_address.ConsolidatedName)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Default</BbTypographyMuted>
+                            <div class="font-medium">@(_address.DefaultAddress == true ? "Yes" : "No")</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div class="font-medium">@FormatDateTime(_address.CreatedAt)</div>
+                        </div>
+                    </div>
+                }
+            </EditableForm>
+        </div>
+    </FadeInContent>
+}
+
+<ConfirmDeleteDialog Open="@_deleteDialogOpen"
+                     OpenChanged="@(value => _deleteDialogOpen = value)"
+                     Message="Delete this address record? This action cannot be undone."
+                     OnConfirm="@ConfirmDelete" />
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+
+    private IdentityAddress? _address;
+    private List<IdentityInformation> _users = [];
+    private EditableForm<IdentityAddress>? _editableForm;
+
+    private bool _loading = true;
+    private bool _saving;
+    private bool _deleteDialogOpen;
+    private bool _outsideTenantContext;
+
+    private string _formIdentityInfoId = string.Empty;
+    private string _formUnitNumber = string.Empty;
+    private string _formStreet = string.Empty;
+    private string _formBuilding = string.Empty;
+    private string _formSubdivision = string.Empty;
+    private string _formConsolidatedName = string.Empty;
+    private bool _formIsDefault;
+
+    private string AddressTitle =>
+        !string.IsNullOrWhiteSpace(_address?.ConsolidatedName)
+            ? _address.ConsolidatedName
+            : !string.IsNullOrWhiteSpace(_address?.Street)
+                ? _address.Street
+                : "Address";
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await ReloadData();
+    }
+
+    private async Task ReloadData()
+    {
+        _loading = true;
+        try
+        {
+            _outsideTenantContext = false;
+            _address = await DataContext.Query<IdentityAddress>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.IdentityInfo)
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            if (_address is null)
+            {
+                _users = [];
+                return;
+            }
+
+            _outsideTenantContext = TenantFilter.SelectedTenantId is Guid tenantId && tenantId != _address.TenantId;
+            if (_outsideTenantContext)
+            {
+                _users = [];
+                return;
+            }
+
+            SyncFormFields();
+            await LoadLookups(_address.TenantId);
+        }
+        catch
+        {
+            _address = null;
+            _users = [];
+            ToastService.Error("Address could not be loaded.", "Load failed");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task LoadLookups(Guid tenantId)
+    {
+        _users = await DataContext.Query<IdentityInformation>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .OrderBy(x => x.LastName)
+            .ThenBy(x => x.FirstName)
+            .Take(500)
+            .ToListAsync();
+    }
+
+    private void SyncFormFields()
+    {
+        if (_address is null)
+        {
+            return;
+        }
+
+        _formIdentityInfoId = _address.IdentityInfoId.ToString();
+        _formUnitNumber = _address.UnitNumber ?? string.Empty;
+        _formStreet = _address.Street ?? string.Empty;
+        _formBuilding = _address.Building ?? string.Empty;
+        _formSubdivision = _address.Subdivision ?? string.Empty;
+        _formConsolidatedName = _address.ConsolidatedName ?? string.Empty;
+        _formIsDefault = _address.DefaultAddress == true;
+    }
+
+    private void DiscardAddressEdit() => SyncFormFields();
+
+    private async Task SaveAddress()
+    {
+        if (_address is null)
+        {
+            return;
+        }
+
+        if (!Guid.TryParse(_formIdentityInfoId, out var identityInfoId))
+        {
+            ToastService.Warning("Select a user.", "Missing user");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var fresh = await DataContext.Query<IdentityAddress>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null)
+            {
+                ToastService.Warning("Address was not found.", "Address unavailable");
+                return;
+            }
+
+            fresh.IdentityInfoId = identityInfoId;
+            fresh.UnitNumber = _formUnitNumber;
+            fresh.Street = _formStreet;
+            fresh.Building = _formBuilding;
+            fresh.Subdivision = _formSubdivision;
+            fresh.ConsolidatedName = _formConsolidatedName;
+            fresh.DefaultAddress = _formIsDefault;
+            fresh.ModifiedAt = DateTime.UtcNow;
+
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Address updated.", "Saved");
+                _editableForm?.ExitEditMode();
+                await ReloadData();
+            }
+            else
+            {
+                ToastService.Error("Address could not be updated.", "Save failed");
+            }
+        }
+        catch
+        {
+            ToastService.Error("Address could not be updated.", "Save failed");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private void OpenDeleteDialog()
+    {
+        _deleteDialogOpen = true;
+    }
+
+    private async Task ConfirmDelete()
+    {
+        if (_address is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _address.IsDeleted = true;
+            _address.IsEnabled = false;
+            DataContext.Update(_address);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Address deleted.", "Deleted");
+                BackToAddresses();
+            }
+            else
+            {
+                ToastService.Error("Address could not be deleted.", "Delete failed");
+            }
+        }
+        catch
+        {
+            ToastService.Error("Address could not be deleted.", "Delete failed");
+        }
+        finally
+        {
+            _deleteDialogOpen = false;
+        }
+    }
+
+    private void BackToAddresses() => Navigation.NavigateTo("/identity/addresses");
+
+    private static string GetUserPickerValue(IdentityInformation user) => user.Id.ToString();
+
+    private static string GetUserLabel(IdentityInformation user) =>
+        !string.IsNullOrWhiteSpace(user.FullName)
+            ? user.FullName
+            : !string.IsNullOrWhiteSpace(user.IdentityName)
+                ? user.IdentityName
+                : user.Id.ToString()[..8];
+
+    private string GetUserLabelById(Guid identityInfoId) =>
+        _users.FirstOrDefault(x => x.Id == identityInfoId) is { } user
+            ? GetUserLabel(user)
+            : _address?.IdentityInfo is { } loadedUser
+                ? GetUserLabel(loadedUser)
+                : "Unknown user";
+
+    private static string GetUserSearchText(IdentityInformation user) =>
+        $"{user.FullName} {user.IdentityName} {user.Gender} {user.CivilStatus}";
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityInformation>> UserAdvancedColumns =>
+    [
+        new("Full Name", GetUserLabel),
+        new("Identity Name", x => x.IdentityName),
+        new("Gender", x => x.Gender?.ToString()),
+        new("Civil Status", x => x.CivilStatus?.ToString()),
+        new("Verified", x => FormatBoolean(x.IsVerified)),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityInformation>> UserAdvancedFilters =>
+    [
+        new("verified", "Verified", YesNoFilterOptions, x => x.IsVerified ? "true" : "false", "All users"),
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses"),
+        new("gender", "Gender", BuildDistinctFilterOptions(_users, x => x.Gender?.ToString()), x => x.Gender?.ToString(), "All genders")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private static IReadOnlyList<XfEntityPickerFilterOption> BuildDistinctFilterOptions<TItem>(
+        IEnumerable<TItem> items,
+        Func<TItem, string?> valueSelector) =>
+        items
+            .Select(valueSelector)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .Select(value => new XfEntityPickerFilterOption(value!, value!))
+            .ToArray();
+
+    private static string DisplayValue(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "N/A" : value;
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDateTime(DateTime value) => value == default ? "N/A" : value.ToString("g");
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Addresses.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Addresses.razor
@@ -3,12 +3,17 @@
 <PageTitle>Addresses - Control Panel</PageTitle>
 
 <div class="space-y-4">
-    <div class="flex items-center justify-between">
-        <BbTypographyH3>Addresses</BbTypographyH3>
+    <div class="xf-page-header">
+        <div>
+            <BbTypographyH3>Addresses</BbTypographyH3>
+            <BbTypographyMuted>Scan address records and open a detail page to edit relationships.</BbTypographyMuted>
+        </div>
+        <div class="xf-page-actions">
         <BbButton OnClick="@OpenAddDialog">
             <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
             Add Address
         </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -17,26 +22,35 @@
     }
     else
     {
-    <BbDataGrid Items="@_addresses">
+    <BbDataGrid Items="@_addresses"
+                ShowPagination="true"
+                InitialPageSize="20"
+                ShowSearch="true"
+                SearchPlaceholder="Search addresses..."
+                OnRowClick="@((IdentityAddress item) => OpenAddressDetail(item))">
         <Columns>
-            <BbDataGridPropertyColumn Property="@(x => x.IdentityInfoId)" Title="User ID" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.Street)" Title="Street" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.Building)" Title="Building" />
-            <BbDataGridPropertyColumn Property="@(x => x.Subdivision)" Title="Subdivision" />
-            <BbDataGridPropertyColumn Property="@(x => x.ConsolidatedName)" Title="Full Address" Sortable="true" />
-            <BbDataGridTemplateColumn Title="Default">
+            <BbDataGridTemplateColumn Title="User" Filterable="true" FilterBy="@(item => GetUserLabelById(item.IdentityInfoId))">
+                <ChildContent Context="item">
+                    @GetUserLabelById(item.IdentityInfoId)
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridPropertyColumn Property="@(x => x.Street)" Title="Street" Sortable="true" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.Building)" Title="Building" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.Subdivision)" Title="Subdivision" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.ConsolidatedName)" Title="Full Address" Sortable="true" Filterable="true" />
+            <BbDataGridTemplateColumn Title="Default" Filterable="true" FilterBy="@(item => GetDefaultAddressLabel(item))">
                 <ChildContent Context="item">
                     <StatusBadge Text="@(item.DefaultAddress == true ? "Default" : "No")"
                                  Status="@(item.DefaultAddress == true ? "active" : "inactive")" />
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
             <BbDataGridTemplateColumn Title="Actions">
                 <ChildContent Context="item">
                     <div class="flex items-center gap-2">
                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
-                                  OnClick="@(() => OpenEditDialog(item))">
-                            <LucideIcon Name="pencil" class="h-4 w-4" />
+                                  OnClick="@(() => OpenAddressDetail(item))">
+                            <LucideIcon Name="eye" class="h-4 w-4" />
                         </BbButton>
                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
                                   OnClick="@(() => OpenDeleteDialog(item))">
@@ -46,6 +60,9 @@
                 </ChildContent>
             </BbDataGridTemplateColumn>
         </Columns>
+        <EmptyTemplate>
+            <BbEmpty Title="No addresses" Description="No addresses found for the selected tenant." />
+        </EmptyTemplate>
     </BbDataGrid>
     }
 </div>
@@ -53,10 +70,8 @@
 <BbDialog Open="@_dialogOpen" OpenChanged="@(v => _dialogOpen = v)">
     <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
-            <BbDialogTitle>@(_isEditing ? "Edit Address" : "Add Address")</BbDialogTitle>
-            <BbDialogDescription>
-                @(_isEditing ? "Update address details." : "Create a new address record.")
-            </BbDialogDescription>
+            <BbDialogTitle>Add Address</BbDialogTitle>
+            <BbDialogDescription>Create a new address record.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
             <XfEntityPicker TItem="IdentityInformation"
@@ -103,7 +118,7 @@
         </div>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _dialogOpen = false)">Cancel</BbButton>
-            <BbButton OnClick="@SaveAddress">@(_isEditing ? "Update" : "Create")</BbButton>
+            <BbButton OnClick="@SaveAddress">Create</BbButton>
         </BbDialogFooter>
     </BbDialogContent>
 </BbDialog>
@@ -114,6 +129,7 @@
 
 @code {
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
@@ -122,8 +138,6 @@
     private bool _loading = true;
     private bool _dialogOpen;
     private bool _deleteDialogOpen;
-    private bool _isEditing;
-    private Guid _editingId;
     private IdentityAddress? _deletingAddress;
 
     private string _formIdentityInfoId = "";
@@ -172,12 +186,16 @@
 
             _users = await userQuery.Take(500).ToListAsync();
         }
-        catch { /* query may fail */ }
+        catch
+        {
+            _addresses = [];
+            _users = [];
+            ToastService.Error("Addresses could not be loaded.", "Load failed");
+        }
     }
 
     private void OpenAddDialog()
     {
-        _isEditing = false;
         _formIdentityInfoId = "";
         _formUnitNumber = "";
         _formStreet = "";
@@ -187,18 +205,8 @@
         _dialogOpen = true;
     }
 
-    private void OpenEditDialog(IdentityAddress addr)
-    {
-        _isEditing = true;
-        _editingId = addr.Id;
-        _formIdentityInfoId = addr.IdentityInfoId.ToString();
-        _formUnitNumber = addr.UnitNumber ?? "";
-        _formStreet = addr.Street ?? "";
-        _formBuilding = addr.Building ?? "";
-        _formSubdivision = addr.Subdivision ?? "";
-        _formConsolidatedName = addr.ConsolidatedName ?? "";
-        _dialogOpen = true;
-    }
+    private void OpenAddressDetail(IdentityAddress address) =>
+        Navigation.NavigateTo($"/identity/addresses/{address.Id}");
 
     private void OpenDeleteDialog(IdentityAddress addr)
     {
@@ -210,54 +218,31 @@
     {
         if (!Guid.TryParse(_formIdentityInfoId, out var identityInfoId))
         {
-            ToastService.Show("Invalid User ID.");
+            ToastService.Warning("Select a user.", "Missing user");
             return;
         }
 
         try
         {
-            if (_isEditing)
+            var addr = new IdentityAddress
             {
-                var addr = await DataContext.Query<IdentityAddress>()
-                    .Where(x => x.Id == _editingId)
-                    .FirstOrDefaultAsync();
-
-                if (addr is not null)
-                {
-                    addr.IdentityInfoId = identityInfoId;
-                    addr.UnitNumber = _formUnitNumber;
-                    addr.Street = _formStreet;
-                    addr.Building = _formBuilding;
-                    addr.Subdivision = _formSubdivision;
-                    addr.ConsolidatedName = _formConsolidatedName;
-                    addr.ModifiedAt = DateTime.UtcNow;
-                    DataContext.Update(addr);
-                    var result = await DataContext.SaveChangesAsync();
-                    ToastService.Show(result.IsSuccess ? "Address updated." : $"Error: {result.Message}");
-                }
-            }
-            else
-            {
-                var addr = new IdentityAddress
-                {
-                    Id = Guid.NewGuid(),
-                    TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
-                    IdentityInfoId = identityInfoId,
-                    UnitNumber = _formUnitNumber,
-                    Street = _formStreet,
-                    Building = _formBuilding,
-                    Subdivision = _formSubdivision,
-                    ConsolidatedName = _formConsolidatedName,
-                    CreatedAt = DateTime.UtcNow
-                };
-                DataContext.Add(addr);
-                var result = await DataContext.SaveChangesAsync();
-                ToastService.Show(result.IsSuccess ? "Address created." : $"Error: {result.Message}");
-            }
+                Id = Guid.NewGuid(),
+                TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
+                IdentityInfoId = identityInfoId,
+                UnitNumber = _formUnitNumber,
+                Street = _formStreet,
+                Building = _formBuilding,
+                Subdivision = _formSubdivision,
+                ConsolidatedName = _formConsolidatedName,
+                CreatedAt = DateTime.UtcNow
+            };
+            DataContext.Add(addr);
+            var result = await DataContext.SaveChangesAsync();
+            ShowSaveResult(result.IsSuccess, "Address created.", "Address could not be created.");
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("Address could not be saved.", "Save failed");
         }
 
         _dialogOpen = false;
@@ -274,11 +259,11 @@
                 _deletingAddress.IsEnabled = false;
                 DataContext.Update(_deletingAddress);
                 var result = await DataContext.SaveChangesAsync();
-                ToastService.Show(result.IsSuccess ? "Address deleted." : $"Error: {result.Message}");
+                ShowSaveResult(result.IsSuccess, "Address deleted.", "Address could not be deleted.");
             }
-            catch (Exception ex)
+            catch
             {
-                ToastService.Show($"Error: {ex.Message}");
+                ToastService.Error("Address could not be deleted.", "Delete failed");
             }
             finally
             {
@@ -296,6 +281,25 @@
             : !string.IsNullOrWhiteSpace(user.IdentityName)
                 ? user.IdentityName
                 : user.Id.ToString()[..8];
+
+    private string GetUserLabelById(Guid identityInfoId) =>
+        _users.FirstOrDefault(x => x.Id == identityInfoId) is { } user
+            ? GetUserLabel(user)
+            : "Unknown user";
+
+    private static string GetDefaultAddressLabel(IdentityAddress address) =>
+        address.DefaultAddress == true ? "Default" : "No";
+
+    private void ShowSaveResult(bool isSuccess, string successMessage, string errorMessage)
+    {
+        if (isSuccess)
+        {
+            ToastService.Success(successMessage, "Saved");
+            return;
+        }
+
+        ToastService.Error(errorMessage, "Save failed");
+    }
 
     private static string GetUserSearchText(IdentityInformation user) =>
         $"{user.FullName} {user.IdentityName} {user.Gender} {user.CivilStatus}";

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/AuthLogs.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/AuthLogs.razor
@@ -16,20 +16,27 @@
     }
     else
     {
-    <BbDataGrid Items="@_logs">
+    <BbDataGrid Items="@_logs" ShowPagination="true" InitialPageSize="20" ShowSearch="true" SearchPlaceholder="Search authorization logs...">
         <Columns>
-            <BbDataGridPropertyColumn Property="@(x => x.CredentialId)" Title="Credential ID" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.Ipaddress)" Title="IP Address" Sortable="true" />
-            <BbDataGridTemplateColumn Title="Success">
+            <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(item => GetCredentialLabel(item))">
+                <ChildContent Context="item">
+                    @GetCredentialLabel(item)
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridPropertyColumn Property="@(x => x.Ipaddress)" Title="IP Address" Sortable="true" Filterable="true" />
+            <BbDataGridTemplateColumn Title="Success" Filterable="true" FilterBy="@(item => GetResultLabel(item))">
                 <ChildContent Context="item">
                     <StatusBadge Text="@(item.IsSuccess == true ? "Success" : "Failed")"
                                  Status="@(item.IsSuccess == true ? "success" : "failed")" />
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridPropertyColumn Property="@(x => x.LoginSource)" Title="Login Source" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.DeviceName)" Title="Device" />
-            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.LoginSource)" Title="Login Source" Sortable="true" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.DeviceName)" Title="Device" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
         </Columns>
+        <EmptyTemplate>
+            <BbEmpty Title="No authorization logs" Description="No authorization logs found for the selected tenant." />
+        </EmptyTemplate>
     </BbDataGrid>
     }
 </div>
@@ -37,6 +44,7 @@
 @code {
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
 
     private List<AuthorizationLog> _logs = [];
     private bool _loading = true;
@@ -51,7 +59,8 @@
         _loading = true;
         try
         {
-            var query = DataContext.Query<AuthorizationLog>();
+            var query = DataContext.Query<AuthorizationLog>()
+                .Include(x => x.IdentityCredentials);
             if (TenantFilter.SelectedTenantId is { } tenantId)
             {
                 query = query.Where(x => x.TenantId == tenantId);
@@ -61,10 +70,29 @@
                 .OrderByDescending(x => x.CreatedAt)
                 .ToList();
         }
-        catch { /* query may fail */ }
+        catch
+        {
+            _logs = [];
+            ToastService.Error("Authorization logs could not be loaded.", "Load failed");
+        }
         finally
         {
             _loading = false;
         }
     }
+
+    private static string GetCredentialLabel(AuthorizationLog log)
+    {
+        var credential = log.IdentityCredentials;
+        if (!string.IsNullOrWhiteSpace(credential?.UserName))
+            return credential.UserName;
+
+        if (!string.IsNullOrWhiteSpace(credential?.UserAlias))
+            return credential.UserAlias;
+
+        return "Unknown credential";
+    }
+
+    private static string GetResultLabel(AuthorizationLog log) =>
+        log.IsSuccess == true ? "Success" : "Failed";
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/ContactDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/ContactDetail.razor
@@ -1,0 +1,517 @@
+@page "/identity/contacts/{Id:guid}"
+
+<PageTitle>Contact Detail - Control Panel</PageTitle>
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (_contact is null)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@BackToContacts">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Contacts
+        </BbButton>
+        <BbAlert Variant="AlertVariant.Danger">
+            <BbAlertTitle>Contact Not Found</BbAlertTitle>
+            <BbAlertDescription>No contact found with the specified ID.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else if (_outsideTenantContext)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@BackToContacts">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Contacts
+        </BbButton>
+        <BbAlert>
+            <BbAlertTitle>Contact Outside Active Tenant</BbAlertTitle>
+            <BbAlertDescription>Switch to All Tenants or the contact's tenant to view this record.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="xf-page-header">
+                <div>
+                    <div class="flex items-center gap-2">
+                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" OnClick="@BackToContacts">
+                            <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                        </BbButton>
+                        <div>
+                            <BbTypographyH3>@ContactTitle</BbTypographyH3>
+                            <BbTypographyMuted>@GetCredentialLabelById(_contact.CredentialId)</BbTypographyMuted>
+                        </div>
+                    </div>
+                </div>
+                <div class="xf-page-actions">
+                    <StatusBadge Text="@(_contact.IsEnabled ? "Enabled" : "Disabled")"
+                                 Status="@(_contact.IsEnabled ? "active" : "inactive")" />
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ReloadData">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Refresh
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Destructive" OnClick="@OpenDeleteDialog">
+                        <LucideIcon Name="trash-2" class="mr-2 h-4 w-4" />
+                        Delete
+                    </BbButton>
+                </div>
+            </div>
+
+            <EditableForm @ref="_editableForm"
+                          TModel="IdentityContact"
+                          Model="_contact"
+                          OnSave="SaveContact"
+                          OnDiscard="DiscardContactEdit"
+                          Saving="_saving"
+                          RequireDirtyForSave="false"
+                          Title="Contact Details">
+                @if (_editableForm?.IsEditing == true)
+                {
+                    <div class="xf-detail-field-grid">
+                        <BbFormFieldInput TValue="string"
+                                          @bind-Value="_formValue"
+                                          Label="Value"
+                                          Placeholder="Email, phone number, or other contact value"
+                                          Required="true" />
+                        <XfEntityPicker TItem="IdentityCredential"
+                                        Label="Credential"
+                                        Value="@_formCredentialId"
+                                        ValueChanged="@(value => _formCredentialId = value ?? string.Empty)"
+                                        Items="@_credentials"
+                                        ValueSelector="@GetCredentialPickerValue"
+                                        TextSelector="@GetCredentialLabel"
+                                        SearchTextSelector="@GetCredentialSearchText"
+                                        AdvancedColumns="@CredentialAdvancedColumns"
+                                        AdvancedFilters="@CredentialAdvancedFilters"
+                                        AdvancedSearchScope="Searches username, alias, owning identity, online state, device, location, last seen, and created date."
+                                        Placeholder="Select credential"
+                                        SearchPlaceholder="Search credentials..."
+                                        EmptyMessage="No credentials found."
+                                        ShowCreate="false"
+                                        AdvancedSearchTitle="Find Credential"
+                                        AdvancedSearchDescription="Search credentials in the contact tenant." />
+                        <XfEntityPicker TItem="IdentityContactType"
+                                        Label="Contact Type"
+                                        Value="@_formTypeId"
+                                        ValueChanged="@(value => _formTypeId = value ?? string.Empty)"
+                                        Items="@_contactTypes"
+                                        ValueSelector="@GetContactTypePickerValue"
+                                        TextSelector="@GetContactTypeLabel"
+                                        SearchTextSelector="@GetContactTypeSearchText"
+                                        AdvancedColumns="@ContactTypeAdvancedColumns"
+                                        AdvancedFilters="@ContactTypeAdvancedFilters"
+                                        AdvancedSearchScope="Searches contact type name, enabled state, system reference, and created date."
+                                        Placeholder="No contact type"
+                                        SearchPlaceholder="Search contact types..."
+                                        EmptyMessage="No contact types found."
+                                        AllowClear="true"
+                                        ClearText="No contact type"
+                                        ShowCreate="false"
+                                        AdvancedSearchTitle="Find Contact Type"
+                                        AdvancedSearchDescription="Search contact classification types." />
+                        <XfEntityPicker TItem="IdentityContactGroup"
+                                        Label="Contact Group"
+                                        Value="@_formGroupId"
+                                        ValueChanged="@(value => _formGroupId = value ?? string.Empty)"
+                                        Items="@_contactGroups"
+                                        ValueSelector="@GetContactGroupPickerValue"
+                                        TextSelector="@GetContactGroupLabel"
+                                        SearchTextSelector="@GetContactGroupSearchText"
+                                        AdvancedColumns="@ContactGroupAdvancedColumns"
+                                        AdvancedFilters="@ContactGroupAdvancedFilters"
+                                        AdvancedSearchScope="Searches contact group name, enabled state, system reference, and created date."
+                                        Placeholder="Select contact group"
+                                        SearchPlaceholder="Search contact groups..."
+                                        EmptyMessage="No contact groups found."
+                                        ShowCreate="false"
+                                        AdvancedSearchTitle="Find Contact Group"
+                                        AdvancedSearchDescription="Search contact groups in the contact tenant." />
+                    </div>
+                }
+                else
+                {
+                    <div class="xf-summary-grid">
+                        <div>
+                            <BbTypographyMuted>Value</BbTypographyMuted>
+                            <div class="font-medium">@_contact.Value</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Credential</BbTypographyMuted>
+                            <div class="font-medium">@GetCredentialLabelById(_contact.CredentialId)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Contact Type</BbTypographyMuted>
+                            <div class="font-medium">@GetContactTypeLabel(_contact)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Contact Group</BbTypographyMuted>
+                            <div class="font-medium">@GetContactGroupLabelById(_contact.GroupId)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Created</BbTypographyMuted>
+                            <div class="font-medium">@FormatDateTime(_contact.CreatedAt)</div>
+                        </div>
+                        <div>
+                            <BbTypographyMuted>Updated</BbTypographyMuted>
+                            <div class="font-medium">@FormatDateTime(_contact.ModifiedAt)</div>
+                        </div>
+                    </div>
+                }
+            </EditableForm>
+        </div>
+    </FadeInContent>
+}
+
+<ConfirmDeleteDialog Open="@_deleteDialogOpen"
+                     OpenChanged="@(value => _deleteDialogOpen = value)"
+                     Message="Delete this contact record? This action cannot be undone."
+                     OnConfirm="@ConfirmDelete" />
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+
+    private IdentityContact? _contact;
+    private List<IdentityCredential> _credentials = [];
+    private List<IdentityContactType> _contactTypes = [];
+    private List<IdentityContactGroup> _contactGroups = [];
+    private EditableForm<IdentityContact>? _editableForm;
+
+    private bool _loading = true;
+    private bool _saving;
+    private bool _deleteDialogOpen;
+    private bool _outsideTenantContext;
+
+    private string _formValue = string.Empty;
+    private string _formCredentialId = string.Empty;
+    private string _formTypeId = string.Empty;
+    private string _formGroupId = string.Empty;
+
+    private string ContactTitle =>
+        string.IsNullOrWhiteSpace(_contact?.Value) ? "Contact" : _contact.Value;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await ReloadData();
+    }
+
+    private async Task ReloadData()
+    {
+        _loading = true;
+        try
+        {
+            _outsideTenantContext = false;
+            _contact = await DataContext.Query<IdentityContact>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Type)
+                .Include(x => x.Group)
+                .Include(x => x.Credential)
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            if (_contact is null)
+            {
+                ClearLookups();
+                return;
+            }
+
+            _outsideTenantContext = TenantFilter.SelectedTenantId is Guid tenantId && tenantId != _contact.TenantId;
+            if (_outsideTenantContext)
+            {
+                ClearLookups();
+                return;
+            }
+
+            SyncFormFields();
+            await LoadLookups(_contact.TenantId);
+        }
+        catch
+        {
+            _contact = null;
+            ClearLookups();
+            ToastService.Error("Contact could not be loaded.", "Load failed");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void ClearLookups()
+    {
+        _credentials = [];
+        _contactTypes = [];
+        _contactGroups = [];
+    }
+
+    private async Task LoadLookups(Guid tenantId)
+    {
+        var credentialQuery = DataContext.Query<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Include(x => x.IdentityInfo)
+            .Where(x => x.TenantId == tenantId)
+            .OrderBy(x => x.UserName);
+
+        var typeQuery = DataContext.Query<IdentityContactType>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .OrderBy(x => x.Name);
+
+        var groupQuery = DataContext.Query<IdentityContactGroup>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .OrderBy(x => x.Name);
+
+        _credentials = await credentialQuery.Take(500).ToListAsync();
+        _contactTypes = await typeQuery.Take(100).ToListAsync();
+        _contactGroups = await groupQuery.Take(100).ToListAsync();
+    }
+
+    private void SyncFormFields()
+    {
+        if (_contact is null)
+        {
+            return;
+        }
+
+        _formValue = _contact.Value;
+        _formCredentialId = _contact.CredentialId.ToString();
+        _formTypeId = _contact.TypeId?.ToString() ?? string.Empty;
+        _formGroupId = _contact.GroupId.ToString();
+    }
+
+    private void DiscardContactEdit() => SyncFormFields();
+
+    private async Task SaveContact()
+    {
+        if (_contact is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_formValue))
+        {
+            ToastService.Warning("Contact value is required.", "Missing value");
+            return;
+        }
+
+        if (!Guid.TryParse(_formCredentialId, out var credentialId))
+        {
+            ToastService.Warning("Select a credential.", "Missing credential");
+            return;
+        }
+
+        if (!Guid.TryParse(_formGroupId, out var groupId))
+        {
+            ToastService.Warning("Select a contact group.", "Missing contact group");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var fresh = await DataContext.Query<IdentityContact>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            if (fresh is null)
+            {
+                ToastService.Warning("Contact was not found.", "Contact unavailable");
+                return;
+            }
+
+            fresh.Value = _formValue;
+            fresh.CredentialId = credentialId;
+            fresh.TypeId = Guid.TryParse(_formTypeId, out var typeId) ? typeId : null;
+            fresh.GroupId = groupId;
+            fresh.ModifiedAt = DateTime.UtcNow;
+
+            DataContext.Update(fresh);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Contact updated.", "Saved");
+                _editableForm?.ExitEditMode();
+                await ReloadData();
+            }
+            else
+            {
+                ToastService.Error("Contact could not be updated.", "Save failed");
+            }
+        }
+        catch
+        {
+            ToastService.Error("Contact could not be updated.", "Save failed");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private void OpenDeleteDialog()
+    {
+        _deleteDialogOpen = true;
+    }
+
+    private async Task ConfirmDelete()
+    {
+        if (_contact is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _contact.IsDeleted = true;
+            _contact.IsEnabled = false;
+            DataContext.Update(_contact);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Contact deleted.", "Deleted");
+                BackToContacts();
+            }
+            else
+            {
+                ToastService.Error("Contact could not be deleted.", "Delete failed");
+            }
+        }
+        catch
+        {
+            ToastService.Error("Contact could not be deleted.", "Delete failed");
+        }
+        finally
+        {
+            _deleteDialogOpen = false;
+        }
+    }
+
+    private void BackToContacts() => Navigation.NavigateTo("/identity/contacts");
+
+    private static string GetCredentialPickerValue(IdentityCredential credential) => credential.Id.ToString();
+    private static string GetContactTypePickerValue(IdentityContactType contactType) => contactType.Id.ToString();
+    private static string GetContactGroupPickerValue(IdentityContactGroup contactGroup) => contactGroup.Id.ToString();
+
+    private static string GetCredentialLabel(IdentityCredential credential)
+    {
+        if (!string.IsNullOrWhiteSpace(credential.UserName))
+        {
+            return credential.UserName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(credential.UserAlias))
+        {
+            return credential.UserAlias;
+        }
+
+        return credential.Id.ToString()[..8];
+    }
+
+    private string GetCredentialLabelById(Guid credentialId) =>
+        _credentials.FirstOrDefault(x => x.Id == credentialId) is { } credential
+            ? GetCredentialLabel(credential)
+            : _contact?.Credential is { } loadedCredential
+                ? GetCredentialLabel(loadedCredential)
+                : "Unknown credential";
+
+    private static string GetContactTypeLabel(IdentityContactType contactType) =>
+        string.IsNullOrWhiteSpace(contactType.Name)
+            ? contactType.Id.ToString()[..8]
+            : contactType.Name;
+
+    private static string GetContactTypeLabel(IdentityContact contact) =>
+        string.IsNullOrWhiteSpace(contact.Type?.Name)
+            ? "No contact type"
+            : contact.Type.Name;
+
+    private static string GetContactGroupLabel(IdentityContactGroup contactGroup) =>
+        string.IsNullOrWhiteSpace(contactGroup.Name)
+            ? contactGroup.Id.ToString()[..8]
+            : contactGroup.Name;
+
+    private string GetContactGroupLabelById(Guid groupId) =>
+        _contactGroups.FirstOrDefault(x => x.Id == groupId) is { } group
+            ? GetContactGroupLabel(group)
+            : _contact?.Group is { } loadedGroup
+                ? GetContactGroupLabel(loadedGroup)
+                : "Unknown group";
+
+    private static string GetCredentialSearchText(IdentityCredential credential) =>
+        $"{credential.UserName} {credential.UserAlias} {credential.Device} {credential.Location} {credential.IdentityInfo?.FullName} {credential.IdentityInfo?.IdentityName}";
+
+    private static string GetContactTypeSearchText(IdentityContactType contactType) =>
+        $"{contactType.Name} {contactType.SystemReferenceId}";
+
+    private static string GetContactGroupSearchText(IdentityContactGroup contactGroup) =>
+        $"{contactGroup.Name} {contactGroup.SystemReferenceId}";
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityCredential>> CredentialAdvancedColumns =>
+    [
+        new("Username", x => x.UserName),
+        new("Alias", x => x.UserAlias),
+        new("Identity", x => x.IdentityInfo?.FullName ?? x.IdentityInfo?.IdentityName),
+        new("Online", x => FormatBoolean(x.IsOnline)),
+        new("Device", x => x.Device),
+        new("Location", x => x.Location),
+        new("Last Seen", x => FormatDateTime(x.LastSeen)),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityCredential>> CredentialAdvancedFilters =>
+    [
+        new("online", "Online", YesNoFilterOptions, x => x.IsOnline ? "true" : "false", "All credentials"),
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityContactType>> ContactTypeAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("System Ref", x => x.SystemReferenceId.ToString()[..8]),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityContactType>> ContactTypeAdvancedFilters =>
+    [
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityContactGroup>> ContactGroupAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("System Ref", x => x.SystemReferenceId.ToString()[..8]),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<IdentityContactGroup>> ContactGroupAdvancedFilters =>
+    [
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All statuses")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> YesNoFilterOptions =
+    [
+        new("true", "Yes"),
+        new("false", "No")
+    ];
+
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDateTime(DateTime value) => value == default ? "N/A" : value.ToString("g");
+    private static string FormatDateTime(DateTime? value) => value.HasValue ? FormatDateTime(value.Value) : "N/A";
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Contacts.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Contacts.razor
@@ -3,12 +3,17 @@
 <PageTitle>Contacts - Control Panel</PageTitle>
 
 <div class="space-y-4">
-    <div class="flex items-center justify-between">
-        <BbTypographyH3>Contacts</BbTypographyH3>
+    <div class="xf-page-header">
+        <div>
+            <BbTypographyH3>Contacts</BbTypographyH3>
+            <BbTypographyMuted>Scan contact records and open a detail page to edit relationships.</BbTypographyMuted>
+        </div>
+        <div class="xf-page-actions">
         <BbButton OnClick="@OpenAddDialog">
             <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
             Add Contact
         </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -17,23 +22,36 @@
     }
     else
     {
-    <BbDataGrid Items="@_contacts">
+    <BbDataGrid Items="@_contacts"
+                ShowPagination="true"
+                InitialPageSize="20"
+                ShowSearch="true"
+                SearchPlaceholder="Search contacts..."
+                OnRowClick="@((IdentityContact item) => OpenContactDetail(item))">
         <Columns>
-            <BbDataGridPropertyColumn Property="@(x => x.CredentialId)" Title="Credential ID" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.Value)" Title="Value" Sortable="true" />
-            <BbDataGridTemplateColumn Title="Type">
+            <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(item => GetCredentialLabelById(item.CredentialId))">
                 <ChildContent Context="item">
-                    @(item.Type?.Name ?? item.TypeId?.ToString() ?? "N/A")
+                    @GetCredentialLabelById(item.CredentialId)
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridPropertyColumn Property="@(x => x.GroupId)" Title="Group ID" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.Value)" Title="Value" Sortable="true" Filterable="true" />
+            <BbDataGridTemplateColumn Title="Type" Filterable="true" FilterBy="@(item => GetContactTypeLabel(item))">
+                <ChildContent Context="item">
+                    @GetContactTypeLabel(item)
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridTemplateColumn Title="Group" Filterable="true" FilterBy="@(item => GetContactGroupLabelById(item.GroupId))">
+                <ChildContent Context="item">
+                    @GetContactGroupLabelById(item.GroupId)
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
             <BbDataGridTemplateColumn Title="Actions">
                 <ChildContent Context="item">
                     <div class="flex items-center gap-2">
                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
-                                  OnClick="@(() => OpenEditDialog(item))">
-                            <LucideIcon Name="pencil" class="h-4 w-4" />
+                                  OnClick="@(() => OpenContactDetail(item))">
+                            <LucideIcon Name="eye" class="h-4 w-4" />
                         </BbButton>
                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
                                   OnClick="@(() => OpenDeleteDialog(item))">
@@ -43,6 +61,9 @@
                 </ChildContent>
             </BbDataGridTemplateColumn>
         </Columns>
+        <EmptyTemplate>
+            <BbEmpty Title="No contacts" Description="No contacts found for the selected tenant." />
+        </EmptyTemplate>
     </BbDataGrid>
     }
 </div>
@@ -50,10 +71,8 @@
 <BbDialog Open="@_dialogOpen" OpenChanged="@(v => _dialogOpen = v)">
     <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
-            <BbDialogTitle>@(_isEditing ? "Edit Contact" : "Add Contact")</BbDialogTitle>
-            <BbDialogDescription>
-                @(_isEditing ? "Update contact information." : "Create a new contact record.")
-            </BbDialogDescription>
+            <BbDialogTitle>Add Contact</BbDialogTitle>
+            <BbDialogDescription>Create a new contact record.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
             <BbFormFieldInput TValue="string"
@@ -117,7 +136,7 @@
         </div>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _dialogOpen = false)">Cancel</BbButton>
-            <BbButton OnClick="@SaveContact">@(_isEditing ? "Update" : "Create")</BbButton>
+            <BbButton OnClick="@SaveContact">Create</BbButton>
         </BbDialogFooter>
     </BbDialogContent>
 </BbDialog>
@@ -128,6 +147,7 @@
 
 @code {
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
 
@@ -138,8 +158,6 @@
     private bool _loading = true;
     private bool _dialogOpen;
     private bool _deleteDialogOpen;
-    private bool _isEditing;
-    private Guid _editingId;
     private IdentityContact? _deletingContact;
 
     private string _formValue = "";
@@ -200,12 +218,18 @@
             _contactTypes = await typeQuery.Take(100).ToListAsync();
             _contactGroups = await groupQuery.Take(100).ToListAsync();
         }
-        catch { /* query may fail */ }
+        catch
+        {
+            _contacts = [];
+            _credentials = [];
+            _contactTypes = [];
+            _contactGroups = [];
+            ToastService.Error("Contacts could not be loaded.", "Load failed");
+        }
     }
 
     private void OpenAddDialog()
     {
-        _isEditing = false;
         _formValue = "";
         _formCredentialId = "";
         _formTypeId = "";
@@ -217,16 +241,8 @@
         _dialogOpen = true;
     }
 
-    private void OpenEditDialog(IdentityContact contact)
-    {
-        _isEditing = true;
-        _editingId = contact.Id;
-        _formValue = contact.Value;
-        _formCredentialId = contact.CredentialId.ToString();
-        _formTypeId = contact.TypeId?.ToString() ?? "";
-        _formGroupId = contact.GroupId.ToString();
-        _dialogOpen = true;
-    }
+    private void OpenContactDetail(IdentityContact contact) =>
+        Navigation.NavigateTo($"/identity/contacts/{contact.Id}");
 
     private void OpenDeleteDialog(IdentityContact contact)
     {
@@ -238,62 +254,41 @@
     {
         if (string.IsNullOrWhiteSpace(_formValue))
         {
-            ToastService.Show("Value is required.");
+            ToastService.Warning("Value is required.", "Missing value");
             return;
         }
 
         if (!Guid.TryParse(_formCredentialId, out var credentialId))
         {
-            ToastService.Show("Invalid selected credential.");
+            ToastService.Warning("Select a credential.", "Missing credential");
             return;
         }
 
         if (!Guid.TryParse(_formGroupId, out var groupId))
         {
-            ToastService.Show("Invalid selected contact group.");
+            ToastService.Warning("Select a contact group.", "Missing contact group");
             return;
         }
 
         try
         {
-            if (_isEditing)
+            var contact = new IdentityContact
             {
-                var contact = await DataContext.Query<IdentityContact>()
-                    .Where(x => x.Id == _editingId)
-                    .FirstOrDefaultAsync();
-
-                if (contact is not null)
-                {
-                    contact.Value = _formValue;
-                    contact.CredentialId = credentialId;
-                    contact.TypeId = Guid.TryParse(_formTypeId, out var typeId) ? typeId : null;
-                    contact.GroupId = groupId;
-                    contact.ModifiedAt = DateTime.UtcNow;
-                    DataContext.Update(contact);
-                    var result = await DataContext.SaveChangesAsync();
-                    ToastService.Show(result.IsSuccess ? "Contact updated." : $"Error: {result.Message}");
-                }
-            }
-            else
-            {
-                var contact = new IdentityContact
-                {
-                    Id = Guid.NewGuid(),
-                    TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
-                    Value = _formValue,
-                    CredentialId = credentialId,
-                    TypeId = Guid.TryParse(_formTypeId, out var typeId) ? typeId : null,
-                    GroupId = groupId,
-                    CreatedAt = DateTime.UtcNow
-                };
-                DataContext.Add(contact);
-                var result = await DataContext.SaveChangesAsync();
-                ToastService.Show(result.IsSuccess ? "Contact created." : $"Error: {result.Message}");
-            }
+                Id = Guid.NewGuid(),
+                TenantId = TenantFilter.SelectedTenantId ?? Guid.Empty,
+                Value = _formValue,
+                CredentialId = credentialId,
+                TypeId = Guid.TryParse(_formTypeId, out var typeId) ? typeId : null,
+                GroupId = groupId,
+                CreatedAt = DateTime.UtcNow
+            };
+            DataContext.Add(contact);
+            var result = await DataContext.SaveChangesAsync();
+            ShowSaveResult(result.IsSuccess, "Contact created.", "Contact could not be created.");
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("Contact could not be saved.", "Save failed");
         }
 
         _dialogOpen = false;
@@ -310,11 +305,11 @@
                 _deletingContact.IsEnabled = false;
                 DataContext.Update(_deletingContact);
                 var result = await DataContext.SaveChangesAsync();
-                ToastService.Show(result.IsSuccess ? "Contact deleted." : $"Error: {result.Message}");
+                ShowSaveResult(result.IsSuccess, "Contact deleted.", "Contact could not be deleted.");
             }
-            catch (Exception ex)
+            catch
             {
-                ToastService.Show($"Error: {ex.Message}");
+                ToastService.Error("Contact could not be deleted.", "Delete failed");
             }
             finally
             {
@@ -349,6 +344,32 @@
         string.IsNullOrWhiteSpace(contactGroup.Name)
             ? contactGroup.Id.ToString()[..8]
             : contactGroup.Name;
+
+    private string GetCredentialLabelById(Guid credentialId) =>
+        _credentials.FirstOrDefault(x => x.Id == credentialId) is { } credential
+            ? GetCredentialLabel(credential)
+            : "Unknown credential";
+
+    private static string GetContactTypeLabel(IdentityContact contact) =>
+        string.IsNullOrWhiteSpace(contact.Type?.Name)
+            ? "Unknown contact type"
+            : contact.Type.Name;
+
+    private string GetContactGroupLabelById(Guid groupId) =>
+        _contactGroups.FirstOrDefault(x => x.Id == groupId) is { } group
+            ? GetContactGroupLabel(group)
+            : "Unknown group";
+
+    private void ShowSaveResult(bool isSuccess, string successMessage, string errorMessage)
+    {
+        if (isSuccess)
+        {
+            ToastService.Success(successMessage, "Saved");
+            return;
+        }
+
+        ToastService.Error(errorMessage, "Save failed");
+    }
 
     private static string GetCredentialSearchText(IdentityCredential credential) =>
         $"{credential.UserName} {credential.UserAlias} {credential.Device} {credential.Location} {credential.IdentityInfo?.FullName} {credential.IdentityInfo?.IdentityName}";

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Credentials.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Credentials.razor
@@ -13,20 +13,25 @@
     }
     else
     {
-    <BbDataGrid Items="@_credentials">
+    <BbDataGrid Items="@_credentials" ShowPagination="true" InitialPageSize="20" ShowSearch="true" SearchPlaceholder="Search credentials...">
         <Columns>
-            <BbDataGridPropertyColumn Property="@(x => x.UserName)" Title="Username" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.UserAlias)" Title="Alias" Sortable="true" />
-            <BbDataGridTemplateColumn Title="Online">
+            <BbDataGridPropertyColumn Property="@(x => x.UserName)" Title="Username" Sortable="true" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.UserAlias)" Title="Alias" Sortable="true" Filterable="true" />
+            <BbDataGridTemplateColumn Title="Identity" Filterable="true" FilterBy="@(item => GetIdentityLabel(item))">
+                <ChildContent Context="item">
+                    @GetIdentityLabel(item)
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridTemplateColumn Title="Online" Filterable="true" FilterBy="@(item => GetOnlineLabel(item))">
                 <ChildContent Context="item">
                     <StatusBadge Text="@(item.IsOnline ? "Online" : "Offline")"
                                  Status="@(item.IsOnline ? "online" : "inactive")" />
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridPropertyColumn Property="@(x => x.LastSeen)" Title="Last Seen" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.Device)" Title="Device" />
-            <BbDataGridPropertyColumn Property="@(x => x.Location)" Title="Location" />
-            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.LastSeen)" Title="Last Seen" Sortable="true" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.Device)" Title="Device" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.Location)" Title="Location" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
             <BbDataGridTemplateColumn Title="Actions">
                 <ChildContent Context="item">
                     <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
@@ -36,6 +41,9 @@
                 </ChildContent>
             </BbDataGridTemplateColumn>
         </Columns>
+        <EmptyTemplate>
+            <BbEmpty Title="No credentials" Description="No credentials found for the selected tenant." />
+        </EmptyTemplate>
     </BbDataGrid>
     }
 </div>
@@ -44,6 +52,7 @@
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
 
     private List<IdentityCredential> _credentials = [];
     private bool _loading = true;
@@ -58,7 +67,8 @@
         _loading = true;
         try
         {
-            var query = DataContext.Query<IdentityCredential>();
+            var query = DataContext.Query<IdentityCredential>()
+                .Include(x => x.IdentityInfo);
             if (TenantFilter.SelectedTenantId is { } tenantId)
             {
                 query = query.Where(x => x.TenantId == tenantId);
@@ -68,10 +78,29 @@
                 .OrderByDescending(x => x.CreatedAt)
                 .ToList();
         }
-        catch { /* query may fail */ }
+        catch
+        {
+            _credentials = [];
+            ToastService.Error("Credentials could not be loaded.", "Load failed");
+        }
         finally
         {
             _loading = false;
         }
     }
+
+    private static string GetIdentityLabel(IdentityCredential credential)
+    {
+        var identity = credential.IdentityInfo;
+        if (!string.IsNullOrWhiteSpace(identity?.FullName))
+            return identity.FullName;
+
+        if (!string.IsNullOrWhiteSpace(identity?.IdentityName))
+            return identity.IdentityName;
+
+        return "Unknown identity";
+    }
+
+    private static string GetOnlineLabel(IdentityCredential credential) =>
+        credential.IsOnline ? "Online" : "Offline";
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Sessions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Sessions.razor
@@ -16,23 +16,30 @@
     }
     else
     {
-    <BbDataGrid Items="@_sessions">
+    <BbDataGrid Items="@_sessions" ShowPagination="true" InitialPageSize="20" ShowSearch="true" SearchPlaceholder="Search sessions...">
         <Columns>
-            <BbDataGridPropertyColumn Property="@(x => x.CredentialId)" Title="Credential ID" Sortable="true" />
-            <BbDataGridTemplateColumn Title="Status">
+            <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(item => GetCredentialLabel(item.CredentialId))">
+                <ChildContent Context="item">
+                    @GetCredentialLabel(item.CredentialId)
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => GetStatusText(item.Status))">
                 <ChildContent Context="item">
                     <StatusBadge Text="@GetStatusText(item.Status)"
                                  Status="@GetStatusKey(item.Status)" />
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridTemplateColumn Title="Session Data">
+            <BbDataGridTemplateColumn Title="Session Type" Filterable="true" FilterBy="@(item => GetSessionTypeLabel(item))">
                 <ChildContent Context="item">
-                    @(Truncate(item.SessionData, 50))
+                    @GetSessionTypeLabel(item)
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires At" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires At" Sortable="true" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
         </Columns>
+        <EmptyTemplate>
+            <BbEmpty Title="No sessions" Description="No sessions found for the selected tenant." />
+        </EmptyTemplate>
     </BbDataGrid>
     }
 </div>
@@ -40,8 +47,10 @@
 @code {
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
 
     private List<Session> _sessions = [];
+    private List<IdentityCredential> _credentials = [];
     private bool _loading = true;
 
     protected override async Task OnInitializedAsync()
@@ -54,7 +63,8 @@
         _loading = true;
         try
         {
-            var query = DataContext.Query<Session>();
+            var query = DataContext.Query<Session>()
+                .Include(x => x.SessionType);
             if (TenantFilter.SelectedTenantId is { } tenantId)
             {
                 query = query.Where(x => x.TenantId == tenantId);
@@ -63,10 +73,23 @@
             _sessions = (await query.Take(100).ToListAsync())
                 .OrderByDescending(x => x.CreatedAt)
                 .ToList();
+
+            var credentialQuery = DataContext.Query<IdentityCredential>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .OrderBy(x => x.UserName);
+            if (TenantFilter.SelectedTenantId is { } credentialTenantId)
+            {
+                credentialQuery = credentialQuery.Where(x => x.TenantId == credentialTenantId);
+            }
+
+            _credentials = await credentialQuery.Take(500).ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            System.Diagnostics.Debug.WriteLine($"Sessions load error: {ex.Message}");
+            _sessions = [];
+            _credentials = [];
+            ToastService.Error("Sessions could not be loaded.", "Load failed");
         }
         finally
         {
@@ -92,9 +115,26 @@
         _ => "inactive"
     };
 
-    private static string Truncate(string? value, int maxLength)
+    private string GetCredentialLabel(Guid credentialId) =>
+        _credentials.FirstOrDefault(x => x.Id == credentialId) is { } credential
+            ? GetCredentialLabel(credential)
+            : "Unknown credential";
+
+    private static string GetCredentialLabel(IdentityCredential credential)
     {
-        if (string.IsNullOrEmpty(value)) return "N/A";
-        return value.Length <= maxLength ? value : value[..maxLength] + "...";
+        if (!string.IsNullOrWhiteSpace(credential.UserName))
+            return credential.UserName;
+
+        if (!string.IsNullOrWhiteSpace(credential.UserAlias))
+            return credential.UserAlias;
+
+        return "Unnamed credential";
     }
+
+    private static string GetSessionTypeLabel(Session session) =>
+        !string.IsNullOrWhiteSpace(session.SessionType?.Name)
+            ? session.SessionType.Name
+            : session.SessionTypeId.HasValue
+                ? "Unknown session type"
+                : "Default session";
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -83,9 +83,6 @@ else
                         <EditableField Label="Availability Date" @bind-Value="_editAvailability"
                                        DisplayValue="@(_tenant.AvailabilityDate?.ToString("yyyy-MM-dd") ?? "N/A")"
                                        Placeholder="YYYY-MM-DD" />
-                        <EditableField Label="Parent Tenant" @bind-Value="_editParentTenantId"
-                                       DisplayValue="@(_tenant.ParentTenantId?.ToString() ?? "None (root)")"
-                                       Placeholder="GUID or blank for root" />
                         <EditableField Label="Created" DisplayValue="@_tenant.CreatedAt.ToString("g")" ReadOnly="true" />
                         <EditableField Label="Last Modified" DisplayValue="@(_tenant.ModifiedAt?.ToString("g") ?? "Never")" ReadOnly="true" />
                         <EditableField Label="Enabled" ReadOnly="true">
@@ -98,6 +95,16 @@ else
                         <EditableField Label="Configurations" DisplayValue="@_detailConfigs.Count.ToString()" ReadOnly="true" />
                     </div>
                 </EditableForm>
+                <div class="mt-4 flex flex-col gap-3 rounded-md border bg-card p-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <div class="text-sm font-medium">Parent Tenant</div>
+                        <div class="mt-1 text-sm text-muted-foreground">@GetParentTenantDisplay()</div>
+                    </div>
+                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@OpenParentTenantDialog">
+                        <LucideIcon Name="network" class="mr-2 h-4 w-4" />
+                        Change Parent
+                    </BbButton>
+                </div>
             </BbTabsContent>
 
             <BbTabsContent Value="modules" Class="xf-fade-in">
@@ -223,17 +230,17 @@ else
                                         OnRowClick="@((IdentityInformation user) => OpenUserDetail(user))"
                                         Class="cursor-pointer">
                                 <Columns>
-                                    <BbDataGridPropertyColumn Property="@(x => x.FirstName)" Title="First Name" Sortable="true" />
-                                    <BbDataGridPropertyColumn Property="@(x => x.LastName)" Title="Last Name" Sortable="true" />
-                                    <BbDataGridPropertyColumn Property="@(x => x.IdentityName)" Title="Identity Name" Sortable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.FirstName)" Title="First Name" Sortable="true" Filterable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.LastName)" Title="Last Name" Sortable="true" Filterable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.IdentityName)" Title="Identity Name" Sortable="true" Filterable="true" />
                                     <BbDataGridTemplateColumn Title="Verified">
                                         <ChildContent Context="user">
                                             <StatusBadge Text="@(user.IsVerified ? "Verified" : "Unverified")"
                                                          Status="@(user.IsVerified ? "active" : "inactive")" />
                                         </ChildContent>
                                     </BbDataGridTemplateColumn>
-                                    <BbDataGridPropertyColumn Property="@(x => x.BirthDate)" Title="Birth Date" Sortable="true" />
-                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.BirthDate)" Title="Birth Date" Sortable="true" Filterable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 </Columns>
                             </BbDataGrid>
                         }
@@ -261,9 +268,9 @@ else
                         {
                             <BbDataGrid Items="@_detailConfigs" ShowPagination="true" InitialPageSize="10">
                                 <Columns>
-                                    <BbDataGridPropertyColumn Property="@(x => x.Key)" Title="Key" Sortable="true" />
-                                    <BbDataGridPropertyColumn Property="@(x => x.Value)" Title="Value" />
-                                    <BbDataGridPropertyColumn Property="@(x => x.Unit)" Title="Unit" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.Key)" Title="Key" Sortable="true" Filterable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.Value)" Title="Value" Filterable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.Unit)" Title="Unit" Filterable="true" />
                                     <BbDataGridTemplateColumn Title="Group">
                                         <ChildContent Context="cfg">
                                             @(cfg.Group?.Name ?? cfg.GroupId.ToString()[..8])
@@ -275,7 +282,7 @@ else
                                                          Status="@(cfg.IsEnabled ? "active" : "inactive")" />
                                         </ChildContent>
                                     </BbDataGridTemplateColumn>
-                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                     <BbDataGridTemplateColumn Title="Actions">
                                         <ChildContent Context="cfg">
                                             <div class="flex items-center gap-1">
@@ -308,7 +315,7 @@ else
                         {
                             <BbDataGrid Items="@_detailRoleTypes" ShowPagination="true" InitialPageSize="10">
                                 <Columns>
-                                    <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
                                     <BbDataGridTemplateColumn Title="Role Level">
                                         <ChildContent Context="rt">
                                             @(rt.RoleLevel?.ToString() ?? "N/A")
@@ -325,7 +332,7 @@ else
                                                          Status="@(rt.IsEnabled ? "active" : "inactive")" />
                                         </ChildContent>
                                     </BbDataGridTemplateColumn>
-                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 </Columns>
                             </BbDataGrid>
                         }
@@ -382,6 +389,41 @@ else
     </BbDialogContent>
 </BbDialog>
 
+@* -- Parent Tenant Dialog -- *@
+<BbDialog Open="@_parentTenantDialogOpen" OpenChanged="@(value => _parentTenantDialogOpen = value)">
+    <BbDialogContent TrapFocus="false">
+        <BbDialogHeader>
+            <BbDialogTitle>Change Parent Tenant</BbDialogTitle>
+            <BbDialogDescription>Select an existing tenant or clear the parent relationship.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <XfEntityPicker TItem="Tenant"
+                            Label="Parent Tenant"
+                            Value="@_parentTenantId"
+                            ValueChanged="@(value => _parentTenantId = value ?? "")"
+                            Items="@_tenantOptions"
+                            ValueSelector="@GetTenantPickerValue"
+                            TextSelector="@GetTenantLabel"
+                            SearchTextSelector="@GetTenantSearchText"
+                            AdvancedColumns="@TenantAdvancedColumns"
+                            AdvancedFilters="@TenantAdvancedFilters"
+                            AdvancedSearchScope="Searches tenant name, description, status, version, expiration, enabled state, and created date."
+                            Placeholder="No parent tenant"
+                            SearchPlaceholder="Search tenants..."
+                            EmptyMessage="No eligible parent tenants found."
+                            AllowClear="true"
+                            ClearText="No parent tenant"
+                            ShowCreate="false"
+                            AdvancedSearchTitle="Find Parent Tenant"
+                            AdvancedSearchDescription="Search tenant records before changing this parent relationship." />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _parentTenantDialogOpen = false)">Cancel</BbButton>
+            <BbButton OnClick="@SaveParentTenant" Disabled="@_saving">Save Parent</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
 <ConfirmDeleteDialog Open="@_deleteConfigDialogOpen"
                      OpenChanged="@(v => _deleteConfigDialogOpen = v)"
                      Message="@($"Delete configuration \"{_deletingConfig?.Key}\"? This cannot be undone.")"
@@ -411,7 +453,6 @@ else
     private string? _editVersion;
     private string? _editExpiration;
     private string? _editAvailability;
-    private string? _editParentTenantId;
 
     private static readonly List<SelectOption<string>> _statusOptions =
     [
@@ -426,6 +467,7 @@ else
     private List<RegistryConfiguration> _detailConfigs = [];
     private List<IdentityRoleType> _detailRoleTypes = [];
     private List<TenantModuleFeature> _detailModuleFeatures = [];
+    private List<Tenant> _tenantOptions = [];
     private List<ModuleFeatureRow> _moduleFeatureRows = [];
     private List<ModuleFeatureRow> _rootModuleFeatureRows = [];
     private List<ModuleFeatureRow> _inventarioSubFeatureRows = [];
@@ -441,6 +483,8 @@ else
     private List<RegistryConfigurationGroup> _configGroups = [];
     private bool _deleteConfigDialogOpen;
     private RegistryConfiguration? _deletingConfig;
+    private bool _parentTenantDialogOpen;
+    private string _parentTenantId = "";
 
     protected override void OnInitialized()
     {
@@ -501,7 +545,7 @@ else
                 ClearDetailData();
             }
         }
-        catch (Exception ex) { ToastService.Show($"Failed to load tenant: {ex.Message}"); }
+        catch { ToastService.Error("Tenant could not be loaded.", "Load failed"); }
         finally { _loading = false; }
     }
 
@@ -511,6 +555,7 @@ else
         _detailConfigs = [];
         _detailRoleTypes = [];
         _detailModuleFeatures = [];
+        _tenantOptions = [];
         _moduleFeatureRows = [];
         _rootModuleFeatureRows = [];
         _inventarioSubFeatureRows = [];
@@ -525,7 +570,6 @@ else
         _editVersion = _tenant.Version.ToString("F1");
         _editExpiration = _tenant.Expiration?.ToString("yyyy-MM-dd") ?? "";
         _editAvailability = _tenant.AvailabilityDate?.ToString("yyyy-MM-dd") ?? "";
-        _editParentTenantId = _tenant.ParentTenantId?.ToString() ?? "";
     }
 
     private async Task LoadDetailData()
@@ -570,8 +614,17 @@ else
                     .Take(100)
                     .ToListAsync())
                 .ToList();
+
+            _tenantOptions = (await DataContext.Query<Tenant>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(x => !x.IsDeleted && x.Id != Id)
+                    .OrderBy(x => x.Name)
+                    .Take(500)
+                    .ToListAsync())
+                .ToList();
         }
-        catch (Exception ex) { ToastService.Show($"Failed to load tenant details: {ex.Message}"); }
+        catch { ToastService.Error("Tenant details could not be loaded.", "Load failed"); }
     }
 
     private async Task LoadModuleFeatures()
@@ -615,7 +668,7 @@ else
                 var seedResult = await DataContext.SaveChangesAsync();
                 if (!seedResult.IsSuccess)
                 {
-                    ToastService.Show($"Failed to initialize module toggles: {seedResult.Message}");
+                    ToastService.Error("Module toggles could not be initialized.", "Initialization failed");
                 }
 
                 _detailModuleFeatures = (await DataContext.Query<TenantModuleFeature>()
@@ -653,9 +706,9 @@ else
                 .ToList();
             ApplyModuleFeatureGrouping();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load module toggles: {ex.Message}");
+            ToastService.Error("Module toggles could not be loaded.", "Load failed");
         }
         finally
         {
@@ -678,13 +731,13 @@ else
     {
         if (enabled && row.IsBlocked)
         {
-            ToastService.Show($"Cannot enable {row.DisplayName}: {row.DependencySummary}");
+            ToastService.Warning($"Cannot enable {row.DisplayName}: {row.DependencySummary}", "Missing dependency");
             return;
         }
 
         if (row.Id == Guid.Empty)
         {
-            ToastService.Show("Module toggle is still initializing. Refresh the page and try again.");
+            ToastService.Warning("Module toggle is still initializing. Refresh the page and try again.", "Toggle unavailable");
             return;
         }
 
@@ -699,7 +752,7 @@ else
 
             if (feature is null)
             {
-                ToastService.Show("Module toggle not found.");
+                ToastService.Warning("Module toggle was not found.", "Toggle unavailable");
                 await LoadModuleFeatures();
                 return;
             }
@@ -719,17 +772,17 @@ else
                     cachedFeature.ModifiedAt = feature.ModifiedAt;
                 }
 
-                ToastService.Show($"{row.DisplayName} {(enabled ? "enabled" : "disabled")}.");
+                ToastService.Success($"{row.DisplayName} {(enabled ? "enabled" : "disabled")}.", "Module updated");
             }
             else
             {
-                ToastService.Show($"Failed to update {row.DisplayName}: {result.Message}");
+                ToastService.Error($"{row.DisplayName} could not be updated.", "Save failed");
                 await LoadModuleFeatures();
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error($"{row.DisplayName} could not be updated.", "Save failed");
             await LoadModuleFeatures();
         }
         finally
@@ -740,7 +793,7 @@ else
 
     private async Task SaveTenant()
     {
-        if (string.IsNullOrWhiteSpace(_editName)) { ToastService.Show("Tenant name is required."); return; }
+        if (string.IsNullOrWhiteSpace(_editName)) { ToastService.Warning("Tenant name is required.", "Missing name"); return; }
         _saving = true;
         try
         {
@@ -749,7 +802,7 @@ else
                 .NoCache()
                 .Where(x => x.Id == Id)
                 .FirstOrDefaultAsync();
-            if (tenant is null) { ToastService.Show("Tenant not found."); return; }
+            if (tenant is null) { ToastService.Warning("Tenant was not found.", "Tenant unavailable"); return; }
 
             tenant.Name = _editName;
             tenant.Description = _editDescription;
@@ -757,19 +810,77 @@ else
             tenant.Status = short.TryParse(_editStatus, out var s) ? s : tenant.Status;
             tenant.Expiration = DateTime.TryParse(_editExpiration, out var exp) ? exp : null;
             tenant.AvailabilityDate = DateTime.TryParse(_editAvailability, out var avail) ? avail : null;
-            tenant.ParentTenantId = Guid.TryParse(_editParentTenantId, out var pid) ? pid : null;
             tenant.ModifiedAt = DateTime.UtcNow;
 
             DataContext.Update(tenant);
             var result = await DataContext.SaveChangesAsync();
-            if (result.IsSuccess) { ToastService.Show("Tenant updated."); _tenant = tenant; _editableForm?.ExitEditMode(); }
-            else { ToastService.Show($"Failed: {result.Message}"); }
+            if (result.IsSuccess) { ToastService.Success("Tenant updated.", "Tenant saved"); _tenant = tenant; _editableForm?.ExitEditMode(); }
+            else { ToastService.Error("Tenant could not be updated.", "Save failed"); }
         }
-        catch (Exception ex) { ToastService.Show($"Error: {ex.Message}"); }
+        catch { ToastService.Error("Tenant could not be updated.", "Save failed"); }
         finally { _saving = false; }
     }
 
     private void DiscardTenantEdit() => SyncEditFields();
+
+    private void OpenParentTenantDialog()
+    {
+        _parentTenantId = _tenant?.ParentTenantId?.ToString() ?? "";
+        _parentTenantDialogOpen = true;
+    }
+
+    private async Task SaveParentTenant()
+    {
+        if (!string.IsNullOrWhiteSpace(_parentTenantId)
+            && !Guid.TryParse(_parentTenantId, out _))
+        {
+            ToastService.Warning("Select a valid parent tenant.", "Invalid parent");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var tenant = await DataContext.Query<Tenant>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.Id == Id)
+                .FirstOrDefaultAsync();
+
+            if (tenant is null)
+            {
+                ToastService.Error("Tenant was not found.", "Save failed");
+                return;
+            }
+
+            tenant.ParentTenantId = Guid.TryParse(_parentTenantId, out var parentTenantId)
+                ? parentTenantId
+                : null;
+            tenant.ModifiedAt = DateTime.UtcNow;
+
+            DataContext.Update(tenant);
+            var result = await DataContext.SaveChangesAsync();
+            if (result.IsSuccess)
+            {
+                _tenant = tenant;
+                SyncEditFields();
+                _parentTenantDialogOpen = false;
+                ToastService.Success("Parent tenant updated.", "Tenant updated");
+            }
+            else
+            {
+                ToastService.Error("Parent tenant could not be updated.", "Save failed");
+            }
+        }
+        catch
+        {
+            ToastService.Error("Parent tenant could not be updated.", "Save failed");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
 
     private async Task ToggleEnabled()
     {
@@ -781,15 +892,15 @@ else
                 .NoCache()
                 .Where(x => x.Id == Id)
                 .FirstOrDefaultAsync();
-            if (fresh is null) { ToastService.Show("Tenant not found."); return; }
+            if (fresh is null) { ToastService.Warning("Tenant was not found.", "Tenant unavailable"); return; }
             fresh.IsEnabled = !fresh.IsEnabled;
             fresh.ModifiedAt = DateTime.UtcNow;
             DataContext.Update(fresh);
             var result = await DataContext.SaveChangesAsync();
-            if (result.IsSuccess) { ToastService.Show(fresh.IsEnabled ? "Tenant enabled." : "Tenant disabled."); _tenant = fresh; }
-            else { ToastService.Show($"Failed: {result.Message}"); }
+            if (result.IsSuccess) { ToastService.Success(fresh.IsEnabled ? "Tenant enabled." : "Tenant disabled.", "Tenant updated"); _tenant = fresh; }
+            else { ToastService.Error("Tenant status could not be updated.", "Save failed"); }
         }
-        catch (Exception ex) { ToastService.Show($"Error: {ex.Message}"); }
+        catch { ToastService.Error("Tenant status could not be updated.", "Save failed"); }
     }
 
     private static string GetStatusText(short? status) => status switch { 0 => "Pending", 1 => "Active", 2 => "Suspended", 3 => "Inactive", _ => "Unknown" };
@@ -888,7 +999,7 @@ else
 
     private async Task SaveConfig()
     {
-        if (string.IsNullOrWhiteSpace(_configForm.Key)) { ToastService.Show("Key is required."); return; }
+        if (string.IsNullOrWhiteSpace(_configForm.Key)) { ToastService.Warning("Key is required.", "Missing key"); return; }
         _saving = true;
         try
         {
@@ -899,25 +1010,25 @@ else
                     .NoCache()
                     .Where(x => x.Id == _editingConfigId)
                     .FirstOrDefaultAsync();
-                if (c is null) { ToastService.Show("Not found."); return; }
+                if (c is null) { ToastService.Warning("Configuration was not found.", "Configuration unavailable"); return; }
                 c.Key = _configForm.Key; c.Value = _configForm.Value; c.Unit = _configForm.Unit;
                 c.GroupId = Guid.TryParse(_configForm.GroupIdString, out var gid) ? gid : c.GroupId;
                 c.ModifiedAt = DateTime.UtcNow;
                 DataContext.Update(c);
                 var r = await DataContext.SaveChangesAsync();
-                ToastService.Show(r.IsSuccess ? "Updated." : $"Error: {r.Message}");
+                ShowConfigMutationResult(r.IsSuccess, "Configuration updated.", "Configuration could not be updated.");
             }
             else
             {
                 var config = new RegistryConfiguration { Id = Guid.NewGuid(), Key = _configForm.Key, Value = _configForm.Value, Unit = _configForm.Unit, GroupId = Guid.TryParse(_configForm.GroupIdString, out var gid) ? gid : Guid.Empty, TenantId = Id, CreatedAt = DateTime.UtcNow, IsEnabled = true };
                 DataContext.Add(config);
                 var r = await DataContext.SaveChangesAsync();
-                ToastService.Show(r.IsSuccess ? "Created." : $"Error: {r.Message}");
+                ShowConfigMutationResult(r.IsSuccess, "Configuration created.", "Configuration could not be created.");
             }
             _configDialogOpen = false;
             await LoadDetailData();
         }
-        catch (Exception ex) { ToastService.Show($"Error: {ex.Message}"); }
+        catch { ToastService.Error("Configuration could not be saved.", "Save failed"); }
         finally { _saving = false; }
     }
 
@@ -930,11 +1041,22 @@ else
             _deletingConfig.IsEnabled = false;
             DataContext.Update(_deletingConfig);
             var r = await DataContext.SaveChangesAsync();
-            ToastService.Show(r.IsSuccess ? "Deleted." : $"Error: {r.Message}");
+            ShowConfigMutationResult(r.IsSuccess, "Configuration deleted.", "Configuration could not be deleted.");
             _deleteConfigDialogOpen = false; _deletingConfig = null;
             await LoadDetailData();
         }
-        catch (Exception ex) { ToastService.Show($"Error: {ex.Message}"); }
+        catch { ToastService.Error("Configuration could not be deleted.", "Delete failed"); }
+    }
+
+    private void ShowConfigMutationResult(bool isSuccess, string successMessage, string errorMessage)
+    {
+        if (isSuccess)
+        {
+            ToastService.Success(successMessage, "Saved");
+            return;
+        }
+
+        ToastService.Error(errorMessage, "Save failed");
     }
 
     private class ConfigFormModel
@@ -953,6 +1075,48 @@ else
 
     private static string GetConfigurationGroupSearchText(RegistryConfigurationGroup group) =>
         $"{group.Name} {group.Description} {group.SystemReferenceId}";
+
+    private static string GetTenantPickerValue(Tenant tenant) => tenant.Id.ToString();
+
+    private static string GetTenantLabel(Tenant tenant) =>
+        string.IsNullOrWhiteSpace(tenant.Name)
+            ? "Unnamed tenant"
+            : tenant.Name;
+
+    private static string GetTenantSearchText(Tenant tenant) =>
+        $"{tenant.Name} {tenant.Description} {GetStatusText(tenant.Status)} {tenant.Version}";
+
+    private string GetParentTenantDisplay() =>
+        _tenant?.ParentTenantId is { } parentTenantId
+            ? _tenantOptions.FirstOrDefault(x => x.Id == parentTenantId) is { } parentTenant
+                ? GetTenantLabel(parentTenant)
+                : "Unknown parent tenant"
+            : "None (root tenant)";
+
+    private IReadOnlyList<XfEntityPickerColumn<Tenant>> TenantAdvancedColumns =>
+    [
+        new("Name", x => x.Name),
+        new("Description", x => x.Description),
+        new("Status", x => GetStatusText(x.Status)),
+        new("Version", x => x.Version.ToString("0.##")),
+        new("Expiration", x => x.Expiration?.ToString("yyyy-MM-dd")),
+        new("Enabled", x => FormatBoolean(x.IsEnabled)),
+        new("Created", x => FormatDateTime(x.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerFilter<Tenant>> TenantAdvancedFilters =>
+    [
+        new("status", "Status", TenantStatusFilterOptions, x => x.Status?.ToString(), "All statuses"),
+        new("enabled", "Enabled", YesNoFilterOptions, x => x.IsEnabled ? "true" : "false", "All tenants")
+    ];
+
+    private static readonly IReadOnlyList<XfEntityPickerFilterOption> TenantStatusFilterOptions =
+    [
+        new("0", "Pending"),
+        new("1", "Active"),
+        new("2", "Suspended"),
+        new("3", "Inactive")
+    ];
 
     private IReadOnlyList<XfEntityPickerColumn<RegistryConfigurationGroup>> ConfigurationGroupAdvancedColumns =>
     [

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
@@ -31,11 +31,12 @@
         </BbCardHeader>
         <BbCardContent>
             <BbDataGrid Items="@_tenants" ShowPagination="true" InitialPageSize="15"
+                        ShowSearch="true" SearchPlaceholder="Search tenants..."
                         OnRowClick="@((Tenant item) => Navigation.NavigateTo($"/identity/tenants/{item.Id}"))" Class="cursor-pointer">
                 <Columns>
-                    <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                    <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" />
-                    <BbDataGridTemplateColumn Title="Status">
+                    <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                    <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" Filterable="true" />
+                    <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => GetTenantStatusText(item.Status))">
                         <ChildContent Context="item">
                             @{
                                 var statusText = item.Status switch
@@ -58,8 +59,8 @@
                             <StatusBadge Text="@statusText" Status="@statusKey" />
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridPropertyColumn Property="@(x => x.Version)" Title="Version" Sortable="true" />
-                    <BbDataGridTemplateColumn Title="Expiration" Sortable="true">
+                    <BbDataGridPropertyColumn Property="@(x => x.Version)" Title="Version" Sortable="true" Filterable="true" />
+                    <BbDataGridTemplateColumn Title="Expiration" Sortable="true" Filterable="true" FilterBy="@(item => FormatDate(item.Expiration))">
                         <ChildContent Context="item">
                             @if (item.Expiration.HasValue)
                             {
@@ -74,8 +75,8 @@
                             }
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                    <BbDataGridTemplateColumn Title="Enabled">
+                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
+                    <BbDataGridTemplateColumn Title="Enabled" Filterable="true" FilterBy="@(item => FormatBoolean(item.IsEnabled))">
                         <ChildContent Context="item">
                             <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")"
                                          Status="@(item.IsEnabled ? "active" : "inactive")" />
@@ -96,6 +97,9 @@
                         </ChildContent>
                     </BbDataGridTemplateColumn>
                 </Columns>
+                <EmptyTemplate>
+                    <BbEmpty Title="No tenants" Description="No tenants found." />
+                </EmptyTemplate>
             </BbDataGrid>
         </BbCardContent>
     </BbCard>
@@ -222,9 +226,9 @@
                 .Take(100)
                 .ToListAsync();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Failed to load tenants: {ex.Message}");
+            ToastService.Error("Tenants could not be loaded.", "Load failed");
         }
         finally
         {
@@ -248,7 +252,7 @@
     {
         if (string.IsNullOrWhiteSpace(_tenantForm.Name))
         {
-            ToastService.Show("Tenant name is required.");
+            ToastService.Warning("Tenant name is required.", "Missing name");
             return;
         }
 
@@ -285,23 +289,23 @@
 
                 if (createdTenant is null || createdTenant.IsDeleted)
                 {
-                    ToastService.Show("Tenant save completed, but the tenant could not be reloaded.");
+                    ToastService.Warning("Tenant save completed, but the tenant could not be reloaded.", "Reload needed");
                     return;
                 }
 
-                ToastService.Show("Tenant created successfully.");
+                ToastService.Success("Tenant created successfully.", "Tenant saved");
                 _tenantDialogOpen = false;
                 await LoadTenants();
                 TenantFilter.NotifyTenantsChanged();
             }
             else
             {
-                ToastService.Show($"Failed to create tenant: {result.Message}");
+                ToastService.Error("Tenant could not be created.", "Save failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error creating tenant: {ex.Message}");
+            ToastService.Error("Tenant could not be created.", "Save failed");
         }
         finally
         {
@@ -330,7 +334,7 @@
 
             if (fresh is null)
             {
-                ToastService.Show("Tenant not found.");
+                ToastService.Warning("Tenant was not found.", "Tenant unavailable");
                 _deleteDialogOpen = false;
                 return;
             }
@@ -345,21 +349,21 @@
 
             if (result.IsSuccess)
             {
-                ToastService.Show("Tenant deleted.");
+                ToastService.Success("Tenant deleted.", "Tenant deleted");
                 TenantFilter.NotifyTenantsChanged();
             }
             else
             {
-                ToastService.Show($"Failed to delete tenant: {result.Message}");
+                ToastService.Error("Tenant could not be deleted.", "Delete failed");
             }
 
             _deleteDialogOpen = false;
             _deletingTenant = null;
             await LoadTenants();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error deleting tenant: {ex.Message}");
+            ToastService.Error("Tenant could not be deleted.", "Delete failed");
         }
     }
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/UserDetail.razor
@@ -1,4 +1,5 @@
 @page "/identity/users/{Id:guid}"
+@page "/identity/users/{Id:guid}/{Section}"
 @using global::Wallets.Domain.Shared.Enums
 @implements IDisposable
 
@@ -39,7 +40,7 @@ else
     <FadeInContent>
     <div class="space-y-6">
         <!-- Header -->
-        <div class="flex items-center justify-between">
+        <div class="xf-page-header">
             <div class="flex items-center gap-4">
                 <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
                           OnClick="@(() => Navigation.NavigateTo("/identity/users"))">
@@ -56,31 +57,22 @@ else
                     <BbTypographyMuted>@(_user.IdentityName ?? "No identity name") &mdash; ID: @_user.Id.ToString()[..8]...</BbTypographyMuted>
                 </div>
             </div>
-            <BbButton Variant="ButtonVariant.Outline" OnClick="@ReloadAllData">
-                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-                Refresh
-            </BbButton>
+            <div class="xf-page-actions">
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@ReloadAllData">
+                    <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    Refresh
+                </BbButton>
+            </div>
         </div>
 
-        <!-- Tabbed Detail Sections -->
-        <BbTabs DefaultValue="info">
-            <BbTabsList>
-                <BbTabsTrigger Value="info">User Info</BbTabsTrigger>
-                <BbTabsTrigger Value="credentials">Credentials (@_credentials.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="roles">Roles (@_roles.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="contacts">Contacts (@_contacts.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="addresses">Addresses (@_addresses.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="sessions">Sessions (@_sessions.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="auth-logs">Auth Logs (@_authLogs.Count)</BbTabsTrigger>
-                <BbTabsTrigger Value="wallets">Wallets (@_wallets.Count)</BbTabsTrigger>
-            </BbTabsList>
-
-            <!-- User Info Tab -->
-            <BbTabsContent Value="info" Class="xf-fade-in">
+        @switch (CurrentSection)
+        {
+            case "summary":
+                <div class="xf-fade-in">
                 <EditableForm @ref="_editableForm" TModel="IdentityInformation" Model="_user"
                               OnSave="SaveUserEdit" OnDiscard="DiscardUserEdit"
                               Saving="_saving" Title="User Information">
-                    <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
+                    <div class="xf-detail-field-grid">
                         <EditableField Label="First Name" @bind-Value="_editFirstName" />
                         <EditableField Label="Middle Name" @bind-Value="_editMiddleName" />
                         <EditableField Label="Last Name" @bind-Value="_editLastName" />
@@ -103,10 +95,11 @@ else
                         <EditableField Label="Created" DisplayValue="@_user.CreatedAt.ToString("g")" ReadOnly="true" />
                     </div>
                 </EditableForm>
-            </BbTabsContent>
+                </div>
+                break;
 
-            <!-- Credentials Tab -->
-            <BbTabsContent Value="credentials" Class="xf-fade-in">
+            case "credentials":
+                <div class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -118,11 +111,11 @@ else
                         </div>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_credentials">
+                        <BbDataGrid Items="@_credentials" ShowPagination="true" InitialPageSize="10" ShowSearch="true" SearchPlaceholder="Search credentials...">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.UserName)" Title="Username" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.UserAlias)" Title="Alias" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="Online">
+                                <BbDataGridPropertyColumn Property="@(x => x.UserName)" Title="Username" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.UserAlias)" Title="Alias" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Online" Filterable="true" FilterBy="@(cred => GetCredentialOnlineFilter(cred))">
                                     <ChildContent Context="cred">
                                         <StatusBadge Text="@(cred.IsOnline ? "Online" : "Offline")"
                                                      Status="@(cred.IsOnline ? "online" : "inactive")" />
@@ -133,23 +126,27 @@ else
                                         @(cred.LastSeen == default ? "Never" : cred.LastSeen.ToString("g"))
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.Device)" Title="Device" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Location)" Title="Location" />
-                                <BbDataGridTemplateColumn Title="Status">
+                                <BbDataGridPropertyColumn Property="@(x => x.Device)" Title="Device" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Location)" Title="Location" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(cred => GetEnabledFilter(cred.IsEnabled))">
                                     <ChildContent Context="cred">
                                         <StatusBadge Text="@(cred.IsEnabled ? "Enabled" : "Disabled")"
                                                      Status="@(cred.IsEnabled ? "active" : "inactive")" />
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No credentials" Description="No credentials are linked to this user." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
-            </BbTabsContent>
+                </div>
+                break;
 
-            <!-- Roles Tab -->
-            <BbTabsContent Value="roles" Class="xf-fade-in">
+            case "roles":
+                <div class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -161,19 +158,19 @@ else
                         </div>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_roles">
+                        <BbDataGrid Items="@_roles" ShowPagination="true" InitialPageSize="10" ShowSearch="true" SearchPlaceholder="Search roles...">
                             <Columns>
-                                <BbDataGridTemplateColumn Title="Role Type" Sortable="true">
+                                <BbDataGridTemplateColumn Title="Role Type" Sortable="true" Filterable="true" FilterBy="@(role => GetRoleTypeColumnFilter(role))">
                                     <ChildContent Context="role">
-                                        @(role.Type?.Name ?? role.TypeId?.ToString()?[..8] ?? "N/A")
+                                        @(role.Type?.Name ?? "Unknown role type")
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Credential">
+                                <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(role => GetCredentialLabelById(role.CredentialId))">
                                     <ChildContent Context="role">
                                         @{
                                             var roleCred = _credentials.FirstOrDefault(c => c.Id == role.CredentialId);
                                         }
-                                        <span class="text-sm">@(roleCred?.UserName ?? role.CredentialId.ToString()[..8] + "...")</span>
+                                        <span class="text-sm">@(roleCred is null ? "Unknown credential" : GetCredentialLabel(roleCred))</span>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                                 <BbDataGridTemplateColumn Title="Level">
@@ -196,7 +193,7 @@ else
                                         </span>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="role">
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
@@ -206,13 +203,17 @@ else
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No assigned roles" Description="No roles are assigned to this user's credentials." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
-            </BbTabsContent>
+                </div>
+                break;
 
-            <!-- Contacts Tab -->
-            <BbTabsContent Value="contacts" Class="xf-fade-in">
+            case "contacts":
+                <div class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -224,45 +225,44 @@ else
                         </div>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_contacts">
+                        <BbDataGrid Items="@_contacts" ShowPagination="true" InitialPageSize="10" ShowSearch="true" SearchPlaceholder="Search contacts...">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.Value)" Title="Value" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="Type">
+                                <BbDataGridPropertyColumn Property="@(x => x.Value)" Title="Value" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Type" Filterable="true" FilterBy="@(contact => GetContactTypeColumnFilter(contact))">
                                     <ChildContent Context="contact">
                                         @(contact.Type?.Name ?? "N/A")
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Credential">
+                                <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(contact => GetCredentialLabelById(contact.CredentialId))">
                                     <ChildContent Context="contact">
                                         @{
                                             var contactCred = _credentials.FirstOrDefault(c => c.Id == contact.CredentialId);
                                         }
-                                        <span class="text-sm">@(contactCred?.UserName ?? contact.CredentialId.ToString()[..8] + "...")</span>
+                                        <span class="text-sm">@(contactCred is null ? "Unknown credential" : GetCredentialLabel(contactCred))</span>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="contact">
-                                        <div class="flex items-center gap-1">
-                                            <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
-                                                      OnClick="@(() => OpenEditContactDialog(contact))">
-                                                <LucideIcon Name="pencil" class="h-4 w-4" />
-                                            </BbButton>
-                                            <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
-                                                      OnClick="@(() => DeleteContact(contact))">
-                                                <LucideIcon Name="trash-2" class="h-4 w-4 text-destructive" />
-                                            </BbButton>
-                                        </div>
+                                        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/identity/contacts/{contact.Id}"))">
+                                            <LucideIcon Name="external-link" class="mr-1 h-3 w-3" />
+                                            View
+                                        </BbButton>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No contacts" Description="No contact records are linked to this user." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
-            </BbTabsContent>
+                </div>
+                break;
 
-            <!-- Addresses Tab -->
-            <BbTabsContent Value="addresses" Class="xf-fade-in">
+            case "addresses":
+                <div class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
@@ -274,58 +274,57 @@ else
                         </div>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_addresses">
+                        <BbDataGrid Items="@_addresses" ShowPagination="true" InitialPageSize="10" ShowSearch="true" SearchPlaceholder="Search addresses...">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.UnitNumber)" Title="Unit" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Street)" Title="Street" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Building)" Title="Building" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Subdivision)" Title="Subdivision" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ConsolidatedName)" Title="Full Address" />
-                                <BbDataGridTemplateColumn Title="Default">
+                                <BbDataGridPropertyColumn Property="@(x => x.UnitNumber)" Title="Unit" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Street)" Title="Street" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Building)" Title="Building" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Subdivision)" Title="Subdivision" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ConsolidatedName)" Title="Full Address" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Default" Filterable="true" FilterBy="@(addr => GetDefaultAddressFilter(addr))">
                                     <ChildContent Context="addr">
                                         <StatusBadge Text="@(addr.DefaultAddress == true ? "Default" : "No")"
                                                      Status="@(addr.DefaultAddress == true ? "active" : "inactive")" />
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="addr">
-                                        <div class="flex items-center gap-1">
-                                            <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
-                                                      OnClick="@(() => OpenEditAddressDialog(addr))">
-                                                <LucideIcon Name="pencil" class="h-4 w-4" />
-                                            </BbButton>
-                                            <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
-                                                      OnClick="@(() => DeleteAddress(addr))">
-                                                <LucideIcon Name="trash-2" class="h-4 w-4 text-destructive" />
-                                            </BbButton>
-                                        </div>
+                                        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/identity/addresses/{addr.Id}"))">
+                                            <LucideIcon Name="external-link" class="mr-1 h-3 w-3" />
+                                            View
+                                        </BbButton>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No addresses" Description="No address records are linked to this user." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
-            </BbTabsContent>
+                </div>
+                break;
 
-            <!-- Sessions Tab -->
-            <BbTabsContent Value="sessions" Class="xf-fade-in">
+            case "sessions":
+                <div class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <BbCardTitle>Sessions</BbCardTitle>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_sessions">
+                        <BbDataGrid Items="@_sessions" ShowPagination="true" InitialPageSize="10" ShowSearch="true" SearchPlaceholder="Search sessions...">
                             <Columns>
-                                <BbDataGridTemplateColumn Title="Credential">
+                                <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(session => GetCredentialLabelById(session.CredentialId))">
                                     <ChildContent Context="session">
                                         @{
                                             var sessCred = _credentials.FirstOrDefault(c => c.Id == session.CredentialId);
                                         }
-                                        <span class="text-sm">@(sessCred?.UserName ?? session.CredentialId.ToString()[..8] + "...")</span>
+                                        <span class="text-sm">@(sessCred is null ? "Unknown credential" : GetCredentialLabel(sessCred))</span>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Status">
+                                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(session => session.Status.ToString())">
                                     <ChildContent Context="session">
                                         @{
                                             var sessStatusText = session.Status.ToString();
@@ -341,13 +340,9 @@ else
                                         <StatusBadge Text="@sessStatusText" Status="@sessStatusKey" />
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Session Data">
+                                <BbDataGridTemplateColumn Title="Session Type" Filterable="true" FilterBy="@(session => GetSessionTypeLabel(session))">
                                     <ChildContent Context="session">
-                                        <span class="text-xs font-mono">
-                                            @(session.SessionData is { Length: > 50 }
-                                                ? session.SessionData[..50] + "..."
-                                                : session.SessionData ?? "N/A")
-                                        </span>
+                                        @GetSessionTypeLabel(session)
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                                 <BbDataGridTemplateColumn Title="Expires At" Sortable="true">
@@ -355,7 +350,7 @@ else
                                         @(session.ExpiresAt?.ToString("g") ?? "N/A")
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="session">
                                         @if (session.Status == CurrentSessionState.Active)
@@ -368,61 +363,69 @@ else
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No sessions" Description="No sessions are linked to this user's credentials." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
-            </BbTabsContent>
+                </div>
+                break;
 
-            <!-- Auth Logs Tab -->
-            <BbTabsContent Value="auth-logs" Class="xf-fade-in">
+            case "auth-logs":
+                <div class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <BbCardTitle>Authorization Logs</BbCardTitle>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_authLogs" ShowPagination="true" InitialPageSize="20">
+                        <BbDataGrid Items="@_authLogs" ShowPagination="true" InitialPageSize="20" ShowSearch="true" SearchPlaceholder="Search authorization logs...">
                             <Columns>
-                                <BbDataGridTemplateColumn Title="Credential">
+                                <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(log => GetCredentialLabelById(log.CredentialId))">
                                     <ChildContent Context="log">
                                         @{
                                             var logCred = _credentials.FirstOrDefault(c => c.Id == log.CredentialId);
                                         }
-                                        <span class="text-sm">@(logCred?.UserName ?? log.CredentialId.ToString()[..8] + "...")</span>
+                                        <span class="text-sm">@(logCred is null ? "Unknown credential" : GetCredentialLabel(logCred))</span>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Result">
+                                <BbDataGridTemplateColumn Title="Result" Filterable="true" FilterBy="@(log => GetAuthorizationLogResultFilter(log))">
                                     <ChildContent Context="log">
                                         <StatusBadge Text="@(log.IsSuccess == true ? "Success" : log.IsSuccess == false ? "Failed" : "Unknown")"
                                                      Status="@(log.IsSuccess == true ? "success" : log.IsSuccess == false ? "failed" : "inactive")" />
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.Ipaddress)" Title="IP Address" />
-                                <BbDataGridPropertyColumn Property="@(x => x.LoginSource)" Title="Source" />
-                                <BbDataGridPropertyColumn Property="@(x => x.DeviceName)" Title="Device" />
-                                <BbDataGridPropertyColumn Property="@(x => x.DeviceAgent)" Title="Agent" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Time" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Ipaddress)" Title="IP Address" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.LoginSource)" Title="Source" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DeviceName)" Title="Device" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DeviceAgent)" Title="Agent" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Time" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No authorization logs" Description="No authorization logs are linked to this user's credentials." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
-            </BbTabsContent>
+                </div>
+                break;
 
-            <!-- Wallets Tab -->
-            <BbTabsContent Value="wallets" Class="xf-fade-in">
+            case "wallets":
+                <div class="xf-fade-in">
                 <BbCard>
                     <BbCardHeader>
                         <BbCardTitle>Wallets</BbCardTitle>
                     </BbCardHeader>
                     <BbCardContent>
-                        <BbDataGrid Items="@_wallets">
+                        <BbDataGrid Items="@_wallets" ShowPagination="true" InitialPageSize="10" ShowSearch="true" SearchPlaceholder="Search wallets...">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.AccountNumber)" Title="Account Number" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="Credential">
+                                <BbDataGridPropertyColumn Property="@(x => x.AccountNumber)" Title="Account Number" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(wallet => GetCredentialLabelById(wallet.CredentialId))">
                                     <ChildContent Context="wallet">
                                         @{
                                             var walCred = _credentials.FirstOrDefault(c => c.Id == wallet.CredentialId);
                                         }
-                                        <span class="text-sm">@(walCred?.UserName ?? wallet.CredentialId.ToString()[..8] + "...")</span>
+                                        <span class="text-sm">@(walCred is null ? "Unknown credential" : GetCredentialLabel(walCred))</span>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                                 <BbDataGridTemplateColumn Title="Balance" Sortable="true">
@@ -440,7 +443,7 @@ else
                                         <span class="font-mono text-muted-foreground">@wallet.DebitOnHoldBalance.ToString("N2")</span>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Status">
+                                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(wallet => wallet.Status.ToString())">
                                     <ChildContent Context="wallet">
                                         @{
                                             var walStatusText = wallet.Status.ToString();
@@ -466,11 +469,15 @@ else
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No wallets" Description="No wallets are linked to this user's credentials." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
-            </BbTabsContent>
-        </BbTabs>
+                </div>
+                break;
+        }
     </div>
     </FadeInContent>
 }
@@ -579,12 +586,12 @@ else
                      Message="@($"Remove the role \"{_removingRole?.Type?.Name ?? "this role"}\" from the credential? This action cannot be undone.")"
                      OnConfirm="@ConfirmRemoveRole" />
 
-<!-- Create/Edit Contact Dialog -->
+<!-- Create Contact Dialog -->
 <BbDialog Open="@_contactDialogOpen" OpenChanged="@(v => _contactDialogOpen = v)">
     <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
-            <BbDialogTitle>@(_editingContact is not null ? "Edit Contact" : "Add Contact")</BbDialogTitle>
-            <BbDialogDescription>@(_editingContact is not null ? "Update contact information." : "Add a new contact entry.")</BbDialogDescription>
+            <BbDialogTitle>Add Contact</BbDialogTitle>
+            <BbDialogDescription>Add a new contact entry.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
             <XfEntityPicker TItem="IdentityCredential"
@@ -649,18 +656,18 @@ else
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _contactDialogOpen = false)">Cancel</BbButton>
             <BbButton OnClick="@SaveContact" Disabled="@_saving">
-                @(_saving ? "Saving..." : (_editingContact is not null ? "Update" : "Create"))
+                @(_saving ? "Saving..." : "Create")
             </BbButton>
         </BbDialogFooter>
     </BbDialogContent>
 </BbDialog>
 
-<!-- Create/Edit Address Dialog -->
+<!-- Create Address Dialog -->
 <BbDialog Open="@_addressDialogOpen" OpenChanged="@(v => _addressDialogOpen = v)">
     <BbDialogContent>
         <BbDialogHeader>
-            <BbDialogTitle>@(_editingAddress is not null ? "Edit Address" : "Add Address")</BbDialogTitle>
-            <BbDialogDescription>@(_editingAddress is not null ? "Update address information." : "Add a new address.")</BbDialogDescription>
+            <BbDialogTitle>Add Address</BbDialogTitle>
+            <BbDialogDescription>Add a new address.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
             <div class="grid grid-cols-2 gap-4">
@@ -692,7 +699,7 @@ else
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _addressDialogOpen = false)">Cancel</BbButton>
             <BbButton OnClick="@SaveAddress" Disabled="@_saving">
-                @(_saving ? "Saving..." : (_editingAddress is not null ? "Update" : "Create"))
+                @(_saving ? "Saving..." : "Create")
             </BbButton>
         </BbDialogFooter>
     </BbDialogContent>
@@ -700,11 +707,13 @@ else
 
 @code {
     [Parameter] public Guid Id { get; set; }
+    [Parameter] public string? Section { get; set; }
 
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private IIdentityServerServiceWrapper IdentityServer { get; set; } = default!;
 
     // Main data
     private IdentityInformation? _user;
@@ -726,6 +735,7 @@ else
     private bool _saving;
     private bool _outsideTenantContext;
     private Guid? _loadedId;
+    private string CurrentSection => NormalizeSection(Section);
 
     // Editable form
     private EditableForm<IdentityInformation>? _editableForm;
@@ -764,12 +774,10 @@ else
 
     // Contact dialog
     private bool _contactDialogOpen;
-    private IdentityContact? _editingContact;
     private ContactForm _contactForm = new();
 
     // Address dialog
     private bool _addressDialogOpen;
-    private IdentityAddress? _editingAddress;
     private AddressForm _addressForm = new();
 
     protected override void OnInitialized()
@@ -779,6 +787,12 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        var normalizedSection = NormalizeSection(Section);
+        if (ShouldCanonicalizeSection(normalizedSection))
+        {
+            Navigation.NavigateTo(GetSectionHref(normalizedSection), replace: true);
+        }
+
         if (_loadedId == Id)
         {
             return;
@@ -786,6 +800,34 @@ else
 
         _loadedId = Id;
         await ReloadAllData();
+    }
+
+    private bool ShouldCanonicalizeSection(string normalizedSection) =>
+        Section is not null
+        && (!string.Equals(Section, normalizedSection, StringComparison.OrdinalIgnoreCase)
+            || normalizedSection == "summary");
+
+    private string GetSectionHref(string section) =>
+        section == "summary" ? $"/identity/users/{Id}" : $"/identity/users/{Id}/{section}";
+
+    private static string NormalizeSection(string? section)
+    {
+        if (string.IsNullOrWhiteSpace(section) || section.Equals("info", StringComparison.OrdinalIgnoreCase))
+        {
+            return "summary";
+        }
+
+        var normalized = section.ToLowerInvariant();
+        return normalized is "summary"
+            or "credentials"
+            or "roles"
+            or "contacts"
+            or "addresses"
+            or "sessions"
+            or "auth-logs"
+            or "wallets"
+            ? normalized
+            : "summary";
     }
 
     private void OnTenantFilterChanged()
@@ -831,9 +873,9 @@ else
             await LoadWallets();
             await LoadLookups();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error loading user data: {ex.Message}");
+            ToastService.Error("The user data could not be loaded.", "Load failed");
         }
         finally
         {
@@ -942,6 +984,7 @@ else
                     .IgnoreQueryFilters()
                     .NoCache()
                     .Where(x => x.CredentialId == credId)
+                    .Include(x => x.SessionType)
                     .OrderByDescending(x => x.CreatedAt)
                     .Take(100)
                     .ToListAsync();
@@ -1058,7 +1101,7 @@ else
 
             if (fresh is null)
             {
-                ToastService.Show("User not found.");
+                ToastService.Warning("User was not found.", "User unavailable");
                 return;
             }
 
@@ -1078,19 +1121,19 @@ else
 
             if (result.IsSuccess)
             {
-                ToastService.Show("User updated successfully.");
+                ToastService.Success("User updated successfully.", "User saved");
                 _user = fresh;
                 SyncEditFields();
                 _editableForm?.ExitEditMode();
             }
             else
             {
-                ToastService.Show($"Error: {result.Message}");
+                ToastService.Error("User could not be updated.", "Save failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("User could not be updated.", "Save failed");
         }
         finally
         {
@@ -1110,52 +1153,46 @@ else
     {
         if (string.IsNullOrWhiteSpace(_credForm.UserName))
         {
-            ToastService.Show("Username is required.");
+            ToastService.Warning("Username is required.", "Missing username");
             return;
         }
         if (string.IsNullOrWhiteSpace(_credForm.Password))
         {
-            ToastService.Show("Password is required.");
+            ToastService.Warning("Password is required.", "Missing password");
             return;
         }
         if (_credForm.Password != _credForm.ConfirmPassword)
         {
-            ToastService.Show("Passwords do not match.");
+            ToastService.Warning("Passwords do not match.", "Password mismatch");
             return;
         }
 
         _saving = true;
         try
         {
-            var credential = new IdentityCredential
+            var result = await IdentityServer.CreateCredential(new CreateCredentialRequest
             {
-                Id = Guid.NewGuid(),
-                TenantId = _user!.TenantId,
                 IdentityInfoId = Id,
                 UserName = _credForm.UserName,
                 UserAlias = _credForm.UserAlias,
-                PasswordByte = System.Text.Encoding.ASCII.GetBytes(BCrypt.Net.BCrypt.HashPassword(inputKey: _credForm.Password, workFactor: 11)),
-                IsEnabled = true,
-                CreatedAt = DateTime.UtcNow
-            };
-
-            DataContext.Add(credential);
-            var result = await DataContext.SaveChangesAsync();
+                Password = _credForm.Password,
+                Metadata = CreateMetadata(_user!.TenantId)
+            });
 
             if (result.IsSuccess)
             {
-                ToastService.Show("Credential created.");
+                ToastService.Success("Credential created.", "Credential saved");
                 _createCredDialogOpen = false;
                 await LoadCredentials();
             }
             else
             {
-                ToastService.Show($"Error: {result.Message}");
+                ToastService.Error("Credential creation failed.", "Credential failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("Credential creation failed.", "Credential failed");
         }
         finally
         {
@@ -1175,12 +1212,12 @@ else
     {
         if (!Guid.TryParse(_roleForm.CredentialId, out var credId))
         {
-            ToastService.Show("Please select a credential.");
+            ToastService.Warning("Please select a credential.", "Missing credential");
             return;
         }
         if (!Guid.TryParse(_roleForm.RoleTypeId, out var typeId))
         {
-            ToastService.Show("Please select a role type.");
+            ToastService.Warning("Please select a role type.", "Missing role type");
             return;
         }
 
@@ -1189,7 +1226,7 @@ else
         {
             if (!TryResolveRoleExpiration(_roleForm.ExpirationString, out var expiration))
             {
-                ToastService.Show("Choose a valid expiration date and time.");
+                ToastService.Warning("Choose a valid expiration date and time.", "Invalid expiration");
                 return;
             }
 
@@ -1209,18 +1246,18 @@ else
 
             if (result.IsSuccess)
             {
-                ToastService.Show("Role assigned.");
+                ToastService.Success("Role assigned.", "Role saved");
                 _assignRoleDialogOpen = false;
                 await LoadRoles();
             }
             else
             {
-                ToastService.Show($"Error: {result.Message}");
+                ToastService.Error("Role could not be assigned.", "Save failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("Role could not be assigned.", "Save failed");
         }
         finally
         {
@@ -1247,16 +1284,16 @@ else
 
             if (result.IsSuccess)
             {
-                ToastService.Show("Role removed.");
+                ToastService.Success("Role removed.", "Role removed");
             }
             else
             {
-                ToastService.Show($"Error: {result.Message}");
+                ToastService.Error("Role could not be removed.", "Delete failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("Role could not be removed.", "Delete failed");
         }
         finally
         {
@@ -1270,7 +1307,6 @@ else
 
     private void OpenCreateContactDialog()
     {
-        _editingContact = null;
         _contactForm = new ContactForm();
         if (_credentials.Count == 1)
         {
@@ -1283,86 +1319,49 @@ else
         _contactDialogOpen = true;
     }
 
-    private void OpenEditContactDialog(IdentityContact contact)
-    {
-        _editingContact = contact;
-        _contactForm = new ContactForm
-        {
-            CredentialId = contact.CredentialId.ToString(),
-            TypeId = contact.TypeId?.ToString() ?? "",
-            GroupId = contact.GroupId.ToString(),
-            Value = contact.Value
-        };
-        _contactDialogOpen = true;
-    }
-
     private async Task SaveContact()
     {
         if (string.IsNullOrWhiteSpace(_contactForm.Value))
         {
-            ToastService.Show("Contact value is required.");
+            ToastService.Warning("Contact value is required.", "Missing value");
             return;
         }
         if (!Guid.TryParse(_contactForm.CredentialId, out var credId))
         {
-            ToastService.Show("Please select a credential.");
+            ToastService.Warning("Please select a credential.", "Missing credential");
             return;
         }
         if (!Guid.TryParse(_contactForm.GroupId, out var groupId))
         {
-            ToastService.Show("Please select a contact group.");
+            ToastService.Warning("Please select a contact group.", "Missing contact group");
             return;
         }
 
         _saving = true;
         try
         {
-            if (_editingContact is not null)
+            var contact = new IdentityContact
             {
-                var fresh = await DataContext.Query<IdentityContact>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.Id == _editingContact.Id)
-                    .FirstOrDefaultAsync();
+                Id = Guid.NewGuid(),
+                TenantId = _user!.TenantId,
+                CredentialId = credId,
+                TypeId = Guid.TryParse(_contactForm.TypeId, out var tid) ? tid : null,
+                GroupId = groupId,
+                Value = _contactForm.Value,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow
+            };
 
-                if (fresh is not null)
-                {
-                    fresh.Value = _contactForm.Value;
-                    fresh.CredentialId = credId;
-                    fresh.TypeId = Guid.TryParse(_contactForm.TypeId, out var tid) ? tid : null;
-                    fresh.GroupId = groupId;
-                    fresh.ModifiedAt = DateTime.UtcNow;
-
-                    DataContext.Update(fresh);
-                    var result = await DataContext.SaveChangesAsync();
-                    ToastService.Show(result.IsSuccess ? "Contact updated." : $"Error: {result.Message}");
-                }
-            }
-            else
-            {
-                var contact = new IdentityContact
-                {
-                    Id = Guid.NewGuid(),
-                    TenantId = _user!.TenantId,
-                    CredentialId = credId,
-                    TypeId = Guid.TryParse(_contactForm.TypeId, out var tid) ? tid : null,
-                    GroupId = groupId,
-                    Value = _contactForm.Value,
-                    IsEnabled = true,
-                    CreatedAt = DateTime.UtcNow
-                };
-
-                DataContext.Add(contact);
-                var result = await DataContext.SaveChangesAsync();
-                ToastService.Show(result.IsSuccess ? "Contact created." : $"Error: {result.Message}");
-            }
+            DataContext.Add(contact);
+            var result = await DataContext.SaveChangesAsync();
+            ShowMutationResult(result.IsSuccess, "Contact created.", "Contact could not be created.");
 
             _contactDialogOpen = false;
             await LoadContacts();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("Contact could not be saved.", "Save failed");
         }
         finally
         {
@@ -1370,44 +1369,11 @@ else
         }
     }
 
-    private async Task DeleteContact(IdentityContact contact)
-    {
-        try
-        {
-            contact.IsDeleted = true;
-            contact.IsEnabled = false;
-            DataContext.Update(contact);
-            var result = await DataContext.SaveChangesAsync();
-            ToastService.Show(result.IsSuccess ? "Contact deleted." : $"Error: {result.Message}");
-            await LoadContacts();
-        }
-        catch (Exception ex)
-        {
-            ToastService.Show($"Error: {ex.Message}");
-        }
-    }
-
     // ─── Addresses ────────────────────────────────────────────────────
 
     private void OpenCreateAddressDialog()
     {
-        _editingAddress = null;
         _addressForm = new AddressForm();
-        _addressDialogOpen = true;
-    }
-
-    private void OpenEditAddressDialog(IdentityAddress address)
-    {
-        _editingAddress = address;
-        _addressForm = new AddressForm
-        {
-            UnitNumber = address.UnitNumber,
-            Street = address.Street,
-            Building = address.Building,
-            Subdivision = address.Subdivision,
-            ConsolidatedName = address.ConsolidatedName,
-            IsDefault = address.DefaultAddress == true
-        };
         _addressDialogOpen = true;
     }
 
@@ -1416,78 +1382,35 @@ else
         _saving = true;
         try
         {
-            if (_editingAddress is not null)
+            var address = new IdentityAddress
             {
-                var fresh = await DataContext.Query<IdentityAddress>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.Id == _editingAddress.Id)
-                    .FirstOrDefaultAsync();
+                Id = Guid.NewGuid(),
+                TenantId = _user!.TenantId,
+                IdentityInfoId = Id,
+                UnitNumber = _addressForm.UnitNumber,
+                Street = _addressForm.Street,
+                Building = _addressForm.Building,
+                Subdivision = _addressForm.Subdivision,
+                ConsolidatedName = _addressForm.ConsolidatedName,
+                DefaultAddress = _addressForm.IsDefault,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow
+            };
 
-                if (fresh is not null)
-                {
-                    fresh.UnitNumber = _addressForm.UnitNumber;
-                    fresh.Street = _addressForm.Street;
-                    fresh.Building = _addressForm.Building;
-                    fresh.Subdivision = _addressForm.Subdivision;
-                    fresh.ConsolidatedName = _addressForm.ConsolidatedName;
-                    fresh.DefaultAddress = _addressForm.IsDefault;
-                    fresh.ModifiedAt = DateTime.UtcNow;
-
-                    DataContext.Update(fresh);
-                    var result = await DataContext.SaveChangesAsync();
-                    ToastService.Show(result.IsSuccess ? "Address updated." : $"Error: {result.Message}");
-                }
-            }
-            else
-            {
-                var address = new IdentityAddress
-                {
-                    Id = Guid.NewGuid(),
-                    TenantId = _user!.TenantId,
-                    IdentityInfoId = Id,
-                    UnitNumber = _addressForm.UnitNumber,
-                    Street = _addressForm.Street,
-                    Building = _addressForm.Building,
-                    Subdivision = _addressForm.Subdivision,
-                    ConsolidatedName = _addressForm.ConsolidatedName,
-                    DefaultAddress = _addressForm.IsDefault,
-                    IsEnabled = true,
-                    CreatedAt = DateTime.UtcNow
-                };
-
-                DataContext.Add(address);
-                var result = await DataContext.SaveChangesAsync();
-                ToastService.Show(result.IsSuccess ? "Address created." : $"Error: {result.Message}");
-            }
+            DataContext.Add(address);
+            var result = await DataContext.SaveChangesAsync();
+            ShowMutationResult(result.IsSuccess, "Address created.", "Address could not be created.");
 
             _addressDialogOpen = false;
             await LoadAddresses();
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("Address could not be saved.", "Save failed");
         }
         finally
         {
             _saving = false;
-        }
-    }
-
-    private async Task DeleteAddress(IdentityAddress address)
-    {
-        try
-        {
-            address.IsDeleted = true;
-            address.IsEnabled = false;
-            DataContext.Update(address);
-            var result = await DataContext.SaveChangesAsync();
-            ToastService.Show(result.IsSuccess ? "Address deleted." : $"Error: {result.Message}");
-            await LoadAddresses();
-        }
-        catch (Exception ex)
-        {
-            ToastService.Show($"Error: {ex.Message}");
         }
     }
 
@@ -1497,37 +1420,26 @@ else
     {
         try
         {
-            var fresh = await DataContext.Query<Session>()
-                .IgnoreQueryFilters()
-                .NoCache()
-                .Where(x => x.Id == session.Id)
-                .FirstOrDefaultAsync();
-
-            if (fresh is null)
+            var result = await IdentityServer.Logout(new LogoutRequest
             {
-                ToastService.Show("Session not found.");
-                return;
-            }
-
-            fresh.Status = CurrentSessionState.Inactive;
-            fresh.ModifiedAt = DateTime.UtcNow;
-
-            DataContext.Update(fresh);
-            var result = await DataContext.SaveChangesAsync();
+                SessionId = session.Id,
+                CredentialId = session.CredentialId,
+                Metadata = CreateMetadata(session.TenantId)
+            });
 
             if (result.IsSuccess)
             {
-                ToastService.Show("Session terminated.");
+                ToastService.Success("Session terminated.", "Session updated");
                 await LoadSessions();
             }
             else
             {
-                ToastService.Show($"Error: {result.Message}");
+                ToastService.Error("Session termination failed.", "Session failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("Session termination failed.", "Session failed");
         }
     }
 
@@ -1547,6 +1459,61 @@ else
 
         return credential.Id.ToString()[..8];
     }
+
+    private string GetCredentialLabelById(Guid credentialId) =>
+        _credentials.FirstOrDefault(c => c.Id == credentialId) is { } credential
+            ? GetCredentialLabel(credential)
+            : "Unknown credential";
+
+    private static string GetSessionTypeLabel(Session session) =>
+        !string.IsNullOrWhiteSpace(session.SessionType?.Name)
+            ? session.SessionType.Name
+            : session.SessionTypeId.HasValue
+                ? "Unknown session type"
+                : "Default session";
+
+    private void ShowMutationResult(bool isSuccess, string successMessage, string errorMessage)
+    {
+        if (isSuccess)
+        {
+            ToastService.Success(successMessage, "Saved");
+            return;
+        }
+
+        ToastService.Error(errorMessage, "Save failed");
+    }
+
+    private static string GetRoleTypeColumnFilter(IdentityRole role) =>
+        role.Type?.Name ?? string.Empty;
+
+    private static string GetContactTypeColumnFilter(IdentityContact contact) =>
+        contact.Type?.Name ?? string.Empty;
+
+    private static string GetCredentialOnlineFilter(IdentityCredential credential) =>
+        credential.IsOnline ? "Online" : "Offline";
+
+    private static string GetEnabledFilter(bool isEnabled) =>
+        isEnabled ? "Enabled" : "Disabled";
+
+    private static string GetDefaultAddressFilter(IdentityAddress address) =>
+        address.DefaultAddress == true ? "Default" : "No";
+
+    private static string GetAuthorizationLogResultFilter(AuthorizationLog log) =>
+        log.IsSuccess == true
+            ? "Success"
+            : log.IsSuccess == false
+                ? "Failed"
+                : "Unknown";
+
+    private static RequestMetadata CreateMetadata(Guid? tenantId) => new()
+    {
+        TenantId = tenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "ControlPanel",
+        DeviceName = "ControlPanel",
+        DeviceAgent = "ControlPanel",
+        IpAddress = "ControlPanel"
+    };
 
     private static string GetRoleTypeLabel(IdentityRoleType roleType)
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Users.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Users.razor
@@ -33,9 +33,10 @@
             </BbCardHeader>
             <BbCardContent>
                 <BbDataGrid Items="@_users" ShowPagination="true" InitialPageSize="20"
+                            ShowSearch="true" SearchPlaceholder="Search users..."
                             OnRowClick="@((IdentityInformation item) => Navigation.NavigateTo($"/identity/users/{item.Id}"))" Class="cursor-pointer">
                     <Columns>
-                        <BbDataGridTemplateColumn Title="Full Name" Sortable="true">
+                        <BbDataGridTemplateColumn Title="Full Name" Sortable="true" Filterable="true" FilterBy="@(item => GetUserSearchLabel(item))">
                             <ChildContent Context="item">
                                 <div class="flex items-center gap-2">
                                     <div>
@@ -45,7 +46,7 @@
                                 </div>
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Username">
+                        <BbDataGridTemplateColumn Title="Username" Filterable="true" FilterBy="@(item => GetPrimaryUsername(item.Id) ?? string.Empty)">
                             <ChildContent Context="item">
                                 @{
                                     var username = GetPrimaryUsername(item.Id);
@@ -53,19 +54,19 @@
                                 <span class="text-sm">@(username ?? "No credential")</span>
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Verified">
+                        <BbDataGridTemplateColumn Title="Verified" Filterable="true" FilterBy="@(item => GetVerifiedLabel(item))">
                             <ChildContent Context="item">
                                 <StatusBadge Text="@(item.IsVerified ? "Verified" : "Unverified")"
                                              Status="@(item.IsVerified ? "active" : "inactive")" />
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Gender">
+                        <BbDataGridTemplateColumn Title="Gender" Filterable="true" FilterBy="@(item => GetGenderLabel(item))">
                             <ChildContent Context="item">
                                 @(item.Gender?.ToString() ?? "N/A")
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                        <BbDataGridTemplateColumn Title="Status">
+                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
+                        <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => GetEnabledLabel(item))">
                             <ChildContent Context="item">
                                 <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")"
                                              Status="@(item.IsEnabled ? "active" : "inactive")" />
@@ -97,6 +98,9 @@
                             </ChildContent>
                         </BbDataGridTemplateColumn>
                     </Columns>
+                    <EmptyTemplate>
+                        <BbEmpty Title="No users" Description="No users found for the selected tenant." />
+                    </EmptyTemplate>
                 </BbDataGrid>
             </BbCardContent>
         </BbCard>
@@ -106,7 +110,7 @@
 
 <!-- Create User Dialog -->
 <BbDialog Open="@_createDialogOpen" OpenChanged="@(v => _createDialogOpen = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
             <BbDialogTitle>Create User</BbDialogTitle>
             <BbDialogDescription>Create a new identity information record.</BbDialogDescription>
@@ -240,9 +244,9 @@
                 _credentialUsernames[user.Id] = cred?.UserName;
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error loading users: {ex.Message}");
+            ToastService.Error("Users could not be loaded.", "Load failed");
         }
         finally
         {
@@ -254,6 +258,18 @@
     {
         return _credentialUsernames.TryGetValue(userId, out var username) ? username : null;
     }
+
+    private static string GetUserSearchLabel(IdentityInformation user) =>
+        $"{user.FullName} {user.IdentityName}";
+
+    private static string GetVerifiedLabel(IdentityInformation user) =>
+        user.IsVerified ? "Verified" : "Unverified";
+
+    private static string GetEnabledLabel(IdentityInformation user) =>
+        user.IsEnabled ? "Enabled" : "Disabled";
+
+    private static string GetGenderLabel(IdentityInformation user) =>
+        user.Gender?.ToString() ?? string.Empty;
 
     private void NavigateToDetail(Guid id)
     {
@@ -286,9 +302,10 @@
             var tenant = await tenantQuery.Take(1).FirstOrDefaultAsync();
             if (tenant is null)
             {
-                ToastService.Show(TenantFilter.SelectedTenantId is null
+                ToastService.Warning(TenantFilter.SelectedTenantId is null
                     ? "No tenants exist. Create a tenant first."
-                    : "Selected tenant was not found. Refresh tenants and try again.");
+                    : "Selected tenant was not found. Refresh tenants and try again.",
+                    "Tenant required");
                 _saving = false;
                 return;
             }
@@ -314,18 +331,18 @@
 
             if (result.IsSuccess)
             {
-                ToastService.Show("User created successfully.");
+                ToastService.Success("User created successfully.", "User saved");
                 _createDialogOpen = false;
                 await LoadData();
             }
             else
             {
-                ToastService.Show($"Error creating user: {result.Message}");
+                ToastService.Error("User could not be created.", "Save failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("User could not be created.", "Save failed");
         }
         finally
         {
@@ -345,7 +362,7 @@
 
             if (fresh is null)
             {
-                ToastService.Show("User not found.");
+                ToastService.Warning("User was not found.", "User unavailable");
                 return;
             }
 
@@ -356,17 +373,17 @@
 
             if (result.IsSuccess)
             {
-                ToastService.Show(fresh.IsEnabled ? "User enabled." : "User disabled.");
+                ToastService.Success(fresh.IsEnabled ? "User enabled." : "User disabled.", "User updated");
                 await LoadData();
             }
             else
             {
-                ToastService.Show($"Error: {result.Message}");
+                ToastService.Error("User status could not be updated.", "Save failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("User status could not be updated.", "Save failed");
         }
     }
 
@@ -390,7 +407,7 @@
 
             if (fresh is null)
             {
-                ToastService.Show("User not found.");
+                ToastService.Warning("User was not found.", "User unavailable");
                 return;
             }
 
@@ -403,16 +420,16 @@
 
             if (result.IsSuccess)
             {
-                ToastService.Show("User deleted.");
+                ToastService.Success("User deleted.", "User deleted");
             }
             else
             {
-                ToastService.Show($"Error: {result.Message}");
+                ToastService.Error("User could not be deleted.", "Delete failed");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ToastService.Show($"Error: {ex.Message}");
+            ToastService.Error("User could not be deleted.", "Delete failed");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Verifications.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Verifications.razor
@@ -13,43 +13,30 @@
     }
     else
     {
-    <BbDataGrid Items="@_verifications">
+    <BbDataGrid Items="@_verifications" ShowPagination="true" InitialPageSize="20" ShowSearch="true" SearchPlaceholder="Search verifications...">
         <Columns>
-            <BbDataGridPropertyColumn Property="@(x => x.CredentialId)" Title="Credential ID" Sortable="true" />
-            <BbDataGridTemplateColumn Title="Verification Type">
+            <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(item => GetCredentialLabel(item))">
                 <ChildContent Context="item">
-                    @(item.VerificationType?.Name ?? item.VerificationTypeId?.ToString() ?? "N/A")
+                    @GetCredentialLabel(item)
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridTemplateColumn Title="Status">
+            <BbDataGridTemplateColumn Title="Verification Type" Filterable="true" FilterBy="@(item => GetVerificationTypeLabel(item))">
                 <ChildContent Context="item">
-                    @{
-                        var statusText = item.Status switch
-                        {
-                            0 => "Pending",
-                            1 => "Verified",
-                            2 => "Rejected",
-                            _ => "Unknown"
-                        };
-                        var statusKey = item.Status switch
-                        {
-                            0 => "pending",
-                            1 => "active",
-                            2 => "failed",
-                            _ => "inactive"
-                        };
-                    }
-                    <StatusBadge Text="@statusText" Status="@statusKey" />
+                    @GetVerificationTypeLabel(item)
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridTemplateColumn Title="Token">
+            <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => GetStatusText(item.Status))">
                 <ChildContent Context="item">
-                    @(Truncate(item.Token, 20))
+                    <StatusBadge Text="@GetStatusText(item.Status)" Status="@GetStatusKey(item.Status)" />
                 </ChildContent>
             </BbDataGridTemplateColumn>
-            <BbDataGridPropertyColumn Property="@(x => x.Expiry)" Title="Expiry" Sortable="true" />
-            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.Expiry)" Title="Expiry" Sortable="true" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.StatusUpdatedOn)" Title="Status Updated" Sortable="true" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
         </Columns>
+        <EmptyTemplate>
+            <BbEmpty Title="No verifications" Description="No verification records found for the selected tenant." />
+        </EmptyTemplate>
     </BbDataGrid>
     }
 </div>
@@ -57,6 +44,7 @@
 @code {
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
 
     private List<IdentityVerification> _verifications = [];
     private bool _loading = true;
@@ -72,6 +60,7 @@
         try
         {
             var query = DataContext.Query<IdentityVerification>()
+                .Include(x => x.Credential)
                 .Include(x => x.VerificationType);
             if (TenantFilter.SelectedTenantId is { } tenantId)
             {
@@ -82,16 +71,47 @@
                 .OrderByDescending(x => x.CreatedAt)
                 .ToList();
         }
-        catch { /* query may fail */ }
+        catch
+        {
+            _verifications = [];
+            ToastService.Error("Verifications could not be loaded.", "Load failed");
+        }
         finally
         {
             _loading = false;
         }
     }
 
-    private static string Truncate(string? value, int maxLength)
+    private static string GetCredentialLabel(IdentityVerification verification)
     {
-        if (string.IsNullOrEmpty(value)) return "N/A";
-        return value.Length <= maxLength ? value : value[..maxLength] + "...";
+        var credential = verification.Credential;
+        if (!string.IsNullOrWhiteSpace(credential?.UserName))
+            return credential.UserName;
+
+        if (!string.IsNullOrWhiteSpace(credential?.UserAlias))
+            return credential.UserAlias;
+
+        return "Unknown credential";
     }
+
+    private static string GetVerificationTypeLabel(IdentityVerification verification) =>
+        string.IsNullOrWhiteSpace(verification.VerificationType?.Name)
+            ? "Unknown verification type"
+            : verification.VerificationType.Name;
+
+    private static string GetStatusText(short? status) => status switch
+    {
+        0 => "Pending",
+        1 => "Verified",
+        2 => "Rejected",
+        _ => "Unknown"
+    };
+
+    private static string GetStatusKey(short? status) => status switch
+    {
+        0 => "pending",
+        1 => "active",
+        2 => "failed",
+        _ => "inactive"
+    };
 }

--- a/src/Presentation/ControlPanel.Server/Components/Shared/EditableForm.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Shared/EditableForm.razor
@@ -18,7 +18,7 @@
                     <BbButton Variant="ButtonVariant.Ghost" OnClick="Discard" Disabled="@Saving">
                         Discard Changes
                     </BbButton>
-                    <BbButton OnClick="Save" Disabled="@(!_context.IsDirty || Saving)">
+                    <BbButton OnClick="Save" Disabled="@((RequireDirtyForSave && !_context.IsDirty) || Saving)">
                         @if (Saving)
                         {
                             <BbSpinner Size="SpinnerSize.Small" Class="mr-2" />
@@ -42,6 +42,7 @@
     [Parameter] public EventCallback OnSave { get; set; }
     [Parameter] public EventCallback OnDiscard { get; set; }
     [Parameter] public bool Saving { get; set; }
+    [Parameter] public bool RequireDirtyForSave { get; set; } = true;
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     private readonly EditableFormContext _context = new();

--- a/src/Presentation/ControlPanel.Server/Components/_Imports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/_Imports.razor
@@ -24,6 +24,7 @@
 @using XFramework.Domain.Shared.BusinessObjects
 @using XFramework.Domain.Shared.Contracts.Responses
 @using IdentityServer.Domain.Shared.Contracts
+@using IdentityServer.Domain.Shared.Contracts.Requests
 @using IdentityServer.Integration.Drivers
 @using XFramework.Inventario.Domain.Shared.Contracts
 @using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products

--- a/src/Tests/ControlPanel.E2ETests/IdentityServerControlPanelContractTests.cs
+++ b/src/Tests/ControlPanel.E2ETests/IdentityServerControlPanelContractTests.cs
@@ -23,7 +23,9 @@ public sealed class IdentityServerControlPanelContractTests
 
         var userDetail = File.ReadAllText(Path.Combine(pagesRoot, "UserDetail.razor"));
         var contacts = File.ReadAllText(Path.Combine(pagesRoot, "Contacts.razor"));
+        var contactDetail = File.ReadAllText(Path.Combine(pagesRoot, "ContactDetail.razor"));
         var addresses = File.ReadAllText(Path.Combine(pagesRoot, "Addresses.razor"));
+        var addressDetail = File.ReadAllText(Path.Combine(pagesRoot, "AddressDetail.razor"));
         var tenants = File.ReadAllText(Path.Combine(pagesRoot, "Tenants.razor"));
         var tenantDetail = File.ReadAllText(Path.Combine(pagesRoot, "TenantDetail.razor"));
 
@@ -53,10 +55,25 @@ public sealed class IdentityServerControlPanelContractTests
         contacts.Should().NotContain("Label=\"Type ID\"");
         contacts.Should().NotContain("Label=\"Group ID\"");
 
+        contactDetail.Should().Contain("<XfEntityPicker TItem=\"IdentityCredential\"");
+        contactDetail.Should().Contain("<XfEntityPicker TItem=\"IdentityContactType\"");
+        contactDetail.Should().Contain("<XfEntityPicker TItem=\"IdentityContactGroup\"");
+        contactDetail.Should().Contain("AdvancedColumns=\"@CredentialAdvancedColumns\"");
+        contactDetail.Should().Contain("AdvancedFilters=\"@CredentialAdvancedFilters\"");
+        contactDetail.Should().Contain("AdvancedColumns=\"@ContactTypeAdvancedColumns\"");
+        contactDetail.Should().Contain("AdvancedFilters=\"@ContactTypeAdvancedFilters\"");
+        contactDetail.Should().Contain("AdvancedColumns=\"@ContactGroupAdvancedColumns\"");
+        contactDetail.Should().Contain("AdvancedFilters=\"@ContactGroupAdvancedFilters\"");
+
         addresses.Should().Contain("<XfEntityPicker TItem=\"IdentityInformation\"");
         addresses.Should().Contain("AdvancedColumns=\"@UserAdvancedColumns\"");
         addresses.Should().Contain("AdvancedFilters=\"@UserAdvancedFilters\"");
         addresses.Should().NotContain("Label=\"User ID (IdentityInfoId)\"");
+
+        addressDetail.Should().Contain("<XfEntityPicker TItem=\"IdentityInformation\"");
+        addressDetail.Should().Contain("AdvancedColumns=\"@UserAdvancedColumns\"");
+        addressDetail.Should().Contain("AdvancedFilters=\"@UserAdvancedFilters\"");
+        addressDetail.Should().NotContain("Label=\"User ID (IdentityInfoId)\"");
 
         tenants.Should().Contain("<XfEntityPicker TItem=\"Tenant\"");
         tenants.Should().Contain("AdvancedColumns=\"@TenantAdvancedColumns\"");
@@ -67,7 +84,185 @@ public sealed class IdentityServerControlPanelContractTests
         tenantDetail.Should().Contain("<XfEntityPicker TItem=\"RegistryConfigurationGroup\"");
         tenantDetail.Should().Contain("AdvancedColumns=\"@ConfigurationGroupAdvancedColumns\"");
         tenantDetail.Should().Contain("AdvancedFilters=\"@ConfigurationGroupAdvancedFilters\"");
+        tenantDetail.Should().Contain("<XfEntityPicker TItem=\"Tenant\"");
+        tenantDetail.Should().Contain("AdvancedColumns=\"@TenantAdvancedColumns\"");
+        tenantDetail.Should().Contain("AdvancedFilters=\"@TenantAdvancedFilters\"");
+        tenantDetail.Should().Contain("AdvancedSearchScope=\"Searches tenant name, description, status, version, expiration, enabled state, and created date.\"");
+        tenantDetail.Should().NotContain("Placeholder=\"GUID or blank for root\"");
         tenantDetail.Should().NotContain("<BbFormFieldNativeSelect");
+    }
+
+    [Test]
+    public void IdentityServerContactAndAddressLists_NavigateExistingRecordsToDetailPages()
+    {
+        var pagesRoot = GetIdentityPagesRoot();
+        var contacts = File.ReadAllText(Path.Combine(pagesRoot, "Contacts.razor"));
+        var addresses = File.ReadAllText(Path.Combine(pagesRoot, "Addresses.razor"));
+        var userDetail = File.ReadAllText(Path.Combine(pagesRoot, "UserDetail.razor"));
+
+        contacts.Should().Contain("@page \"/identity/contacts\"");
+        contacts.Should().Contain("OnRowClick=\"@((IdentityContact item) => OpenContactDetail(item))\"");
+        contacts.Should().Contain("Navigation.NavigateTo($\"/identity/contacts/{contact.Id}\")");
+        contacts.Should().NotContain("OpenEditDialog");
+        contacts.Should().NotContain("Edit Contact");
+
+        addresses.Should().Contain("@page \"/identity/addresses\"");
+        addresses.Should().Contain("OnRowClick=\"@((IdentityAddress item) => OpenAddressDetail(item))\"");
+        addresses.Should().Contain("Navigation.NavigateTo($\"/identity/addresses/{address.Id}\")");
+        addresses.Should().NotContain("OpenEditDialog");
+        addresses.Should().NotContain("Edit Address");
+
+        userDetail.Should().Contain("Navigation.NavigateTo($\"/identity/contacts/{contact.Id}\")");
+        userDetail.Should().Contain("Navigation.NavigateTo($\"/identity/addresses/{addr.Id}\")");
+        userDetail.Should().NotContain("OpenEditContactDialog");
+        userDetail.Should().NotContain("OpenEditAddressDialog");
+    }
+
+    [Test]
+    public void IdentityServerUserDetail_UsesRouteBackedSidebarSections()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = GetIdentityPagesRoot();
+        var layoutRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Layout");
+
+        var userDetail = File.ReadAllText(Path.Combine(pagesRoot, "UserDetail.razor"));
+        var mainLayout = File.ReadAllText(Path.Combine(layoutRoot, "MainLayout.razor"));
+        var sidebar = File.ReadAllText(Path.Combine(layoutRoot, "UserDetailSidebar.razor"));
+
+        userDetail.Should().Contain("@page \"/identity/users/{Id:guid}/{Section}\"");
+        userDetail.Should().Contain("@switch (CurrentSection)");
+        userDetail.Should().Contain("NormalizeSection");
+        userDetail.Should().NotContain("<BbTabsList");
+        userDetail.Should().NotContain("<BbTabsTrigger");
+        userDetail.Should().NotContain("<BbTabsContent");
+
+        mainLayout.Should().Contain("TryGetUserDetailRoute(out var userRouteId");
+        mainLayout.Should().Contain("<UserDetailSidebar UserId=\"@userRouteId\" />");
+        sidebar.Should().Contain("GroupId=\"user-detail\"");
+        sidebar.Should().Contain("SectionHref(\"summary\")");
+        sidebar.Should().Contain("SectionHref(\"credentials\")");
+        sidebar.Should().Contain("SectionHref(\"roles\")");
+        sidebar.Should().Contain("SectionHref(\"contacts\")");
+        sidebar.Should().Contain("SectionHref(\"addresses\")");
+        sidebar.Should().Contain("SectionHref(\"sessions\")");
+        sidebar.Should().Contain("SectionHref(\"auth-logs\")");
+        sidebar.Should().Contain("SectionHref(\"wallets\")");
+    }
+
+    [Test]
+    public void IdentityServerSensitiveMutations_UseServiceWrapperPaths()
+    {
+        var pagesRoot = GetIdentityPagesRoot();
+        var userDetail = File.ReadAllText(Path.Combine(pagesRoot, "UserDetail.razor"));
+
+        userDetail.Should().Contain("[Inject] private IIdentityServerServiceWrapper IdentityServer");
+        userDetail.Should().Contain("IdentityServer.CreateCredential(new CreateCredentialRequest");
+        userDetail.Should().Contain("IdentityServer.Logout(new LogoutRequest");
+        userDetail.Should().NotContain("BCrypt.Net.BCrypt.HashPassword");
+        userDetail.Should().NotContain("DataContext.Add(credential)");
+        userDetail.Should().NotContain("DataContext.Update(session)");
+        userDetail.Should().NotContain("fresh.Status = CurrentSessionState.Inactive");
+    }
+
+    [Test]
+    public void IdentityServerPages_DoNotRenderSensitiveTokensOrRawPayloads()
+    {
+        var pagesRoot = GetIdentityPagesRoot();
+        var source = string.Join(
+            Environment.NewLine,
+            Directory.EnumerateFiles(pagesRoot, "*.razor").Select(File.ReadAllText));
+
+        source.Should().NotContain("Title=\"Token\"");
+        source.Should().NotContain("Title=\"Session Data\"");
+        source.Should().NotContain("Truncate(item.Token");
+        source.Should().NotContain("Truncate(item.SessionData");
+    }
+
+    [Test]
+    public void IdentityServerRelationshipGrids_RenderLabelsInsteadOfRawGuidColumns()
+    {
+        var pagesRoot = GetIdentityPagesRoot();
+        var source = string.Join(
+            Environment.NewLine,
+            Directory.EnumerateFiles(pagesRoot, "*.razor").Select(File.ReadAllText));
+
+        source.Should().NotContain("Title=\"Credential ID\"");
+        source.Should().NotContain("Title=\"User ID\"");
+        source.Should().NotContain("Title=\"Group ID\"");
+        source.Should().NotContain("Label=\"Credential ID\"");
+        source.Should().NotContain("Label=\"User ID (IdentityInfoId)\"");
+        source.Should().NotContain("Label=\"Group ID\"");
+        source.Should().NotContain("GUID or blank for root");
+    }
+
+    [Test]
+    public void IdentityServerPages_UseSemanticSafeToasts()
+    {
+        var pagesRoot = GetIdentityPagesRoot();
+        var source = string.Join(
+            Environment.NewLine,
+            Directory.EnumerateFiles(pagesRoot, "*.razor").Select(File.ReadAllText));
+
+        source.Should().NotContain("ToastService.Show(");
+        source.Should().NotContain("ex.Message");
+        source.Should().NotContain("result.Message");
+        source.Should().NotContain("r.Message");
+        source.Should().Contain("ToastService.Success(");
+        source.Should().Contain("ToastService.Error(");
+        source.Should().Contain("ToastService.Warning(");
+    }
+
+    [Test]
+    public void IdentityServerListGrids_UsePaginationFiltersAndEmptyTemplates()
+    {
+        var pagesRoot = GetIdentityPagesRoot();
+        var gridPages = new[]
+        {
+            "Addresses.razor",
+            "AuthLogs.razor",
+            "Contacts.razor",
+            "Credentials.razor",
+            "Sessions.razor",
+            "Tenants.razor",
+            "Users.razor",
+            "Verifications.razor"
+        };
+
+        foreach (var page in gridPages)
+        {
+            var source = File.ReadAllText(Path.Combine(pagesRoot, page));
+            source.Should().Contain("ShowPagination=\"true\"", page);
+            source.Should().Contain("InitialPageSize=", page);
+            source.Should().Contain("Filterable=\"true\"", page);
+            source.Should().Contain("<EmptyTemplate>", page);
+            source.Should().Contain("<BbEmpty", page);
+        }
+    }
+
+    [Test]
+    public void IdentityServerPropertyGridColumns_UseNativeFiltering()
+    {
+        var pagesRoot = GetIdentityPagesRoot();
+        foreach (var page in Directory.EnumerateFiles(pagesRoot, "*.razor"))
+        {
+            var propertyColumns = File.ReadAllLines(page)
+                .Where(line => line.Contains("<BbDataGridPropertyColumn", StringComparison.Ordinal))
+                .ToArray();
+            if (propertyColumns.Length == 0)
+            {
+                continue;
+            }
+
+            propertyColumns
+                .Should()
+                .OnlyContain(column => column.Contains("Filterable=\"true\""), $"{Path.GetFileName(page)} property columns should opt into native grid filtering");
+        }
     }
 
     [Test]
@@ -85,9 +280,23 @@ public sealed class IdentityServerControlPanelContractTests
 
         var pickerText = File.ReadAllText(pickerPath);
 
-        pickerText.Should().Contain("xf-entity-picker-advanced-table");
-        pickerText.Should().Contain("ToggleAdvancedSort");
+        pickerText.Should().Contain("<BbDataGrid Items=\"@AdvancedFilteredItems\"");
+        pickerText.Should().Contain("EffectiveAdvancedColumns");
         pickerText.Should().Contain("AdvancedFilters");
+        pickerText.Should().Contain("FilterBy=\"@(item => FormatAdvancedCell(column.ValueSelector(item)))\"");
+    }
+
+    private static string GetIdentityPagesRoot()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        return Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Pages",
+            "Identity");
     }
 
     private static DirectoryInfo FindRepositoryRoot()

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/CredentialTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/CredentialTests.cs
@@ -1,37 +1,73 @@
 using System.Net;
 using System.Text;
+using IdentityServer.Domain.Shared.Contracts;
+using IdentityServer.Domain.Shared.Contracts.Requests;
 using Microsoft.EntityFrameworkCore;
 using XFramework.Domain.Shared.BusinessObjects;
-using IdentityServer.Domain.Shared.Contracts;
 using XFramework.Domain.Shared.Contracts.Requests;
 
 namespace IdentityServer.IntegrationTests.Tests;
 
 /// <summary>
 /// Integration tests for credential CRUD operations.
-/// Note: IdentityCredential.Password has [JsonIgnore] so it cannot be sent via JSON.
-/// Password-based credential creation is tested through the Authenticate flow in AuthenticationTests.
-/// These tests cover the credential CRUD endpoints for non-password fields.
 /// </summary>
 [TestFixture]
 public class CredentialTests : IntegrationTestBase
 {
     [Test]
-    [Ignore("IdentityCredential.Password has [JsonIgnore] — cannot be sent via JSON. " +
-            "Password hashing is tested via AuthenticationTests.SeedCredentialWithRole.")]
-    public async Task CreateCredential_WithValidData_Returns201()
+    public async Task CreateCredential_WithValidData_ReturnsOk()
     {
-        // This endpoint requires Password but the property has [JsonIgnore] on IdentityCredential.
-        // Credential creation with password is done internally (not via public API).
-        await Task.CompletedTask;
+        var info = await SeedIdentityInfo();
+        var username = UniqueUsername();
+        var request = new CreateCredentialRequest
+        {
+            IdentityInfoId = info.Id,
+            UserName = username,
+            UserAlias = "Test Alias",
+            Password = "TestPassword123!",
+            Metadata = CreateMetadata()
+        };
+
+        var response = await HttpClient.PostAsJsonAsync("/api/credentials", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDbContext();
+        var created = await db.Set<IdentityCredential>()
+            .FirstOrDefaultAsync(c => c.IdentityInfoId == info.Id && c.UserName == username);
+
+        created.Should().NotBeNull();
+        created!.TenantId.Should().Be(IntegrationTestFixture.TestTenantId);
+        created.UserAlias.Should().Be("Test Alias");
+        created.IsEnabled.Should().BeTrue();
     }
 
     [Test]
-    [Ignore("IdentityCredential.Password has [JsonIgnore] — cannot be sent via JSON. " +
-            "Password hashing is verified in AuthenticationTests where credentials are seeded with BCrypt.")]
     public async Task CreateCredential_PasswordIsHashed_NotStoredPlaintext()
     {
-        await Task.CompletedTask;
+        var info = await SeedIdentityInfo();
+        var username = UniqueUsername();
+        var password = "AnotherPassword123!";
+        var request = new CreateCredentialRequest
+        {
+            IdentityInfoId = info.Id,
+            UserName = username,
+            Password = password,
+            Metadata = CreateMetadata()
+        };
+
+        var response = await HttpClient.PostAsJsonAsync("/api/credentials", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDbContext();
+        var created = await db.Set<IdentityCredential>()
+            .FirstOrDefaultAsync(c => c.IdentityInfoId == info.Id && c.UserName == username);
+
+        created.Should().NotBeNull();
+        created!.PasswordByte.Should().NotBeNullOrEmpty();
+        Encoding.ASCII.GetString(created.PasswordByte!).Should().NotBe(password);
+        BCrypt.Net.BCrypt.Verify(password, Encoding.ASCII.GetString(created.PasswordByte!)).Should().BeTrue();
     }
 
     [Test]
@@ -81,8 +117,6 @@ public class CredentialTests : IntegrationTestBase
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
-
-    #region Helpers
 
     private static RequestMetadata CreateMetadata() => new()
     {
@@ -137,6 +171,4 @@ public class CredentialTests : IntegrationTestBase
         await db.SaveChangesAsync();
         return credential;
     }
-
-    #endregion
 }

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
@@ -20,6 +20,45 @@ namespace IdentityServer.IntegrationTests.Tests;
 public sealed class WrapperCoverageTests : IntegrationTestBase
 {
     [Test]
+    public async Task CreateCredential_WithValidData_HashesPasswordAndCreatesCredential()
+    {
+        var info = await SeedIdentityInfo();
+        var username = UniqueUsername();
+        var password = "WrapperPassword123!";
+
+        var result = await IntegrationTestFixture.ServiceWrapper.CreateCredential(new CreateCredentialRequest
+        {
+            IdentityInfoId = info.Id,
+            UserName = username,
+            UserAlias = "Wrapper Alias",
+            Password = password,
+            Metadata = CreateMetadata()
+        });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        result.IsSuccess.Should().BeTrue();
+
+        await using var db = CreateDbContext();
+        var credential = await db.Set<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(c => c.IdentityInfoId == info.Id && c.UserName == username);
+
+        credential.Should().NotBeNull();
+        credential!.PasswordByte.Should().NotBeNullOrEmpty();
+        BCrypt.Net.BCrypt.Verify(password, Encoding.ASCII.GetString(credential.PasswordByte!)).Should().BeTrue();
+
+        var verify = await IntegrationTestFixture.ServiceWrapper.VerifyPassword(
+            new VerifyPasswordRequest
+            {
+                CredentialId = credential.Id,
+                Password = password,
+                Metadata = CreateMetadata()
+            });
+
+        verify.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Test]
     public async Task ForgotPassword_WithUnknownEmail_ReturnsSuccess()
     {
         var result = await IntegrationTestFixture.ServiceWrapper.ForgotPassword(new ForgotPasswordRequest
@@ -195,6 +234,23 @@ public sealed class WrapperCoverageTests : IntegrationTestBase
         result.Response.Credential.Should().NotBeNull();
 
         return result;
+    }
+
+    private async Task<IdentityInformation> SeedIdentityInfo()
+    {
+        await using var db = CreateDbContext();
+
+        var info = new IdentityInformation
+        {
+            Id = Guid.NewGuid(),
+            FirstName = "Test",
+            LastName = "User",
+            TenantId = IntegrationTestFixture.TestTenantId
+        };
+        db.Set<IdentityInformation>().Add(info);
+
+        await db.SaveChangesAsync();
+        return info;
     }
 
     private async Task<IdentityCredential> SeedCredentialWithRole(string username, string password)


### PR DESCRIPTION
## Summary
- Adds route-backed IdentityServer contact/address detail pages with shared entity picker editing.
- Converts IdentityServer contacts/addresses lists to scan-and-navigate surfaces and moves user detail sections to route-backed sidebar navigation.
- Adds native grid filtering guards and ControlPanel contract coverage for the updated IdentityServer UI rules.
- Adds the IdentityServer credential wrapper request path and wrapper/integration coverage needed by the secure credential creation flow.

## Verification
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false`
- `dotnet test src/Tests/ControlPanel.E2ETests/ControlPanel.E2ETests.csproj --filter TestCategory=Area:ControlPanelContract`