### PR TITLE
Polish Wallets ControlPanel UI guidelines

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -193,6 +193,8 @@
     private string _userInitials = "A";
     private Guid? _breadcrumbProductId;
     private string? _breadcrumbProductLabel;
+    private Guid? _breadcrumbWalletId;
+    private string? _breadcrumbWalletLabel;
     private bool _profileMenuOpen;
 
     private string _selectedTenantName => TenantFilter.SelectedTenantName ?? "";
@@ -224,6 +226,11 @@
             return BuildInventarioProductBreadcrumbs(productId, section);
         }
 
+        if (TryGetWalletDetailRoute(out var walletId, out section))
+        {
+            return BuildWalletBreadcrumbs(walletId, section);
+        }
+
         var path = new Uri(Nav.Uri).AbsolutePath.Trim('/');
         if (string.IsNullOrEmpty(path)) return [];
 
@@ -250,6 +257,24 @@
             ? _breadcrumbProductLabel
             : ShortId(productId);
 
+    private List<string> BuildWalletBreadcrumbs(Guid walletId, string section)
+    {
+        var normalizedSection = NormalizeWalletDetailSection(section);
+
+        return
+        [
+            "Finance",
+            "Wallets",
+            GetWalletBreadcrumbLabel(walletId),
+            WalletSectionLabel(normalizedSection)
+        ];
+    }
+
+    private string GetWalletBreadcrumbLabel(Guid walletId) =>
+        _breadcrumbWalletId == walletId && !string.IsNullOrWhiteSpace(_breadcrumbWalletLabel)
+            ? _breadcrumbWalletLabel
+            : $"Wallet {ShortId(walletId)}";
+
     private static string NormalizeProductDetailSection(string? section) =>
         string.IsNullOrWhiteSpace(section)
             ? "summary"
@@ -270,6 +295,28 @@
         "replenishment" => "Replenishment",
         "variations" => "Variations",
         "transactions" => "Transactions",
+        _ => HumanizeSegment(section)
+    };
+
+    private static string NormalizeWalletDetailSection(string? section) =>
+        string.IsNullOrWhiteSpace(section)
+            ? "summary"
+            : section.ToLowerInvariant() switch
+            {
+                "activity" => "transactions",
+                "history" => "transactions",
+                "operations" => "workflows",
+                "workflow" => "workflows",
+                "limits" => "rules",
+                _ => section.ToLowerInvariant()
+            };
+
+    private static string WalletSectionLabel(string section) => section switch
+    {
+        "summary" => "Summary",
+        "workflows" => "Workflows",
+        "transactions" => "Transactions",
+        "rules" => "Rules",
         _ => HumanizeSegment(section)
     };
 
@@ -666,13 +713,30 @@
 
     private async Task RefreshBreadcrumbEntityLabels()
     {
-        if (!TryGetInventarioProductDetailRoute(out var productId, out _))
+        if (TryGetInventarioProductDetailRoute(out var productId, out _))
         {
-            _breadcrumbProductId = null;
-            _breadcrumbProductLabel = null;
+            _breadcrumbWalletId = null;
+            _breadcrumbWalletLabel = null;
+            await RefreshProductBreadcrumbLabel(productId);
             return;
         }
 
+        if (TryGetWalletDetailRoute(out var walletId, out _))
+        {
+            _breadcrumbProductId = null;
+            _breadcrumbProductLabel = null;
+            await RefreshWalletBreadcrumbLabel(walletId);
+            return;
+        }
+
+        _breadcrumbProductId = null;
+        _breadcrumbProductLabel = null;
+        _breadcrumbWalletId = null;
+        _breadcrumbWalletLabel = null;
+    }
+
+    private async Task RefreshProductBreadcrumbLabel(Guid productId)
+    {
         if (_breadcrumbProductId == productId && !string.IsNullOrWhiteSpace(_breadcrumbProductLabel))
         {
             return;
@@ -702,6 +766,38 @@
         catch
         {
             _breadcrumbProductLabel = ShortId(productId);
+        }
+    }
+
+    private async Task RefreshWalletBreadcrumbLabel(Guid walletId)
+    {
+        if (_breadcrumbWalletId == walletId && !string.IsNullOrWhiteSpace(_breadcrumbWalletLabel))
+        {
+            return;
+        }
+
+        _breadcrumbWalletId = walletId;
+        _breadcrumbWalletLabel = $"Wallet {ShortId(walletId)}";
+
+        try
+        {
+            var wallet = (await DataContext.Query<Wallet>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.WalletType)
+                .Include(x => x.Credential)
+                .Where(x => x.Id == walletId && !x.IsDeleted)
+                .Take(1)
+                .ToListAsync())
+                .FirstOrDefault();
+
+            _breadcrumbWalletLabel = wallet is null
+                ? $"Wallet {ShortId(walletId)}"
+                : WalletsControlPanelDisplayService.BuildWalletLabel(wallet);
+        }
+        catch
+        {
+            _breadcrumbWalletLabel = $"Wallet {ShortId(walletId)}";
         }
     }
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/BatchOperations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/BatchOperations.razor
@@ -5,16 +5,22 @@
 
 <PageTitle>Batch Operations - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Batch Operations</BbTypographyH3>
             <BbTypographyMuted>Submit ledger-backed batch wallet operations and inspect recent batch activity.</BbTypographyMuted>
         </div>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton OnClick="@OpenBatchDialog" Disabled="@(_wallets.Count == 0)">
+                <LucideIcon Name="play" class="mr-2 h-4 w-4" />
+                Submit Batch
+            </BbButton>
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -31,83 +37,7 @@
     }
     else
     {
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Submit Batch Item</BbCardTitle>
-                <BbCardDescription>Runs through the Wallets batch ledger API with tenant and actor context.</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                    <BbFormFieldSelect TValue="string" @bind-Value="_operation" Label="Operation">
-                        <BbSelectItem Value="@BatchIncrement">Increment</BbSelectItem>
-                        <BbSelectItem Value="@BatchDecrement">Decrement</BbSelectItem>
-                        <BbSelectItem Value="@BatchTransfer">Transfer</BbSelectItem>
-                    </BbFormFieldSelect>
-                    <XfEntityPicker TItem="Wallet"
-                                    Label="@SourceWalletLabel"
-                                    Value="@_sourceWalletId"
-                                    ValueChanged="@(value => _sourceWalletId = value ?? NoSelectionValue)"
-                                    Items="@_wallets"
-                                    ValueSelector="@GetWalletPickerValue"
-                                    TextSelector="@BuildWalletLabel"
-                                    SearchTextSelector="@GetWalletSearchText"
-                                    AdvancedColumns="@WalletAdvancedColumns"
-                                    AdvancedFilters="@WalletAdvancedFilters"
-                                    AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
-                                    Placeholder="Select wallet"
-                                    SearchPlaceholder="Search wallets..."
-                                    EmptyMessage="No wallets found."
-                                    AllowClear="true"
-                                    ClearText="Clear wallet"
-                                    AdvancedSearchTitle="Find Source Wallet"
-                                    AdvancedSearchDescription="Search wallets for batch increment, decrement, or transfer source." />
-                    @if (_operation == BatchTransfer)
-                    {
-                        <XfEntityPicker TItem="Wallet"
-                                        Label="Destination Wallet"
-                                        Value="@_destinationWalletId"
-                                        ValueChanged="@(value => _destinationWalletId = value ?? NoSelectionValue)"
-                                        Items="@DestinationWalletOptions"
-                                        ValueSelector="@GetWalletPickerValue"
-                                        TextSelector="@BuildWalletLabel"
-                                        SearchTextSelector="@GetWalletSearchText"
-                                        AdvancedColumns="@WalletAdvancedColumns"
-                                        AdvancedFilters="@WalletAdvancedFilters"
-                                        AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
-                                        Placeholder="Select destination wallet"
-                                        SearchPlaceholder="Search destination wallets..."
-                                        EmptyMessage="No destination wallets found."
-                                        AllowClear="true"
-                                        ClearText="Clear destination wallet"
-                                        AdvancedSearchTitle="Find Destination Wallet"
-                                        AdvancedSearchDescription="Search wallets that can receive this batch transfer." />
-                    }
-                    <BbFormFieldInput TValue="decimal" @bind-Value="_amount" Label="Amount" />
-                    <BbFormFieldInput TValue="decimal" @bind-Value="_fee" Label="Fee" />
-                    <BbFormFieldSelect TValue="string" @bind-Value="_onHold" Label="Hold">
-                        <BbSelectItem Value="false">No</BbSelectItem>
-                        <BbSelectItem Value="true">Yes</BbSelectItem>
-                    </BbFormFieldSelect>
-                    <BbFormFieldInput TValue="string" @bind-Value="_referenceNumber" Label="Reference" Placeholder="Optional batch reference" />
-                </div>
-                <div class="mt-4 flex flex-wrap gap-2">
-                    <BbButton OnClick="@SubmitBatch" Disabled="@(_acting || _wallets.Count == 0)">
-                        @if (_acting)
-                        {
-                            <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
-                        }
-                        <LucideIcon Name="play" class="mr-2 h-4 w-4" />
-                        Submit
-                    </BbButton>
-                    @if (!string.IsNullOrWhiteSpace(_lastOutcome))
-                    {
-                        <BbBadge Variant="BadgeVariant.Outline">@_lastOutcome</BbBadge>
-                    }
-                </div>
-            </BbCardContent>
-        </BbCard>
-
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div class="xf-summary-grid xf-summary-grid-3">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -136,15 +66,93 @@
 
         <BbDataGrid Items="@_batchOperations" ShowPagination="true" InitialPageSize="20">
             <Columns>
-                <BbDataGridPropertyColumn Property="@(x => x.Id)" Title="Operation" />
-                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
-                <BbDataGridPropertyColumn Property="@(x => x.ActorCredentialId)" Title="Actor" />
-                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                <BbDataGridTemplateColumn Title="Operation" Filterable="true" FilterBy="@(item => BuildOperationLabel(item))">
+                    <ChildContent Context="item">@BuildOperationLabel(item)</ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Filterable="true" />
+                <BbDataGridTemplateColumn Title="Actor" Filterable="true" FilterBy="@(item => GetCredentialLabel(item.ActorCredentialId))">
+                    <ChildContent Context="item">@GetCredentialLabel(item.ActorCredentialId)</ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
             </Columns>
+            <EmptyTemplate>
+                <BbEmpty Title="No batch operations found" Description="Submit a batch item to review ledger-backed batch activity." />
+            </EmptyTemplate>
         </BbDataGrid>
     }
 </div>
+
+<BbDialog Open="@_batchDialogOpen" OpenChanged="@OnBatchDialogChanged">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
+        <BbDialogHeader>
+            <BbDialogTitle>Submit Batch</BbDialogTitle>
+            <BbDialogDescription>Runs through the Wallets batch ledger API with tenant and actor context.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <BbFormFieldSelect TValue="string" @bind-Value="_operation" Label="Operation">
+                    <BbSelectItem Value="@BatchIncrement">Increment</BbSelectItem>
+                    <BbSelectItem Value="@BatchDecrement">Decrement</BbSelectItem>
+                    <BbSelectItem Value="@BatchTransfer">Transfer</BbSelectItem>
+                </BbFormFieldSelect>
+                <XfEntityPicker TItem="Wallet"
+                                Label="@SourceWalletLabel"
+                                Value="@_sourceWalletId"
+                                ValueChanged="@(value => _sourceWalletId = value ?? NoSelectionValue)"
+                                Items="@_wallets"
+                                ValueSelector="@GetWalletPickerValue"
+                                TextSelector="@BuildWalletLabel"
+                                SearchTextSelector="@GetWalletSearchText"
+                                AdvancedColumns="@WalletAdvancedColumns"
+                                AdvancedFilters="@WalletAdvancedFilters"
+                                AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
+                                Placeholder="Select wallet"
+                                SearchPlaceholder="Search wallets..."
+                                EmptyMessage="No wallets found."
+                                AllowClear="true"
+                                ClearText="Clear wallet"
+                                AdvancedSearchTitle="Find Source Wallet"
+                                AdvancedSearchDescription="Search wallets for batch increment, decrement, or transfer source." />
+                @if (_operation == BatchTransfer)
+                {
+                    <XfEntityPicker TItem="Wallet"
+                                    Label="Destination Wallet"
+                                    Value="@_destinationWalletId"
+                                    ValueChanged="@(value => _destinationWalletId = value ?? NoSelectionValue)"
+                                    Items="@DestinationWalletOptions"
+                                    ValueSelector="@GetWalletPickerValue"
+                                    TextSelector="@BuildWalletLabel"
+                                    SearchTextSelector="@GetWalletSearchText"
+                                    AdvancedColumns="@WalletAdvancedColumns"
+                                    AdvancedFilters="@WalletAdvancedFilters"
+                                    AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
+                                    Placeholder="Select destination wallet"
+                                    SearchPlaceholder="Search destination wallets..."
+                                    EmptyMessage="No destination wallets found."
+                                    AllowClear="true"
+                                    ClearText="Clear destination wallet"
+                                    AdvancedSearchTitle="Find Destination Wallet"
+                                    AdvancedSearchDescription="Search wallets that can receive this batch transfer." />
+                }
+                <BbFormFieldCurrencyInput @bind-Value="_amount" Label="Amount" ShowSymbol="false" Min="0" />
+                <BbFormFieldCurrencyInput @bind-Value="_fee" Label="Fee" ShowSymbol="false" Min="0" />
+                <BbFormFieldSwitch Checked="@_onHold" CheckedChanged="@((bool value) => _onHold = value)" Label="Hold" />
+                <BbFormFieldInput TValue="string" @bind-Value="_referenceNumber" Label="Reference" Placeholder="Optional batch reference" />
+            </div>
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@CloseBatchDialog" Disabled="@_acting">Cancel</BbButton>
+            <BbButton OnClick="@SubmitBatch" Disabled="@(_acting || _wallets.Count == 0)">
+                @if (_acting)
+                {
+                    <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                }
+                Submit
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
 
 @code {
     private const string NoSelectionValue = "__none__";
@@ -157,19 +165,23 @@
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private WalletsControlPanelDisplayService DisplayService { get; set; } = default!;
+    [Inject] private ILogger<BatchOperations> Logger { get; set; } = default!;
 
     private List<Wallet> _wallets = [];
     private List<WalletOperation> _batchOperations = [];
+    private IReadOnlyDictionary<Guid, string> _credentialLabels = new Dictionary<Guid, string>();
     private bool _loading = true;
     private bool _acting;
     private bool _hasTenant;
     private bool _moduleEnabled;
+    private bool _batchDialogOpen;
     private DateTime? _latest;
     private string? _lastOutcome;
     private string _operation = BatchIncrement;
     private string _sourceWalletId = NoSelectionValue;
     private string _destinationWalletId = NoSelectionValue;
-    private string _onHold = "false";
+    private bool _onHold;
     private string _referenceNumber = "";
     private decimal _amount;
     private decimal _fee;
@@ -200,6 +212,7 @@
             _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.WalletsBatch);
             _wallets = [];
             _batchOperations = [];
+            _credentialLabels = new Dictionary<Guid, string>();
             _latest = null;
 
             if (!_hasTenant || !_moduleEnabled)
@@ -232,6 +245,9 @@
                 .Where(x => x.OperationType == WalletOperationType.Batch)
                 .Take(100)
                 .ToList();
+            _credentialLabels = await DisplayService.LoadCredentialLabelsAsync(
+                tenantId,
+                _batchOperations.Select(x => x.ActorCredentialId));
 
             _latest = _batchOperations.Count == 0 ? null : _batchOperations.Max(x => x.CreatedAt);
         }
@@ -239,8 +255,10 @@
         {
             _wallets = [];
             _batchOperations = [];
+            _credentialLabels = new Dictionary<Guid, string>();
             _latest = null;
-            ToastService.Show($"Failed to load batch operations: {ex.Message}");
+            Logger.LogError(ex, "Failed to load batch operations.");
+            ToastService.Error("Could not load batch operations.", "Wallets");
         }
         finally
         {
@@ -253,20 +271,20 @@
     {
         if (!Guid.TryParse(_sourceWalletId, out var sourceWalletId))
         {
-            ToastService.Show("Select a wallet.");
+            ToastService.Warning("Select a wallet.", "Validation");
             return;
         }
 
         if (_amount <= 0 || _fee < 0)
         {
-            ToastService.Show("Amount must be greater than zero and fee cannot be negative.");
+            ToastService.Warning("Amount must be greater than zero and fee cannot be negative.", "Validation");
             return;
         }
 
         var sourceWallet = _wallets.FirstOrDefault(x => x.Id == sourceWalletId);
         if (sourceWallet is null)
         {
-            ToastService.Show("Selected wallet is not available.");
+            ToastService.Warning("Selected wallet is not available.", "Validation");
             return;
         }
 
@@ -290,7 +308,7 @@
                             CredentialId = sourceWallet.CredentialId,
                             Amount = _amount,
                             Fee = _fee,
-                            OnHold = bool.Parse(_onHold),
+                            OnHold = _onHold,
                             ReferenceNumber = referenceNumber,
                             Remarks = "ControlPanel batch increment"
                         }
@@ -306,7 +324,7 @@
                             CredentialId = sourceWallet.CredentialId,
                             Amount = _amount,
                             Fee = _fee,
-                            OnHold = bool.Parse(_onHold),
+                            OnHold = _onHold,
                             ReferenceNumber = referenceNumber,
                             Remarks = "ControlPanel batch decrement"
                         }
@@ -323,16 +341,19 @@
             if (response.IsSuccess)
             {
                 _lastOutcome = $"{_operation} accepted";
-                ToastService.Show(response.Message ?? $"Batch {_operation} submitted.");
+                ToastService.Success($"Batch {_operation} submitted.", "Wallets");
+                CloseBatchDialog();
                 await LoadData();
                 return;
             }
 
-            ToastService.Show(response.Message ?? "Batch operation failed.");
+            Logger.LogWarning("Batch operation failed: {Message}", response.Message);
+            ToastService.Error("Batch operation could not be completed.", "Wallets");
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Batch operation failed: {ex.Message}");
+            Logger.LogError(ex, "Batch operation failed.");
+            ToastService.Error("Batch operation could not be completed.", "Wallets");
         }
         finally
         {
@@ -380,6 +401,48 @@
         });
     }
 
+    private void OpenBatchDialog()
+    {
+        ResetBatchForm();
+        _batchDialogOpen = true;
+    }
+
+    private void CloseBatchDialog()
+    {
+        _batchDialogOpen = false;
+        ResetBatchForm();
+    }
+
+    private Task OnBatchDialogChanged(bool open)
+    {
+        _batchDialogOpen = open;
+        if (!open)
+        {
+            ResetBatchForm();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ResetBatchForm()
+    {
+        _operation = BatchIncrement;
+        _sourceWalletId = NoSelectionValue;
+        _destinationWalletId = NoSelectionValue;
+        _onHold = false;
+        _referenceNumber = "";
+        _amount = 0;
+        _fee = 0;
+    }
+
+    private static string BuildOperationLabel(WalletOperation operation)
+    {
+        var reference = string.IsNullOrWhiteSpace(operation.ReferenceNumber)
+            ? $"Operation {operation.Id.ToString()[..8]}"
+            : operation.ReferenceNumber;
+        return $"{reference} - {operation.Status}";
+    }
+
     private static string BuildWalletLabel(Wallet wallet)
     {
         var balance = wallet.Balance.ToString("N2", CultureInfo.InvariantCulture);
@@ -424,6 +487,9 @@
 
         return wallet.CredentialId.ToString()[..8];
     }
+
+    private string GetCredentialLabel(Guid? credentialId) =>
+        DisplayService.CredentialLabel(credentialId, _credentialLabels);
 
     private static IReadOnlyList<XfEntityPickerFilterOption> BuildEnumFilterOptions<TEnum>()
         where TEnum : struct, Enum =>

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/DepositRequests.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/DepositRequests.razor
@@ -6,16 +6,22 @@
 
 <PageTitle>Deposit Requests - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Deposit Requests</BbTypographyH3>
             <BbTypographyMuted>Inspect deposit requests and hand off approvals to the Wallets workflow.</BbTypographyMuted>
         </div>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton OnClick="@OpenCreateDialog">
+                <LucideIcon Name="circle-plus" class="mr-2 h-4 w-4" />
+                Create Deposit
+            </BbButton>
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -32,123 +38,7 @@
     }
     else
     {
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Create Deposit Request</BbCardTitle>
-                <BbCardDescription>Submit cash-in requests through the Wallets deposit workflow.</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                    <XfEntityPicker TItem="IdentityCredential"
-                                    Label="Credential"
-                                    Value="@_createCredentialId"
-                                    ValueChanged="@(value => _createCredentialId = value ?? "")"
-                                    Items="@_credentials"
-                                    ValueSelector="@GetCredentialPickerValue"
-                                    TextSelector="@BuildCredentialLabel"
-                                    SearchTextSelector="@GetCredentialSearchText"
-                                    AdvancedColumns="@CredentialAdvancedColumns"
-                                    AdvancedFilters="@CredentialAdvancedFilters"
-                                    AdvancedSearchScope="Searches credential username, alias, identity name, verified state, online state, last seen date, and credential id."
-                                    Placeholder="Select credential"
-                                    SearchPlaceholder="Search users or credentials..."
-                                    EmptyMessage="No credentials found."
-                                    AllowClear="true"
-                                    ClearText="Clear credential"
-                                    AdvancedSearchTitle="Find Credential"
-                                    AdvancedSearchDescription="Search credentials for the active tenant." />
-                    <XfEntityPicker TItem="Wallet"
-                                    Label="Existing Wallet"
-                                    Value="@_createWalletId"
-                                    ValueChanged="@OnCreateWalletChanged"
-                                    Items="@_wallets"
-                                    ValueSelector="@GetWalletPickerValue"
-                                    TextSelector="@BuildWalletLabel"
-                                    SearchTextSelector="@GetWalletSearchText"
-                                    AdvancedColumns="@WalletAdvancedColumns"
-                                    AdvancedFilters="@WalletAdvancedFilters"
-                                    AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
-                                    Placeholder="Create or resolve by wallet type"
-                                    SearchPlaceholder="Search wallets..."
-                                    EmptyMessage="No wallets found."
-                                    AllowClear="true"
-                                    ClearText="Create or resolve by wallet type"
-                                    AdvancedSearchTitle="Find Wallet"
-                                    AdvancedSearchDescription="Search active-tenant wallets before creating a deposit request." />
-                    <XfEntityPicker TItem="global::Wallets.Domain.Shared.Contracts.WalletType"
-                                    Label="Wallet Type"
-                                    Value="@_createWalletTypeId"
-                                    ValueChanged="@(value => _createWalletTypeId = value ?? NoSelectionValue)"
-                                    Items="@_walletTypes"
-                                    ValueSelector="@GetWalletTypePickerValue"
-                                    TextSelector="@BuildWalletTypeLabel"
-                                    SearchTextSelector="@GetWalletTypeSearchText"
-                                    AdvancedColumns="@WalletTypeAdvancedColumns"
-                                    AdvancedFilters="@WalletTypeAdvancedFilters"
-                                    AdvancedSearchScope="Searches wallet type code, name, currency, type code, transfer rules, and created date."
-                                    Placeholder="Use selected wallet"
-                                    SearchPlaceholder="Search wallet types..."
-                                    EmptyMessage="No wallet types found."
-                                    AllowClear="true"
-                                    ClearText="Use selected wallet"
-                                    AdvancedSearchTitle="Find Wallet Type"
-                                    AdvancedSearchDescription="Search wallet types when the deposit should resolve or create a wallet." />
-                    <XfEntityPicker TItem="global::Wallets.Domain.Shared.Contracts.CurrencyType"
-                                    Label="Currency"
-                                    Value="@_createCurrencyId"
-                                    ValueChanged="@(value => _createCurrencyId = value ?? NoSelectionValue)"
-                                    Items="@_currencies"
-                                    ValueSelector="@GetCurrencyPickerValue"
-                                    TextSelector="@BuildCurrencyLabel"
-                                    SearchTextSelector="@GetCurrencySearchText"
-                                    AdvancedColumns="@CurrencyAdvancedColumns"
-                                    AdvancedFilters="@CurrencyAdvancedFilters"
-                                    AdvancedSearchScope="Searches currency ISO code, name, type, tenant scope, and description."
-                                    Placeholder="Default wallet currency"
-                                    SearchPlaceholder="Search currencies..."
-                                    EmptyMessage="No currencies found."
-                                    AllowClear="true"
-                                    ClearText="Default wallet currency"
-                                    AdvancedSearchTitle="Find Currency"
-                                    AdvancedSearchDescription="Search tenant and global currencies available to Wallets." />
-                    <XfEntityPicker TItem="PaymentGateway"
-                                    Label="Gateway"
-                                    Value="@_createGatewayId"
-                                    ValueChanged="@(value => _createGatewayId = value ?? NoSelectionValue)"
-                                    Items="@_gateways"
-                                    ValueSelector="@GetGatewayPickerValue"
-                                    TextSelector="@BuildGatewayLabel"
-                                    SearchTextSelector="@GetGatewaySearchText"
-                                    AdvancedColumns="@GatewayAdvancedColumns"
-                                    AdvancedFilters="@GatewayAdvancedFilters"
-                                    AdvancedSearchScope="Searches gateway name, category/provider, enabled state, service charge, convenience fee, discount, and description."
-                                    Placeholder="Select gateway"
-                                    SearchPlaceholder="Search gateways..."
-                                    EmptyMessage="No gateways found."
-                                    AllowClear="true"
-                                    ClearText="Clear gateway"
-                                    AdvancedSearchTitle="Find Payment Gateway"
-                                    AdvancedSearchDescription="Search configured payment gateways for deposit settlement." />
-                    <BbFormFieldInput TValue="decimal" @bind-Value="_createAmount" Label="Amount" />
-                    <BbFormFieldInput TValue="decimal" @bind-Value="_createRequestedFee" Label="Requested Fee" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_createExternalReference" Label="External Reference" Placeholder="Optional provider/reference id" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_createAddress" Label="Address" Placeholder="Optional source address" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_createRemarks" Label="Remarks" Placeholder="Cash-in note" />
-                </div>
-                <div class="mt-4">
-                    <BbButton OnClick="@CreateDeposit" Disabled="@_acting">
-                        @if (_acting)
-                        {
-                            <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
-                        }
-                        <LucideIcon Name="circle-plus" class="mr-2 h-4 w-4" />
-                        Create Deposit
-                    </BbButton>
-                </div>
-            </BbCardContent>
-        </BbCard>
-
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div class="xf-summary-grid xf-summary-grid-4">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -185,28 +75,28 @@
 
         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
             <Columns>
-                <BbDataGridTemplateColumn Title="Credential">
+                <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(item => GetCredentialLabel(item.CredentialId))">
                     <ChildContent Context="item">
-                        <span class="font-mono text-xs">@ShortId(item.CredentialId)</span>
+                        <span>@GetCredentialLabel(item.CredentialId)</span>
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.ConvenienceFee)" Title="Convenience Fee" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.SystemFee)" Title="System Fee" Sortable="true" />
-                <BbDataGridTemplateColumn Title="Workflow">
+                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.ConvenienceFee)" Title="Convenience Fee" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.SystemFee)" Title="System Fee" Sortable="true" Filterable="true" />
+                <BbDataGridTemplateColumn Title="Workflow" Filterable="true" FilterBy="@(item => item.WorkflowStatus.ToString())">
                     <ChildContent Context="item">
                         <StatusBadge Text="@item.WorkflowStatus.ToString()" Status="@GetWorkflowStatusCategory(item.WorkflowStatus)" />
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridTemplateColumn Title="Status">
+                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => GetDepositStatusText(item.DepositStatus))">
                     <ChildContent Context="item">
                         <StatusBadge Text="@GetDepositStatusText(item.DepositStatus)" Status="@GetDepositStatusCategory(item.DepositStatus)" />
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNo)" Title="Reference No" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.Address)" Title="Address" />
-                <BbDataGridPropertyColumn Property="@(x => x.ExpiryDate)" Title="Expiry Date" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNo)" Title="Reference No" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.Address)" Title="Address" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.ExpiryDate)" Title="Expiry Date" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                 <BbDataGridTemplateColumn Title="Actions">
                     <ChildContent Context="item">
                         <div class="flex flex-wrap gap-1">
