### PR TITLE
Group Wallets multi-grid finance pages in tabs

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/OutboxWebhooks.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/OutboxWebhooks.razor
@@ -65,86 +65,105 @@
             </BbCard>
         </div>
 
-        <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
-            <Columns>
-                <BbDataGridPropertyColumn Property="@(x => x.EventType)" Title="Event" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.AggregateType)" Title="Aggregate" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.AggregateId)" Title="Aggregate ID" />
-                <BbDataGridTemplateColumn Title="Status">
-                    <ChildContent Context="item">
-                        <BbBadge Variant="@(item.Status == WalletOutboxStatus.Pending ? BadgeVariant.Outline : BadgeVariant.Default)">@item.Status</BbBadge>
-                    </ChildContent>
-                </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.Attempts)" Title="Attempts" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.NextAttemptAt)" Title="Next Attempt" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.LastError)" Title="Last Error" />
-                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                <BbDataGridTemplateColumn Title="Actions">
-                    <ChildContent Context="item">
-                        @if (item.Status is WalletOutboxStatus.Failed or WalletOutboxStatus.DeadLetter)
-                        {
-                            <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => RetryOutbox(item))" Disabled="@_acting">
-                                Retry
-                            </BbButton>
-                        }
-                        <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => ReplayOutbox(item))" Disabled="@_acting">
-                            Replay
-                        </BbButton>
-                        @if (item.Status is not WalletOutboxStatus.DeadLetter)
-                        {
-                            <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Destructive" OnClick="@(() => DeadLetterOutbox(item))" Disabled="@_acting">
-                                Dead-letter
-                            </BbButton>
-                        }
-                    </ChildContent>
-                </BbDataGridTemplateColumn>
-            </Columns>
-        </BbDataGrid>
+        <BbTabs DefaultValue="outbox-messages">
+            <BbTabsList>
+                <BbTabsTrigger Value="outbox-messages">Outbox Messages (@_items.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="webhook-audit">Webhook Audit (@_webhookEvents.Count)</BbTabsTrigger>
+            </BbTabsList>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Payment Webhook Audit</BbCardTitle>
-                <BbCardDescription>@_webhookEvents.Count provider webhook event(s) loaded</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_webhookEvents" ShowPagination="true" InitialPageSize="20">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.ProviderKey)" Title="Provider" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ExternalEventId)" Title="External Event" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ExternalReference)" Title="Reference" Sortable="true" />
-                        <BbDataGridTemplateColumn Title="Status">
-                            <ChildContent Context="item">
-                                <BbBadge Variant="@GetWebhookStatusVariant(item.ProcessingStatus)">@item.ProcessingStatus</BbBadge>
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Signature">
-                            <ChildContent Context="item">
-                                <BbBadge Variant="@(item.SignatureValid ? BadgeVariant.Default : BadgeVariant.Destructive)">
-                                    @(item.SignatureValid ? "Valid" : "Invalid")
-                                </BbBadge>
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                        <BbDataGridPropertyColumn Property="@(x => x.MappedWorkflowStatus)" Title="Mapped" Sortable="true" />
-                        <BbDataGridTemplateColumn Title="Links">
-                            <ChildContent Context="item">
-                                <div class="space-y-1 text-xs font-mono">
-                                    <div>Dep: @ShortId(item.DepositRequestId)</div>
-                                    <div>Wd: @ShortId(item.WithdrawalRequestId)</div>
-                                    <div>Op: @ShortId(item.OperationId)</div>
-                                </div>
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Error">
-                            <ChildContent Context="item">
-                                @ShortText(item.ProcessingError)
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                        <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ProcessedAt)" Title="Processed" Sortable="true" />
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+            <BbTabsContent Value="outbox-messages" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Outbox Messages</BbCardTitle>
+                        <BbCardDescription>@_items.Count integration event(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.EventType)" Title="Event" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AggregateType)" Title="Aggregate" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AggregateId)" Title="Aggregate ID" />
+                                <BbDataGridTemplateColumn Title="Status">
+                                    <ChildContent Context="item">
+                                        <BbBadge Variant="@(item.Status == WalletOutboxStatus.Pending ? BadgeVariant.Outline : BadgeVariant.Default)">@item.Status</BbBadge>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.Attempts)" Title="Attempts" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.NextAttemptAt)" Title="Next Attempt" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.LastError)" Title="Last Error" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="item">
+                                        @if (item.Status is WalletOutboxStatus.Failed or WalletOutboxStatus.DeadLetter)
+                                        {
+                                            <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => RetryOutbox(item))" Disabled="@_acting">
+                                                Retry
+                                            </BbButton>
+                                        }
+                                        <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => ReplayOutbox(item))" Disabled="@_acting">
+                                            Replay
+                                        </BbButton>
+                                        @if (item.Status is not WalletOutboxStatus.DeadLetter)
+                                        {
+                                            <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Destructive" OnClick="@(() => DeadLetterOutbox(item))" Disabled="@_acting">
+                                                Dead-letter
+                                            </BbButton>
+                                        }
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="webhook-audit" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Payment Webhook Audit</BbCardTitle>
+                        <BbCardDescription>@_webhookEvents.Count provider webhook event(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_webhookEvents" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ProviderKey)" Title="Provider" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ExternalEventId)" Title="External Event" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ExternalReference)" Title="Reference" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Status">
+                                    <ChildContent Context="item">
+                                        <BbBadge Variant="@GetWebhookStatusVariant(item.ProcessingStatus)">@item.ProcessingStatus</BbBadge>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Signature">
+                                    <ChildContent Context="item">
+                                        <BbBadge Variant="@(item.SignatureValid ? BadgeVariant.Default : BadgeVariant.Destructive)">
+                                            @(item.SignatureValid ? "Valid" : "Invalid")
+                                        </BbBadge>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.MappedWorkflowStatus)" Title="Mapped" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Links">
+                                    <ChildContent Context="item">
+                                        <div class="space-y-1 text-xs font-mono">
+                                            <div>Dep: @ShortId(item.DepositRequestId)</div>
+                                            <div>Wd: @ShortId(item.WithdrawalRequestId)</div>
+                                            <div>Op: @ShortId(item.OperationId)</div>
+                                        </div>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Error">
+                                    <ChildContent Context="item">
+                                        @ShortText(item.ProcessingError)
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ProcessedAt)" Title="Processed" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+        </BbTabs>
     }
 </div>
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/PolicyDecisions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/PolicyDecisions.razor
@@ -124,85 +124,100 @@
             </BbCard>
         </div>
 