@@ -229,9 +119,130 @@
                     </ChildContent>
                 </BbDataGridTemplateColumn>
             </Columns>
+            <EmptyTemplate>
+                <BbEmpty Title="No deposit requests found" Description="Create a deposit request to start the workflow." />
+            </EmptyTemplate>
         </BbDataGrid>
     }
 </div>
+
+<BbDialog Open="@_createDialogOpen" OpenChanged="@OnCreateDialogChanged">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
+        <BbDialogHeader>
+            <BbDialogTitle>Create Deposit</BbDialogTitle>
+            <BbDialogDescription>Submit cash-in requests through the Wallets deposit workflow.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <XfEntityPicker TItem="IdentityCredential"
+                                Label="Credential"
+                                Value="@_createCredentialId"
+                                ValueChanged="@(value => _createCredentialId = value ?? "")"
+                                Items="@_credentials"
+                                ValueSelector="@GetCredentialPickerValue"
+                                TextSelector="@BuildCredentialLabel"
+                                SearchTextSelector="@GetCredentialSearchText"
+                                AdvancedColumns="@CredentialAdvancedColumns"
+                                AdvancedFilters="@CredentialAdvancedFilters"
+                                AdvancedSearchScope="Searches credential username, alias, identity name, verified state, online state, last seen date, and credential id."
+                                Placeholder="Select credential"
+                                SearchPlaceholder="Search users or credentials..."
+                                EmptyMessage="No credentials found."
+                                AllowClear="true"
+                                ClearText="Clear credential"
+                                AdvancedSearchTitle="Find Credential"
+                                AdvancedSearchDescription="Search credentials for the active tenant." />
+                <XfEntityPicker TItem="Wallet"
+                                Label="Existing Wallet"
+                                Value="@_createWalletId"
+                                ValueChanged="@OnCreateWalletChanged"
+                                Items="@_wallets"
+                                ValueSelector="@GetWalletPickerValue"
+                                TextSelector="@BuildWalletLabel"
+                                SearchTextSelector="@GetWalletSearchText"
+                                AdvancedColumns="@WalletAdvancedColumns"
+                                AdvancedFilters="@WalletAdvancedFilters"
+                                AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
+                                Placeholder="Create or resolve by wallet type"
+                                SearchPlaceholder="Search wallets..."
+                                EmptyMessage="No wallets found."
+                                AllowClear="true"
+                                ClearText="Create or resolve by wallet type"
+                                AdvancedSearchTitle="Find Wallet"
+                                AdvancedSearchDescription="Search active-tenant wallets before creating a deposit request." />
+                <XfEntityPicker TItem="global::Wallets.Domain.Shared.Contracts.WalletType"
+                                Label="Wallet Type"
+                                Value="@_createWalletTypeId"
+                                ValueChanged="@(value => _createWalletTypeId = value ?? NoSelectionValue)"
+                                Items="@_walletTypes"
+                                ValueSelector="@GetWalletTypePickerValue"
+                                TextSelector="@BuildWalletTypeLabel"
+                                SearchTextSelector="@GetWalletTypeSearchText"
+                                AdvancedColumns="@WalletTypeAdvancedColumns"
+                                AdvancedFilters="@WalletTypeAdvancedFilters"
+                                AdvancedSearchScope="Searches wallet type code, name, currency, type code, transfer rules, and created date."
+                                Placeholder="Use selected wallet"
+                                SearchPlaceholder="Search wallet types..."
+                                EmptyMessage="No wallet types found."
+                                AllowClear="true"
+                                ClearText="Use selected wallet"
+                                AdvancedSearchTitle="Find Wallet Type"
+                                AdvancedSearchDescription="Search wallet types when the deposit should resolve or create a wallet." />
+                <XfEntityPicker TItem="global::Wallets.Domain.Shared.Contracts.CurrencyType"
+                                Label="Currency"
+                                Value="@_createCurrencyId"
+                                ValueChanged="@(value => _createCurrencyId = value ?? NoSelectionValue)"
+                                Items="@_currencies"
+                                ValueSelector="@GetCurrencyPickerValue"
+                                TextSelector="@BuildCurrencyLabel"
+                                SearchTextSelector="@GetCurrencySearchText"
+                                AdvancedColumns="@CurrencyAdvancedColumns"
+                                AdvancedFilters="@CurrencyAdvancedFilters"
+                                AdvancedSearchScope="Searches currency ISO code, name, type, tenant scope, and description."
+                                Placeholder="Default wallet currency"
+                                SearchPlaceholder="Search currencies..."
+                                EmptyMessage="No currencies found."
+                                AllowClear="true"
+                                ClearText="Default wallet currency"
+                                AdvancedSearchTitle="Find Currency"
+                                AdvancedSearchDescription="Search tenant and global currencies available to Wallets." />
+                <XfEntityPicker TItem="PaymentGateway"
+                                Label="Gateway"
+                                Value="@_createGatewayId"
+                                ValueChanged="@(value => _createGatewayId = value ?? NoSelectionValue)"
+                                Items="@_gateways"
+                                ValueSelector="@GetGatewayPickerValue"
+                                TextSelector="@BuildGatewayLabel"
+                                SearchTextSelector="@GetGatewaySearchText"
+                                AdvancedColumns="@GatewayAdvancedColumns"
+                                AdvancedFilters="@GatewayAdvancedFilters"
+                                AdvancedSearchScope="Searches gateway name, category/provider, enabled state, service charge, convenience fee, discount, and description."
+                                Placeholder="Select gateway"
+                                SearchPlaceholder="Search gateways..."
+                                EmptyMessage="No gateways found."
+                                AllowClear="true"
+                                ClearText="Clear gateway"
+                                AdvancedSearchTitle="Find Payment Gateway"
+                                AdvancedSearchDescription="Search configured payment gateways for deposit settlement." />
+                <BbFormFieldCurrencyInput @bind-Value="_createAmount" Label="Amount" ShowSymbol="false" Min="0" />
+                <BbFormFieldCurrencyInput @bind-Value="_createRequestedFee" Label="Requested Fee" ShowSymbol="false" Min="0" />
+                <BbFormFieldInput TValue="string" @bind-Value="_createExternalReference" Label="External Reference" Placeholder="Optional provider/reference id" />
+                <BbFormFieldInput TValue="string" @bind-Value="_createAddress" Label="Address" Placeholder="Optional source address" />
+                <BbFormFieldInput TValue="string" @bind-Value="_createRemarks" Label="Remarks" Placeholder="Cash-in note" />
+            </div>
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@CloseCreateDialog" Disabled="@_acting">Cancel</BbButton>
+            <BbButton OnClick="@CreateDeposit" Disabled="@_acting">
+                @if (_acting)
+                {
+                    <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                }
+                Create Deposit
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
 
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
@@ -239,6 +250,8 @@
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private ILogger<DepositRequests> Logger { get; set; } = default!;
 
     private const string NoSelectionValue = "__none";
 
@@ -251,6 +264,7 @@
     private Dictionary<Guid, string> _credentialLabels = [];
     private bool _loading = true;
     private bool _acting;
+    private bool _createDialogOpen;
     private bool _hasTenant;
     private bool _moduleEnabled;
     private int _pendingCount;
@@ -316,7 +330,8 @@
             _items = [];
             ResetCreateOptions();
             ResetSummary();
-            ToastService.Show($"Failed to load deposit requests: {ex.Message}");
+            Logger.LogError(ex, "Failed to load deposit requests.");
+            ToastService.Error("Could not load deposit requests.", "Wallets");
         }
         finally
         {
@@ -401,19 +416,19 @@
     {
         if (_createAmount <= 0)
         {
-            ToastService.Show("Enter a deposit amount greater than zero.");
+            ToastService.Warning("Enter a deposit amount greater than zero.", "Validation");
             return;
         }
 
         if (_createRequestedFee < 0)
         {
-            ToastService.Show("Requested fee cannot be negative.");
+            ToastService.Warning("Requested fee cannot be negative.", "Validation");
             return;
         }
 
         if (!Guid.TryParse(_createGatewayId, out var gatewayId))
         {
-            ToastService.Show("Select a payment gateway.");
+            ToastService.Warning("Select a payment gateway.", "Validation");
             return;
         }
 
@@ -429,13 +444,13 @@
 
         if (!Guid.TryParse(credentialText, out var credentialId))
         {
-            ToastService.Show("Select a credential for the deposit request.");
+            ToastService.Warning("Select a credential for the deposit request.", "Validation");
             return;
         }
 
         if (wallet is not null && wallet.CredentialId != credentialId)
         {
-            ToastService.Show("Selected wallet does not belong to the selected credential.");
+            ToastService.Warning("Selected wallet does not belong to the selected credential.", "Validation");
             return;
         }
 
@@ -445,7 +460,7 @@
             : wallet?.WalletTypeId;
         if (!walletId.HasValue && !walletTypeId.HasValue)
         {
-            ToastService.Show("Select an existing wallet or wallet type.");
+            ToastService.Warning("Select an existing wallet or wallet type.", "Validation");
             return;
         }
 
@@ -471,12 +486,23 @@
                 IdempotencyKey = $"control-panel-deposit:{Guid.NewGuid():N}"
             });
 
-            ToastService.Show(result.IsSuccess ? "Deposit request created." : result.Message ?? "Deposit request creation failed.");
             if (result.IsSuccess)
             {
+                ToastService.Success("Deposit request created.", "Wallets");
+                _createDialogOpen = false;
                 ResetCreateForm();
                 await LoadData();
             }
+            else
+            {
+                Logger.LogWarning("Deposit request creation failed: {Message}", result.Message);
+                ToastService.Error("Deposit request could not be created.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Deposit request creation failed.");
+            ToastService.Error("Deposit request could not be created.", "Wallets");
         }
         finally
         {
@@ -485,19 +511,59 @@
     }
 
     private async Task ApproveDeposit(DepositRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.ApproveDepositAsync(item.Id), "Deposit approval");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.ApproveDepositAsync(item.Id),
+            "Approve Deposit",
+            "Approve this deposit request?",
+            "Deposit approval",
+            false);
 
     private async Task RejectDeposit(DepositRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.RejectDepositAsync(item.Id), "Deposit rejection");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.RejectDepositAsync(item.Id),
+            "Reject Deposit",
+            "Reject this deposit request?",
+            "Deposit rejection",
+            true);
 
     private async Task SettleDeposit(DepositRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.SettleDepositAsync(item.Id), "Deposit settlement");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.SettleDepositAsync(item.Id),
+            "Settle Deposit",
+            "Settle this deposit request and create the ledger posting?",
+            "Deposit settlement",
+            false);
 
     private async Task FailDeposit(DepositRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.FailDepositAsync(item.Id), "Deposit failure");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.FailDepositAsync(item.Id),
+            "Fail Deposit",
+            "Mark this deposit request as failed?",
+            "Deposit failure",
+            true);
 
     private async Task CancelDeposit(DepositRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.CancelDepositAsync(item.Id), "Deposit cancellation");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.CancelDepositAsync(item.Id),
+            "Cancel Deposit",
+            "Cancel this deposit request?",
+            "Deposit cancellation",
+            true);
+
+    private async Task ConfirmAndRunAction(
+        Func<Task<CmdResponse>> action,
+        string title,
+        string description,
+        string label,
+        bool destructive)
+    {
+        if (!await DialogService.Confirm(title, description, new ConfirmDialogOptions { Destructive = destructive }))
+        {
+            return;
+        }
+
+        await RunUnsupportedAction(action, label);
+    }
 
     private async Task RunUnsupportedAction(Func<Task<CmdResponse>> action, string label)
     {
@@ -505,13 +571,49 @@
         try
         {
             var result = await action();
-            ToastService.Show(result.IsSuccess ? $"{label} submitted." : result.Message ?? $"{label} is not available.");
-            await LoadData();
+            if (result.IsSuccess)
+            {
+                ToastService.Success($"{label} submitted.", "Wallets");
+                await LoadData();
+            }
+            else
+            {
+                Logger.LogWarning("{Label} failed: {Message}", label, result.Message);
+                ToastService.Error($"{label} could not be completed.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "{Label} failed.", label);
+            ToastService.Error($"{label} could not be completed.", "Wallets");
         }
         finally
         {
             _acting = false;
         }
+    }
+
+    private void OpenCreateDialog()
+    {
+        ResetCreateForm();
+        _createDialogOpen = true;
+    }
+
+    private void CloseCreateDialog()
+    {
+        _createDialogOpen = false;
+        ResetCreateForm();
+    }
+
+    private Task OnCreateDialogChanged(bool open)
+    {
+        _createDialogOpen = open;
+        if (!open)
+        {
+            ResetCreateForm();
+        }
+
+        return Task.CompletedTask;
     }
 
     private void ResetSummary()

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/OutboxWebhooks.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/OutboxWebhooks.razor
@@ -4,16 +4,18 @@
 
 <PageTitle>Wallet Outbox - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Outbox & Webhooks</BbTypographyH3>
             <BbTypographyMuted>Monitor Wallets integration events and failed webhook deliveries.</BbTypographyMuted>
         </div>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -30,7 +32,7 @@
     }
     else
     {
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div class="xf-summary-grid xf-summary-grid-4">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -80,18 +82,21 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.EventType)" Title="Event" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.AggregateType)" Title="Aggregate" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.AggregateId)" Title="Aggregate ID" />
-                                <BbDataGridTemplateColumn Title="Status">
+                                <BbDataGridPropertyColumn Property="@(x => x.EventType)" Title="Event" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Aggregate" Filterable="true" FilterBy="@(item => GetAggregateLabel(item))">
+                                    <ChildContent Context="item">@GetAggregateLabel(item)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status.ToString())">
                                     <ChildContent Context="item">
                                         <BbBadge Variant="@(item.Status == WalletOutboxStatus.Pending ? BadgeVariant.Outline : BadgeVariant.Default)">@item.Status</BbBadge>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.Attempts)" Title="Attempts" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.NextAttemptAt)" Title="Next Attempt" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.LastError)" Title="Last Error" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Attempts)" Title="Attempts" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.NextAttemptAt)" Title="Next Attempt" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Delivery" Filterable="true" FilterBy="@(item => GetOutboxDeliverySummary(item))">
+                                    <ChildContent Context="item">@GetOutboxDeliverySummary(item)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
                                         @if (item.Status is WalletOutboxStatus.Failed or WalletOutboxStatus.DeadLetter)
@@ -112,6 +117,9 @@
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No outbox messages found" Description="Wallet integration events will appear here after ledger operations." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -126,39 +134,42 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_webhookEvents" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.ProviderKey)" Title="Provider" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ExternalEventId)" Title="External Event" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ExternalReference)" Title="Reference" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="Status">
+                                <BbDataGridPropertyColumn Property="@(x => x.ProviderKey)" Title="Provider" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ExternalEventId)" Title="External Event" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ExternalReference)" Title="Reference" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.ProcessingStatus.ToString())">
                                     <ChildContent Context="item">
                                         <BbBadge Variant="@GetWebhookStatusVariant(item.ProcessingStatus)">@item.ProcessingStatus</BbBadge>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Signature">
+                                <BbDataGridTemplateColumn Title="Signature" Filterable="true" FilterBy="@(item => item.SignatureValid)">
                                     <ChildContent Context="item">
                                         <BbBadge Variant="@(item.SignatureValid ? BadgeVariant.Default : BadgeVariant.Destructive)">
                                             @(item.SignatureValid ? "Valid" : "Invalid")
                                         </BbBadge>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.MappedWorkflowStatus)" Title="Mapped" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="Links">
+                                <BbDataGridPropertyColumn Property="@(x => x.MappedWorkflowStatus)" Title="Mapped" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Links" Filterable="true" FilterBy="@(item => GetWebhookLinksLabel(item))">
                                     <ChildContent Context="item">
-                                        <div class="space-y-1 text-xs font-mono">
-                                            <div>Dep: @ShortId(item.DepositRequestId)</div>
-                                            <div>Wd: @ShortId(item.WithdrawalRequestId)</div>
-                                            <div>Op: @ShortId(item.OperationId)</div>
+                                        <div class="space-y-1 text-xs">
+                                            <div>@GetWebhookDepositLabel(item.DepositRequestId)</div>
+                                            <div>@GetWebhookWithdrawalLabel(item.WithdrawalRequestId)</div>
+                                            <div>@GetOperationLabel(item.OperationId)</div>
                                         </div>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Error">
+                                <BbDataGridTemplateColumn Title="Processing" Filterable="true" FilterBy="@(item => WalletsControlPanelDisplayService.SafeFailureSummary(item.ProcessingError))">
                                     <ChildContent Context="item">
-                                        @ShortText(item.ProcessingError)
+                                        @WalletsControlPanelDisplayService.SafeFailureSummary(item.ProcessingError)
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ProcessedAt)" Title="Processed" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReceivedAt)" Title="Received" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ProcessedAt)" Title="Processed" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No webhook events found" Description="Provider webhook audit records will appear here." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -173,9 +184,13 @@
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private WalletsControlPanelDisplayService DisplayService { get; set; } = default!;
+    [Inject] private ILogger<OutboxWebhooks> Logger { get; set; } = default!;
 
     private List<WalletOutboxMessage> _items = [];
     private List<WalletPaymentWebhookEvent> _webhookEvents = [];
+    private IReadOnlyDictionary<Guid, string> _operationLabels = new Dictionary<Guid, string>();
     private bool _loading = true;
     private bool _acting;
     private bool _hasTenant;
@@ -208,6 +223,7 @@
             _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.WalletsWebhooks);
             _items = [];
             _webhookEvents = [];
+            _operationLabels = new Dictionary<Guid, string>();
             ResetSummary();
 
             if (!_hasTenant || !_moduleEnabled)
@@ -231,6 +247,10 @@
                 .Take(200)
                 .ToListAsync();
 
+            _operationLabels = await DisplayService.LoadOperationLabelsAsync(
+                tenantId,
+                _items.Select(x => x.OperationId).Concat(_webhookEvents.Select(x => x.OperationId)));
+
             _pendingCount = _items.Count(x => x.Status == WalletOutboxStatus.Pending);
             _failedCount = _items.Count(x => x.Status == WalletOutboxStatus.Failed);
             _deadLetterCount = _items.Count(x => x.Status == WalletOutboxStatus.DeadLetter);
@@ -240,8 +260,10 @@
         {
             _items = [];
             _webhookEvents = [];
+            _operationLabels = new Dictionary<Guid, string>();
             ResetSummary();
-            ToastService.Show($"Failed to load wallet outbox messages: {ex.Message}");
+            Logger.LogError(ex, "Failed to load wallet outbox messages.");
+            ToastService.Error("Could not load wallet outbox messages.", "Wallets");
         }
         finally
         {
@@ -252,12 +274,30 @@
 
     private async Task RetryOutbox(WalletOutboxMessage item)
     {
+        if (!await DialogService.Confirm("Retry Outbox Message", "Retry delivery for this outbox message?", new ConfirmDialogOptions()))
+        {
+            return;
+        }
+
         _acting = true;
         try
         {
             var result = await WalletsAdminContracts.RetryOutboxMessageAsync(item.Id);
-            ToastService.Show(result.IsSuccess ? "Outbox retry submitted." : result.Message ?? "Outbox retry is not available.");
-            await LoadData();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Outbox retry submitted.", "Wallets");
+                await LoadData();
+            }
+            else
+            {
+                Logger.LogWarning("Outbox retry failed: {Message}", result.Message);
+                ToastService.Error("Outbox retry could not be submitted.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Outbox retry failed.");
+            ToastService.Error("Outbox retry could not be submitted.", "Wallets");
         }
         finally
         {
@@ -267,12 +307,30 @@
 
     private async Task ReplayOutbox(WalletOutboxMessage item)
     {
+        if (!await DialogService.Confirm("Replay Outbox Message", "Replay this outbox message?", new ConfirmDialogOptions()))
+        {
+            return;
+        }
+
         _acting = true;
         try
         {
             var result = await WalletsAdminContracts.ReplayOutboxMessageAsync(item.Id);
-            ToastService.Show(result.IsSuccess ? "Outbox replay submitted." : result.Message ?? "Outbox replay is not available.");
-            await LoadData();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Outbox replay submitted.", "Wallets");
+                await LoadData();
+            }
+            else
+            {
+                Logger.LogWarning("Outbox replay failed: {Message}", result.Message);
+                ToastService.Error("Outbox replay could not be submitted.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Outbox replay failed.");
+            ToastService.Error("Outbox replay could not be submitted.", "Wallets");
         }
         finally
         {
@@ -282,12 +340,33 @@
 
     private async Task DeadLetterOutbox(WalletOutboxMessage item)
     {
+        if (!await DialogService.Confirm(
+                "Dead-letter Outbox Message",
+                "Move this outbox message to dead-letter status?",
+                new ConfirmDialogOptions { Destructive = true }))
+        {
+            return;
+        }
+
         _acting = true;
         try
         {
             var result = await WalletsAdminContracts.DeadLetterOutboxMessageAsync(item.Id);
-            ToastService.Show(result.IsSuccess ? "Outbox message dead-lettered." : result.Message ?? "Outbox dead-letter is not available.");
-            await LoadData();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Outbox message dead-lettered.", "Wallets");
+                await LoadData();
+            }
+            else
+            {
+                Logger.LogWarning("Outbox dead-letter failed: {Message}", result.Message);
+                ToastService.Error("Outbox message could not be dead-lettered.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Outbox dead-letter failed.");
+            ToastService.Error("Outbox message could not be dead-lettered.", "Wallets");
         }
         finally
         {
@@ -310,17 +389,32 @@
         _ => BadgeVariant.Outline
     };
 
-    private static string ShortId(Guid? id) => id.HasValue ? id.Value.ToString()[..8] : "N/A";
+    private string GetOperationLabel(Guid? operationId) =>
+        DisplayService.OperationLabel(operationId, _operationLabels);
 
-    private static string ShortText(string? value)
+    private string GetAggregateLabel(WalletOutboxMessage item)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (item.OperationId is Guid operationId)
         {
-            return "N/A";
+            return GetOperationLabel(operationId);
         }
 
-        return value.Length <= 96 ? value : $"{value[..96]}...";
+        return $"{item.AggregateType} {WalletsControlPanelDisplayService.ShortId(item.AggregateId)}";
     }
+
+    private static string GetWebhookDepositLabel(Guid? depositRequestId) =>
+        depositRequestId is Guid value ? $"Deposit request {WalletsControlPanelDisplayService.ShortId(value)}" : "No deposit request";
+
+    private static string GetWebhookWithdrawalLabel(Guid? withdrawalRequestId) =>
+        withdrawalRequestId is Guid value ? $"Withdrawal request {WalletsControlPanelDisplayService.ShortId(value)}" : "No withdrawal request";
+
+    private string GetWebhookLinksLabel(WalletPaymentWebhookEvent item) =>
+        $"{GetWebhookDepositLabel(item.DepositRequestId)} {GetWebhookWithdrawalLabel(item.WithdrawalRequestId)} {GetOperationLabel(item.OperationId)}";
+
+    private static string GetOutboxDeliverySummary(WalletOutboxMessage item) =>
+        item.Status is WalletOutboxStatus.Failed or WalletOutboxStatus.DeadLetter
+            ? $"Delivery failed after {item.Attempts} attempt(s)"
+            : $"{item.Status} after {item.Attempts} attempt(s)";
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/PolicyDecisions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/PolicyDecisions.razor
@@ -5,16 +5,26 @@
 
 <PageTitle>Wallet Policy Decisions - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Policy & Fees</BbTypographyH3>
             <BbTypographyMuted>Inspect policy decisions, risk outcomes, and wallet fee postings.</BbTypographyMuted>
         </div>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton OnClick="@OpenPolicyDialog">
+                <LucideIcon Name="shield-check" class="mr-2 h-4 w-4" />
+                New Policy Rule
+            </BbButton>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@OpenFeeDialog">
+                <LucideIcon Name="receipt" class="mr-2 h-4 w-4" />
+                New Fee Schedule
+            </BbButton>
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -31,7 +41,7 @@
     }
     else
     {
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div class="xf-summary-grid xf-summary-grid-4">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -66,64 +76,6 @@
             </BbCard>
         </div>
 
-        <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-            <BbCard>
-                <BbCardHeader>
-                    <BbCardTitle>Policy Rule</BbCardTitle>
-                    <BbCardDescription>Create tenant-scoped limits, velocity checks, and approval thresholds.</BbCardDescription>
-                </BbCardHeader>
-                <BbCardContent>
-                    <div class="grid gap-3 md:grid-cols-2">
-                        <BbFormFieldInput TValue="string" @bind-Value="_policyName" Label="Name" Placeholder="Large transfer approval" />
-                        <BbFormFieldSelect TValue="string" @bind-Value="_policyOperationType" Label="Operation">
-                            @foreach (var operationType in Enum.GetValues<WalletOperationType>())
-                            {
-                                <BbSelectItem Value="@operationType.ToString()">@operationType</BbSelectItem>
-                            }
-                        </BbFormFieldSelect>
-                        <BbFormFieldInput TValue="decimal" @bind-Value="_policyMaxSingle" Label="Max Single" />
-                        <BbFormFieldInput TValue="decimal" @bind-Value="_policyDailyVelocity" Label="Daily Velocity" />
-                        <BbFormFieldInput TValue="decimal" @bind-Value="_policyMonthlyVelocity" Label="Monthly Velocity" />
-                        <BbFormFieldInput TValue="decimal" @bind-Value="_policyApprovalThreshold" Label="Approval Threshold" />
-                    </div>
-                    <div class="mt-4">
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@SavePolicyRule" Disabled="@_acting">
-                            <LucideIcon Name="shield-check" class="mr-2 h-4 w-4" />
-                            Save Policy
-                        </BbButton>
-                    </div>
-                </BbCardContent>
-            </BbCard>
-
-            <BbCard>
-                <BbCardHeader>
-                    <BbCardTitle>Fee Schedule</BbCardTitle>
-                    <BbCardDescription>Create server-calculated fixed and percentage fees.</BbCardDescription>
-                </BbCardHeader>
-                <BbCardContent>
-                    <div class="grid gap-3 md:grid-cols-2">
-                        <BbFormFieldInput TValue="string" @bind-Value="_feeName" Label="Name" Placeholder="Standard transfer fee" />
-                        <BbFormFieldSelect TValue="string" @bind-Value="_feeOperationType" Label="Operation">
-                            @foreach (var operationType in Enum.GetValues<WalletOperationType>())
-                            {
-                                <BbSelectItem Value="@operationType.ToString()">@operationType</BbSelectItem>
-                            }
-                        </BbFormFieldSelect>
-                        <BbFormFieldInput TValue="decimal" @bind-Value="_fixedFee" Label="Fixed Fee" />
-                        <BbFormFieldInput TValue="decimal" @bind-Value="_percentageFee" Label="Percentage Fee" />
-                        <BbFormFieldInput TValue="decimal" @bind-Value="_minimumFee" Label="Minimum Fee" />
-                        <BbFormFieldInput TValue="decimal" @bind-Value="_maximumFee" Label="Maximum Fee" />
-                    </div>
-                    <div class="mt-4">
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@SaveFeeSchedule" Disabled="@_acting">
-                            <LucideIcon Name="receipt" class="mr-2 h-4 w-4" />
-                            Save Fee
-                        </BbButton>
-                    </div>
-                </BbCardContent>
-            </BbCard>
-        </div>
-
         <BbTabs DefaultValue="policy-rules">
             <BbTabsList>
                 <BbTabsTrigger Value="policy-rules">Policy Rules (@_rules.Count)</BbTabsTrigger>
@@ -141,13 +93,16 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_rules" ShowPagination="true" InitialPageSize="10">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.MaxSingleTransactionAmount)" Title="Max Single" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.DailyVelocityLimit)" Title="Daily" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ApprovalThreshold)" Title="Approval" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.IsEnabled)" Title="Enabled" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MaxSingleTransactionAmount)" Title="Max Single" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DailyVelocityLimit)" Title="Daily" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ApprovalThreshold)" Title="Approval" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.IsEnabled)" Title="Enabled" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No policy rules found" Description="Create a policy rule to apply Wallets operation controls." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -162,14 +117,17 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_feeSchedules" ShowPagination="true" InitialPageSize="10">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.FixedFee)" Title="Fixed" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.PercentageFee)" Title="Percent" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.MinimumFee)" Title="Min" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.MaximumFee)" Title="Max" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.IsEnabled)" Title="Enabled" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.FixedFee)" Title="Fixed" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.PercentageFee)" Title="Percent" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MinimumFee)" Title="Min" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.MaximumFee)" Title="Max" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.IsEnabled)" Title="Enabled" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No fee schedules found" Description="Create a fee schedule to calculate Wallets fees server-side." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -184,13 +142,18 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.RiskDecision)" Title="Risk" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.PolicyDecision)" Title="Policy" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ActorCredentialId)" Title="Actor" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Operation" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.RiskDecision)" Title="Risk" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.PolicyDecision)" Title="Policy" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Actor" Filterable="true" FilterBy="@(item => GetCredentialLabel(item.ActorCredentialId))">
+                                    <ChildContent Context="item">@GetCredentialLabel(item.ActorCredentialId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No policy decisions found" Description="Operations with policy or risk output will appear here." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -205,14 +168,19 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_fees" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Direction)" Title="Direction" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.BalanceBucket)" Title="Bucket" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Wallet" Filterable="true" FilterBy="@(item => GetWalletLabel(item.WalletId))">
+                                    <ChildContent Context="item">@GetWalletLabel(item.WalletId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.Direction)" Title="Direction" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.BalanceBucket)" Title="Bucket" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Description)" Title="Description" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No fee postings found" Description="Ledger fee postings will appear here." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -221,21 +189,79 @@
     }
 </div>
 
+<BbDialog Open="@_policyDialogOpen" OpenChanged="@OnPolicyDialogChanged">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>New Policy Rule</BbDialogTitle>
+            <BbDialogDescription>Create tenant-scoped limits, velocity checks, and approval thresholds.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4 md:grid-cols-2">
+            <BbFormFieldInput TValue="string" @bind-Value="_policyName" Label="Name" Placeholder="Large transfer approval" />
+            <BbFormFieldSelect TValue="string" @bind-Value="_policyOperationType" Label="Operation">
+                @foreach (var operationType in Enum.GetValues<WalletOperationType>())
+                {
+                    <BbSelectItem Value="@operationType.ToString()">@operationType</BbSelectItem>
+                }
+            </BbFormFieldSelect>
+            <BbFormFieldCurrencyInput @bind-Value="_policyMaxSingle" Label="Max Single" ShowSymbol="false" Min="0" />
+            <BbFormFieldNumericInput TValue="decimal" @bind-Value="_policyDailyVelocity" Label="Daily Velocity" DecimalPlaces="2" Step="1" />
+            <BbFormFieldNumericInput TValue="decimal" @bind-Value="_policyMonthlyVelocity" Label="Monthly Velocity" DecimalPlaces="2" Step="1" />
+            <BbFormFieldCurrencyInput @bind-Value="_policyApprovalThreshold" Label="Approval Threshold" ShowSymbol="false" Min="0" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@ClosePolicyDialog" Disabled="@_acting">Cancel</BbButton>
+            <BbButton OnClick="@SavePolicyRule" Disabled="@_acting">Save Policy</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+<BbDialog Open="@_feeDialogOpen" OpenChanged="@OnFeeDialogChanged">
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>New Fee Schedule</BbDialogTitle>
+            <BbDialogDescription>Create server-calculated fixed and percentage fees.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4 md:grid-cols-2">
+            <BbFormFieldInput TValue="string" @bind-Value="_feeName" Label="Name" Placeholder="Standard transfer fee" />
+            <BbFormFieldSelect TValue="string" @bind-Value="_feeOperationType" Label="Operation">
+                @foreach (var operationType in Enum.GetValues<WalletOperationType>())
+                {
+                    <BbSelectItem Value="@operationType.ToString()">@operationType</BbSelectItem>
+                }
+            </BbFormFieldSelect>
+            <BbFormFieldCurrencyInput @bind-Value="_fixedFee" Label="Fixed Fee" ShowSymbol="false" Min="0" />
+            <BbFormFieldNumericInput TValue="decimal" @bind-Value="_percentageFee" Label="Percentage Fee" DecimalPlaces="2" Step="@(0.01m)" />
+            <BbFormFieldCurrencyInput @bind-Value="_minimumFee" Label="Minimum Fee" ShowSymbol="false" Min="0" />
+            <BbFormFieldCurrencyInput @bind-Value="_maximumFee" Label="Maximum Fee" ShowSymbol="false" Min="0" />
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@CloseFeeDialog" Disabled="@_acting">Cancel</BbButton>
+            <BbButton OnClick="@SaveFeeSchedule" Disabled="@_acting">Save Fee</BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private ControlPanel.Server.Services.TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private WalletsControlPanelDisplayService DisplayService { get; set; } = default!;
+    [Inject] private ILogger<PolicyDecisions> Logger { get; set; } = default!;
 
     private List<WalletOperation> _items = [];
     private List<WalletLedgerEntry> _fees = [];
     private List<WalletPolicyRule> _rules = [];
     private List<WalletFeeSchedule> _feeSchedules = [];
+    private IReadOnlyDictionary<Guid, string> _credentialLabels = new Dictionary<Guid, string>();
+    private IReadOnlyDictionary<Guid, string> _walletLabels = new Dictionary<Guid, string>();
     private bool _loading = true;
     private bool _acting;
     private bool _hasTenant;
     private bool _moduleEnabled;
+    private bool _policyDialogOpen;
+    private bool _feeDialogOpen;
     private int _rejectedCount;
     private decimal _totalFees;
     private string _policyName = "";
@@ -276,6 +302,8 @@
             _fees = [];
             _rules = [];
             _feeSchedules = [];
+            _credentialLabels = new Dictionary<Guid, string>();
+            _walletLabels = new Dictionary<Guid, string>();
             _rejectedCount = 0;
             _totalFees = 0;
 
@@ -327,6 +355,13 @@
                 .Take(100)
                 .ToListAsync();
 
+            _credentialLabels = await DisplayService.LoadCredentialLabelsAsync(
+                tenantId,
+                _items.Select(x => x.ActorCredentialId));
+            _walletLabels = await DisplayService.LoadWalletLabelsAsync(
+                tenantId,
+                _fees.Select(x => x.WalletId));
+
             _rejectedCount = _items.Count(x => x.Status == WalletOperationStatus.Rejected || (x.PolicyDecision != null && x.PolicyDecision.Contains("reject")));
             _totalFees = _fees.Sum(x => x.Amount);
         }
@@ -336,9 +371,12 @@
             _fees = [];
             _rules = [];
             _feeSchedules = [];
+            _credentialLabels = new Dictionary<Guid, string>();
+            _walletLabels = new Dictionary<Guid, string>();
             _rejectedCount = 0;
             _totalFees = 0;
-            ToastService.Show($"Failed to load wallet policy decisions: {ex.Message}");
+            Logger.LogError(ex, "Failed to load wallet policy decisions.");
+            ToastService.Error("Could not load wallet policy decisions.", "Wallets");
         }
         finally
         {
@@ -351,7 +389,7 @@
     {
         if (!Enum.TryParse<WalletOperationType>(_policyOperationType, out var operationType))
         {
-            ToastService.Show("Select a valid operation type.");
+            ToastService.Warning("Select a valid operation type.", "Validation");
             return;
         }
 
@@ -370,16 +408,23 @@
                 IsEnabled = true
             });
 
-            ToastService.Show(result.IsSuccess ? "Policy rule saved." : result.Message ?? "Policy rule save failed.");
             if (result.IsSuccess)
             {
-                _policyName = "";
-                _policyMaxSingle = 0;
-                _policyDailyVelocity = 0;
-                _policyMonthlyVelocity = 0;
-                _policyApprovalThreshold = 0;
+                ToastService.Success("Policy rule saved.", "Wallets");
+                _policyDialogOpen = false;
+                ResetPolicyForm();
                 await LoadData();
             }
+            else
+            {
+                Logger.LogWarning("Policy rule save failed: {Message}", result.Message);
+                ToastService.Error("Policy rule could not be saved.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Policy rule save failed.");
+            ToastService.Error("Policy rule could not be saved.", "Wallets");
         }
         finally
         {
@@ -391,7 +436,7 @@
     {
         if (!Enum.TryParse<WalletOperationType>(_feeOperationType, out var operationType))
         {
-            ToastService.Show("Select a valid operation type.");
+            ToastService.Warning("Select a valid operation type.", "Validation");
             return;
         }
 
@@ -409,16 +454,23 @@
                 IsEnabled = true
             });
 
-            ToastService.Show(result.IsSuccess ? "Fee schedule saved." : result.Message ?? "Fee schedule save failed.");
             if (result.IsSuccess)
             {
-                _feeName = "";
-                _fixedFee = 0;
-                _percentageFee = 0;
-                _minimumFee = 0;
-                _maximumFee = 0;
+                ToastService.Success("Fee schedule saved.", "Wallets");
+                _feeDialogOpen = false;
+                ResetFeeForm();
                 await LoadData();
             }
+            else
+            {
+                Logger.LogWarning("Fee schedule save failed: {Message}", result.Message);
+                ToastService.Error("Fee schedule could not be saved.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Fee schedule save failed.");
+            ToastService.Error("Fee schedule could not be saved.", "Wallets");
         }
         finally
         {
@@ -427,6 +479,78 @@
     }
 
     private static decimal? PositiveOrNull(decimal value) => value > 0 ? value : null;
+
+    private void OpenPolicyDialog()
+    {
+        ResetPolicyForm();
+        _policyDialogOpen = true;
+    }
+
+    private void ClosePolicyDialog()
+    {
+        _policyDialogOpen = false;
+        ResetPolicyForm();
+    }
+
+    private Task OnPolicyDialogChanged(bool open)
+    {
+        _policyDialogOpen = open;
+        if (!open)
+        {
+            ResetPolicyForm();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void OpenFeeDialog()
+    {
+        ResetFeeForm();
+        _feeDialogOpen = true;
+    }
+
+    private void CloseFeeDialog()
+    {
+        _feeDialogOpen = false;
+        ResetFeeForm();
+    }
+
+    private Task OnFeeDialogChanged(bool open)
+    {
+        _feeDialogOpen = open;
+        if (!open)
+        {
+            ResetFeeForm();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ResetPolicyForm()
+    {
+        _policyName = "";
+        _policyOperationType = WalletOperationType.Transfer.ToString();
+        _policyMaxSingle = 0;
+        _policyDailyVelocity = 0;
+        _policyMonthlyVelocity = 0;
+        _policyApprovalThreshold = 0;
+    }
+
+    private void ResetFeeForm()
+    {
+        _feeName = "";
+        _feeOperationType = WalletOperationType.Transfer.ToString();
+        _fixedFee = 0;
+        _percentageFee = 0;
+        _minimumFee = 0;
+        _maximumFee = 0;
+    }
+
+    private string GetCredentialLabel(Guid? credentialId) =>
+        DisplayService.CredentialLabel(credentialId, _credentialLabels);
+
+    private string GetWalletLabel(Guid? walletId) =>
+        DisplayService.WalletLabel(walletId, _walletLabels);
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Reconciliation.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Reconciliation.razor
@@ -4,13 +4,13 @@
 
 <PageTitle>Wallet Reconciliation - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Wallet Reconciliation</BbTypographyH3>
             <BbTypographyMuted>Review reconciliation snapshots and surface drift remediation actions.</BbTypographyMuted>
         </div>
-        <div class="flex flex-wrap gap-2">
+        <div class="xf-page-actions">
             <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@RunTenantReconciliation" Disabled="@_acting">
                 <LucideIcon Name="scan-line" class="mr-2 h-4 w-4" />
                 Run Drift Checks
@@ -36,7 +36,7 @@
     }
     else
     {
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div class="xf-summary-grid xf-summary-grid-4">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -86,19 +86,21 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Balance)" Title="Balance" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.AvailableBalance)" Title="Available" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.TransferableBalance)" Title="Transferable" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.DriftAmount)" Title="Drift" Sortable="true" />
-                                <BbDataGridTemplateColumn Title="State">
+                                <BbDataGridTemplateColumn Title="Wallet" Sortable="true" Filterable="true" FilterBy="@(item => GetWalletLabel(item.WalletId))">
+                                    <ChildContent Context="item">@GetWalletLabel(item.WalletId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.Balance)" Title="Balance" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableBalance)" Title="Available" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransferableBalance)" Title="Transferable" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DriftAmount)" Title="Drift" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="State" Filterable="true" FilterBy="@(item => item.IsReconciled ? "Reconciled" : "Drift")">
                                     <ChildContent Context="item">
                                         <BbBadge Variant="@(item.IsReconciled ? BadgeVariant.Default : BadgeVariant.Destructive)">
                                             @(item.IsReconciled ? "Reconciled" : "Drift")
                                         </BbBadge>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.ReconciledAt)" Title="Checked" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReconciledAt)" Title="Checked" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
                                         @if (!item.IsReconciled)
@@ -110,6 +112,9 @@
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No balance snapshots found" Description="Run drift checks to create reconciliation snapshots." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -123,20 +128,22 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_reconciliationItems" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.CheckType)" Title="Check" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                                <BbDataGridTemplateColumn Title="Status">
+                                <BbDataGridPropertyColumn Property="@(x => x.CheckType)" Title="Check" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Wallet" Filterable="true" FilterBy="@(item => GetWalletLabel(item.WalletId))">
+                                    <ChildContent Context="item">@GetWalletLabel(item.WalletId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status.ToString())">
                                     <ChildContent Context="item">
                                         <BbBadge Variant="@(item.Status == WalletReconciliationStatus.Drifted ? BadgeVariant.Destructive : BadgeVariant.Default)">
                                             @item.Status
                                         </BbBadge>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridPropertyColumn Property="@(x => x.ExpectedAmount)" Title="Expected" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ActualAmount)" Title="Actual" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.DriftAmount)" Title="Drift" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
-                                <BbDataGridPropertyColumn Property="@(x => x.RepairSuggestion)" Title="Repair Suggestion" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ExpectedAmount)" Title="Expected" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ActualAmount)" Title="Actual" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DriftAmount)" Title="Drift" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.RepairSuggestion)" Title="Repair Suggestion" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
                                         @if (item.Status == WalletReconciliationStatus.Drifted)
@@ -148,6 +155,9 @@
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No reconciliation items found" Description="Drift details and repair suggestions will appear here." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -162,9 +172,13 @@
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private WalletsControlPanelDisplayService DisplayService { get; set; } = default!;
+    [Inject] private ILogger<Reconciliation> Logger { get; set; } = default!;
 
     private List<WalletBalanceSnapshot> _items = [];
     private List<WalletReconciliationItem> _reconciliationItems = [];
+    private IReadOnlyDictionary<Guid, string> _walletLabels = new Dictionary<Guid, string>();
     private bool _loading = true;
     private bool _acting;
     private bool _hasTenant;
@@ -196,6 +210,7 @@
             _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.WalletsReconciliation);
             _items = [];
             _reconciliationItems = [];
+            _walletLabels = new Dictionary<Guid, string>();
             ResetSummary();
 
             if (!_hasTenant || !_moduleEnabled)
@@ -225,13 +240,19 @@
                 .OrderByDescending(x => x.CreatedAt)
                 .Take(200)
                 .ToListAsync();