-        <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-            <BbCard>
-                <BbCardHeader>
-                    <BbCardTitle>Policy Rules</BbCardTitle>
-                    <BbCardDescription>@_rules.Count active rule(s) loaded</BbCardDescription>
-                </BbCardHeader>
-                <BbCardContent>
-                    <BbDataGrid Items="@_rules" ShowPagination="true" InitialPageSize="10">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MaxSingleTransactionAmount)" Title="Max Single" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.DailyVelocityLimit)" Title="Daily" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.ApprovalThreshold)" Title="Approval" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.IsEnabled)" Title="Enabled" Sortable="true" />
-                        </Columns>
-                    </BbDataGrid>
-                </BbCardContent>
-            </BbCard>
+        <BbTabs DefaultValue="policy-rules">
+            <BbTabsList>
+                <BbTabsTrigger Value="policy-rules">Policy Rules (@_rules.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="fee-schedules">Fee Schedules (@_feeSchedules.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="policy-decisions">Policy Decisions (@_items.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="fee-ledger">Fee Ledger (@_fees.Count)</BbTabsTrigger>
+            </BbTabsList>
 
-            <BbCard>
-                <BbCardHeader>
-                    <BbCardTitle>Fee Schedules</BbCardTitle>
-                    <BbCardDescription>@_feeSchedules.Count active schedule(s) loaded</BbCardDescription>
-                </BbCardHeader>
-                <BbCardContent>
-                    <BbDataGrid Items="@_feeSchedules" ShowPagination="true" InitialPageSize="10">
-                        <Columns>
-                            <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.FixedFee)" Title="Fixed" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.PercentageFee)" Title="Percent" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MinimumFee)" Title="Min" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.MaximumFee)" Title="Max" Sortable="true" />
-                            <BbDataGridPropertyColumn Property="@(x => x.IsEnabled)" Title="Enabled" Sortable="true" />
-                        </Columns>
-                    </BbDataGrid>
-                </BbCardContent>
-            </BbCard>
-        </div>
+            <BbTabsContent Value="policy-rules" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Policy Rules</BbCardTitle>
+                        <BbCardDescription>@_rules.Count active rule(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_rules" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MaxSingleTransactionAmount)" Title="Max Single" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DailyVelocityLimit)" Title="Daily" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ApprovalThreshold)" Title="Approval" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.IsEnabled)" Title="Enabled" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Policy Decisions</BbCardTitle>
-                <BbCardDescription>@_items.Count operation(s) with risk or policy output</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.RiskDecision)" Title="Risk" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.PolicyDecision)" Title="Policy" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ActorCredentialId)" Title="Actor" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+            <BbTabsContent Value="fee-schedules" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Fee Schedules</BbCardTitle>
+                        <BbCardDescription>@_feeSchedules.Count active schedule(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_feeSchedules" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.FixedFee)" Title="Fixed" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.PercentageFee)" Title="Percent" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MinimumFee)" Title="Min" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MaximumFee)" Title="Max" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.IsEnabled)" Title="Enabled" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Fee Ledger</BbCardTitle>
-                <BbCardDescription>@_fees.Count fee posting(s) loaded</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_fees" ShowPagination="true" InitialPageSize="20">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Direction)" Title="Direction" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.BalanceBucket)" Title="Bucket" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+            <BbTabsContent Value="policy-decisions" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Policy Decisions</BbCardTitle>
+                        <BbCardDescription>@_items.Count operation(s) with risk or policy output</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.RiskDecision)" Title="Risk" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.PolicyDecision)" Title="Policy" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ActorCredentialId)" Title="Actor" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="fee-ledger" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Fee Ledger</BbCardTitle>
+                        <BbCardDescription>@_fees.Count fee posting(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_fees" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Direction)" Title="Direction" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.BalanceBucket)" Title="Bucket" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+        </BbTabs>
     }
 </div>
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Reconciliation.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Reconciliation.razor
@@ -71,69 +71,88 @@
             </BbCard>
         </div>
 
-        <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
-            <Columns>
-                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.Balance)" Title="Balance" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.AvailableBalance)" Title="Available" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.TransferableBalance)" Title="Transferable" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.DriftAmount)" Title="Drift" Sortable="true" />
-                <BbDataGridTemplateColumn Title="State">
-                    <ChildContent Context="item">
-                        <BbBadge Variant="@(item.IsReconciled ? BadgeVariant.Default : BadgeVariant.Destructive)">
-                            @(item.IsReconciled ? "Reconciled" : "Drift")
-                        </BbBadge>
-                    </ChildContent>
-                </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.ReconciledAt)" Title="Checked" Sortable="true" />
-                <BbDataGridTemplateColumn Title="Actions">
-                    <ChildContent Context="item">
-                        @if (!item.IsReconciled)
-                        {
-                            <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => RunWalletReconciliation(item.WalletId))" Disabled="@_acting">
-                                Re-run
-                            </BbButton>
-                        }
-                    </ChildContent>
-                </BbDataGridTemplateColumn>
-            </Columns>
-        </BbDataGrid>
+        <BbTabs DefaultValue="balance-snapshots">
+            <BbTabsList>
+                <BbTabsTrigger Value="balance-snapshots">Balance Snapshots (@_items.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="reconciliation-items">Reconciliation Items (@_reconciliationItems.Count)</BbTabsTrigger>
+            </BbTabsList>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Reconciliation Items</BbCardTitle>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_reconciliationItems" ShowPagination="true" InitialPageSize="20">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.CheckType)" Title="Check" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                        <BbDataGridTemplateColumn Title="Status">
-                            <ChildContent Context="item">
-                                <BbBadge Variant="@(item.Status == WalletReconciliationStatus.Drifted ? BadgeVariant.Destructive : BadgeVariant.Default)">
-                                    @item.Status
-                                </BbBadge>
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                        <BbDataGridPropertyColumn Property="@(x => x.ExpectedAmount)" Title="Expected" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ActualAmount)" Title="Actual" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.DriftAmount)" Title="Drift" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
-                        <BbDataGridPropertyColumn Property="@(x => x.RepairSuggestion)" Title="Repair Suggestion" />
-                        <BbDataGridTemplateColumn Title="Actions">
-                            <ChildContent Context="item">
-                                @if (item.Status == WalletReconciliationStatus.Drifted)
-                                {
-                                    <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => MarkReconciled(item))" Disabled="@_acting">
-                                        Mark Reconciled
-                                    </BbButton>
-                                }
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+            <BbTabsContent Value="balance-snapshots" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Balance Snapshots</BbCardTitle>
+                        <BbCardDescription>@_items.Count snapshot(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Balance)" Title="Balance" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableBalance)" Title="Available" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransferableBalance)" Title="Transferable" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DriftAmount)" Title="Drift" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="State">
+                                    <ChildContent Context="item">
+                                        <BbBadge Variant="@(item.IsReconciled ? BadgeVariant.Default : BadgeVariant.Destructive)">
+                                            @(item.IsReconciled ? "Reconciled" : "Drift")
+                                        </BbBadge>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.ReconciledAt)" Title="Checked" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="item">
+                                        @if (!item.IsReconciled)
+                                        {
+                                            <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => RunWalletReconciliation(item.WalletId))" Disabled="@_acting">
+                                                Re-run
+                                            </BbButton>
+                                        }
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="reconciliation-items" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Reconciliation Items</BbCardTitle>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_reconciliationItems" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.CheckType)" Title="Check" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
+                                <BbDataGridTemplateColumn Title="Status">
+                                    <ChildContent Context="item">
+                                        <BbBadge Variant="@(item.Status == WalletReconciliationStatus.Drifted ? BadgeVariant.Destructive : BadgeVariant.Default)">
+                                            @item.Status
+                                        </BbBadge>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.ExpectedAmount)" Title="Expected" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ActualAmount)" Title="Actual" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DriftAmount)" Title="Drift" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
+                                <BbDataGridPropertyColumn Property="@(x => x.RepairSuggestion)" Title="Repair Suggestion" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="item">
+                                        @if (item.Status == WalletReconciliationStatus.Drifted)
+                                        {
+                                            <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => MarkReconciled(item))" Disabled="@_acting">
+                                                Mark Reconciled
+                                            </BbButton>
+                                        }
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+        </BbTabs>
     }
 </div>
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/RefundsDisputes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/RefundsDisputes.razor
@@ -118,85 +118,99 @@
             </BbCard>
         </div>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Open Cases</BbCardTitle>