+
+            _walletLabels = await DisplayService.LoadWalletLabelsAsync(
+                tenantId,
+                _items.Select(x => (Guid?)x.WalletId).Concat(_reconciliationItems.Select(x => x.WalletId)));
         }
         catch (Exception ex)
         {
             _items = [];
             _reconciliationItems = [];
+            _walletLabels = new Dictionary<Guid, string>();
             ResetSummary();
-            ToastService.Show($"Failed to load wallet reconciliation: {ex.Message}");
+            Logger.LogError(ex, "Failed to load wallet reconciliation.");
+            ToastService.Error("Could not load wallet reconciliation.", "Wallets");
         }
         finally
         {
@@ -242,17 +263,40 @@
 
     private async Task RunTenantReconciliation()
     {
+        if (!await DialogService.Confirm("Run Drift Checks", "Run reconciliation drift checks for this tenant?", new ConfirmDialogOptions()))
+        {
+            return;
+        }
+
         await RunWalletReconciliation(null);
     }
 
     private async Task RunWalletReconciliation(Guid? walletId)
     {
+        if (walletId.HasValue && !await DialogService.Confirm("Re-run Wallet Reconciliation", "Re-run drift checks for this wallet?", new ConfirmDialogOptions()))
+        {
+            return;
+        }
+
         _acting = true;
         try
         {
             var result = await WalletsAdminContracts.RunReconciliationAsync(walletId);
-            ToastService.Show(result.IsSuccess ? "Reconciliation submitted." : result.Message ?? "Reconciliation is not available.");
-            await LoadData();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Reconciliation submitted.", "Wallets");
+                await LoadData();
+            }
+            else
+            {
+                Logger.LogWarning("Reconciliation failed: {Message}", result.Message);
+                ToastService.Error("Reconciliation could not be submitted.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Reconciliation failed.");
+            ToastService.Error("Reconciliation could not be submitted.", "Wallets");
         }
         finally
         {
@@ -262,18 +306,39 @@
 
     private async Task MarkReconciled(WalletReconciliationItem item)
     {
+        if (!await DialogService.Confirm("Mark Reconciled", "Mark this reconciliation item as reconciled?", new ConfirmDialogOptions()))
+        {
+            return;
+        }
+
         _acting = true;
         try
         {
             var result = await WalletsAdminContracts.MarkReconciliationItemAsync(item.Id);
-            ToastService.Show(result.IsSuccess ? "Reconciliation item marked." : result.Message ?? "Mark reconciled is not available.");
-            await LoadData();
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Reconciliation item marked.", "Wallets");
+                await LoadData();
+            }
+            else
+            {
+                Logger.LogWarning("Mark reconciliation item failed: {Message}", result.Message);
+                ToastService.Error("Reconciliation item could not be marked.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Mark reconciliation item failed.");
+            ToastService.Error("Reconciliation item could not be marked.", "Wallets");
         }
         finally
         {
             _acting = false;
         }
     }
+
+    private string GetWalletLabel(Guid? walletId) =>
+        DisplayService.WalletLabel(walletId, _walletLabels);
 
     private void ResetSummary()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/RefundsDisputes.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/RefundsDisputes.razor
@@ -4,16 +4,22 @@
 
 <PageTitle>Refunds & Disputes - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Refunds & Disputes</BbTypographyH3>
             <BbTypographyMuted>Create refund, dispute, and chargeback cases through Wallets workflow APIs.</BbTypographyMuted>
         </div>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton Variant="ButtonVariant.Destructive" OnClick="@OpenCaseDialog">
+                <LucideIcon Name="file-warning" class="mr-2 h-4 w-4" />
+                Open Case
+            </BbButton>
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -30,68 +36,7 @@
     }
     else
     {
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Open Refund / Dispute Case</BbCardTitle>
-                <BbCardDescription>Select a transaction or enter wallet details, then submit a case for workflow settlement.</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <div class="grid gap-3 md:grid-cols-5">
-                    <BbFormFieldSelect TValue="string" @bind-Value="_caseType" Label="Case Type">
-                        @foreach (var caseType in Enum.GetValues<WalletCaseType>())
-                        {
-                            <BbSelectItem Value="@caseType.ToString()">@caseType</BbSelectItem>
-                        }
-                    </BbFormFieldSelect>
-                    <XfEntityPicker TItem="Wallet"
-                                    Label="Wallet"
-                                    Value="@_walletId"
-                                    ValueChanged="@(value => _walletId = value ?? "")"
-                                    Items="@_wallets"
-                                    ValueSelector="@GetWalletPickerValue"
-                                    TextSelector="@BuildWalletLabel"
-                                    SearchTextSelector="@GetWalletSearchText"
-                                    AdvancedColumns="@WalletAdvancedColumns"
-                                    AdvancedFilters="@WalletAdvancedFilters"
-                                    AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
-                                    Placeholder="Select wallet"
-                                    SearchPlaceholder="Search wallets..."
-                                    EmptyMessage="No wallets found."
-                                    AllowClear="true"
-                                    ClearText="Clear wallet"
-                                    AdvancedSearchTitle="Find Wallet"
-                                    AdvancedSearchDescription="Search wallets before creating a refund, dispute, or chargeback case." />
-                    <XfEntityPicker TItem="WalletTransaction"
-                                    Label="Original Transaction"
-                                    Value="@_transactionId"
-                                    ValueChanged="@OnTransactionPickerChanged"
-                                    Items="@_transactions"
-                                    ValueSelector="@GetTransactionPickerValue"
-                                    TextSelector="@BuildTransactionLabel"
-                                    SearchTextSelector="@GetTransactionSearchText"
-                                    AdvancedColumns="@TransactionAdvancedColumns"
-                                    AdvancedFilters="@TransactionAdvancedFilters"
-                                    AdvancedSearchScope="Searches transaction id, wallet, type, amount, fee, reference, held/released state, and created date."
-                                    Placeholder="No original transaction"
-                                    SearchPlaceholder="Search transactions..."
-                                    EmptyMessage="No transactions found."
-                                    AllowClear="true"
-                                    ClearText="No original transaction"
-                                    AdvancedSearchTitle="Find Original Transaction"
-                                    AdvancedSearchDescription="Search recent wallet transactions to link the case to its original movement." />
-                    <BbFormFieldInput TValue="decimal" @bind-Value="_amount" Label="Amount" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_reason" Label="Reason" Placeholder="Customer refund or dispute reason" />
-                </div>
-                <div class="mt-4">
-                    <BbButton Variant="ButtonVariant.Destructive" OnClick="@SubmitCase" Disabled="@_acting">
-                        <LucideIcon Name="file-warning" class="mr-2 h-4 w-4" />
-                        Create Case
-                    </BbButton>
-                </div>
-            </BbCardContent>
-        </BbCard>
-
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div class="xf-summary-grid xf-summary-grid-3">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -134,12 +79,14 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_cases" ShowPagination="true" InitialPageSize="10">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.CaseType)" Title="Type" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReasonCode)" Title="Reason Code" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CaseType)" Title="Type" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Wallet" Filterable="true" FilterBy="@(item => GetWalletLabel(item.WalletId))">
+                                    <ChildContent Context="item">@GetWalletLabel(item.WalletId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReasonCode)" Title="Reason Code" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
                                         @if (item.Status is WalletCaseStatus.Open or WalletCaseStatus.OnHold)
@@ -156,6 +103,9 @@
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No open cases found" Description="Open a refund, dispute, or chargeback case to start review." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -170,13 +120,18 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_refundOperations" ShowPagination="true" InitialPageSize="10">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Type" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" />
-                                <BbDataGridPropertyColumn Property="@(x => x.FailureMessage)" Title="Failure" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.OperationType)" Title="Type" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Reason)" Title="Reason" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Failure" Filterable="true" FilterBy="@(item => WalletsControlPanelDisplayService.SafeFailureSummary(item.FailureMessage))">
+                                    <ChildContent Context="item">@WalletsControlPanelDisplayService.SafeFailureSummary(item.FailureMessage)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No refund operations found" Description="Refund, reversal, and dispute operations will appear here." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -191,13 +146,17 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.Id)" Title="Transaction" />
-                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.TransactionType)" Title="Type" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Transaction" Filterable="true" FilterBy="@(item => BuildTransactionLabel(item))">
+                                    <ChildContent Context="item">@BuildTransactionLabel(item)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Wallet" Filterable="true" FilterBy="@(item => GetWalletLabel(item.WalletId))">
+                                    <ChildContent Context="item">@GetWalletLabel(item.WalletId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransactionType)" Title="Type" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
                                         <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => SelectTransaction(item))">
@@ -206,6 +165,9 @@
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No recent transactions found" Description="Recent transactions available for case linking will appear here." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -214,12 +176,77 @@
     }
 </div>
 
+<BbDialog Open="@_caseDialogOpen" OpenChanged="@OnCaseDialogChanged">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
+        <BbDialogHeader>
+            <BbDialogTitle>Open Case</BbDialogTitle>
+            <BbDialogDescription>Select a transaction or wallet details, then submit a case for workflow settlement.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <BbFormFieldSelect TValue="string" @bind-Value="_caseType" Label="Case Type">
+                    @foreach (var caseType in Enum.GetValues<WalletCaseType>())
+                    {
+                        <BbSelectItem Value="@caseType.ToString()">@caseType</BbSelectItem>
+                    }
+                </BbFormFieldSelect>
+                <XfEntityPicker TItem="Wallet"
+                                Label="Wallet"
+                                Value="@_walletId"
+                                ValueChanged="@(value => _walletId = value ?? "")"
+                                Items="@_wallets"
+                                ValueSelector="@GetWalletPickerValue"
+                                TextSelector="@BuildWalletLabel"
+                                SearchTextSelector="@GetWalletSearchText"
+                                AdvancedColumns="@WalletAdvancedColumns"
+                                AdvancedFilters="@WalletAdvancedFilters"
+                                AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
+                                Placeholder="Select wallet"
+                                SearchPlaceholder="Search wallets..."
+                                EmptyMessage="No wallets found."
+                                AllowClear="true"
+                                ClearText="Clear wallet"
+                                AdvancedSearchTitle="Find Wallet"
+                                AdvancedSearchDescription="Search wallets before creating a refund, dispute, or chargeback case." />
+                <XfEntityPicker TItem="WalletTransaction"
+                                Label="Original Transaction"
+                                Value="@_transactionId"
+                                ValueChanged="@OnTransactionPickerChanged"
+                                Items="@_transactions"
+                                ValueSelector="@GetTransactionPickerValue"
+                                TextSelector="@BuildTransactionLabel"
+                                SearchTextSelector="@GetTransactionSearchText"
+                                AdvancedColumns="@TransactionAdvancedColumns"
+                                AdvancedFilters="@TransactionAdvancedFilters"
+                                AdvancedSearchScope="Searches transaction reference, wallet, type, amount, fee, held/released state, and created date."
+                                Placeholder="No original transaction"
+                                SearchPlaceholder="Search transactions..."
+                                EmptyMessage="No transactions found."
+                                AllowClear="true"
+                                ClearText="No original transaction"
+                                AdvancedSearchTitle="Find Original Transaction"
+                                AdvancedSearchDescription="Search recent wallet transactions to link the case to its original movement." />
+                <BbFormFieldCurrencyInput @bind-Value="_amount" Label="Amount" ShowSymbol="false" Min="0" />
+                <BbFormFieldInput TValue="string" @bind-Value="_reason" Label="Reason" Placeholder="Customer refund or dispute reason" />
+            </div>
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@CloseCaseDialog" Disabled="@_acting">Cancel</BbButton>
+            <BbButton Variant="ButtonVariant.Destructive" OnClick="@SubmitCase" Disabled="@_acting">
+                Open Case
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private ILogger<RefundsDisputes> Logger { get; set; } = default!;
 
     private List<WalletTransaction> _transactions = [];
     private List<Wallet> _wallets = [];
@@ -229,6 +256,7 @@
     private bool _acting;
     private bool _hasTenant;
     private bool _moduleEnabled;
+    private bool _caseDialogOpen;
     private int _creditCount;
     private int _debitCount;
     private string _caseType = WalletCaseType.Refund.ToString();
@@ -320,7 +348,8 @@
             _wallets = [];
             _refundOperations = [];
             _cases = [];
-            ToastService.Show($"Failed to load refunds and disputes: {ex.Message}");
+            Logger.LogError(ex, "Failed to load refunds and disputes.");
+            ToastService.Error("Could not load refunds and disputes.", "Wallets");
         }
         finally
         {
@@ -331,6 +360,15 @@
 
     private async Task ResolveCase(WalletCase walletCase, bool approve)
     {
+        var title = approve ? "Approve Case" : "Reject Case";
+        var description = approve
+            ? "Approve this wallet case and continue settlement?"
+            : "Reject this wallet case?";
+        if (!await DialogService.Confirm(title, description, new ConfirmDialogOptions { Destructive = !approve }))
+        {
+            return;
+        }
+
         _acting = true;
         try
         {
@@ -339,11 +377,21 @@
                 approve,
                 approve ? "ControlPanel case approval" : "ControlPanel case rejection");
 
-            ToastService.Show(result.IsSuccess ? "Wallet case updated." : result.Message ?? "Wallet case action failed.");
             if (result.IsSuccess)
             {
+                ToastService.Success("Wallet case updated.", "Wallets");
                 await LoadData();
             }
+            else
+            {
+                Logger.LogWarning("Wallet case action failed: {Message}", result.Message);
+                ToastService.Error("Wallet case could not be updated.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Wallet case action failed.");
+            ToastService.Error("Wallet case could not be updated.", "Wallets");
         }
         finally
         {
@@ -376,19 +424,19 @@
     {
         if (!Guid.TryParse(_walletId, out var walletId))
         {
-            ToastService.Show("Enter a valid wallet ID.");
+            ToastService.Warning("Select a wallet.", "Validation");
             return;
         }
 
         if (_amount <= 0)
         {
-            ToastService.Show("Enter an amount greater than zero.");
+            ToastService.Warning("Enter an amount greater than zero.", "Validation");
             return;
         }
 
         if (!Enum.TryParse<WalletCaseType>(_caseType, out var caseType))
         {
-            ToastService.Show("Select a valid case type.");
+            ToastService.Warning("Select a valid case type.", "Validation");
             return;
         }
 
@@ -406,20 +454,60 @@
                 transactionId,
                 string.IsNullOrWhiteSpace(_reason) ? "ControlPanel case" : _reason.Trim());
 
-            ToastService.Show(result.IsSuccess ? "Wallet case created." : $"Failed to create wallet case: {result.Message}");
             if (result.IsSuccess)
             {
-                _walletId = "";
-                _transactionId = "";
-                _amount = 0;
-                _reason = "";
+                ToastService.Success("Wallet case created.", "Wallets");
+                _caseDialogOpen = false;
+                ResetCaseForm();
                 await LoadData();
             }
+            else
+            {
+                Logger.LogWarning("Wallet case creation failed: {Message}", result.Message);
+                ToastService.Error("Wallet case could not be created.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Wallet case creation failed.");
+            ToastService.Error("Wallet case could not be created.", "Wallets");
         }
         finally
         {
             _acting = false;
         }
+    }
+
+    private void OpenCaseDialog()
+    {
+        ResetCaseForm();
+        _caseDialogOpen = true;
+    }
+
+    private void CloseCaseDialog()
+    {
+        _caseDialogOpen = false;
+        ResetCaseForm();
+    }
+
+    private Task OnCaseDialogChanged(bool open)
+    {
+        _caseDialogOpen = open;
+        if (!open)
+        {
+            ResetCaseForm();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ResetCaseForm()
+    {
+        _caseType = WalletCaseType.Refund.ToString();
+        _walletId = "";
+        _transactionId = "";
+        _amount = 0;
+        _reason = "";
     }
 
     private static string GetWalletPickerValue(Wallet wallet) => wallet.Id.ToString();
@@ -451,7 +539,7 @@
     }
 
     private string GetTransactionSearchText(WalletTransaction transaction) =>
-        $"{transaction.Id} {transaction.WalletId} {GetWalletLabel(transaction.WalletId)} {transaction.TransactionType} {transaction.Amount} {transaction.TransactionFee} {transaction.ReferenceNumber} {transaction.Remarks}";
+        $"{BuildTransactionLabel(transaction)} {WalletsControlPanelDisplayService.ShortId(transaction.Id)} {GetWalletLabel(transaction.WalletId)} {transaction.TransactionType} {transaction.Amount} {transaction.TransactionFee} {transaction.ReferenceNumber} {transaction.Remarks}";
 
     private IReadOnlyList<XfEntityPickerColumn<Wallet>> WalletAdvancedColumns =>
     [
@@ -472,12 +560,11 @@
 
     private IReadOnlyList<XfEntityPickerColumn<WalletTransaction>> TransactionAdvancedColumns =>
     [
-        new("Transaction", x => x.Id.ToString()[..8]),
+        new("Reference", x => string.IsNullOrWhiteSpace(x.ReferenceNumber) ? BuildTransactionLabel(x) : x.ReferenceNumber),
         new("Wallet", x => GetWalletLabel(x.WalletId)),
         new("Type", x => x.TransactionType?.ToString()),
         new("Amount", x => FormatDecimal(x.Amount)),
         new("Fee", x => FormatDecimal(x.TransactionFee)),
-        new("Reference", x => x.ReferenceNumber),
         new("Held", x => FormatBoolean(x.Held)),
         new("Released", x => FormatBoolean(x.Released)),
         new("Created", x => FormatDateTime(x.CreatedAt))

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Statements.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Statements.razor
@@ -4,13 +4,13 @@
 
 <PageTitle>Wallet Statements - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Statements & Reporting</BbTypographyH3>
             <BbTypographyMuted>Build tenant-level wallet reports from ledger and transaction records.</BbTypographyMuted>
         </div>
-        <div class="flex flex-wrap gap-2">
+        <div class="xf-page-actions">
             <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@GenerateFirstStatement" Disabled="@(_acting || _wallets.Count == 0)">
                 <LucideIcon Name="file-output" class="mr-2 h-4 w-4" />
                 Generate Statement
@@ -36,7 +36,7 @@
     }
     else
     {
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div class="xf-summary-grid xf-summary-grid-4">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -86,14 +86,16 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_wallets" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.AccountNumber)" Title="Account" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CredentialId)" Title="Credential" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Balance)" Title="Balance" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.AvailableBalance)" Title="Available" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.DebitOnHoldBalance)" Title="Debit Hold" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreditOnHoldBalance)" Title="Credit Hold" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AccountNumber)" Title="Account" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(item => GetCredentialLabel(item.CredentialId))">
+                                    <ChildContent Context="item">@GetCredentialLabel(item.CredentialId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.Status)" Title="Status" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Balance)" Title="Balance" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.AvailableBalance)" Title="Available" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.DebitOnHoldBalance)" Title="Debit Hold" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreditOnHoldBalance)" Title="Credit Hold" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="item">
                                         <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => GenerateStatement(item.Id))" Disabled="@_acting">
@@ -102,6 +104,9 @@
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No wallet balances found" Description="Wallet balances for the selected tenant will appear here." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -116,15 +121,20 @@
                     <BbCardContent>
                         <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
                             <Columns>
-                                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.TransactionType)" Title="Type" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.RunningBalance)" Title="Running Balance" Sortable="true" />
-                                <BbDataGridPropertyColumn Property="@(x => x.Remarks)" Title="Remarks" />
-                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                                <BbDataGridTemplateColumn Title="Wallet" Filterable="true" FilterBy="@(item => GetWalletLabel(item.WalletId))">
+                                    <ChildContent Context="item">@GetWalletLabel(item.WalletId)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransactionType)" Title="Type" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.RunningBalance)" Title="Running Balance" Sortable="true" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.Remarks)" Title="Remarks" Filterable="true" />
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                             </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No statement lines found" Description="Recent wallet transactions will appear here." />
+                            </EmptyTemplate>
                         </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
@@ -139,9 +149,13 @@
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private WalletsControlPanelDisplayService DisplayService { get; set; } = default!;
+    [Inject] private ILogger<Statements> Logger { get; set; } = default!;
 
     private List<Wallet> _wallets = [];
     private List<WalletTransaction> _transactions = [];
+    private IReadOnlyDictionary<Guid, string> _walletLabels = new Dictionary<Guid, string>();
+    private IReadOnlyDictionary<Guid, string> _credentialLabels = new Dictionary<Guid, string>();
     private bool _loading = true;
     private bool _acting;
     private bool _hasTenant;
@@ -193,6 +207,13 @@
                 .Take(500)
                 .ToListAsync();
 
+            _walletLabels = await DisplayService.LoadWalletLabelsAsync(
+                tenantId,
+                _wallets.Select(x => (Guid?)x.Id).Concat(_transactions.Select(x => (Guid?)x.WalletId)));
+            _credentialLabels = await DisplayService.LoadCredentialLabelsAsync(
+                tenantId,
+                _wallets.Select(x => (Guid?)x.CredentialId));
+
             _totalBalance = _wallets.Sum(x => x.Balance);
             _creditAmount = _transactions.Where(x => x.TransactionType == TransactionType.Credit).Sum(x => Math.Abs(x.Amount));
             _debitAmount = _transactions.Where(x => x.TransactionType == TransactionType.Debit).Sum(x => Math.Abs(x.Amount));
@@ -201,7 +222,8 @@
         catch (Exception ex)
         {
             ResetData();
-            ToastService.Show($"Failed to load wallet reporting data: {ex.Message}");
+            Logger.LogError(ex, "Failed to load wallet reporting data.");
+            ToastService.Error("Could not load wallet reporting data.", "Wallets");
         }
         finally
         {
@@ -222,7 +244,20 @@
         try
         {
             var result = await WalletsAdminContracts.GenerateStatementAsync(walletId);
-            ToastService.Show(result.IsSuccess ? "Statement generation submitted." : result.Message ?? "Statement generation is not available.");
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Statement generation submitted.", "Wallets");
+            }
+            else
+            {
+                Logger.LogWarning("Statement generation failed: {Message}", result.Message);
+                ToastService.Error("Statement generation could not be submitted.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Statement generation failed.");
+            ToastService.Error("Statement generation could not be submitted.", "Wallets");
         }
         finally
         {
@@ -234,11 +269,19 @@
     {
         _wallets = [];
         _transactions = [];
+        _walletLabels = new Dictionary<Guid, string>();
+        _credentialLabels = new Dictionary<Guid, string>();
         _totalBalance = 0;
         _creditAmount = 0;
         _debitAmount = 0;
         _feeAmount = 0;
     }
+
+    private string GetWalletLabel(Guid walletId) =>
+        DisplayService.WalletLabel(walletId, _walletLabels);
+
+    private string GetCredentialLabel(Guid credentialId) =>
+        DisplayService.CredentialLabel(credentialId, _credentialLabels);
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Transfers.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Transfers.razor
@@ -4,16 +4,18 @@
 
 <PageTitle>Transfers - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Transfers</BbTypographyH3>
             <BbTypographyMuted>Inspect paired wallet transfers, fees, and transaction links.</BbTypographyMuted>
         </div>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -30,7 +32,7 @@
     }
     else
     {
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div class="xf-summary-grid xf-summary-grid-3">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -59,17 +61,26 @@
 
         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
             <Columns>
-                <BbDataGridPropertyColumn Property="@(x => x.Id)" Title="Transfer" />
-                <BbDataGridPropertyColumn Property="@(x => x.SenderTransactionId)" Title="Sender Transaction" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.RecipientTransactionId)" Title="Recipient Transaction" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" />
-                <BbDataGridTemplateColumn Title="Purpose">
+                <BbDataGridTemplateColumn Title="Transfer" Filterable="true" FilterBy="@(item => WalletsControlPanelDisplayService.BuildTransferLabel(item))">
+                    <ChildContent Context="item">@WalletsControlPanelDisplayService.BuildTransferLabel(item)</ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridTemplateColumn Title="Sender Transaction" Sortable="true" Filterable="true" FilterBy="@(item => GetTransactionLabel(item.SenderTransactionId))">
+                    <ChildContent Context="item">@GetTransactionLabel(item.SenderTransactionId)</ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridTemplateColumn Title="Recipient Transaction" Sortable="true" Filterable="true" FilterBy="@(item => GetTransactionLabel(item.RecipientTransactionId))">
+                    <ChildContent Context="item">@GetTransactionLabel(item.RecipientTransactionId)</ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridPropertyColumn Property="@(x => x.TransactionFee)" Title="Fee" Sortable="true" Filterable="true" />
+                <BbDataGridTemplateColumn Title="Purpose" Filterable="true" FilterBy="@(item => item.TransactionPurpose.ToString())">
                     <ChildContent Context="item">
                         <BbBadge Variant="BadgeVariant.Outline">@item.TransactionPurpose</BbBadge>
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
             </Columns>
+            <EmptyTemplate>
+                <BbEmpty Title="No transfers found" Description="Wallet transfer records will appear here." />
+            </EmptyTemplate>
         </BbDataGrid>
     }
 </div>
@@ -79,8 +90,11 @@
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private WalletsControlPanelDisplayService DisplayService { get; set; } = default!;
+    [Inject] private ILogger<Transfers> Logger { get; set; } = default!;
 
     private List<WalletTransfer> _items = [];
+    private IReadOnlyDictionary<Guid, string> _transactionLabels = new Dictionary<Guid, string>();
     private bool _loading = true;
     private bool _hasTenant;
     private bool _moduleEnabled;
@@ -106,6 +120,7 @@
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
             _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.WalletsTransfers);
             _items = [];
+            _transactionLabels = new Dictionary<Guid, string>();
             _totalFees = 0;
             _latest = null;
 
@@ -125,13 +140,18 @@
 
             _totalFees = _items.Sum(x => x.TransactionFee);
             _latest = _items.Count == 0 ? null : _items.Max(x => x.CreatedAt);
+            _transactionLabels = await DisplayService.LoadTransactionLabelsAsync(
+                tenantId,
+                _items.Select(x => (Guid?)x.SenderTransactionId).Concat(_items.Select(x => (Guid?)x.RecipientTransactionId)));
         }
         catch (Exception ex)
         {
             _items = [];
+            _transactionLabels = new Dictionary<Guid, string>();
             _totalFees = 0;
             _latest = null;
-            ToastService.Show($"Failed to load transfers: {ex.Message}");
+            Logger.LogError(ex, "Failed to load transfers.");
+            ToastService.Error("Could not load transfers.", "Wallets");
         }
         finally
         {
@@ -139,6 +159,9 @@
             StateHasChanged();
         }
     }
+
+    private string GetTransactionLabel(Guid transactionId) =>
+        DisplayService.TransactionLabel(transactionId, _transactionLabels);
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletApprovals.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletApprovals.razor
@@ -1,4 +1,5 @@
 @page "/finance/wallet-approvals"
+@using System.Text.RegularExpressions
 @using global::Wallets.Domain.Shared.Enums
 @using XFramework.Domain.Shared.BusinessObjects
 @using XFramework.Domain.Shared.DataContext