-                <BbCardDescription>@_cases.Count case(s) loaded</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_cases" ShowPagination="true" InitialPageSize="10">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.CaseType)" Title="Type" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ReasonCode)" Title="Reason Code" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                        <BbDataGridTemplateColumn Title="Actions">
-                            <ChildContent Context="item">
-                                @if (item.Status is WalletCaseStatus.Open or WalletCaseStatus.OnHold)
-                                {
-                                    <div class="flex gap-2">
-                                        <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => ResolveCase(item, true))" Disabled="@_acting">
-                                            Approve
-                                        </BbButton>
-                                        <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Ghost" OnClick="@(() => ResolveCase(item, false))" Disabled="@_acting">
-                                            Reject
-                                        </BbButton>
-                                    </div>
-                                }
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+        <BbTabs DefaultValue="open-cases">
+            <BbTabsList>
+                <BbTabsTrigger Value="open-cases">Open Cases (@_cases.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="refund-operations">Refund Operations (@_refundOperations.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="transactions">Transactions (@_transactions.Count)</BbTabsTrigger>
+            </BbTabsList>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Recent Refund/Reversal Operations</BbCardTitle>
-                <BbCardDescription>@_refundOperations.Count operation(s) loaded</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_refundOperations" ShowPagination="true" InitialPageSize="10">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Type" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" />
-                        <BbDataGridPropertyColumn Property="@(x => x.FailureMessage)" Title="Failure" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+            <BbTabsContent Value="open-cases" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Open Cases</BbCardTitle>
+                        <BbCardDescription>@_cases.Count case(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_cases" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.CaseType)" Title="Type" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReasonCode)" Title="Reason Code" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="item">
+                                        @if (item.Status is WalletCaseStatus.Open or WalletCaseStatus.OnHold)
+                                        {
+                                            <div class="flex gap-2">
+                                                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => ResolveCase(item, true))" Disabled="@_acting">
+                                                    Approve
+                                                </BbButton>
+                                                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Ghost" OnClick="@(() => ResolveCase(item, false))" Disabled="@_acting">
+                                                    Reject
+                                                </BbButton>
+                                            </div>
+                                        }
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Recent Transactions</BbCardTitle>
-                <BbCardDescription>@_transactions.Count transaction(s) available for reversal</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.Id)" Title="Transaction" />
-                        <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.TransactionType)" Title="Type" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                        <BbDataGridTemplateColumn Title="Actions">
-                            <ChildContent Context="item">
-                                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => SelectTransaction(item))">
-                                    Use
-                                </BbButton>
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+            <BbTabsContent Value="refund-operations" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Recent Refund/Reversal Operations</BbCardTitle>
+                        <BbCardDescription>@_refundOperations.Count operation(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_refundOperations" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Type" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" />
+                                <BbDataGridPropertyColumn Property="@(x => x.FailureMessage)" Title="Failure" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="transactions" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Recent Transactions</BbCardTitle>
+                        <BbCardDescription>@_transactions.Count transaction(s) available for reversal</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.Id)" Title="Transaction" />
+                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransactionType)" Title="Type" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="item">
+                                        <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => SelectTransaction(item))">
+                                            Use
+                                        </BbButton>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+        </BbTabs>
     }
 </div>
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Statements.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Statements.razor
@@ -71,54 +71,65 @@
             </BbCard>
         </div>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Wallet Balances</BbCardTitle>
-                <BbCardDescription>@_wallets.Count wallet(s) loaded for the selected tenant</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_wallets" ShowPagination="true" InitialPageSize="20">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.AccountNumber)" Title="Account" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CredentialId)" Title="Credential" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Balance)" Title="Balance" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.AvailableBalance)" Title="Available" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.DebitOnHoldBalance)" Title="Debit Hold" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CreditOnHoldBalance)" Title="Credit Hold" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                        <BbDataGridTemplateColumn Title="Actions">
-                            <ChildContent Context="item">
-                                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => GenerateStatement(item.Id))" Disabled="@_acting">
-                                    Statement
-                                </BbButton>
-                            </ChildContent>
-                        </BbDataGridTemplateColumn>
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+        <BbTabs DefaultValue="wallet-balances">
+            <BbTabsList>
+                <BbTabsTrigger Value="wallet-balances">Wallet Balances (@_wallets.Count)</BbTabsTrigger>
+                <BbTabsTrigger Value="statement-lines">Statement Lines (@_transactions.Count)</BbTabsTrigger>
+            </BbTabsList>
 
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Recent Statement Lines</BbCardTitle>
-                <BbCardDescription>@_transactions.Count transaction(s) loaded</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
-                    <Columns>
-                        <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                        <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.TransactionType)" Title="Type" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.RunningBalance)" Title="Running Balance" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.Remarks)" Title="Remarks" />
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
-                    </Columns>
-                </BbDataGrid>
-            </BbCardContent>
-        </BbCard>
+            <BbTabsContent Value="wallet-balances" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Wallet Balances</BbCardTitle>
+                        <BbCardDescription>@_wallets.Count wallet(s) loaded for the selected tenant</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_wallets" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.AccountNumber)" Title="Account" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CredentialId)" Title="Credential" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Balance)" Title="Balance" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableBalance)" Title="Available" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DebitOnHoldBalance)" Title="Debit Hold" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreditOnHoldBalance)" Title="Credit Hold" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="item">
+                                        <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => GenerateStatement(item.Id))" Disabled="@_acting">
+                                            Statement
+                                        </BbButton>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+
+            <BbTabsContent Value="statement-lines" Class="xf-fade-in">
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Recent Statement Lines</BbCardTitle>
+                        <BbCardDescription>@_transactions.Count transaction(s) loaded</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransactionType)" Title="Type" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.RunningBalance)" Title="Running Balance" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Remarks)" Title="Remarks" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                            </Columns>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
+            </BbTabsContent>
+        </BbTabs>
     }
 </div>
 

--- a/src/Tests/Wallets.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Wallets.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -39,6 +39,15 @@ public sealed class ControlPanelContractTests
         "RefundsDisputes.razor"
     ];
 