@@ -6,16 +7,18 @@
 
 <PageTitle>Wallet Approvals - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Wallet Approvals</BbTypographyH3>
             <BbTypographyMuted>Review maker-checker requests for sensitive wallet operations.</BbTypographyMuted>
         </div>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -32,7 +35,7 @@
     }
     else
     {
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div class="xf-summary-grid xf-summary-grid-4">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -75,22 +78,22 @@
             <BbCardContent>
                 <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
                     <Columns>
-                        <BbDataGridTemplateColumn Title="Operation" Sortable="true">
+                        <BbDataGridTemplateColumn Title="Operation" Sortable="true" Filterable="true" FilterBy="@(item => item.OperationType.ToString())">
                             <ChildContent Context="item">
                                 <BbBadge Variant="BadgeVariant.Outline">@item.OperationType</BbBadge>
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Status" Sortable="true">
+                        <BbDataGridTemplateColumn Title="Status" Sortable="true" Filterable="true" FilterBy="@(item => item.Status.ToString())">
                             <ChildContent Context="item">
                                 <StatusBadge Text="@item.Status.ToString()" Status="@GetStatusCategory(item.Status)" />
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Wallet">
+                        <BbDataGridTemplateColumn Title="Wallet" Filterable="true" FilterBy="@(item => GetWalletLabel(item))">
                             <ChildContent Context="item">
                                 @if (item.WalletId is Guid walletId)
                                 {
                                     <BbButton Variant="ButtonVariant.Link" Size="ButtonSize.Small" OnClick="@(() => NavigationManager.NavigateTo($"/finance/wallets/{walletId}"))">
-                                        @(item.Wallet?.AccountNumber ?? walletId.ToString()[..8])
+                                        @GetWalletLabel(item)
                                     </BbButton>
                                 }
                                 else
@@ -99,18 +102,18 @@
                                 }
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Amount" Sortable="true">
+                        <BbDataGridTemplateColumn Title="Amount" Sortable="true" Filterable="true" FilterBy="@(item => item.Amount)">
                             <ChildContent Context="item">
                                 @(item.Amount?.ToString("N2") ?? "-")
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Reason">
+                        <BbDataGridTemplateColumn Title="Reason" Filterable="true" FilterBy="@(item => FormatReason(item.Reason, 44))">
                             <ChildContent Context="item">
-                                <span title="@item.Reason">@(Trim(item.Reason, 44))</span>
+                                <span title="@FormatReason(item.Reason, 160)">@(FormatReason(item.Reason, 44))</span>
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridPropertyColumn Property="@(x => x.RequestedAt)" Title="Requested" Sortable="true" />
-                        <BbDataGridPropertyColumn Property="@(x => x.DecidedAt)" Title="Decided" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.RequestedAt)" Title="Requested" Sortable="true" Filterable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.DecidedAt)" Title="Decided" Sortable="true" Filterable="true" />
                         <BbDataGridTemplateColumn Title="Actions">
                             <ChildContent Context="item">
                                 <div class="flex flex-wrap gap-1">
@@ -131,6 +134,9 @@
                             </ChildContent>
                         </BbDataGridTemplateColumn>
                     </Columns>
+                    <EmptyTemplate>
+                        <BbEmpty Title="No approval requests found" Description="Sensitive Wallets workflow approvals will appear here." />
+                    </EmptyTemplate>
                 </BbDataGrid>
             </BbCardContent>
         </BbCard>
@@ -144,6 +150,8 @@
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private ILogger<WalletApprovals> Logger { get; set; } = default!;
 
     private List<WalletApprovalRequest> _items = [];
     private bool _loading = true;
@@ -198,7 +206,8 @@
         {
             _items = [];
             ResetSummary();
-            ToastService.Show($"Failed to load wallet approvals: {ex.Message}");
+            Logger.LogError(ex, "Failed to load wallet approvals.");
+            ToastService.Error("Could not load wallet approvals.", "Wallets");
         }
         finally
         {
@@ -208,10 +217,35 @@
     }
 
     private async Task Approve(WalletApprovalRequest item) =>
-        await RunDecision(() => WalletsAdminContracts.ApproveWalletApprovalAsync(item.Id), "Approval");
+        await ConfirmAndRunDecision(
+            () => WalletsAdminContracts.ApproveWalletApprovalAsync(item.Id),
+            "Approve Wallet Request",
+            "Approve this wallet operation request?",
+            "Approval",
+            false);
 
     private async Task Reject(WalletApprovalRequest item) =>
-        await RunDecision(() => WalletsAdminContracts.RejectWalletApprovalAsync(item.Id), "Rejection");
+        await ConfirmAndRunDecision(
+            () => WalletsAdminContracts.RejectWalletApprovalAsync(item.Id),
+            "Reject Wallet Request",
+            "Reject this wallet operation request?",
+            "Rejection",
+            true);
+
+    private async Task ConfirmAndRunDecision(
+        Func<Task<CmdResponse>> action,
+        string title,
+        string description,
+        string label,
+        bool destructive)
+    {
+        if (!await DialogService.Confirm(title, description, new ConfirmDialogOptions { Destructive = destructive }))
+        {
+            return;
+        }
+
+        await RunDecision(action, label);
+    }
 
     private async Task RunDecision(Func<Task<CmdResponse>> action, string label)
     {
@@ -219,8 +253,21 @@
         try
         {
             var result = await action();
-            ToastService.Show(result.IsSuccess ? $"{label} submitted." : result.Message ?? $"{label} failed.");
-            await LoadData();
+            if (result.IsSuccess)
+            {
+                ToastService.Success($"{label} submitted.", "Wallets");
+                await LoadData();
+            }
+            else
+            {
+                Logger.LogWarning("{Label} failed: {Message}", label, result.Message);
+                ToastService.Error($"{label} could not be completed.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "{Label} failed.", label);
+            ToastService.Error($"{label} could not be completed.", "Wallets");
         }
         finally
         {
@@ -243,6 +290,29 @@
         WalletApprovalStatus.Rejected => "failed",
         _ => "inactive"
     };
+
+    private static string GetWalletLabel(WalletApprovalRequest item) =>
+        item.Wallet is { } wallet
+            ? WalletsControlPanelDisplayService.BuildWalletLabel(wallet)
+            : item.WalletId is Guid walletId ? $"Wallet {WalletsControlPanelDisplayService.ShortId(walletId)}" : "None";
+
+    private static readonly Regex GuidTextPattern = new(
+        @"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static string FormatReason(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "-";
+        }
+
+        var sanitized = GuidTextPattern.Replace(
+            value,
+            match => $"record {WalletsControlPanelDisplayService.ShortId(Guid.Parse(match.Value))}");
+
+        return Trim(sanitized, maxLength);
+    }
 
     private static string Trim(string? value, int maxLength)
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletAudit.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletAudit.razor
@@ -4,13 +4,18 @@
 
 <PageTitle>Wallet Audit - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex items-center justify-between">
-        <BbTypographyH3>Wallet Audit</BbTypographyH3>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+<div class="space-y-6">
+    <div class="xf-page-header">
+        <div>
+            <BbTypographyH3>Wallet Audit</BbTypographyH3>
+            <BbTypographyMuted>Inspect ledger postings and running balance movement.</BbTypographyMuted>
+        </div>
+        <div class="xf-page-actions">
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -29,19 +34,26 @@
     {
         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
             <Columns>
-                <BbDataGridPropertyColumn Property="@(x => x.OperationId)" Title="Operation" />
-                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" />
-                <BbDataGridPropertyColumn Property="@(x => x.WalletId)" Title="Wallet" />
-                <BbDataGridTemplateColumn Title="Direction">
+                <BbDataGridTemplateColumn Title="Operation" Filterable="true" FilterBy="@(item => GetOperationLabel(item.OperationId))">
+                    <ChildContent Context="item">@GetOperationLabel(item.OperationId)</ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Filterable="true" />
+                <BbDataGridTemplateColumn Title="Wallet" Filterable="true" FilterBy="@(item => GetWalletLabel(item.WalletId))">
+                    <ChildContent Context="item">@GetWalletLabel(item.WalletId)</ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridTemplateColumn Title="Direction" Filterable="true" FilterBy="@(item => item.Direction.ToString())">
                     <ChildContent Context="item">
                         <BbBadge Variant="BadgeVariant.Outline">@item.Direction</BbBadge>
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.BalanceBucket)" Title="Bucket" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.RunningBalance)" Title="Running Balance" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.BalanceBucket)" Title="Bucket" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.RunningBalance)" Title="Running Balance" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
             </Columns>
+            <EmptyTemplate>
+                <BbEmpty Title="No audit entries found" Description="Ledger postings will appear here after wallet operations." />
+            </EmptyTemplate>
         </BbDataGrid>
     }
 </div>
@@ -51,8 +63,12 @@
     [Inject] private ControlPanel.Server.Services.TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private WalletsControlPanelDisplayService DisplayService { get; set; } = default!;
+    [Inject] private ILogger<WalletAudit> Logger { get; set; } = default!;
 
     private List<WalletLedgerEntry> _items = [];
+    private IReadOnlyDictionary<Guid, string> _walletLabels = new Dictionary<Guid, string>();
+    private IReadOnlyDictionary<Guid, string> _operationLabels = new Dictionary<Guid, string>();
     private bool _loading = true;
     private bool _hasTenant;
     private bool _moduleEnabled;
@@ -79,6 +95,8 @@
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
             _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.WalletsReporting);
             _items = [];
+            _walletLabels = new Dictionary<Guid, string>();
+            _operationLabels = new Dictionary<Guid, string>();
 
             if (!_hasTenant || !_moduleEnabled)
             {
@@ -93,11 +111,16 @@
                 .OrderByDescending(x => x.CreatedAt);
 
             _items = await query.Take(200).ToListAsync();
+            _walletLabels = await DisplayService.LoadWalletLabelsAsync(tenantId, _items.Select(x => x.WalletId));
+            _operationLabels = await DisplayService.LoadOperationLabelsAsync(tenantId, _items.Select(x => (Guid?)x.OperationId));
         }
         catch (Exception ex)
         {
             _items = [];
-            ToastService.Show($"Failed to load wallet audit entries: {ex.Message}");
+            _walletLabels = new Dictionary<Guid, string>();
+            _operationLabels = new Dictionary<Guid, string>();
+            Logger.LogError(ex, "Failed to load wallet audit entries.");
+            ToastService.Error("Could not load wallet audit entries.", "Wallets");
         }
         finally
         {
@@ -105,6 +128,12 @@
             StateHasChanged();
         }
     }
+
+    private string GetWalletLabel(Guid? walletId) =>
+        DisplayService.WalletLabel(walletId, _walletLabels);
+
+    private string GetOperationLabel(Guid operationId) =>
+        DisplayService.OperationLabel(operationId, _operationLabels);
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletDetail.razor
@@ -36,8 +36,9 @@ else
     <FadeInContent>
     <div class="space-y-6">
         @* Header *@
-        <div class="flex items-center gap-4">
+        <div class="xf-page-header">
             <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                      AriaLabel="Back to wallets"
                       OnClick="@GoBack">
                 <LucideIcon Name="arrow-left" class="h-4 w-4" />
             </BbButton>
@@ -46,10 +47,10 @@ else
                     Wallet: @(_wallet.AccountNumber ?? _wallet.Id.ToString()[..8] + "...")
                 </BbTypographyH3>
                 <BbTypographyMuted>
-                    ID: @_wallet.Id &mdash; Type: @(_wallet.WalletType?.Name ?? "N/A")
+                    Type: @(_wallet.WalletType?.Name ?? "N/A") - @WalletsControlPanelDisplayService.ShortId(_wallet.Id)
                 </BbTypographyMuted>
             </div>
-            <div class="flex items-center gap-2">
+            <div class="xf-page-actions">
                 @if (_wallet.Status == WalletStatus.Active)
                 {
                     <BbButton Variant="ButtonVariant.Outline" OnClick="@FreezeWallet">
@@ -66,7 +67,7 @@ else
                 }
                 @if (_wallet.Status != WalletStatus.Closed)
                 {
-                    <BbButton Variant="ButtonVariant.Destructive" OnClick="@(() => _showCloseDialog = true)">
+                    <BbButton Variant="ButtonVariant.Destructive" OnClick="@CloseWallet">
                         <LucideIcon Name="x" class="mr-2 h-4 w-4" />
                         Request Close
                     </BbButton>
@@ -83,14 +84,14 @@ else
                     <div>
                         <BbCardTitle>Wallet Summary</BbCardTitle>
                         <BbCardDescription>
-                            Credential: <span class="font-mono">@_wallet.CredentialId</span>
+                            Credential: @WalletsControlPanelDisplayService.ShortId(_wallet.CredentialId)
                         </BbCardDescription>
                     </div>
                     <StatusBadge Text="@_wallet.Status.ToString()" Status="@GetStatusKey(_wallet.Status)" />
                 </div>
             </BbCardHeader>
             <BbCardContent>
-                <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                <div class="xf-summary-grid xf-summary-grid-4">
                     <BbCard>
                         <BbCardContent>
                             <div class="space-y-1 pt-4">
@@ -171,11 +172,11 @@ else
 
                     <BbTabsContent Value="add-funds" Class="xf-fade-in">
                         <div class="grid gap-4 py-4 md:grid-cols-2 xl:grid-cols-5">
-                            <BbFormFieldInput TValue="string"
-                                              @bind-Value="_addFundsAmount"
-                                              Label="Amount"
-                                              Placeholder="0.00"
-                                              Required="true" />
+                            <BbFormFieldCurrencyInput @bind-Value="_addFundsAmount"
+                                                      Label="Amount"
+                                                      ShowSymbol="false"
+                                                      Min="0"
+                                                      Required="true" />
                             <XfEntityPicker TItem="PaymentGateway"
                                             Label="Gateway"
                                             Value="@_addFundsGatewayId"
@@ -233,11 +234,11 @@ else
 
                     <BbTabsContent Value="withdraw-funds" Class="xf-fade-in">
                         <div class="grid gap-4 py-4 md:grid-cols-2 xl:grid-cols-5">
-                            <BbFormFieldInput TValue="string"
-                                              @bind-Value="_withdrawAmount"
-                                              Label="Amount"
-                                              Placeholder="0.00"
-                                              Required="true" />
+                            <BbFormFieldCurrencyInput @bind-Value="_withdrawAmount"
+                                                      Label="Amount"
+                                                      ShowSymbol="false"
+                                                      Min="0"
+                                                      Required="true" />
                             <XfEntityPicker TItem="PaymentGateway"
                                             Label="Gateway"
                                             Value="@_withdrawGatewayId"
@@ -301,11 +302,11 @@ else
                             </BbAlertDescription>
                         </BbAlert>
                         <div class="grid gap-4 py-4 md:grid-cols-2">
-                            <BbFormFieldInput TValue="string"
-                                              @bind-Value="_adjustBalance"
-                                              Label="New Balance"
-                                              Placeholder="0.00"
-                                              Required="true" />
+                            <BbFormFieldCurrencyInput @bind-Value="_adjustBalance"
+                                                      Label="New Balance"
+                                                      ShowSymbol="false"
+                                                      Min="0"
+                                                      Required="true" />
                             <BbFormFieldInput TValue="string"
                                               @bind-Value="_adjustRemarks"
                                               Label="Remarks"
@@ -336,14 +337,14 @@ else
             <BbCardContent>
                 <BbDataGrid Items="@_transactions" ShowPagination="true" InitialPageSize="20">
                     <Columns>
-                        <BbDataGridTemplateColumn Title="Amount" Sortable="true">
+                        <BbDataGridTemplateColumn Title="Amount" Sortable="true" Filterable="true" FilterBy="@(item => item.Amount)">
                             <ChildContent Context="item">
                                 <span class="font-semibold @(item.TransactionType == TransactionType.Credit ? "text-green-600" : "text-red-600")">
                                     @(item.TransactionType == TransactionType.Credit ? "+" : "")@item.Amount.ToString("N2")
                                 </span>
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Type">
+                        <BbDataGridTemplateColumn Title="Type" Filterable="true" FilterBy="@(item => GetTransactionTypeText(item))">
                             <ChildContent Context="item">
                                 @if (item.TransactionType == TransactionType.Credit)
                                 {
@@ -359,7 +360,7 @@ else
                                 }
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Fee" Sortable="true">
+                        <BbDataGridTemplateColumn Title="Fee" Sortable="true" Filterable="true" FilterBy="@(item => item.TransactionFee)">
                             <ChildContent Context="item">
                                 @if (item.TransactionFee > 0)
                                 {
@@ -371,26 +372,26 @@ else
                                 }
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Held">
+                        <BbDataGridTemplateColumn Title="Held" Filterable="true" FilterBy="@(item => item.Held)">
                             <ChildContent Context="item">
                                 <BbBadge Variant="@(item.Held ? BadgeVariant.Outline : BadgeVariant.Secondary)">
                                     @(item.Held ? "Held" : "No")
                                 </BbBadge>
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Released">
+                        <BbDataGridTemplateColumn Title="Released" Filterable="true" FilterBy="@(item => item.Released)">
                             <ChildContent Context="item">
                                 <BbBadge Variant="@(item.Released ? BadgeVariant.Default : BadgeVariant.Secondary)">
                                     @(item.Released ? "Released" : "No")
                                 </BbBadge>
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Reference">
+                        <BbDataGridTemplateColumn Title="Reference" Filterable="true" FilterBy="@(item => item.ReferenceNumber ?? string.Empty)">
                             <ChildContent Context="item">
                                 <span class="font-mono text-xs">@(item.ReferenceNumber ?? "N/A")</span>
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Remarks">
+                        <BbDataGridTemplateColumn Title="Remarks" Filterable="true" FilterBy="@(item => item.Remarks ?? string.Empty)">
                             <ChildContent Context="item">
                                 @if (!string.IsNullOrEmpty(item.Remarks))
                                 {
@@ -404,12 +405,12 @@ else
                                 }
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridTemplateColumn Title="Running Balance" Sortable="true">
+                        <BbDataGridTemplateColumn Title="Running Balance" Sortable="true" Filterable="true" FilterBy="@(item => item.RunningBalance)">
                             <ChildContent Context="item">
                                 @(item.RunningBalance?.ToString("N2") ?? "N/A")
                             </ChildContent>
                         </BbDataGridTemplateColumn>
-                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                        <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                         <BbDataGridTemplateColumn Title="Actions">
                             <ChildContent Context="item">
                                 <div class="flex flex-wrap gap-1">
@@ -426,6 +427,9 @@ else
                             </ChildContent>
                         </BbDataGridTemplateColumn>
                     </Columns>
+                    <EmptyTemplate>
+                        <BbEmpty Title="No transactions found" Description="Wallet transactions will appear here." />
+                    </EmptyTemplate>
                 </BbDataGrid>
             </BbCardContent>
         </BbCard>
@@ -455,22 +459,46 @@ else
                 {
                     <div class="space-y-4">
                         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                            <BbFormFieldInput TValue="string"
-                                              @bind-Value="_rulesMinTransfer"
-                                              Label="Min Transfer Rule"
-                                              Placeholder="No minimum" />
-                            <BbFormFieldInput TValue="string"
-                                              @bind-Value="_rulesMaxTransfer"
-                                              Label="Max Transfer Rule"
-                                              Placeholder="No maximum" />
-                            <BbFormFieldInput TValue="string"
-                                              @bind-Value="_rulesBondBalance"
-                                              Label="Bond Balance Rule"
-                                              Placeholder="Not set" />
-                            <BbFormFieldInput TValue="string"
-                                              @bind-Value="_rulesMaintainingBalance"
-                                              Label="Maintaining Balance Rule"
-                                              Placeholder="Not set" />
+                            <div class="space-y-3">
+                                <BbFormFieldSwitch @bind-Value="_rulesMinTransferEnabled" Label="Use Min Transfer Rule" />
+                                @if (_rulesMinTransferEnabled)
+                                {
+                                    <BbFormFieldCurrencyInput @bind-Value="_rulesMinTransfer"
+                                                              Label="Min Transfer Rule"
+                                                              ShowSymbol="false"
+                                                              Min="0" />
+                                }
+                            </div>
+                            <div class="space-y-3">
+                                <BbFormFieldSwitch @bind-Value="_rulesMaxTransferEnabled" Label="Use Max Transfer Rule" />
+                                @if (_rulesMaxTransferEnabled)
+                                {
+                                    <BbFormFieldCurrencyInput @bind-Value="_rulesMaxTransfer"
+                                                              Label="Max Transfer Rule"
+                                                              ShowSymbol="false"
+                                                              Min="0" />
+                                }
+                            </div>
+                            <div class="space-y-3">
+                                <BbFormFieldSwitch @bind-Value="_rulesBondBalanceEnabled" Label="Use Bond Balance Rule" />
+                                @if (_rulesBondBalanceEnabled)
+                                {
+                                    <BbFormFieldCurrencyInput @bind-Value="_rulesBondBalance"
+                                                              Label="Bond Balance Rule"
+                                                              ShowSymbol="false"
+                                                              Min="0" />
+                                }
+                            </div>
+                            <div class="space-y-3">
+                                <BbFormFieldSwitch @bind-Value="_rulesMaintainingBalanceEnabled" Label="Use Maintaining Balance Rule" />
+                                @if (_rulesMaintainingBalanceEnabled)
+                                {
+                                    <BbFormFieldCurrencyInput @bind-Value="_rulesMaintainingBalance"
+                                                              Label="Maintaining Balance Rule"
+                                                              ShowSymbol="false"
+                                                              Min="0" />
+                                }
+                            </div>
                         </div>
                         <div class="flex flex-wrap items-center justify-end gap-2">
                             <BbButton Variant="ButtonVariant.Outline" OnClick="@CancelEditRules" Disabled="@_savingRules">
@@ -527,30 +555,6 @@ else
     </FadeInContent>
 }
 
-@* Close Wallet Confirmation Dialog *@
-<BbDialog Open="@_showCloseDialog" OpenChanged="@(v => _showCloseDialog = v)">
-    <BbDialogContent>
-        <BbDialogHeader>
-            <BbDialogTitle>Close Wallet</BbDialogTitle>
-            <BbDialogDescription>
-                This creates a maker-checker approval request. Approved closure can then be executed through the wallet workflow.
-                @if (_wallet?.Balance != 0 || _wallet?.DebitOnHoldBalance != 0 || _wallet?.CreditOnHoldBalance != 0)
-                {
-                    <span class="mt-2 block font-semibold text-red-500">
-                        Wallets can only be closed after balance and held funds are zero.
-                    </span>
-                }
-            </BbDialogDescription>
-        </BbDialogHeader>
-        <BbDialogFooter>
-            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _showCloseDialog = false)">Cancel</BbButton>
-            <BbButton Variant="ButtonVariant.Destructive" OnClick="@CloseWallet" Disabled="@_isProcessing">
-                Request Close
-            </BbButton>
-        </BbDialogFooter>
-    </BbDialogContent>
-</BbDialog>
-
 @code {
     [Parameter] public Guid Id { get; set; }
     [Parameter] public string? Section { get; set; }
@@ -563,6 +567,8 @@ else
     [Inject] private IWalletsServiceWrapper WalletsService { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private RequestMetadata RequestMetadata { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private ILogger<WalletDetail> Logger { get; set; } = default!;
 
     private const string NoSelectionValue = "__none";
     private Wallet? _wallet;
@@ -571,34 +577,37 @@ else
     private List<PaymentGateway> _gateways = [];
     private bool _loading = true;
     private bool _isProcessing;
-    private bool _showCloseDialog;
     private bool _outsideTenantContext;
     private bool MoneyOperationsDisabled => _isProcessing || _wallet?.Status == WalletStatus.Closed;
 
     // Add Funds form
-    private string _addFundsAmount = "";
+    private decimal _addFundsAmount;
     private string _addFundsRef = "";
     private string _addFundsRemarks = "";
     private string _addFundsGatewayId = NoSelectionValue;
     private string _addFundsCurrencyId = NoSelectionValue;
 
     // Withdraw Funds form
-    private string _withdrawAmount = "";
+    private decimal _withdrawAmount;
     private string _withdrawRef = "";
     private string _withdrawRemarks = "";
     private string _withdrawGatewayId = NoSelectionValue;
     private string _withdrawCurrencyId = NoSelectionValue;
 
     // Adjust Balance form
-    private string _adjustBalance = "";
+    private decimal _adjustBalance;
     private string _adjustRemarks = "";
     private Guid? _loadedId;
     private bool _editingRules;
     private bool _savingRules;
-    private string _rulesMinTransfer = "";
-    private string _rulesMaxTransfer = "";
-    private string _rulesBondBalance = "";
-    private string _rulesMaintainingBalance = "";
+    private bool _rulesMinTransferEnabled;
+    private bool _rulesMaxTransferEnabled;
+    private bool _rulesBondBalanceEnabled;
+    private bool _rulesMaintainingBalanceEnabled;
+    private decimal _rulesMinTransfer;
+    private decimal _rulesMaxTransfer;
+    private decimal _rulesBondBalance;
+    private decimal _rulesMaintainingBalance;
     private string CurrentSection => NormalizeSection(Section);
 
     private static string NormalizeSection(string? section) =>
@@ -661,7 +670,8 @@ else
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Failed to load wallet: {ex.Message}");
+            Logger.LogError(ex, "Failed to load wallet detail.");
+            ToastService.Error("Could not load wallet details.", "Wallets");
         }
         finally
         {
@@ -739,10 +749,14 @@ else
             return;
         }
 
-        _rulesMinTransfer = FormatRuleInput(_wallet.MinTransferRule);
-        _rulesMaxTransfer = FormatRuleInput(_wallet.MaxTransferRule);
-        _rulesBondBalance = FormatRuleInput(_wallet.BondBalanceRule);
-        _rulesMaintainingBalance = FormatRuleInput(_wallet.MaintainingBalanceRule);
+        _rulesMinTransferEnabled = _wallet.MinTransferRule.HasValue;
+        _rulesMaxTransferEnabled = _wallet.MaxTransferRule.HasValue;
+        _rulesBondBalanceEnabled = _wallet.BondBalanceRule.HasValue;
+        _rulesMaintainingBalanceEnabled = _wallet.MaintainingBalanceRule.HasValue;
+        _rulesMinTransfer = _wallet.MinTransferRule ?? 0;
+        _rulesMaxTransfer = _wallet.MaxTransferRule ?? 0;
+        _rulesBondBalance = _wallet.BondBalanceRule ?? 0;
+        _rulesMaintainingBalance = _wallet.MaintainingBalanceRule ?? 0;
         _editingRules = true;
     }
 
@@ -753,40 +767,43 @@ else
 
     private async Task SaveRules()
     {
-        if (!TryParseRule(_rulesMinTransfer, "Min transfer rule", out var minTransfer, out var error)
-            || !TryParseRule(_rulesMaxTransfer, "Max transfer rule", out var maxTransfer, out error)
-            || !TryParseRule(_rulesBondBalance, "Bond balance rule", out var bondBalance, out error)
-            || !TryParseRule(_rulesMaintainingBalance, "Maintaining balance rule", out var maintainingBalance, out error))
+        var minTransfer = _rulesMinTransferEnabled ? _rulesMinTransfer : (decimal?)null;
+        var maxTransfer = _rulesMaxTransferEnabled ? _rulesMaxTransfer : (decimal?)null;
+        var bondBalance = _rulesBondBalanceEnabled ? _rulesBondBalance : (decimal?)null;
+        var maintainingBalance = _rulesMaintainingBalanceEnabled ? _rulesMaintainingBalance : (decimal?)null;
+
+        if (!ValidateRule(minTransfer, "Min transfer rule", out var error)
+            || !ValidateRule(maxTransfer, "Max transfer rule", out error)
+            || !ValidateRule(bondBalance, "Bond balance rule", out error)
+            || !ValidateRule(maintainingBalance, "Maintaining balance rule", out error))
         {
-            ToastService.Show(error);
+            ToastService.Warning(error, "Validation");
             return;
         }
 
         if (minTransfer is not null && maxTransfer is not null && minTransfer > maxTransfer)
         {
-            ToastService.Show("Min transfer rule cannot be greater than max transfer rule.");
+            ToastService.Warning("Min transfer rule cannot be greater than max transfer rule.", "Validation");
             return;
         }
 
         _savingRules = true;
         try
         {
-            ToastService.Show("Wallet rule changes require the backend policy workflow and were not saved.");
+            ToastService.Info("Wallet rule changes require the backend policy workflow and were not saved.", "Wallets");
             _editingRules = false;
             await Task.CompletedTask;
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error updating wallet rules: {ex.Message}");
+            Logger.LogError(ex, "Wallet rule update failed.");
+            ToastService.Error("Wallet rules could not be updated.", "Wallets");
         }
         finally
         {
             _savingRules = false;
         }
     }
-
-    private static string FormatRuleInput(decimal? value) =>
-        value?.ToString("0.##", CultureInfo.InvariantCulture) ?? "";
 
     private RequestMetadata BuildCommandMetadata(Guid tenantId) => new()
     {
@@ -800,30 +817,21 @@ else
         IpAddress = RequestMetadata.IpAddress
     };
 
-    private static bool TryParseRule(string value, string label, out decimal? parsed, out string error)
+    private static bool ValidateRule(decimal? value, string label, out string error)
     {
-        parsed = null;
         error = "";
 
-        if (string.IsNullOrWhiteSpace(value))
+        if (value is null)
         {
             return true;
         }
 
-        if (!decimal.TryParse(value, NumberStyles.Number, CultureInfo.CurrentCulture, out var rule)
-            && !decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out rule))
-        {
-            error = $"{label} must be a valid number.";
-            return false;
-        }
-
-        if (rule < 0)
+        if (value < 0)
         {
             error = $"{label} cannot be negative.";
             return false;
         }
 
-        parsed = rule;
         return true;
     }
 
@@ -877,15 +885,15 @@ else
 
     private async Task AddFunds()
     {
-        if (!decimal.TryParse(_addFundsAmount, out var amount) || amount <= 0)
+        if (_addFundsAmount <= 0)
         {
-            ToastService.Show("Please enter a valid positive amount.");
+            ToastService.Warning("Please enter a valid positive amount.", "Validation");
             return;
         }
 
         if (!Guid.TryParse(_addFundsGatewayId, out var gatewayId))
         {
-            ToastService.Show("Select a payment gateway for the deposit request.");
+            ToastService.Warning("Select a payment gateway for the deposit request.", "Validation");
             return;
         }
 
@@ -900,7 +908,7 @@ else
 
             if (fresh is null)
             {
-                ToastService.Show("Wallet not found.");
+                ToastService.Warning("Wallet not found.", "Wallets");
                 return;
             }
 
@@ -915,7 +923,7 @@ else
                 WalletId = fresh.Id,
                 CurrencyId = ParseOptionalGuid(_addFundsCurrencyId),
                 GatewayId = gatewayId,
-                Amount = amount,
+                Amount = _addFundsAmount,
                 ExternalReference = string.IsNullOrWhiteSpace(_addFundsRef) ? null : _addFundsRef.Trim(),
                 Remarks = string.IsNullOrWhiteSpace(_addFundsRemarks) ? "Admin credit" : _addFundsRemarks.Trim(),
                 IdempotencyKey = $"controlpanel-deposit-{Guid.NewGuid():N}"
@@ -923,8 +931,8 @@ else
 
             if (response.IsSuccess)
             {
-                ToastService.Show($"Deposit request created for {amount:N2}.");
-                _addFundsAmount = "";
+                ToastService.Success($"Deposit request created for {_addFundsAmount:N2}.", "Wallets");
+                _addFundsAmount = 0;
                 _addFundsRef = "";
                 _addFundsRemarks = "";
                 _addFundsGatewayId = NoSelectionValue;
@@ -933,12 +941,14 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to create deposit request: {response.Message}");
+                Logger.LogWarning("Deposit request creation failed: {Message}", response.Message);
+                ToastService.Error("Deposit request could not be created.", "Wallets");
             }
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error creating deposit request: {ex.Message}");
+            Logger.LogError(ex, "Deposit request creation failed.");
+            ToastService.Error("Deposit request could not be created.", "Wallets");
         }
         finally
         {
@@ -948,9 +958,9 @@ else
 
     private async Task WithdrawFunds()
     {
-        if (!decimal.TryParse(_withdrawAmount, out var amount) || amount <= 0)
+        if (_withdrawAmount <= 0)
         {
-            ToastService.Show("Please enter a valid positive amount.");
+            ToastService.Warning("Please enter a valid positive amount.", "Validation");
             return;
         }
 
@@ -965,7 +975,7 @@ else
 
             if (fresh is null)
             {
-                ToastService.Show("Wallet not found.");
+                ToastService.Warning("Wallet not found.", "Wallets");
                 return;
             }
 
@@ -974,9 +984,9 @@ else
                 return;
             }
 
-            if (fresh.AvailableBalance < amount)
+            if (fresh.AvailableBalance < _withdrawAmount)
             {
-                ToastService.Show($"Insufficient balance. Available: {fresh.AvailableBalance:N2}, requested: {amount:N2}");
+                ToastService.Warning($"Insufficient balance. Available: {fresh.AvailableBalance:N2}, requested: {_withdrawAmount:N2}", "Validation");
                 return;
             }
 
@@ -986,7 +996,7 @@ else
                 WalletId = fresh.Id,
                 GatewayId = ParseOptionalGuid(_withdrawGatewayId),
                 CurrencyId = ParseOptionalGuid(_withdrawCurrencyId),
-                Amount = amount,
+                Amount = _withdrawAmount,
                 ExternalReference = string.IsNullOrWhiteSpace(_withdrawRef) ? null : _withdrawRef.Trim(),
                 Remarks = string.IsNullOrWhiteSpace(_withdrawRemarks) ? "Admin debit" : _withdrawRemarks.Trim(),
                 IdempotencyKey = $"controlpanel-withdrawal-{Guid.NewGuid():N}"
@@ -994,8 +1004,8 @@ else
 
             if (response.IsSuccess)
             {
-                ToastService.Show($"Withdrawal request created for {amount:N2}.");
-                _withdrawAmount = "";
+                ToastService.Success($"Withdrawal request created for {_withdrawAmount:N2}.", "Wallets");
+                _withdrawAmount = 0;
                 _withdrawRef = "";
                 _withdrawRemarks = "";
                 _withdrawGatewayId = NoSelectionValue;
@@ -1004,12 +1014,14 @@ else
             }
             else
             {
-                ToastService.Show($"Failed to create withdrawal request: {response.Message}");
+                Logger.LogWarning("Withdrawal request creation failed: {Message}", response.Message);
+                ToastService.Error("Withdrawal request could not be created.", "Wallets");
             }
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error creating withdrawal request: {ex.Message}");
+            Logger.LogError(ex, "Withdrawal request creation failed.");
+            ToastService.Error("Withdrawal request could not be created.", "Wallets");
         }
         finally
         {
@@ -1019,9 +1031,9 @@ else
 
     private async Task AdjustBalance()
     {
-        if (!decimal.TryParse(_adjustBalance, out var newBalance))
+        if (_adjustBalance < 0)
         {
-            ToastService.Show("Please enter a valid balance amount.");
+            ToastService.Warning("Please enter a valid balance amount.", "Validation");
             return;
         }
 
@@ -1037,7 +1049,7 @@ else
 
             if (fresh is null)
             {
-                ToastService.Show("Wallet not found.");
+                ToastService.Warning("Wallet not found.", "Wallets");
                 return;
             }
 
@@ -1046,16 +1058,16 @@ else
                 return;
             }
 
-            var difference = newBalance - fresh.Balance;
+            var difference = _adjustBalance - fresh.Balance;
             if (difference == 0)
             {
-                ToastService.Show("Balance is already at the requested amount.");
+                ToastService.Info("Balance is already at the requested amount.", "Wallets");
                 return;
             }
 
             var referenceNumber = $"ADJ-{DateTime.UtcNow:yyyyMMddHHmmss}";
             var remarks = string.IsNullOrWhiteSpace(_adjustRemarks)
-                ? $"Admin balance adjustment: {fresh.Balance:N2} -> {newBalance:N2}"
+                ? $"Admin balance adjustment: {fresh.Balance:N2} -> {_adjustBalance:N2}"
                 : _adjustRemarks.Trim();
 
             var response = await WalletsAdminContracts.CreateWalletApprovalAsync(
@@ -1066,18 +1078,20 @@ else
 
             if (response.IsSuccess)
             {
-                ToastService.Show($"Balance adjustment approval requested for {newBalance:N2}.");
-                _adjustBalance = "";
+                ToastService.Success($"Balance adjustment approval requested for {_adjustBalance:N2}.", "Wallets");
+                _adjustBalance = 0;
                 _adjustRemarks = "";
             }
             else
             {
-                ToastService.Show($"Failed to request balance adjustment: {response.Message}");
+                Logger.LogWarning("Balance adjustment request failed: {Message}", response.Message);
+                ToastService.Error("Balance adjustment could not be requested.", "Wallets");
             }
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error adjusting balance: {ex.Message}");
+            Logger.LogError(ex, "Balance adjustment request failed.");
+            ToastService.Error("Balance adjustment could not be requested.", "Wallets");
         }
         finally
         {
@@ -1092,7 +1106,7 @@ else
             return true;
         }
 
-        ToastService.Show("This wallet has no wallet type. Assign a wallet type before submitting money operations.");
+        ToastService.Warning("This wallet has no wallet type. Assign a wallet type before submitting money operations.", "Wallets");
         return false;
     }
 
@@ -1186,11 +1200,29 @@ else
 
     private static string ShortId(Guid id) => id.ToString()[..8];
 
+    private static string GetTransactionTypeText(WalletTransaction transaction) =>
+        transaction.TransactionType?.ToString() ?? "Unknown";
+
+    private static string BuildTransactionApprovalLabel(WalletTransaction transaction)
+    {
+        var type = GetTransactionTypeText(transaction).ToLowerInvariant();
+        var reference = string.IsNullOrWhiteSpace(transaction.ReferenceNumber)
+            ? WalletsControlPanelDisplayService.ShortId(transaction.Id)
+            : transaction.ReferenceNumber;
+
+        return $"{type} transaction {reference}";
+    }
+
     private async Task ReleaseTransaction(WalletTransaction transaction)
     {
         if (_wallet is null)
         {
-            ToastService.Show("Wallet not loaded.");
+            ToastService.Warning("Wallet not loaded.", "Wallets");
+            return;
+        }
+
+        if (!await DialogService.Confirm("Release Held Transaction", "Release this held wallet transaction?", new ConfirmDialogOptions()))
+        {
             return;
         }
 
@@ -1205,14 +1237,20 @@ else
 
             if (response.IsSuccess)
             {
-                ToastService.Show("Held transaction released.");
+                ToastService.Success("Held transaction released.", "Wallets");
                 await LoadWallet();
                 await LoadTransactions();
             }
             else
             {
-                ToastService.Show($"Failed to release transaction: {response.Message}");
+                Logger.LogWarning("Held transaction release failed: {Message}", response.Message);
+                ToastService.Error("Held transaction could not be released.", "Wallets");
             }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Held transaction release failed.");
+            ToastService.Error("Held transaction could not be released.", "Wallets");
         }
         finally
         {
@@ -1224,7 +1262,15 @@ else
     {
         if (_wallet is null)
         {
-            ToastService.Show("Wallet not loaded.");
+            ToastService.Warning("Wallet not loaded.", "Wallets");
+            return;
+        }
+
+        if (!await DialogService.Confirm(
+                "Request Transaction Reversal",
+                "Create an approval request to reverse this transaction?",
+                new ConfirmDialogOptions { Destructive = true }))
+        {
             return;
         }
 
@@ -1235,16 +1281,22 @@ else
                 WalletOperationType.Reversal,
                 _wallet.Id,
                 transaction.Amount,
-                $"Reverse transaction {transaction.Id} from ControlPanel wallet detail");
+                $"Reverse {BuildTransactionApprovalLabel(transaction)} from ControlPanel wallet detail");
 
             if (response.IsSuccess)
             {
-                ToastService.Show("Transaction reversal approval requested.");
+                ToastService.Success("Transaction reversal approval requested.", "Wallets");
             }
             else
             {
-                ToastService.Show($"Failed to request reversal approval: {response.Message}");
+                Logger.LogWarning("Transaction reversal request failed: {Message}", response.Message);
+                ToastService.Error("Transaction reversal could not be requested.", "Wallets");
             }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Transaction reversal request failed.");
+            ToastService.Error("Transaction reversal could not be requested.", "Wallets");
         }
         finally
         {
@@ -1264,13 +1316,21 @@ else
 
             if (fresh is null)
             {
-                ToastService.Show("Wallet not found.");
+                ToastService.Warning("Wallet not found.", "Wallets");
                 return;
             }
 
             if (fresh.Status != WalletStatus.Active)
             {
-                ToastService.Show($"Cannot freeze. Wallet status is {fresh.Status}.");
+                ToastService.Warning($"Wallet status is {fresh.Status}; freeze is not available.", "Wallets");
+                return;
+            }
+
+            if (!await DialogService.Confirm(
+                    "Request Wallet Freeze",
+                    "Create an approval request to freeze this wallet?",
+                    new ConfirmDialogOptions { Destructive = true }))
+            {
                 return;
             }
 
@@ -1282,16 +1342,18 @@ else
 
             if (response.IsSuccess)
             {
-                ToastService.Show("Wallet freeze approval requested.");
+                ToastService.Success("Wallet freeze approval requested.", "Wallets");
             }
             else
             {
-                ToastService.Show($"Failed to request wallet freeze: {response.Message}");
+                Logger.LogWarning("Wallet freeze request failed: {Message}", response.Message);
+                ToastService.Error("Wallet freeze could not be requested.", "Wallets");
             }
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error freezing wallet: {ex.Message}");
+            Logger.LogError(ex, "Wallet freeze request failed.");
+            ToastService.Error("Wallet freeze could not be requested.", "Wallets");
         }
     }
 
@@ -1307,13 +1369,18 @@ else
 
             if (fresh is null)
             {
-                ToastService.Show("Wallet not found.");
+                ToastService.Warning("Wallet not found.", "Wallets");
                 return;
             }
 
             if (fresh.Status != WalletStatus.Frozen)
             {
-                ToastService.Show($"Cannot unfreeze. Wallet status is {fresh.Status}.");
+                ToastService.Warning($"Wallet status is {fresh.Status}; unfreeze is not available.", "Wallets");
+                return;
+            }
+
+            if (!await DialogService.Confirm("Request Wallet Unfreeze", "Create an approval request to unfreeze this wallet?", new ConfirmDialogOptions()))
+            {
                 return;
             }
 
@@ -1325,16 +1392,18 @@ else
 
             if (response.IsSuccess)
             {
-                ToastService.Show("Wallet unfreeze approval requested.");
+                ToastService.Success("Wallet unfreeze approval requested.", "Wallets");
             }
             else
             {
-                ToastService.Show($"Failed to request wallet unfreeze: {response.Message}");
+                Logger.LogWarning("Wallet unfreeze request failed: {Message}", response.Message);
+                ToastService.Error("Wallet unfreeze could not be requested.", "Wallets");
             }
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error unfreezing wallet: {ex.Message}");
+            Logger.LogError(ex, "Wallet unfreeze request failed.");
+            ToastService.Error("Wallet unfreeze could not be requested.", "Wallets");
         }
     }
 
@@ -1350,14 +1419,21 @@ else
 
             if (fresh is null)
             {
-                ToastService.Show("Wallet not found.");
+                ToastService.Warning("Wallet not found.", "Wallets");
                 return;
             }
 
             if (fresh.Status == WalletStatus.Closed)
             {
-                ToastService.Show("Wallet is already closed.");
-                _showCloseDialog = false;
+                ToastService.Info("Wallet is already closed.", "Wallets");
+                return;
+            }
+
+            if (!await DialogService.Confirm(
+                    "Request Wallet Close",
+                    "Create a maker-checker approval request to close this wallet?",
+                    new ConfirmDialogOptions { Destructive = true }))
+            {
                 return;
             }
 
@@ -1370,17 +1446,18 @@ else
 
             if (response.IsSuccess)
             {
-                ToastService.Show("Wallet close approval requested.");
-                _showCloseDialog = false;
+                ToastService.Success("Wallet close approval requested.", "Wallets");
             }
             else
             {
-                ToastService.Show($"Failed to request wallet close: {response.Message}");
+                Logger.LogWarning("Wallet close request failed: {Message}", response.Message);
+                ToastService.Error("Wallet close could not be requested.", "Wallets");
             }
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error closing wallet: {ex.Message}");
+            Logger.LogError(ex, "Wallet close request failed.");
+            ToastService.Error("Wallet close could not be requested.", "Wallets");
         }
         finally
         {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletOperations.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WalletOperations.razor
@@ -4,13 +4,18 @@
 
 <PageTitle>Wallet Operations - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex items-center justify-between">
-        <BbTypographyH3>Wallet Operations</BbTypographyH3>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+<div class="space-y-6">
+    <div class="xf-page-header">
+        <div>
+            <BbTypographyH3>Wallet Operations</BbTypographyH3>
+            <BbTypographyMuted>Review Wallets ledger operation history and policy output.</BbTypographyMuted>
+        </div>
+        <div class="xf-page-actions">
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -29,21 +34,26 @@
     {
         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
             <Columns>
-                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                <BbDataGridTemplateColumn Title="Type">
+                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" Filterable="true" />
+                <BbDataGridTemplateColumn Title="Type" Filterable="true" FilterBy="@(item => item.OperationType.ToString())">
                     <ChildContent Context="item">
                         <BbBadge Variant="BadgeVariant.Outline">@item.OperationType</BbBadge>
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridTemplateColumn Title="Status">
+                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status.ToString())">
                     <ChildContent Context="item">
                         <BbBadge Variant="@(item.Status == WalletOperationStatus.Completed ? BadgeVariant.Default : BadgeVariant.Outline)">@item.Status</BbBadge>
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.IdempotencyKey)" Title="Idempotency Key" />
-                <BbDataGridPropertyColumn Property="@(x => x.ActorCredentialId)" Title="Actor" />
-                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.IdempotencyKey)" Title="Idempotency Key" Filterable="true" />
+                <BbDataGridTemplateColumn Title="Actor" Filterable="true" FilterBy="@(item => GetCredentialLabel(item.ActorCredentialId))">
+                    <ChildContent Context="item">@GetCredentialLabel(item.ActorCredentialId)</ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
             </Columns>
+            <EmptyTemplate>
+                <BbEmpty Title="No wallet operations found" Description="Ledger operations and policy decisions will appear here." />
+            </EmptyTemplate>
         </BbDataGrid>
     }
 </div>
@@ -53,8 +63,11 @@
     [Inject] private ControlPanel.Server.Services.TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private WalletsControlPanelDisplayService DisplayService { get; set; } = default!;
+    [Inject] private ILogger<WalletOperations> Logger { get; set; } = default!;
 
     private List<WalletOperation> _items = [];
+    private IReadOnlyDictionary<Guid, string> _credentialLabels = new Dictionary<Guid, string>();
     private bool _loading = true;
     private bool _hasTenant;
     private bool _moduleEnabled;
@@ -81,6 +94,7 @@
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
             _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.WalletsReporting);
             _items = [];
+            _credentialLabels = new Dictionary<Guid, string>();
 
             if (!_hasTenant || !_moduleEnabled)
             {
@@ -95,11 +109,16 @@
                 .OrderByDescending(x => x.CreatedAt);
 
             _items = await query.Take(200).ToListAsync();
+            _credentialLabels = await DisplayService.LoadCredentialLabelsAsync(
+                tenantId,
+                _items.Select(x => x.ActorCredentialId));
         }
         catch (Exception ex)
         {
             _items = [];
-            ToastService.Show($"Failed to load wallet operations: {ex.Message}");
+            _credentialLabels = new Dictionary<Guid, string>();
+            Logger.LogError(ex, "Failed to load wallet operations.");
+            ToastService.Error("Could not load wallet operations.", "Wallets");
         }
         finally
         {
@@ -107,6 +126,9 @@
             StateHasChanged();
         }
     }