+    private static readonly (string Page, string DefaultTab, string[] Tabs)[] MultiGridTabbedFinancePages =
+    [
+        ("PolicyDecisions.razor", "policy-rules", ["policy-rules", "fee-schedules", "policy-decisions", "fee-ledger"]),
+        ("RefundsDisputes.razor", "open-cases", ["open-cases", "refund-operations", "transactions"]),
+        ("Statements.razor", "wallet-balances", ["wallet-balances", "statement-lines"]),
+        ("Reconciliation.razor", "balance-snapshots", ["balance-snapshots", "reconciliation-items"]),
+        ("OutboxWebhooks.razor", "outbox-messages", ["outbox-messages", "webhook-audit"])
+    ];
+
     [Test]
     public void WalletsFinancePages_FinancialWorkflowMutations_DoNotUseDirectRemoteDataContextMutation()
     {
@@ -112,6 +121,53 @@ public sealed class ControlPanelContractTests
             .ToArray();
 
         offenders.Should().BeEmpty("Wallets entity dependency pickers should let admins clear mistaken selections where the workflow continues to own creation/mutation");
+    }
+
+    [Test]
+    public void WalletsMultiGridFinancePages_UseTabsInsteadOfStackedGridSections()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = GetFinancePagesRoot(repositoryRoot);
+
+        foreach (var (page, defaultTab, tabs) in MultiGridTabbedFinancePages)
+        {
+            var text = File.ReadAllText(Path.Combine(pagesRoot.FullName, page));
+
+            text.Should().Contain($"<BbTabs DefaultValue=\"{defaultTab}\"",
+                $"{page} should group multiple data-heavy sections in tabs");
+            text.Should().Contain("<BbTabsList>");
+
+            foreach (var tab in tabs)
+            {
+                text.Should().Contain($"<BbTabsTrigger Value=\"{tab}\"");
+                text.Should().Contain($"<BbTabsContent Value=\"{tab}\"");
+
+                var content = Regex.Match(
+                    text,
+                    $@"<BbTabsContent\b(?=[^>]*\bValue=""{Regex.Escape(tab)}"")[\s\S]*?</BbTabsContent>");
+
+                content.Success.Should().BeTrue($"{page} should render tab content for {tab}");
+                Regex.Matches(content.Value, @"<BbDataGrid\b").Count.Should().Be(1,
+                    $"{page} should keep the {tab} grid isolated in its own tab panel");
+            }
+
+            Regex.Matches(text, @"<BbTabsContent\b").Count.Should().Be(tabs.Length,
+                $"{page} should have one tab panel for each data-heavy section");
+            Regex.Matches(text, @"<BbDataGrid\b").Count.Should().Be(tabs.Length,
+                $"{page} should keep each data-heavy grid in its own tab panel");
+
+            var firstTabsIndex = text.IndexOf("<BbTabs", StringComparison.Ordinal);
+            var lastTabsCloseIndex = text.LastIndexOf("</BbTabs>", StringComparison.Ordinal);
+            firstTabsIndex.Should().BeGreaterThanOrEqualTo(0);
+            lastTabsCloseIndex.Should().BeGreaterThan(firstTabsIndex);
+
+            var outsideTabs = string.Concat(
+                text.AsSpan(0, firstTabsIndex).ToString(),
+                text.AsSpan(lastTabsCloseIndex + "</BbTabs>".Length).ToString());
+
+            Regex.Matches(outsideTabs, @"<BbDataGrid\b").Count.Should().Be(0,
+                $"{page} should not stack sibling grids outside the tabbed surface");
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Group Wallets multi-grid finance pages into `BbTabs` so data-heavy grids are not stacked vertically.
- Covered Policy/Fees, Refunds/Disputes, Statements, Reconciliation, and Outbox/Webhooks.
- Added Wallets ControlPanel contract coverage to guard the tab structure and ensure each tab panel owns one grid.

## Verification
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false -v:minimal`
- `dotnet build src\Tests\Wallets.IntegrationTests\Wallets.IntegrationTests.csproj -m:1 /nr:false -v:minimal`
- Static Wallets multi-grid tab assertion passed locally.

## Note
- Focused `dotnet test ... --filter TestCategory=Area:ControlPanelContract` compiled, but local execution is blocked because the Wallets NUnit SetUpFixture starts Testcontainers and Docker.DotNet does not support the configured `ssh://xeon@xeon-dev` Docker context from this local process.