+
+    private string GetCredentialLabel(Guid? credentialId) =>
+        DisplayService.CredentialLabel(credentialId, _credentialLabels);
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Wallets.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/Wallets.razor
@@ -24,19 +24,21 @@ else
 {
 <FadeInContent>
 <div class="space-y-6">
-    <div class="flex items-center justify-between">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Wallet Management</BbTypographyH3>
             <BbTypographyMuted>Manage user wallets, balances, and account statuses</BbTypographyMuted>
         </div>
-        <BbButton OnClick="@OpenCreateDialog">
-            <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
-            Create Wallet
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton OnClick="@OpenCreateDialog">
+                <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                Create Wallet
+            </BbButton>
+        </div>
     </div>
 
     @* Summary Statistics *@
-    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+    <div class="xf-summary-grid xf-summary-grid-4">
         <BbCard>
             <BbCardHeader>
                 <BbCardTitle>Total Wallets</BbCardTitle>
@@ -88,34 +90,34 @@ else
             <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20"
                         OnRowClick="@((Wallet item) => NavigationManager.NavigateTo($"/finance/wallets/{item.Id}"))" Class="cursor-pointer">
                 <Columns>
-                    <BbDataGridTemplateColumn Title="Account Number" Sortable="true">
+                    <BbDataGridTemplateColumn Title="Account Number" Sortable="true" Filterable="true" FilterBy="@(item => item.AccountNumber ?? string.Empty)">
                         <ChildContent Context="item">
                             @(item.AccountNumber ?? "N/A")
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridTemplateColumn Title="User / Credential" Sortable="true">
+                    <BbDataGridTemplateColumn Title="User / Credential" Sortable="true" Filterable="true" FilterBy="@(item => GetCredentialDisplay(item.CredentialId))">
                         <ChildContent Context="item">
                             <span class="text-sm">@GetCredentialDisplay(item.CredentialId)</span>
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridTemplateColumn Title="Wallet Type">
+                    <BbDataGridTemplateColumn Title="Wallet Type" Filterable="true" FilterBy="@(item => GetWalletTypeDisplay(item))">
                         <ChildContent Context="item">
                             @(item.WalletType?.Name ?? "N/A")
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridTemplateColumn Title="Balance" Sortable="true">
+                    <BbDataGridTemplateColumn Title="Balance" Sortable="true" Filterable="true" FilterBy="@(item => item.Balance)">
                         <ChildContent Context="item">
                             <span class="font-semibold">@item.Balance.ToString("N2")</span>
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridTemplateColumn Title="Available Balance" Sortable="true">
+                    <BbDataGridTemplateColumn Title="Available Balance" Sortable="true" Filterable="true" FilterBy="@(item => item.AvailableBalance)">
                         <ChildContent Context="item">
                             <span class="@(item.AvailableBalance < 0 ? "text-red-500 font-semibold" : "")">
                                 @item.AvailableBalance.ToString("N2")
                             </span>
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridTemplateColumn Title="Debit On Hold" Sortable="true">
+                    <BbDataGridTemplateColumn Title="Debit On Hold" Sortable="true" Filterable="true" FilterBy="@(item => item.DebitOnHoldBalance)">
                         <ChildContent Context="item">
                             @if (item.DebitOnHoldBalance > 0)
                             {
@@ -127,22 +129,24 @@ else
                             }
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridTemplateColumn Title="Status">
+                    <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.Status.ToString())">
                         <ChildContent Context="item">
                             <StatusBadge Text="@item.Status.ToString()" Status="@GetStatusKey(item.Status)" />
                         </ChildContent>
                     </BbDataGridTemplateColumn>
-                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                     <BbDataGridTemplateColumn Title="Actions">
                         <ChildContent Context="item">
-                            <div class="flex items-center gap-1">
+                            <div class="flex items-center gap-1" @onclick:stopPropagation="true">
                                 <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                          AriaLabel="View wallet"
                                           OnClick="@(() => NavigationManager.NavigateTo($"/finance/wallets/{item.Id}"))">
                                     <LucideIcon Name="eye" class="h-4 w-4" />
                                 </BbButton>
                                 @if (item.Status == WalletStatus.Active)
                                 {
                                     <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              AriaLabel="Request wallet freeze"
                                               OnClick="@(() => ToggleFreeze(item))">
                                         <LucideIcon Name="lock" class="h-4 w-4" />
                                     </BbButton>
@@ -150,6 +154,7 @@ else
                                 else if (item.Status == WalletStatus.Frozen)
                                 {
                                     <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                              AriaLabel="Request wallet unfreeze"
                                               OnClick="@(() => ToggleFreeze(item))">
                                         <LucideIcon Name="lock-open" class="h-4 w-4" />
                                     </BbButton>
@@ -158,6 +163,9 @@ else
                         </ChildContent>
                     </BbDataGridTemplateColumn>
                 </Columns>
+                <EmptyTemplate>
+                    <BbEmpty Title="No wallets found" Description="Create a wallet to begin managing balances." />
+                </EmptyTemplate>
             </BbDataGrid>
         </BbCardContent>
     </BbCard>
@@ -167,7 +175,7 @@ else
 
 @* Create Wallet Dialog *@
 <BbDialog Open="@_showCreateDialog" OpenChanged="@(v => _showCreateDialog = v)">
-    <BbDialogContent>
+    <BbDialogContent TrapFocus="false">
         <BbDialogHeader>
             <BbDialogTitle>Create Wallet</BbDialogTitle>
             <BbDialogDescription>Create a new wallet account for a user credential.</BbDialogDescription>
@@ -209,10 +217,10 @@ else
                             ClearText="Clear wallet type"
                             AdvancedSearchTitle="Find Wallet Type"
                             AdvancedSearchDescription="Search wallet types available to the active tenant." />
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_newInitialBalance"
-                              Label="Initial Balance"
-                              Placeholder="0.00" />
+            <BbFormFieldCurrencyInput @bind-Value="_newInitialBalance"
+                                      Label="Initial Balance"
+                                      ShowSymbol="false"
+                                      Min="0" />
         </div>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _showCreateDialog = false)">Cancel</BbButton>
@@ -236,6 +244,8 @@ else
     [Inject] private IWalletsServiceWrapper WalletsService { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private RequestMetadata RequestMetadata { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private ILogger<Wallets> Logger { get; set; } = default!;
 
     private List<Wallet> _items = [];
     private List<global::Wallets.Domain.Shared.Contracts.WalletType> _walletTypes = [];
@@ -257,7 +267,7 @@ else
     // Create form
     private string _newCredentialId = "";
     private string _newWalletTypeId = "";
-    private string _newInitialBalance = "0";
+    private decimal _newInitialBalance;
 
     protected override void OnInitialized()
     {
@@ -305,7 +315,8 @@ else
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Failed to load wallets: {ex.Message}");
+            Logger.LogError(ex, "Failed to load wallets.");
+            ToastService.Error("Could not load wallets.", "Wallets");
         }
         finally
         {
@@ -387,7 +398,7 @@ else
     {
         _newCredentialId = "";
         _newWalletTypeId = "";
-        _newInitialBalance = "0";
+        _newInitialBalance = 0;
         _showCreateDialog = true;
     }
 
@@ -395,42 +406,32 @@ else
     {
         if (!Guid.TryParse(_newCredentialId, out var credentialId))
         {
-            ToastService.Show("Select a user or credential.");
+            ToastService.Warning("Select a user or credential.", "Validation");
             return;
         }
 
         if (!_credentialTenantIds.TryGetValue(credentialId, out var walletTenantId))
         {
-            ToastService.Show("Selected credential was not found. Refresh and try again.");
+            ToastService.Warning("Selected credential was not found. Refresh and try again.", "Validation");
             return;
         }
 
-        var initialBalanceText = string.IsNullOrWhiteSpace(_newInitialBalance)
-            ? "0"
-            : _newInitialBalance.Trim();
-        if (!decimal.TryParse(initialBalanceText, NumberStyles.Number, CultureInfo.CurrentCulture, out var initialBalance)
-            && !decimal.TryParse(initialBalanceText, NumberStyles.Number, CultureInfo.InvariantCulture, out initialBalance))
+        if (_newInitialBalance < 0)
         {
-            ToastService.Show("Initial balance must be a valid number.");
-            return;
-        }
-
-        if (initialBalance < 0)
-        {
-            ToastService.Show("Initial balance cannot be negative.");
+            ToastService.Warning("Initial balance cannot be negative.", "Validation");
             return;
         }
 
         if (!Guid.TryParse(_newWalletTypeId, out var walletTypeId))
         {
-            ToastService.Show("Select a wallet type.");
+            ToastService.Warning("Select a wallet type.", "Validation");
             return;
         }
 
         var walletType = _walletTypes.FirstOrDefault(x => x.Id == walletTypeId);
         if (walletType is null)
         {
-            ToastService.Show("Selected wallet type was not found. Refresh and try again.");
+            ToastService.Warning("Selected wallet type was not found. Refresh and try again.", "Validation");
             return;
         }
 
@@ -441,24 +442,26 @@ else
             {
                 CredentialId = credentialId,
                 WalletTypeId = walletType.Id,
-                InitialBalance = initialBalance,
+                InitialBalance = _newInitialBalance,
                 Metadata = BuildCommandMetadata(walletTenantId)
             });
 
             if (response.IsSuccess)
             {
-                ToastService.Show("Wallet created successfully.");
+                ToastService.Success("Wallet created successfully.", "Wallets");
                 _showCreateDialog = false;
                 await Reload();
             }
             else
             {
-                ToastService.Show($"Failed to create wallet: {response.Message}");
+                Logger.LogWarning("Wallet creation failed: {Message}", response.Message);
+                ToastService.Error("Wallet could not be created.", "Wallets");
             }
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error creating wallet: {ex.Message}");
+            Logger.LogError(ex, "Wallet creation failed.");
+            ToastService.Error("Wallet could not be created.", "Wallets");
         }
         finally
         {
@@ -492,18 +495,26 @@ else
 
             if (fresh is null)
             {
-                ToastService.Show("Wallet not found. It may have been deleted.");
+                ToastService.Warning("Wallet not found. It may have been deleted.", "Wallets");
                 return;
             }
 
             if (fresh.Status is not (WalletStatus.Active or WalletStatus.Frozen))
             {
-                ToastService.Show($"Cannot toggle freeze. Wallet status is {fresh.Status}.");
+                ToastService.Warning($"Wallet status is {fresh.Status}; freeze changes are not available.", "Wallets");
                 return;
             }
 
             var isFreezing = fresh.Status == WalletStatus.Active;
             var operationType = isFreezing ? WalletOperationType.Freeze : WalletOperationType.Unfreeze;
+            if (!await DialogService.Confirm(
+                    isFreezing ? "Request Wallet Freeze" : "Request Wallet Unfreeze",
+                    isFreezing ? "Create an approval request to freeze this wallet?" : "Create an approval request to unfreeze this wallet?",
+                    new ConfirmDialogOptions { Destructive = isFreezing }))
+            {
+                return;
+            }
+
             var result = await WalletsAdminContracts.CreateWalletApprovalAsync(
                 operationType,
                 fresh.Id,
@@ -512,16 +523,18 @@ else
 
             if (result.IsSuccess)
             {
-                ToastService.Show($"Wallet {(isFreezing ? "freeze" : "unfreeze")} approval requested.");
+                ToastService.Success($"Wallet {(isFreezing ? "freeze" : "unfreeze")} approval requested.", "Wallets");
             }
             else
             {
-                ToastService.Show($"Failed to request wallet status change: {result.Message}");
+                Logger.LogWarning("Wallet status change request failed: {Message}", result.Message);
+                ToastService.Error("Wallet status change could not be requested.", "Wallets");
             }
         }
         catch (Exception ex)
         {
-            ToastService.Show($"Error updating wallet: {ex.Message}");
+            Logger.LogError(ex, "Wallet status change request failed.");
+            ToastService.Error("Wallet status change could not be requested.", "Wallets");
         }
     }
 
@@ -529,6 +542,8 @@ else
         _credentialLabels.TryGetValue(credentialId, out var label)
             ? label
             : $"{credentialId.ToString()[..8]}...";
+
+    private static string GetWalletTypeDisplay(Wallet wallet) => wallet.WalletType is null ? "N/A" : wallet.WalletType.Name;
 
     private static string GetCredentialPickerValue(IdentityCredential credential) => credential.Id.ToString();
 

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WithdrawalRequests.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Finance/WithdrawalRequests.razor
@@ -6,16 +6,22 @@
 
 <PageTitle>Withdrawal Requests - Control Panel</PageTitle>
 
-<div class="space-y-4">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+<div class="space-y-6">
+    <div class="xf-page-header">
         <div>
             <BbTypographyH3>Withdrawal Requests</BbTypographyH3>
             <BbTypographyMuted>Review cash-out requests, fees, and approval workflow readiness.</BbTypographyMuted>
         </div>
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
-            <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
-            Refresh
-        </BbButton>
+        <div class="xf-page-actions">
+            <BbButton OnClick="@OpenCreateDialog">
+                <LucideIcon Name="circle-minus" class="mr-2 h-4 w-4" />
+                Create Withdrawal
+            </BbButton>
+            <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="@LoadData">
+                <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                Refresh
+            </BbButton>
+        </div>
     </div>
 
     @if (_loading)
@@ -32,87 +38,7 @@
     }
     else
     {
-        <BbCard>
-            <BbCardHeader>
-                <BbCardTitle>Create Withdrawal Request</BbCardTitle>
-                <BbCardDescription>Submit cash-out requests through the Wallets withdrawal workflow.</BbCardDescription>
-            </BbCardHeader>
-            <BbCardContent>
-                <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                    <XfEntityPicker TItem="Wallet"
-                                    Label="Wallet"
-                                    Value="@_createWalletId"
-                                    ValueChanged="@(value => _createWalletId = value ?? NoSelectionValue)"
-                                    Items="@_wallets"
-                                    ValueSelector="@GetWalletPickerValue"
-                                    TextSelector="@BuildWalletLabel"
-                                    SearchTextSelector="@GetWalletSearchText"
-                                    AdvancedColumns="@WalletAdvancedColumns"
-                                    AdvancedFilters="@WalletAdvancedFilters"
-                                    AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
-                                    Placeholder="Select wallet"
-                                    SearchPlaceholder="Search wallets..."
-                                    EmptyMessage="No active wallets found."
-                                    AllowClear="true"
-                                    ClearText="Clear wallet"
-                                    AdvancedSearchTitle="Find Wallet"
-                                    AdvancedSearchDescription="Search active wallets before creating a withdrawal request." />
-                    <XfEntityPicker TItem="PaymentGateway"
-                                    Label="Gateway"
-                                    Value="@_createGatewayId"
-                                    ValueChanged="@(value => _createGatewayId = value ?? NoSelectionValue)"
-                                    Items="@_gateways"
-                                    ValueSelector="@GetGatewayPickerValue"
-                                    TextSelector="@BuildGatewayLabel"
-                                    SearchTextSelector="@GetGatewaySearchText"
-                                    AdvancedColumns="@GatewayAdvancedColumns"
-                                    AdvancedFilters="@GatewayAdvancedFilters"
-                                    AdvancedSearchScope="Searches gateway name, category/provider, enabled state, service charge, convenience fee, discount, and description."
-                                    Placeholder="No payout provider yet"
-                                    SearchPlaceholder="Search gateways..."
-                                    EmptyMessage="No gateways found."
-                                    AllowClear="true"
-                                    ClearText="No payout provider"
-                                    AdvancedSearchTitle="Find Payout Gateway"
-                                    AdvancedSearchDescription="Search configured payment gateways for withdrawal settlement." />
-                    <XfEntityPicker TItem="global::Wallets.Domain.Shared.Contracts.CurrencyType"
-                                    Label="Currency"
-                                    Value="@_createCurrencyId"
-                                    ValueChanged="@(value => _createCurrencyId = value ?? NoSelectionValue)"
-                                    Items="@_currencies"
-                                    ValueSelector="@GetCurrencyPickerValue"
-                                    TextSelector="@BuildCurrencyLabel"
-                                    SearchTextSelector="@GetCurrencySearchText"
-                                    AdvancedColumns="@CurrencyAdvancedColumns"
-                                    AdvancedFilters="@CurrencyAdvancedFilters"
-                                    AdvancedSearchScope="Searches currency ISO code, name, type, tenant scope, and description."
-                                    Placeholder="Default wallet currency"
-                                    SearchPlaceholder="Search currencies..."
-                                    EmptyMessage="No currencies found."
-                                    AllowClear="true"
-                                    ClearText="Default wallet currency"
-                                    AdvancedSearchTitle="Find Currency"
-                                    AdvancedSearchDescription="Search tenant and global currencies available to Wallets." />
-                    <BbFormFieldInput TValue="decimal" @bind-Value="_createAmount" Label="Amount" />
-                    <BbFormFieldInput TValue="decimal" @bind-Value="_createRequestedFee" Label="Requested Fee" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_createExternalReference" Label="External Reference" Placeholder="Optional provider/reference id" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_createAddress" Label="Payout Address" Placeholder="Account, wallet, or payout destination" />
-                    <BbFormFieldInput TValue="string" @bind-Value="_createRemarks" Label="Remarks" Placeholder="Cash-out note" />
-                </div>
-                <div class="mt-4">
-                    <BbButton Variant="ButtonVariant.Outline" OnClick="@CreateWithdrawal" Disabled="@_acting">
-                        @if (_acting)
-                        {
-                            <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
-                        }
-                        <LucideIcon Name="circle-minus" class="mr-2 h-4 w-4" />
-                        Create Withdrawal
-                    </BbButton>
-                </div>
-            </BbCardContent>
-        </BbCard>
-
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div class="xf-summary-grid xf-summary-grid-4">
             <BbCard>
                 <BbCardContent>
                     <div class="space-y-1 pt-4">
@@ -149,31 +75,31 @@
 
         <BbDataGrid Items="@_items" ShowPagination="true" InitialPageSize="20">
             <Columns>
-                <BbDataGridTemplateColumn Title="Credential">
+                <BbDataGridTemplateColumn Title="Credential" Filterable="true" FilterBy="@(item => GetCredentialLabel(item.CredentialId))">
                     <ChildContent Context="item">
-                        <span class="font-mono text-xs">@ShortId(item.CredentialId)</span>
+                        <span>@GetCredentialLabel(item.CredentialId)</span>
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridTemplateColumn Title="Wallet">
+                <BbDataGridTemplateColumn Title="Wallet" Filterable="true" FilterBy="@(item => GetWalletLabel(item.WalletId))">
                     <ChildContent Context="item">
-                        <span class="font-mono text-xs">@ShortId(item.WalletId)</span>
+                        <span>@GetWalletLabel(item.WalletId)</span>
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.Fee)" Title="Fee" Sortable="true" />
-                <BbDataGridTemplateColumn Title="Workflow">
+                <BbDataGridPropertyColumn Property="@(x => x.Amount)" Title="Amount" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.Fee)" Title="Fee" Sortable="true" Filterable="true" />
+                <BbDataGridTemplateColumn Title="Workflow" Filterable="true" FilterBy="@(item => item.WorkflowStatus.ToString())">
                     <ChildContent Context="item">
                         <StatusBadge Text="@item.WorkflowStatus.ToString()" Status="@GetWorkflowStatusCategory(item.WorkflowStatus)" />
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridTemplateColumn Title="Status">
+                <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.WithdrawalStatus.ToString())">
                     <ChildContent Context="item">
                         <StatusBadge Text="@item.WithdrawalStatus.ToString()" Status="@GetWithdrawalStatusCategory(item.WithdrawalStatus)" />
                     </ChildContent>
                 </BbDataGridTemplateColumn>
-                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" />
-                <BbDataGridPropertyColumn Property="@(x => x.Address)" Title="Address" />
-                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.ReferenceNumber)" Title="Reference" Sortable="true" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.Address)" Title="Address" Filterable="true" />
+                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                 <BbDataGridTemplateColumn Title="Actions">
                     <ChildContent Context="item">
                         <div class="flex flex-wrap gap-1">
@@ -196,9 +122,94 @@
                     </ChildContent>
                 </BbDataGridTemplateColumn>
             </Columns>
+            <EmptyTemplate>
+                <BbEmpty Title="No withdrawal requests found" Description="Create a withdrawal request to start the workflow." />
+            </EmptyTemplate>
         </BbDataGrid>
     }
 </div>
+
+<BbDialog Open="@_createDialogOpen" OpenChanged="@OnCreateDialogChanged">
+    <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
+        <BbDialogHeader>
+            <BbDialogTitle>Create Withdrawal</BbDialogTitle>
+            <BbDialogDescription>Submit cash-out requests through the Wallets withdrawal workflow.</BbDialogDescription>
+        </BbDialogHeader>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <XfEntityPicker TItem="Wallet"
+                                Label="Wallet"
+                                Value="@_createWalletId"
+                                ValueChanged="@(value => _createWalletId = value ?? NoSelectionValue)"
+                                Items="@_wallets"
+                                ValueSelector="@GetWalletPickerValue"
+                                TextSelector="@BuildWalletLabel"
+                                SearchTextSelector="@GetWalletSearchText"
+                                AdvancedColumns="@WalletAdvancedColumns"
+                                AdvancedFilters="@WalletAdvancedFilters"
+                                AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, available balance, held balance, and created date."
+                                Placeholder="Select wallet"
+                                SearchPlaceholder="Search wallets..."
+                                EmptyMessage="No active wallets found."
+                                AllowClear="true"
+                                ClearText="Clear wallet"
+                                AdvancedSearchTitle="Find Wallet"
+                                AdvancedSearchDescription="Search active wallets before creating a withdrawal request." />
+                <XfEntityPicker TItem="PaymentGateway"
+                                Label="Gateway"
+                                Value="@_createGatewayId"
+                                ValueChanged="@(value => _createGatewayId = value ?? NoSelectionValue)"
+                                Items="@_gateways"
+                                ValueSelector="@GetGatewayPickerValue"
+                                TextSelector="@BuildGatewayLabel"
+                                SearchTextSelector="@GetGatewaySearchText"
+                                AdvancedColumns="@GatewayAdvancedColumns"
+                                AdvancedFilters="@GatewayAdvancedFilters"
+                                AdvancedSearchScope="Searches gateway name, category/provider, enabled state, service charge, convenience fee, discount, and description."
+                                Placeholder="No payout provider yet"
+                                SearchPlaceholder="Search gateways..."
+                                EmptyMessage="No gateways found."
+                                AllowClear="true"
+                                ClearText="No payout provider"
+                                AdvancedSearchTitle="Find Payout Gateway"
+                                AdvancedSearchDescription="Search configured payment gateways for withdrawal settlement." />
+                <XfEntityPicker TItem="global::Wallets.Domain.Shared.Contracts.CurrencyType"
+                                Label="Currency"
+                                Value="@_createCurrencyId"
+                                ValueChanged="@(value => _createCurrencyId = value ?? NoSelectionValue)"
+                                Items="@_currencies"
+                                ValueSelector="@GetCurrencyPickerValue"
+                                TextSelector="@BuildCurrencyLabel"
+                                SearchTextSelector="@GetCurrencySearchText"
+                                AdvancedColumns="@CurrencyAdvancedColumns"
+                                AdvancedFilters="@CurrencyAdvancedFilters"
+                                AdvancedSearchScope="Searches currency ISO code, name, type, tenant scope, and description."
+                                Placeholder="Default wallet currency"
+                                SearchPlaceholder="Search currencies..."
+                                EmptyMessage="No currencies found."
+                                AllowClear="true"
+                                ClearText="Default wallet currency"
+                                AdvancedSearchTitle="Find Currency"
+                                AdvancedSearchDescription="Search tenant and global currencies available to Wallets." />
+                <BbFormFieldCurrencyInput @bind-Value="_createAmount" Label="Amount" ShowSymbol="false" Min="0" />
+                <BbFormFieldCurrencyInput @bind-Value="_createRequestedFee" Label="Requested Fee" ShowSymbol="false" Min="0" />
+                <BbFormFieldInput TValue="string" @bind-Value="_createExternalReference" Label="External Reference" Placeholder="Optional provider/reference id" />
+                <BbFormFieldInput TValue="string" @bind-Value="_createAddress" Label="Payout Address" Placeholder="Account, wallet, or payout destination" />
+                <BbFormFieldInput TValue="string" @bind-Value="_createRemarks" Label="Remarks" Placeholder="Cash-out note" />
+            </div>
+        </div>
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@CloseCreateDialog" Disabled="@_acting">Cancel</BbButton>
+            <BbButton OnClick="@CreateWithdrawal" Disabled="@_acting">
+                @if (_acting)
+                {
+                    <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                }
+                Create Withdrawal
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
 
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;
@@ -206,6 +217,8 @@
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private WalletsAdminBackendContractService WalletsAdminContracts { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private ILogger<WithdrawalRequests> Logger { get; set; } = default!;
 
     private const string NoSelectionValue = "__none";
 
@@ -216,6 +229,7 @@
     private Dictionary<Guid, string> _credentialLabels = [];
     private bool _loading = true;
     private bool _acting;
+    private bool _createDialogOpen;
     private bool _hasTenant;
     private bool _moduleEnabled;
     private int _pendingCount;
@@ -279,7 +293,8 @@
             _items = [];
             ResetCreateOptions();
             ResetSummary();
-            ToastService.Show($"Failed to load withdrawal requests: {ex.Message}");
+            Logger.LogError(ex, "Failed to load withdrawal requests.");
+            ToastService.Error("Could not load withdrawal requests.", "Wallets");
         }
         finally
         {
@@ -353,26 +368,26 @@
     {
         if (_createAmount <= 0)
         {
-            ToastService.Show("Enter a withdrawal amount greater than zero.");
+            ToastService.Warning("Enter a withdrawal amount greater than zero.", "Validation");
             return;
         }
 
         if (_createRequestedFee < 0)
         {
-            ToastService.Show("Requested fee cannot be negative.");
+            ToastService.Warning("Requested fee cannot be negative.", "Validation");
             return;
         }
 
         if (!Guid.TryParse(_createWalletId, out var walletId))
         {
-            ToastService.Show("Select a wallet.");
+            ToastService.Warning("Select a wallet.", "Validation");
             return;
         }
 
         var wallet = _wallets.FirstOrDefault(x => x.Id == walletId);
         if (wallet is null)
         {
-            ToastService.Show("Selected wallet was not found. Refresh and try again.");
+            ToastService.Warning("Selected wallet was not found. Refresh and try again.", "Validation");
             return;
         }
 
@@ -400,12 +415,23 @@
                 IdempotencyKey = $"control-panel-withdrawal:{Guid.NewGuid():N}"
             });
 
-            ToastService.Show(result.IsSuccess ? "Withdrawal request created." : result.Message ?? "Withdrawal request creation failed.");
             if (result.IsSuccess)
             {
+                ToastService.Success("Withdrawal request created.", "Wallets");
+                _createDialogOpen = false;
                 ResetCreateForm();
                 await LoadData();
             }
+            else
+            {
+                Logger.LogWarning("Withdrawal request creation failed: {Message}", result.Message);
+                ToastService.Error("Withdrawal request could not be created.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Withdrawal request creation failed.");
+            ToastService.Error("Withdrawal request could not be created.", "Wallets");
         }
         finally
         {
@@ -414,19 +440,59 @@
     }
 
     private async Task ApproveWithdrawal(WithdrawalRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.ApproveWithdrawalAsync(item.Id), "Withdrawal approval");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.ApproveWithdrawalAsync(item.Id),
+            "Approve Withdrawal",
+            "Approve this withdrawal request?",
+            "Withdrawal approval",
+            false);
 
     private async Task RejectWithdrawal(WithdrawalRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.RejectWithdrawalAsync(item.Id), "Withdrawal rejection");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.RejectWithdrawalAsync(item.Id),
+            "Reject Withdrawal",
+            "Reject this withdrawal request?",
+            "Withdrawal rejection",
+            true);
 
     private async Task SettleWithdrawal(WithdrawalRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.SettleWithdrawalAsync(item.Id), "Withdrawal settlement");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.SettleWithdrawalAsync(item.Id),
+            "Settle Withdrawal",
+            "Settle this withdrawal request and complete the ledger workflow?",
+            "Withdrawal settlement",
+            false);
 
     private async Task FailWithdrawal(WithdrawalRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.FailWithdrawalAsync(item.Id), "Withdrawal failure");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.FailWithdrawalAsync(item.Id),
+            "Fail Withdrawal",
+            "Mark this withdrawal request as failed?",
+            "Withdrawal failure",
+            true);
 
     private async Task CancelWithdrawal(WithdrawalRequest item) =>
-        await RunUnsupportedAction(() => WalletsAdminContracts.CancelWithdrawalAsync(item.Id), "Withdrawal cancellation");
+        await ConfirmAndRunAction(
+            () => WalletsAdminContracts.CancelWithdrawalAsync(item.Id),
+            "Cancel Withdrawal",
+            "Cancel this withdrawal request?",
+            "Withdrawal cancellation",
+            true);
+
+    private async Task ConfirmAndRunAction(
+        Func<Task<CmdResponse>> action,
+        string title,
+        string description,
+        string label,
+        bool destructive)
+    {
+        if (!await DialogService.Confirm(title, description, new ConfirmDialogOptions { Destructive = destructive }))
+        {
+            return;
+        }
+
+        await RunUnsupportedAction(action, label);
+    }
 
     private async Task RunUnsupportedAction(Func<Task<CmdResponse>> action, string label)
     {
@@ -434,13 +500,49 @@
         try
         {
             var result = await action();
-            ToastService.Show(result.IsSuccess ? $"{label} submitted." : result.Message ?? $"{label} is not available.");
-            await LoadData();
+            if (result.IsSuccess)
+            {
+                ToastService.Success($"{label} submitted.", "Wallets");
+                await LoadData();
+            }
+            else
+            {
+                Logger.LogWarning("{Label} failed: {Message}", label, result.Message);
+                ToastService.Error($"{label} could not be completed.", "Wallets");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "{Label} failed.", label);
+            ToastService.Error($"{label} could not be completed.", "Wallets");
         }
         finally
         {
             _acting = false;
         }
+    }
+
+    private void OpenCreateDialog()
+    {
+        ResetCreateForm();
+        _createDialogOpen = true;
+    }
+
+    private void CloseCreateDialog()
+    {
+        _createDialogOpen = false;
+        ResetCreateForm();
+    }
+
+    private Task OnCreateDialogChanged(bool open)
+    {
+        _createDialogOpen = open;
+        if (!open)
+        {
+            ResetCreateForm();
+        }
+
+        return Task.CompletedTask;
     }
 
     private void ResetSummary()
@@ -525,6 +627,9 @@
 
     private string GetCredentialLabel(Guid credentialId) =>
         _credentialLabels.TryGetValue(credentialId, out var label) ? label : credentialId.ToString()[..8];
+
+    private string GetWalletLabel(Guid walletId) =>
+        _wallets.FirstOrDefault(x => x.Id == walletId) is { } wallet ? BuildWalletLabel(wallet) : $"Wallet {walletId.ToString()[..8]}";
 
     private static string BuildCurrencyLabel(global::Wallets.Domain.Shared.Contracts.CurrencyType currency) =>
         string.IsNullOrWhiteSpace(currency.CurrencyIsoCode3)

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -113,6 +113,7 @@ builder.Services.AddScoped<MessagingControlPanelSettingsService>();
 builder.Services.AddScoped<NavigationHistoryService>();
 builder.Services.AddScoped<CommunityControlPanelAccessService>();
 builder.Services.AddScoped<WalletsAdminBackendContractService>();
+builder.Services.AddScoped<WalletsControlPanelDisplayService>();
 builder.Services.AddScoped<ControlPanelAuthService>();
 builder.Services.AddScoped<ControlPanelBootstrapSeeder>();
 builder.Services.AddHostedService<ControlPanelBootstrapHostedService>();

--- a/src/Presentation/ControlPanel.Server/Services/WalletsControlPanelDisplayService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/WalletsControlPanelDisplayService.cs
@@ -1,0 +1,205 @@
+using Microsoft.EntityFrameworkCore;
+using IdentityServer.Domain.Shared.Contracts;
+using Wallets.Domain.Shared.Contracts;
+using XFramework.Domain.Shared.DataContext;
+
+namespace ControlPanel.Server.Services;
+
+public sealed class WalletsControlPanelDisplayService(IDataContext dataContext)
+{
+    public async Task<IReadOnlyDictionary<Guid, string>> LoadWalletLabelsAsync(
+        Guid tenantId,
+        IEnumerable<Guid?> walletIds,
+        CancellationToken cancellationToken = default)
+    {
+        var ids = NormalizeIds(walletIds);
+        if (ids.Length == 0)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        var wallets = await dataContext.Query<Wallet>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Include(x => x.WalletType)
+            .Include(x => x.Credential)
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted && ids.Contains(x.Id))
+            .ToListAsync(cancellationToken);
+
+        return wallets.ToDictionary(x => x.Id, BuildWalletLabel);
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, string>> LoadCredentialLabelsAsync(
+        Guid tenantId,
+        IEnumerable<Guid?> credentialIds,
+        CancellationToken cancellationToken = default)
+    {
+        var ids = NormalizeIds(credentialIds);
+        if (ids.Length == 0)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        var credentials = await dataContext.Query<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Include(x => x.IdentityInfo)
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted && ids.Contains(x.Id))
+            .ToListAsync(cancellationToken);
+
+        return credentials.ToDictionary(x => x.Id, BuildCredentialLabel);
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, string>> LoadOperationLabelsAsync(
+        Guid tenantId,
+        IEnumerable<Guid?> operationIds,
+        CancellationToken cancellationToken = default)
+    {
+        var ids = NormalizeIds(operationIds);
+        if (ids.Length == 0)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        var operations = await dataContext.Query<WalletOperation>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted && ids.Contains(x.Id))
+            .ToListAsync(cancellationToken);
+
+        return operations.ToDictionary(x => x.Id, BuildOperationLabel);
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, string>> LoadTransactionLabelsAsync(
+        Guid tenantId,
+        IEnumerable<Guid?> transactionIds,
+        CancellationToken cancellationToken = default)
+    {
+        var ids = NormalizeIds(transactionIds);
+        if (ids.Length == 0)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        var transactions = await dataContext.Query<WalletTransaction>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted && ids.Contains(x.Id))
+            .ToListAsync(cancellationToken);
+
+        return transactions.ToDictionary(x => x.Id, BuildTransactionLabel);
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, string>> LoadTransferLabelsAsync(
+        Guid tenantId,
+        IEnumerable<Guid?> transferIds,
+        CancellationToken cancellationToken = default)
+    {
+        var ids = NormalizeIds(transferIds);
+        if (ids.Length == 0)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        var transfers = await dataContext.Query<WalletTransfer>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted && ids.Contains(x.Id))
+            .ToListAsync(cancellationToken);
+
+        return transfers.ToDictionary(x => x.Id, BuildTransferLabel);
+    }
+
+    public string WalletLabel(Guid? id, IReadOnlyDictionary<Guid, string> labels) =>
+        LabelOrFallback(id, labels, "Wallet");
+
+    public string CredentialLabel(Guid? id, IReadOnlyDictionary<Guid, string> labels) =>
+        LabelOrFallback(id, labels, "Credential");
+
+    public string OperationLabel(Guid? id, IReadOnlyDictionary<Guid, string> labels) =>
+        LabelOrFallback(id, labels, "Operation");
+
+    public string TransactionLabel(Guid? id, IReadOnlyDictionary<Guid, string> labels) =>
+        LabelOrFallback(id, labels, "Transaction");
+
+    public string TransferLabel(Guid? id, IReadOnlyDictionary<Guid, string> labels) =>
+        LabelOrFallback(id, labels, "Transfer");
+
+    public static string ShortId(Guid? id) => id is Guid value ? value.ToString("N")[..8] : "N/A";
+
+    public static string SafeFailureSummary(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "No failure recorded" : "Failure recorded";
+
+    public static string SafeActionFailure(string noun) => $"{noun} could not be completed.";
+
+    public static string BuildWalletLabel(Wallet wallet)
+    {
+        var account = string.IsNullOrWhiteSpace(wallet.AccountNumber)
+            ? $"Wallet {ShortId(wallet.Id)}"
+            : wallet.AccountNumber;
+        var type = wallet.WalletType?.Code ?? wallet.WalletType?.Name ?? "No type";
+        var status = wallet.Status.ToString();
+        var credential = wallet.Credential is null ? null : BuildCredentialLabel(wallet.Credential);
+
+        return string.IsNullOrWhiteSpace(credential)
+            ? $"{account} - {type} - {status}"
+            : $"{account} - {credential} - {type} - {status}";
+    }
+
+    public static string BuildCredentialLabel(IdentityCredential credential)
+    {
+        var displayName = credential.IdentityInfo?.FullName;
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = credential.IdentityInfo?.IdentityName;
+        }
+
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = credential.UserName ?? credential.UserAlias ?? "Unnamed user";
+        }
+
+        var login = credential.UserName ?? credential.UserAlias;
+        return string.IsNullOrWhiteSpace(login)
+            ? $"{displayName} ({ShortId(credential.Id)})"
+            : $"{displayName} ({login})";
+    }
+
+    public static string BuildOperationLabel(WalletOperation operation)
+    {
+        var reference = string.IsNullOrWhiteSpace(operation.ReferenceNumber)
+            ? $"Operation {ShortId(operation.Id)}"
+            : operation.ReferenceNumber;
+        return $"{reference} - {operation.OperationType} - {operation.Status}";
+    }
+
+    public static string BuildTransactionLabel(WalletTransaction transaction)
+    {
+        var reference = string.IsNullOrWhiteSpace(transaction.ReferenceNumber)
+            ? $"Transaction {ShortId(transaction.Id)}"
+            : transaction.ReferenceNumber;
+        return $"{reference} - {transaction.TransactionType?.ToString() ?? "Unknown"} - {transaction.Amount:N2}";
+    }
+
+    public static string BuildTransferLabel(WalletTransfer transfer) =>
+        $"Transfer {ShortId(transfer.Id)} - {transfer.TransactionPurpose} - fee {transfer.TransactionFee:N2}";
+
+    private static string LabelOrFallback(Guid? id, IReadOnlyDictionary<Guid, string> labels, string noun)
+    {
+        if (id is not Guid value)
+        {
+            return "N/A";
+        }
+
+        return labels.TryGetValue(value, out var label) && !string.IsNullOrWhiteSpace(label)
+            ? label
+            : $"{noun} {ShortId(value)}";
+    }
+
+    private static Guid[] NormalizeIds(IEnumerable<Guid?> ids) =>
+        ids.Where(x => x.HasValue)
+            .Select(x => x!.Value)
+            .Where(x => x != Guid.Empty)
+            .Distinct()
+            .ToArray();
+}

--- a/src/Tests/Wallets.IntegrationTests/Tests/ControlPanelContractTests.cs
+++ b/src/Tests/Wallets.IntegrationTests/Tests/ControlPanelContractTests.cs
@@ -48,6 +48,41 @@ public sealed class ControlPanelContractTests
         ("OutboxWebhooks.razor", "outbox-messages", ["outbox-messages", "webhook-audit"])
     ];
 
+    private static readonly string[] WalletFinancePagesWithGrids =
+    [
+        "Wallets.razor",
+        "DepositRequests.razor",
+        "WithdrawalRequests.razor",
+        "BatchOperations.razor",
+        "Transfers.razor",
+        "WalletOperations.razor",
+        "Statements.razor",
+        "WalletAudit.razor",
+        "Reconciliation.razor",
+        "OutboxWebhooks.razor",
+        "WalletApprovals.razor",
+        "PolicyDecisions.razor",
+        "RefundsDisputes.razor",
+        "WalletDetail.razor"
+    ];
+
+    private static readonly (string Page, string DialogTitle)[] HeaderDialogMutationPages =
+    [
+        ("DepositRequests.razor", "Create Deposit"),
+        ("WithdrawalRequests.razor", "Create Withdrawal"),
+        ("BatchOperations.razor", "Submit Batch"),
+        ("RefundsDisputes.razor", "Open Case")
+    ];
+
+    private static readonly string[] PickerDialogMutationPages =
+    [
+        "DepositRequests.razor",
+        "WithdrawalRequests.razor",
+        "BatchOperations.razor",
+        "RefundsDisputes.razor",
+        "Wallets.razor"
+    ];
+
     [Test]
     public void WalletsFinancePages_FinancialWorkflowMutations_DoNotUseDirectRemoteDataContextMutation()
     {
@@ -64,6 +99,166 @@ public sealed class ControlPanelContractTests
             .ToArray();
 
         offenders.Should().BeEmpty("Wallets financial workflows must go through Wallets service wrappers or API workflows");
+    }
+
+    [Test]
+    public void WalletsFinancePages_DoNotUseRawTablesNativeSelectsOrSaveChanges()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = GetFinancePagesRoot(repositoryRoot);
+        var offenders = Directory.EnumerateFiles(pagesRoot.FullName, "*.razor", SearchOption.TopDirectoryOnly)
+            .Select(path => (Path: Path.GetRelativePath(repositoryRoot.FullName, path), Text: File.ReadAllText(path)))
+            .SelectMany(page =>
+            {
+                var issues = new List<string>();
+                if (Regex.IsMatch(page.Text, @"<table\b", RegexOptions.IgnoreCase))
+                    issues.Add($"{page.Path} uses a raw table");
+                if (Regex.IsMatch(page.Text, @"<select\b", RegexOptions.IgnoreCase))
+                    issues.Add($"{page.Path} uses a native select");
+                if (Regex.IsMatch(page.Text, @"DataContext\.(?:Add|Update|Remove|SaveChangesAsync)\b"))
+                    issues.Add($"{page.Path} uses direct financial DataContext mutation");
+
+                return issues;
+            })
+            .ToArray();
+
+        offenders.Should().BeEmpty("Wallets finance pages should use BlazorBlueprint controls and service-backed mutations");
+    }
+
+    [Test]
+    public void WalletsListReportMutationFlows_LaunchFromHeaderDialogs()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = GetFinancePagesRoot(repositoryRoot);
+
+        foreach (var (page, dialogTitle) in HeaderDialogMutationPages)
+        {
+            var text = File.ReadAllText(Path.Combine(pagesRoot.FullName, page));
+
+            text.Should().Contain("<div class=\"xf-page-header\">", $"{page} should use the shared page header");
+            text.Should().Contain("<div class=\"xf-page-actions\">", $"{page} should expose create actions in the header action group");
+            text.Should().Contain("<BbDialog Open=", $"{page} should launch mutation forms from a focused dialog");
+            text.Should().Contain($"<BbDialogTitle>{dialogTitle}</BbDialogTitle>");
+        }
+
+        var policyText = File.ReadAllText(Path.Combine(pagesRoot.FullName, "PolicyDecisions.razor"));
+        policyText.Should().Contain("<BbDialogTitle>New Policy Rule</BbDialogTitle>");
+        policyText.Should().Contain("<BbDialogTitle>New Fee Schedule</BbDialogTitle>");
+    }
+
+    [Test]
+    public void WalletsListReportPages_DoNotKeepInlineMutationCards()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = GetFinancePagesRoot(repositoryRoot);
+
+        var forbiddenCards = new[]
+        {
+            ("DepositRequests.razor", "<BbCardTitle>Create Deposit Request</BbCardTitle>"),
+            ("WithdrawalRequests.razor", "<BbCardTitle>Create Withdrawal Request</BbCardTitle>"),
+            ("BatchOperations.razor", "<BbCardTitle>Submit Batch Item</BbCardTitle>"),
+            ("RefundsDisputes.razor", "<BbCardTitle>Open Refund / Dispute Case</BbCardTitle>"),
+            ("PolicyDecisions.razor", "<BbCardTitle>Policy Rule</BbCardTitle>"),
+            ("PolicyDecisions.razor", "<BbCardTitle>Fee Schedule</BbCardTitle>")
+        };
+
+        foreach (var (page, forbidden) in forbiddenCards)
+        {
+            var text = File.ReadAllText(Path.Combine(pagesRoot.FullName, page));
+            text.Should().NotContain(forbidden, $"{page} should not stack inline create/update form cards above grids");
+        }
+    }
+
+    [Test]
+    public void WalletsDialogsWithEntityPickers_DisableFocusTrapForPortaledPickers()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = GetFinancePagesRoot(repositoryRoot);
+
+        foreach (var page in PickerDialogMutationPages)
+        {
+            var text = File.ReadAllText(Path.Combine(pagesRoot.FullName, page));
+            var dialogBlocks = Regex.Matches(text, @"<BbDialog[\s\S]*?</BbDialog>")
+                .Cast<Match>()
+                .Where(match => match.Value.Contains("<XfEntityPicker", StringComparison.Ordinal))
+                .ToArray();
+
+            dialogBlocks.Should().NotBeEmpty($"{page} should keep picker-based mutations in dialogs");
+            dialogBlocks.Should().OnlyContain(
+                block => block.Value.Contains("TrapFocus=\"false\"", StringComparison.Ordinal),
+                $"{page} dialogs containing XfEntityPicker must not trap focus around portaled picker popovers/dialogs");
+        }
+    }
+
+    [Test]
+    public void WalletsFinanceGrids_DefineEmptyStatesAndColumnFiltering()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = GetFinancePagesRoot(repositoryRoot);
+
+        foreach (var page in WalletFinancePagesWithGrids)
+        {
+            var text = File.ReadAllText(Path.Combine(pagesRoot.FullName, page));
+            var grids = Regex.Matches(text, @"<BbDataGrid\b[\s\S]*?</BbDataGrid>")
+                .Cast<Match>()
+                .Select(match => match.Value)
+                .ToArray();
+
+            grids.Should().NotBeEmpty($"{page} should use BbDataGrid for data-heavy wallet UI");
+            grids.Should().OnlyContain(grid => grid.Contains("<EmptyTemplate>", StringComparison.Ordinal),
+                $"{page} grids should render an explicit BbEmpty state");
+
+            foreach (var grid in grids)
+            {
+                foreach (Match propertyColumn in Regex.Matches(grid, @"<BbDataGridPropertyColumn\b[^>]*>?", RegexOptions.Multiline))
+                {
+                    propertyColumn.Value.Should().Contain("Filterable=\"true\"",
+                        $"{page} property data columns should use native filtering");
+                }
+
+                foreach (Match templateColumn in Regex.Matches(grid, @"<BbDataGridTemplateColumn\b[^>]*Title=""(?<title>[^""]+)""[\s\S]*?</BbDataGridTemplateColumn>"))
+                {
+                    var title = templateColumn.Groups["title"].Value;
+                    if (title.Equals("Actions", StringComparison.OrdinalIgnoreCase))
+                    {
+                        templateColumn.Value.Should().NotContain("Filterable=\"true\"",
+                            $"{page} action columns should remain unfiltered");
+                        continue;
+                    }
+
+                    templateColumn.Value.Should().Contain("Filterable=\"true\"",
+                        $"{page} template data column '{title}' should be filterable");
+                    templateColumn.Value.Should().Contain("FilterBy=",
+                        $"{page} template data column '{title}' should filter by rendered user-facing text");
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void WalletsFinancePages_DoNotRenderRawDiagnosticMessages()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pagesRoot = GetFinancePagesRoot(repositoryRoot);
+        var offenders = Directory.EnumerateFiles(pagesRoot.FullName, "*.razor", SearchOption.TopDirectoryOnly)
+            .Select(path => (Path: Path.GetRelativePath(repositoryRoot.FullName, path), Text: File.ReadAllText(path)))
+            .SelectMany(page =>
+            {
+                var issues = new List<string>();
+                if (page.Text.Contains("ToastService.Show", StringComparison.Ordinal))
+                    issues.Add($"{page.Path} uses generic/raw ToastService.Show");
+
+                if (Regex.IsMatch(page.Text, @"ToastService\.(?:Success|Info|Warning|Error)\s*\([^;]*(?:ex|result|response)\.Message"))
+                    issues.Add($"{page.Path} renders raw exception or wrapper messages in toasts");
+
+                if (Regex.IsMatch(page.Text, @"<BbDataGridPropertyColumn\b[^>]*Property=""@\([^""]*\.(?:LastError|ProcessingError|FailureMessage|ActorCredentialId|AggregateId)"))
+                    issues.Add($"{page.Path} renders raw diagnostic or technical id property columns");
+
+                return issues;
+            })
+            .ToArray();
+
+        offenders.Should().BeEmpty("diagnostic details should be logged or summarized instead of rendered directly");
     }
 
     [Test]
@@ -190,6 +385,12 @@ public sealed class ControlPanelContractTests
 
         mainLayout.Should().Contain("TryGetWalletDetailRoute", "wallet detail routes should replace the main module nav with the detail sidebar");
         mainLayout.Should().Contain("<WalletDetailSidebar WalletId=\"@walletRouteId\" />");
+        mainLayout.Should().Contain("BuildWalletBreadcrumbs(walletId, section)",
+            "wallet detail breadcrumbs should not humanize raw GUID route segments");
+        mainLayout.Should().Contain("RefreshWalletBreadcrumbLabel(walletId)",
+            "wallet detail breadcrumbs should resolve a read-only wallet label");
+        mainLayout.Should().Contain("WalletsControlPanelDisplayService.BuildWalletLabel(wallet)",
+            "wallet detail breadcrumbs should prefer account and wallet metadata before a short-id fallback");
 
         sidebar.Should().Contain("Wallet List");
         sidebar.Should().Contain("SectionHref(\"summary\")");


### PR DESCRIPTION
## Summary
- Moves Wallets list/report mutation forms into header-launched dialogs with shared layout classes.
- Adds read-only Wallets display labels and applies friendly labels across Wallets finance grids, breadcrumbs, reports, approvals, and outbox/webhook surfaces.
- Completes Wallets UI guideline compliance for tabs, grid filtering/empty states, safe diagnostics, confirmations, typed money/numeric controls, and picker dialogs.
- Extends Wallets ControlPanel contract tests for dialogs, grids, diagnostics, tabs, picker behavior, and wallet detail breadcrumb/sidebar rules.

## Verification
- PASS: `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false -v:minimal`
- PASS: `dotnet build src/Tests/Wallets.IntegrationTests/Wallets.IntegrationTests.csproj -m:1 /nr:false -v:minimal`
- PASS: static guideline scans for raw tables/selects, direct financial DataContext mutations, raw diagnostic columns/toasts, and grid empty states
- PASS: local browser smoke on Wallets, Deposits, Withdrawals, Batch, Transfers, Operations, Statements, Audit, Reconciliation, Outbox/Webhooks, Approvals, Policy/Fees, Refunds/Disputes, and wallet detail breadcrumb/sidebar behavior
- PASS: read-only sub-agent review found no remaining Wallets UI guideline misses
- BLOCKED LOCALLY: `dotnet test src/Tests/Wallets.IntegrationTests/Wallets.IntegrationTests.csproj --filter TestCategory=Area:ControlPanelContract -m:1 /nr:false --logger console;verbosity=minimal` fails in `WalletsTestFixture.GlobalSetup()` before test bodies because local Testcontainers cannot resolve Docker endpoint (`DockerEndpointAuthConfig`).