### PR TITLE
Add configurable Messaging templates

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260625090000_AddMessagingTemplates.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260625090000_AddMessagingTemplates.cs
@@ -1,0 +1,214 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260625090000_AddMessagingTemplates")]
+    public partial class AddMessagingTemplates : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "TemplateId",
+                schema: "Messaging",
+                table: "Message",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TemplateKey",
+                schema: "Messaging",
+                table: "Message",
+                type: "character varying",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TemplateType",
+                schema: "Messaging",
+                table: "Message",
+                type: "character varying",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TemplateVariablesJson",
+                schema: "Messaging",
+                table: "Message",
+                type: "jsonb",
+                nullable: false,
+                defaultValueSql: "'{}'::jsonb");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "TemplateId",
+                schema: "Messaging",
+                table: "MessageDirect",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TemplateKey",
+                schema: "Messaging",
+                table: "MessageDirect",
+                type: "character varying",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TemplateType",
+                schema: "Messaging",
+                table: "MessageDirect",
+                type: "character varying",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TemplateVariablesJson",
+                schema: "Messaging",
+                table: "MessageDirect",
+                type: "jsonb",
+                nullable: false,
+                defaultValueSql: "'{}'::jsonb");
+
+            migrationBuilder.CreateTable(
+                name: "MessageTemplate",
+                schema: "Messaging",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    Key = table.Column<string>(type: "character varying", nullable: false),
+                    Name = table.Column<string>(type: "character varying", nullable: false),
+                    Description = table.Column<string>(type: "character varying", nullable: true),
+                    TemplateType = table.Column<string>(type: "character varying", nullable: false),
+                    Subject = table.Column<string>(type: "character varying", nullable: true),
+                    Body = table.Column<string>(type: "character varying", nullable: false),
+                    RequiredVariablesJson = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'[]'::jsonb"),
+                    OwnerCredentialId = table.Column<Guid>(type: "uuid", nullable: true),
+                    IsDefault = table.Column<bool>(type: "boolean", nullable: false),
+                    IsLocked = table.Column<bool>(type: "boolean", nullable: false),
+                    SystemReferenceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("messagetemplate_pk", x => x.ID);
+                    table.ForeignKey(
+                        name: "messagetemplate_ownercredential_id_fk",
+                        column: x => x.OwnerCredentialId,
+                        principalSchema: "Identity",
+                        principalTable: "IdentityCredential",
+                        principalColumn: "ID");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Message_TemplateId",
+                schema: "Messaging",
+                table: "Message",
+                column: "TemplateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MessageDirect_TemplateId",
+                schema: "Messaging",
+                table: "MessageDirect",
+                column: "TemplateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MessageTemplate_Tenant_Type_Key",
+                schema: "Messaging",
+                table: "MessageTemplate",
+                columns: new[] { "TenantId", "TemplateType", "Key" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MessageTemplate_Tenant_Type_ModifiedAt",
+                schema: "Messaging",
+                table: "MessageTemplate",
+                columns: new[] { "TenantId", "TemplateType", "ModifiedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MessageTemplate_OwnerCredentialId",
+                schema: "Messaging",
+                table: "MessageTemplate",
+                column: "OwnerCredentialId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_MessageTemplate_Tenant_Type_Key_Active",
+                schema: "Messaging",
+                table: "MessageTemplate",
+                columns: new[] { "TenantId", "TemplateType", "Key" },
+                unique: true,
+                filter: "\"IsDeleted\" = false AND \"OwnerCredentialId\" IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_MessageTemplate_User_Key_Active",
+                schema: "Messaging",
+                table: "MessageTemplate",
+                columns: new[] { "TenantId", "OwnerCredentialId", "Key" },
+                unique: true,
+                filter: "\"IsDeleted\" = false AND \"OwnerCredentialId\" IS NOT NULL");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MessageTemplate",
+                schema: "Messaging");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Message_TemplateId",
+                schema: "Messaging",
+                table: "Message");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MessageDirect_TemplateId",
+                schema: "Messaging",
+                table: "MessageDirect");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateId",
+                schema: "Messaging",
+                table: "Message");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateKey",
+                schema: "Messaging",
+                table: "Message");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateType",
+                schema: "Messaging",
+                table: "Message");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateVariablesJson",
+                schema: "Messaging",
+                table: "Message");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateId",
+                schema: "Messaging",
+                table: "MessageDirect");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateKey",
+                schema: "Messaging",
+                table: "MessageDirect");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateType",
+                schema: "Messaging",
+                table: "MessageDirect");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateVariablesJson",
+                schema: "Messaging",
+                table: "MessageDirect");
+        }
+    }
+}

--- a/src/Kernel/XFramework.Domain/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/AppDbContextModelSnapshot.cs
@@ -2639,6 +2639,12 @@ namespace XFramework.Domain.Migrations
                         .HasColumnType("boolean")
                         .HasDefaultValueSql("true");
 
+                    b.Property<string>("MentionedCredentialIdsJson")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("jsonb")
+                        .HasDefaultValueSql("'[]'::jsonb");
+
                     b.Property<Guid>("MessageThreadId")
                         .HasColumnType("uuid");
 
@@ -2650,6 +2656,24 @@ namespace XFramework.Domain.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("now()");
 
+                    b.Property<Guid?>("ParentMessageId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("TemplateId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("TemplateKey")
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("TemplateType")
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("TemplateVariablesJson")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("jsonb")
+                        .HasDefaultValueSql("'{}'::jsonb");
+
                     b.Property<Guid>("TenantId")
                         .HasColumnType("uuid");
 
@@ -2660,6 +2684,11 @@ namespace XFramework.Domain.Migrations
                     b.HasKey("Id")
                         .HasName("message_pk");
 
+                    b.HasIndex("ParentMessageId");
+
+                    b.HasIndex("TemplateId")
+                        .HasDatabaseName("IX_Message_TemplateId");
+
                     b.HasIndex("MessageThreadMemberId", "CreatedAt")
                         .HasDatabaseName("IX_Message_Member_CreatedAt");
 
@@ -2667,6 +2696,58 @@ namespace XFramework.Domain.Migrations
                         .HasDatabaseName("IX_Message_Thread_CreatedAt_Id");
 
                     b.ToTable("Message", "Messaging");
+                });
+
+            modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageBlock", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("ID")
+                        .HasDefaultValueSql("(uuid_generate_v4())");
+
+                    b.Property<Guid>("BlockedCredentialId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("BlockerCredentialId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("ConcurrencyStamp")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsEnabled")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValueSql("true");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id")
+                        .HasName("messageblock_pk");
+
+                    b.HasIndex("BlockerCredentialId", "BlockedCredentialId")
+                        .IsUnique()
+                        .HasDatabaseName("UX_MessageBlock_Blocker_Blocked_Active")
+                        .HasFilter("\"IsDeleted\" = false");
+
+                    b.ToTable("MessageBlock", "Messaging");
                 });
 
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageDelivery", b =>
@@ -2853,6 +2934,21 @@ namespace XFramework.Domain.Migrations
                     b.Property<string>("SubscriptionId")
                         .HasColumnType("text");
 
+                    b.Property<Guid?>("TemplateId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("TemplateKey")
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("TemplateType")
+                        .HasColumnType("character varying");
+
+                    b.Property<string>("TemplateVariablesJson")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("jsonb")
+                        .HasDefaultValueSql("'{}'::jsonb");
+
                     b.Property<Guid>("TenantId")
                         .HasColumnType("uuid");
 
@@ -2867,6 +2963,9 @@ namespace XFramework.Domain.Migrations
                     b.HasIndex("RecipientId");
 
                     b.HasIndex("SenderId");
+
+                    b.HasIndex("TemplateId")
+                        .HasDatabaseName("IX_MessageDirect_TemplateId");
 
                     b.HasIndex("TypeId");
 
@@ -2903,9 +3002,6 @@ namespace XFramework.Domain.Migrations
                     b.Property<Guid>("MessageId")
                         .HasColumnType("uuid");
 
-                    b.Property<Guid?>("MessageId1")
-                        .HasColumnType("uuid");
-
                     b.Property<DateTime?>("ModifiedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
@@ -2921,8 +3017,6 @@ namespace XFramework.Domain.Migrations
                         .HasName("messagefiles_pk");
 
                     b.HasIndex("MessageId");
-
-                    b.HasIndex("MessageId1");
 
                     b.HasIndex("StorageId");
 
@@ -3014,6 +3108,61 @@ namespace XFramework.Domain.Migrations
                         .HasDatabaseName("IX_MessageOutboxEvent_Tenant_Processed_Occurred");
 
                     b.ToTable("MessageOutboxEvent", "Messaging");
+                });
+
+            modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessagePin", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("ID")
+                        .HasDefaultValueSql("(uuid_generate_v4())");
+
+                    b.Property<Guid>("ConcurrencyStamp")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsEnabled")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValueSql("true");
+
+                    b.Property<Guid>("MessageId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("MessageThreadId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<Guid>("PinnedByMemberId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id")
+                        .HasName("messagepin_pk");
+
+                    b.HasIndex("MessageThreadId", "MessageId")
+                        .IsUnique()
+                        .HasDatabaseName("UX_MessagePin_Thread_Message_Active")
+                        .HasFilter("\"IsDeleted\" = false");
+
+                    b.ToTable("MessagePin", "Messaging");
                 });
 
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageReaction", b =>
@@ -3128,6 +3277,214 @@ namespace XFramework.Domain.Migrations
                     b.ToTable("MessageReactionType", "Messaging");
                 });
 
+            modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageReport", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("ID")
+                        .HasDefaultValueSql("(uuid_generate_v4())");
+
+                    b.Property<Guid>("ConcurrencyStamp")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Details")
+                        .HasColumnType("character varying");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsEnabled")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValueSql("true");
+
+                    b.Property<Guid>("MessageId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<string>("Reason")
+                        .IsRequired()
+                        .HasColumnType("character varying");
+
+                    b.Property<Guid>("ReporterMemberId")
+                        .HasColumnType("uuid");
+
+                    b.Property<short>("Status")
+                        .HasColumnType("smallint");
+
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id")
+                        .HasName("messagereport_pk");
+
+                    b.HasIndex("TenantId", "Status", "CreatedAt")
+                        .HasDatabaseName("IX_MessageReport_Tenant_Status_CreatedAt");
+
+                    b.ToTable("MessageReport", "Messaging");
+                });
+
+            modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageSaved", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("ID")
+                        .HasDefaultValueSql("(uuid_generate_v4())");
+
+                    b.Property<Guid>("ConcurrencyStamp")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsEnabled")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValueSql("true");
+
+                    b.Property<Guid>("MessageId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("MessageThreadMemberId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id")
+                        .HasName("messagesaved_pk");
+
+                    b.HasIndex("MessageId", "MessageThreadMemberId")
+                        .IsUnique()
+                        .HasDatabaseName("UX_MessageSaved_Message_Member_Active")
+                        .HasFilter("\"IsDeleted\" = false");
+
+                    b.ToTable("MessageSaved", "Messaging");
+                });
+
+            modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageTemplate", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("ID")
+                        .HasDefaultValueSql("(uuid_generate_v4())");
+
+                    b.Property<string>("Body")
+                        .IsRequired()
+                        .HasColumnType("character varying");
+
+                    b.Property<Guid>("ConcurrencyStamp")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .HasColumnType("character varying");
+
+                    b.Property<bool>("IsDefault")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsEnabled")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValueSql("true");
+
+                    b.Property<bool>("IsLocked")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("Key")
+                        .IsRequired()
+                        .HasColumnType("character varying");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("character varying");
+
+                    b.Property<Guid?>("OwnerCredentialId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("RequiredVariablesJson")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("jsonb")
+                        .HasDefaultValueSql("'[]'::jsonb");
+
+                    b.Property<string>("Subject")
+                        .HasColumnType("character varying");
+
+                    b.Property<Guid?>("SystemReferenceId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("TemplateType")
+                        .IsRequired()
+                        .HasColumnType("character varying");
+
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id")
+                        .HasName("messagetemplate_pk");
+
+                    b.HasIndex("OwnerCredentialId");
+
+                    b.HasIndex("TenantId", "OwnerCredentialId", "Key")
+                        .IsUnique()
+                        .HasDatabaseName("UX_MessageTemplate_User_Key_Active")
+                        .HasFilter("\"IsDeleted\" = false AND \"OwnerCredentialId\" IS NOT NULL");
+
+                    b.HasIndex("TenantId", "TemplateType", "Key")
+                        .IsUnique()
+                        .HasDatabaseName("UX_MessageTemplate_Tenant_Type_Key_Active")
+                        .HasFilter("\"IsDeleted\" = false AND \"OwnerCredentialId\" IS NULL");
+
+                    b.HasIndex("TenantId", "TemplateType", "ModifiedAt")
+                        .HasDatabaseName("IX_MessageTemplate_Tenant_Type_ModifiedAt");
+
+                    b.ToTable("MessageTemplate", "Messaging");
+                });
+
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageThread", b =>
                 {
                     b.Property<Guid>("Id")
@@ -3185,6 +3542,66 @@ namespace XFramework.Domain.Migrations
                     b.ToTable("MessageThread", "Messaging");
                 });
 
+            modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageThreadInvite", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("ID")
+                        .HasDefaultValueSql("(uuid_generate_v4())");
+
+                    b.Property<Guid>("ConcurrencyStamp")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("InvitedByCredentialId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("InvitedCredentialId")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsEnabled")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValueSql("true");
+
+                    b.Property<Guid>("MessageThreadId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now()");
+
+                    b.Property<DateTime?>("RespondedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<short>("Status")
+                        .HasColumnType("smallint");
+
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id")
+                        .HasName("messagethreadinvite_pk");
+
+                    b.HasIndex("MessageThreadId", "InvitedCredentialId", "Status")
+                        .HasDatabaseName("IX_MessageThreadInvite_Thread_Credential_Status")
+                        .HasFilter("\"IsDeleted\" = false");
+
+                    b.ToTable("MessageThreadInvite", "Messaging");
+                });
+
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageThreadMember", b =>
                 {
                     b.Property<Guid>("Id")
@@ -3196,6 +3613,9 @@ namespace XFramework.Domain.Migrations
                     b.Property<string>("Alias")
                         .IsRequired()
                         .HasColumnType("character varying");
+
+                    b.Property<DateTime?>("ArchivedAt")
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("ConcurrencyStamp")
                         .HasColumnType("uuid");
@@ -3222,6 +3642,9 @@ namespace XFramework.Domain.Migrations
                     b.Property<Guid>("GroupId")
                         .HasColumnType("uuid");
 
+                    b.Property<bool>("IsArchived")
+                        .HasColumnType("boolean");
+
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("boolean");
 
@@ -3230,19 +3653,28 @@ namespace XFramework.Domain.Migrations
                         .HasColumnType("boolean")
                         .HasDefaultValueSql("true");
 
+                    b.Property<bool>("IsMuted")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime?>("LastSeenAt")
+                        .HasColumnType("timestamp with time zone");
+
                     b.Property<Guid>("MessageThreadId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("MessageThreadId1")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("MessageThreadMemberGroupId")
                         .HasColumnType("uuid");
 
                     b.Property<DateTime?>("ModifiedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("now()");
+
+                    b.Property<DateTime?>("MutedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Role")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("character varying")
+                        .HasDefaultValue("Member");
 
                     b.Property<short>("Status")
                         .HasColumnType("smallint");
@@ -3254,10 +3686,6 @@ namespace XFramework.Domain.Migrations
                         .HasName("messagethreadmember_pk");
 
                     b.HasIndex("GroupId");
-
-                    b.HasIndex("MessageThreadId1");
-
-                    b.HasIndex("MessageThreadMemberGroupId");
 
                     b.HasIndex("CredentialId", "MessageThreadId")
                         .HasDatabaseName("IX_MessageThreadMember_Credential_Thread");
@@ -3364,9 +3792,6 @@ namespace XFramework.Domain.Migrations
                     b.Property<Guid>("MessageThreadMemberId")
                         .HasColumnType("uuid");
 
-                    b.Property<Guid?>("MessageThreadMemberId1")
-                        .HasColumnType("uuid");
-
                     b.Property<DateTime?>("ModifiedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
@@ -3380,8 +3805,6 @@ namespace XFramework.Domain.Migrations
 
                     b.HasKey("Id")
                         .HasName("messagethreadmemberrole_pk");
-
-                    b.HasIndex("MessageThreadMemberId1");
 
                     b.HasIndex("RoleId")
                         .HasDatabaseName("IX_MessageThreadMemberRole_RoleId");
@@ -8723,9 +9146,16 @@ namespace XFramework.Domain.Migrations
                         .IsRequired()
                         .HasConstraintName("message_messagethreadmember_id_fk");
 
+                    b.HasOne("Messaging.Domain.Shared.Contracts.Message", "ParentMessage")
+                        .WithMany("Replies")
+                        .HasForeignKey("ParentMessageId")
+                        .HasConstraintName("message_parent_message_id_fk");
+
                     b.Navigation("MessageThread");
 
                     b.Navigation("MessageThreadMember");
+
+                    b.Navigation("ParentMessage");
                 });
 
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageDelivery", b =>
@@ -8789,14 +9219,10 @@ namespace XFramework.Domain.Migrations
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageFile", b =>
                 {
                     b.HasOne("Messaging.Domain.Shared.Contracts.Message", "Message")
-                        .WithMany()
+                        .WithMany("MessageFiles")
                         .HasForeignKey("MessageId")
                         .IsRequired()
                         .HasConstraintName("messagefiles_message_id_fk");
-
-                    b.HasOne("Messaging.Domain.Shared.Contracts.Message", null)
-                        .WithMany("MessageFiles")
-                        .HasForeignKey("MessageId1");
 
                     b.HasOne("XFramework.Domain.Shared.Contracts.StorageFile", "Storage")
                         .WithMany()
@@ -8836,6 +9262,16 @@ namespace XFramework.Domain.Migrations
                     b.Navigation("Type");
                 });
 
+            modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageTemplate", b =>
+                {
+                    b.HasOne("IdentityServer.Domain.Shared.Contracts.IdentityCredential", "OwnerCredential")
+                        .WithMany()
+                        .HasForeignKey("OwnerCredentialId")
+                        .HasConstraintName("messagetemplate_ownercredential_id_fk");
+
+                    b.Navigation("OwnerCredential");
+                });
+
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageThread", b =>
                 {
                     b.HasOne("Messaging.Domain.Shared.Contracts.MessageThreadType", "Type")
@@ -8856,24 +9292,16 @@ namespace XFramework.Domain.Migrations
                         .HasConstraintName("messagethreadmember_identitycredential_id_fk");
 
                     b.HasOne("Messaging.Domain.Shared.Contracts.MessageThreadMemberGroup", "Group")
-                        .WithMany()
+                        .WithMany("MessageThreadMembers")
                         .HasForeignKey("GroupId")
                         .IsRequired()
                         .HasConstraintName("messagethreadmember_messagethreadmembergroup_id_fk");
 
                     b.HasOne("Messaging.Domain.Shared.Contracts.MessageThread", "MessageThread")
-                        .WithMany()
+                        .WithMany("MessageThreadMembers")
                         .HasForeignKey("MessageThreadId")
                         .IsRequired()
                         .HasConstraintName("messagethreadmember_messagethread_id_fk");
-
-                    b.HasOne("Messaging.Domain.Shared.Contracts.MessageThread", null)
-                        .WithMany("MessageThreadMembers")
-                        .HasForeignKey("MessageThreadId1");
-
-                    b.HasOne("Messaging.Domain.Shared.Contracts.MessageThreadMemberGroup", null)
-                        .WithMany("MessageThreadMembers")
-                        .HasForeignKey("MessageThreadMemberGroupId");
 
                     b.Navigation("Credential");
 
@@ -8896,14 +9324,10 @@ namespace XFramework.Domain.Migrations
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageThreadMemberRole", b =>
                 {
                     b.HasOne("Messaging.Domain.Shared.Contracts.MessageThreadMember", "MessageThreadMember")
-                        .WithMany()
+                        .WithMany("MessageThreadMemberRoles")
                         .HasForeignKey("MessageThreadMemberId")
                         .IsRequired()
                         .HasConstraintName("messagethreadmemberrole_messagethreadmember_id_fk");
-
-                    b.HasOne("Messaging.Domain.Shared.Contracts.MessageThreadMember", null)
-                        .WithMany("MessageThreadMemberRoles")
-                        .HasForeignKey("MessageThreadMemberId1");
 
                     b.HasOne("IdentityServer.Domain.Shared.Contracts.IdentityRole", "Role")
                         .WithMany()
@@ -10172,6 +10596,8 @@ namespace XFramework.Domain.Migrations
                     b.Navigation("MessageFiles");
 
                     b.Navigation("MessageReactions");
+
+                    b.Navigation("Replies");
                 });
 
             modelBuilder.Entity("Messaging.Domain.Shared.Contracts.MessageDeliveryType", b =>

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/CreateDirect/CreateDirectMessageValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/CreateDirect/CreateDirectMessageValidator.cs
@@ -15,8 +15,16 @@ public sealed class CreateDirectMessageValidator : AbstractValidator<CreateDirec
             .MaximumLength(100).WithMessage("Recipient cannot exceed 100 characters");
 
         RuleFor(x => x.Message)
-            .NotEmpty().WithMessage("Message is required")
-            .MaximumLength(1000).WithMessage("Message cannot exceed 1000 characters");
+            .MaximumLength(4000).WithMessage("Message cannot exceed 4000 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.Message));
+
+        RuleFor(x => x)
+            .Must(x => !string.IsNullOrWhiteSpace(x.Message) || x.TemplateId is not null || !string.IsNullOrWhiteSpace(x.TemplateKey))
+            .WithMessage("Message text or template is required");
+
+        RuleFor(x => x.TemplateKey)
+            .MaximumLength(128).WithMessage("Template key cannot exceed 128 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.TemplateKey));
 
         RuleFor(x => x.MessageTransportType)
             .IsInEnum().WithMessage("Invalid message transport type");

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/CreateMessage/CreateThreadMessageValidator.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Messages/CreateMessage/CreateThreadMessageValidator.cs
@@ -11,7 +11,15 @@ public sealed class CreateThreadMessageValidator : AbstractValidator<CreateThrea
             .NotEmpty().WithMessage("Thread ID is required");
 
         RuleFor(x => x.Text)
-            .NotEmpty().WithMessage("Message text is required")
-            .MaximumLength(5000).WithMessage("Message text cannot exceed 5000 characters");
+            .MaximumLength(5000).WithMessage("Message text cannot exceed 5000 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.Text));
+
+        RuleFor(x => x)
+            .Must(x => !string.IsNullOrWhiteSpace(x.Text) || x.TemplateId is not null || !string.IsNullOrWhiteSpace(x.TemplateKey))
+            .WithMessage("Message text or template is required");
+
+        RuleFor(x => x.TemplateKey)
+            .MaximumLength(128).WithMessage("Template key cannot exceed 128 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.TemplateKey));
     }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Features/Templates/Endpoint.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Features/Templates/Endpoint.cs
@@ -1,0 +1,97 @@
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
+using Messaging.Domain.Shared.Contracts.Responses;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+
+namespace Messaging.Api.Features.Templates;
+
+public static class GetMessageTemplatesEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/messaging/templates", Tags = ["Messaging Templates"],
+        Summary = "List Messaging templates",
+        Description = "Returns system, tenant, and user Messaging templates for the authenticated tenant.")]
+    public static Task<Result<GetMessageTemplatesResponse>> Handle(
+        GetMessageTemplatesRequest request,
+        IMessagingTemplateService templateService,
+        CancellationToken ct) =>
+        templateService.GetTemplatesAsync(request, ct);
+}
+
+public static class GetMessageTemplateEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/messaging/templates/{templateId:guid}", Tags = ["Messaging Templates"],
+        Summary = "Get Messaging template",
+        Description = "Returns a single Messaging template for the authenticated tenant.")]
+    public static Task<Result<MessageTemplateResponse>> Handle(
+        GetMessageTemplateRequest request,
+        IMessagingTemplateService templateService,
+        CancellationToken ct) =>
+        templateService.GetTemplateAsync(request, ct);
+}
+
+public static class CreateMessageTemplateEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/messaging/templates", Tags = ["Messaging Templates"],
+        Summary = "Create Messaging template",
+        Description = "Creates a tenant or user Messaging template.")]
+    public static Task<Result<MessageTemplateResponse>> Handle(
+        CreateMessageTemplateRequest request,
+        IMessagingTemplateService templateService,
+        CancellationToken ct) =>
+        templateService.CreateTemplateAsync(request, ct);
+}
+
+public static class UpdateMessageTemplateEndpoint
+{
+    [BoltHandler]
+    [MapPut("/api/messaging/templates/{templateId:guid}", Tags = ["Messaging Templates"],
+        Summary = "Update Messaging template",
+        Description = "Updates a configurable tenant or user Messaging template.")]
+    public static Task<Result<MessageTemplateResponse>> Handle(
+        UpdateMessageTemplateRequest request,
+        IMessagingTemplateService templateService,
+        CancellationToken ct) =>
+        templateService.UpdateTemplateAsync(request, ct);
+}
+
+public static class DeleteMessageTemplateEndpoint
+{
+    [BoltHandler]
+    [MapDelete("/api/messaging/templates/{templateId:guid}", Tags = ["Messaging Templates"],
+        Summary = "Delete Messaging template",
+        Description = "Soft-deletes a configurable Messaging template.")]
+    public static Task<Result<CmdResponse>> Handle(
+        DeleteMessageTemplateRequest request,
+        IMessagingTemplateService templateService,
+        CancellationToken ct) =>
+        templateService.DeleteTemplateAsync(request, ct);
+}
+
+public static class CloneMessageTemplateEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/messaging/templates/{templateId:guid}/clone", Tags = ["Messaging Templates"],
+        Summary = "Clone Messaging template",
+        Description = "Clones a system, tenant, or user template into a configurable tenant or user template.")]
+    public static Task<Result<MessageTemplateResponse>> Handle(
+        CloneMessageTemplateRequest request,
+        IMessagingTemplateService templateService,
+        CancellationToken ct) =>
+        templateService.CloneTemplateAsync(request, ct);
+}
+
+public static class RenderMessageTemplateEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/messaging/templates/render", Tags = ["Messaging Templates"],
+        Summary = "Render Messaging template",
+        Description = "Renders a Messaging template with supplied variables using server-side validation.")]
+    public static Task<Result<RenderMessageTemplateResponse>> Handle(
+        RenderMessageTemplateRequest request,
+        IMessagingTemplateService templateService,
+        CancellationToken ct) =>
+        templateService.RenderTemplateAsync(request, ct);
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Program.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddScoped<IMessagingRequestContextResolver, MessagingRequestCon
 builder.Services.AddScoped<IMessagingRealtimePublisher, MessagingRealtimePublisher>();
 builder.Services.AddScoped<IMessagingNotificationFanout, MessagingNotificationFanout>();
 builder.Services.AddScoped<IMessagingSettingsService, MessagingSettingsService>();
+builder.Services.AddScoped<IMessagingTemplateService, MessagingTemplateService>();
 
 // Register validators from this assembly
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Services/IMessagingTemplateService.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Services/IMessagingTemplateService.cs
@@ -1,0 +1,36 @@
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
+using Messaging.Domain.Shared.Contracts.Responses;
+using XFramework.Core.Patterns;
+
+namespace Messaging.Api.Services;
+
+public interface IMessagingTemplateService
+{
+    Task<Result<GetMessageTemplatesResponse>> GetTemplatesAsync(
+        GetMessageTemplatesRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<MessageTemplateResponse>> GetTemplateAsync(
+        GetMessageTemplateRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<MessageTemplateResponse>> CreateTemplateAsync(
+        CreateMessageTemplateRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<MessageTemplateResponse>> UpdateTemplateAsync(
+        UpdateMessageTemplateRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<CmdResponse>> DeleteTemplateAsync(
+        DeleteMessageTemplateRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<MessageTemplateResponse>> CloneTemplateAsync(
+        CloneMessageTemplateRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<RenderMessageTemplateResponse>> RenderTemplateAsync(
+        RenderMessageTemplateRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Services/MessagingService.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Services/MessagingService.cs
@@ -1,7 +1,10 @@
 using System.Net;
+using System.Text.Json;
 using Messaging.Domain.Shared;
 using Messaging.Domain.Shared.Contracts.Requests.Create;
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
 using Messaging.Domain.Shared.Contracts.Requests.Update;
+using Messaging.Domain.Shared.Contracts.Responses;
 using SmsGateway.Integration.Drivers;
 using XFramework.Core.Patterns;
 using XFramework.Core.Services;
@@ -16,6 +19,7 @@ public sealed class MessagingService(
     IDataContext dataContext,
     ITenantResolver tenantService,
     ISmsGatewayServiceWrapper smsGatewayServiceWrapper,
+    IMessagingTemplateService templateService,
     ILogger<MessagingService> logger
 ) : IMessagingService
 {
@@ -45,12 +49,44 @@ public sealed class MessagingService(
                 agentClusterId = configuration.Value;
             }
 
+            var messageText = request.Message?.Trim();
+            RenderMessageTemplateResponse? renderedTemplate = null;
+            if (HasTemplate(request.TemplateId, request.TemplateKey))
+            {
+                var renderResult = await templateService.RenderTemplateAsync(new RenderMessageTemplateRequest
+                {
+                    Metadata = request.Metadata,
+                    TemplateId = request.TemplateId,
+                    TemplateKey = request.TemplateKey,
+                    TemplateVariables = request.TemplateVariables
+                }, ct);
+
+                if (!renderResult.IsSuccess || renderResult.Data is null)
+                {
+                    return Result<CmdResponse>.Failure(
+                        renderResult.Message ?? "Message template could not be rendered",
+                        renderResult.StatusCode);
+                }
+
+                renderedTemplate = renderResult.Data;
+                messageText = renderedTemplate.Body;
+            }
+
+            if (string.IsNullOrWhiteSpace(messageText))
+                return Result<CmdResponse>.Failure("Message text or template is required", 400);
+
             var record = new MessageDirect()
             {
                 TenantId = tenant.Id,
                 MessageTransportType = MessageTransportType.Sms,
                 ExternalRecipient = request.Recipient,
-                Message = request.Message,
+                Subject = renderedTemplate?.Subject ?? request.Subject,
+                Message = messageText,
+                TemplateId = renderedTemplate?.TemplateId,
+                TemplateKey = renderedTemplate?.TemplateKey,
+                TemplateType = renderedTemplate?.TemplateType,
+                TemplateVariablesJson = JsonSerializer.Serialize(
+                    renderedTemplate?.TemplateVariables ?? new Dictionary<string, string>()),
                 AgentClusterId = Guid.Parse(agentClusterId),
                 Status = MessageStatus.Queued
             };
@@ -67,7 +103,7 @@ public sealed class MessagingService(
                         Id = record.Id,
                         AgentClusterId = new Guid(agentClusterId),
                         Recipient = request.Recipient.ValidatePhoneNumber(convertOnly: true),
-                        Message = request.Message
+                        Message = messageText
                     });
 
                     return Result<CmdResponse>.Success(result);
@@ -115,7 +151,11 @@ public sealed class MessagingService(
                 Metadata = request.Metadata,
                 MessageTransportType = transportType.Value,
                 Recipient = request.Contact!,
-                Message = request.VerificationToken!,
+                TemplateKey = MessageTemplateKeys.IdentityOtp,
+                TemplateVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Value"] = request.VerificationToken!
+                },
                 Intent = MessageIntents.Verification
             }, ct);
         }
@@ -172,4 +212,7 @@ public sealed class MessagingService(
             return Result<CmdResponse>.Failure($"Error updating message: {ex.Message}");
         }
     }
+
+    private static bool HasTemplate(Guid? templateId, string? templateKey) =>
+        templateId is Guid || !string.IsNullOrWhiteSpace(templateKey);
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Services/MessagingTemplateService.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Services/MessagingTemplateService.cs
@@ -1,0 +1,920 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using IdentityServer.Domain.Shared.Contracts;
+using Messaging.Domain.Shared;
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
+using Messaging.Domain.Shared.Contracts.Responses;
+using XFramework.Core.Patterns;
+using XFramework.Core.Services;
+using XFramework.Domain.Shared.DataContext;
+
+namespace Messaging.Api.Services;
+
+public sealed class MessagingTemplateService(
+    IDataContext dataContext,
+    ITenantResolver tenantResolver,
+    ILogger<MessagingTemplateService> logger) : IMessagingTemplateService
+{
+    private const int MaxKeyLength = 128;
+    private const int MaxNameLength = 160;
+    private const int MaxDescriptionLength = 1000;
+    private const int MaxSubjectLength = 500;
+    private const int MaxBodyLength = 4000;
+    private static readonly Regex TokenRegex = new(@"\|([A-Za-z0-9_.-]+)\|", RegexOptions.Compiled);
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<Result<GetMessageTemplatesResponse>> GetTemplatesAsync(
+        GetMessageTemplatesRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = await ResolveTenantIdAsync(request.Metadata.TenantId);
+        if (!tenantResult.IsSuccess)
+            return Result<GetMessageTemplatesResponse>.Failure(tenantResult.Message ?? "Tenant could not be resolved", tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        await EnsureTenantTemplatesAsync(tenantId, ct);
+
+        var pageIndex = Math.Max(request.PageIndex, 0);
+        var pageSize = request.PageSize <= 0 ? 20 : Math.Min(request.PageSize, 500);
+        var rows = await LoadTemplatesAsync(tenantId, includeInactive: request.IncludeInactive, ct);
+
+        if (!string.IsNullOrWhiteSpace(request.TemplateType))
+        {
+            rows = rows
+                .Where(template => string.Equals(template.TemplateType, request.TemplateType, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        if (request.OwnerCredentialId is Guid ownerCredentialId)
+        {
+            rows = rows
+                .Where(template => template.OwnerCredentialId == ownerCredentialId)
+                .ToList();
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Search))
+        {
+            var search = request.Search.Trim();
+            rows = rows
+                .Where(template =>
+                    template.Key.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                    template.Name.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                    (template.Description?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (template.Body?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false))
+                .ToList();
+        }
+
+        var total = rows.Count;
+        var page = rows
+            .OrderBy(template => TemplateTypeRank(template.TemplateType))
+            .ThenBy(template => template.Key)
+            .Skip(pageIndex * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        var ownerLabels = await LoadOwnerLabelsAsync(tenantId, page.Select(template => template.OwnerCredentialId), ct);
+        return Result<GetMessageTemplatesResponse>.Success(new GetMessageTemplatesResponse
+        {
+            Items = page.Select(template => ToResponse(template, ownerLabels)).ToList(),
+            PageIndex = pageIndex,
+            PageSize = pageSize,
+            TotalCount = total
+        });
+    }
+
+    public async Task<Result<MessageTemplateResponse>> GetTemplateAsync(
+        GetMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = await ResolveTenantIdAsync(request.Metadata.TenantId);
+        if (!tenantResult.IsSuccess)
+            return Result<MessageTemplateResponse>.Failure(tenantResult.Message ?? "Tenant could not be resolved", tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        await EnsureTenantTemplatesAsync(tenantId, ct);
+
+        var template = await FindTemplateByIdAsync(tenantId, request.TemplateId, includeInactive: true, ct);
+        if (template is null)
+            return Result<MessageTemplateResponse>.NotFound("Message template not found.");
+
+        var ownerLabels = await LoadOwnerLabelsAsync(tenantId, [template.OwnerCredentialId], ct);
+        return Result<MessageTemplateResponse>.Success(ToResponse(template, ownerLabels));
+    }
+
+    public async Task<Result<MessageTemplateResponse>> CreateTemplateAsync(
+        CreateMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = await ResolveTenantIdAsync(request.Metadata.TenantId);
+        if (!tenantResult.IsSuccess)
+            return Result<MessageTemplateResponse>.Failure(tenantResult.Message ?? "Tenant could not be resolved", tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        await EnsureTenantTemplatesAsync(tenantId, ct);
+
+        var validation = await ValidateCreateAsync(tenantId, request, ct);
+        if (validation.Count > 0)
+            return Result<MessageTemplateResponse>.ValidationError(validation);
+
+        var now = DateTime.UtcNow;
+        var template = new MessageTemplate
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            TemplateType = NormalizeTemplateType(request.TemplateType),
+            Key = NormalizeKey(request.Key),
+            Name = request.Name.Trim(),
+            Description = NormalizeNullable(request.Description),
+            Subject = NormalizeNullable(request.Subject),
+            Body = request.Body.Trim(),
+            RequiredVariablesJson = SerializeVariables(request.RequiredVariables),
+            OwnerCredentialId = NormalizeTemplateType(request.TemplateType) == MessageTemplateTypes.User
+                ? request.OwnerCredentialId
+                : null,
+            IsDefault = request.IsDefault,
+            IsLocked = false,
+            IsEnabled = request.IsEnabled,
+            CreatedAt = now,
+            ModifiedAt = now,
+            ConcurrencyStamp = Guid.NewGuid()
+        };
+
+        dataContext.Add(template);
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<MessageTemplateResponse>.Failure(saveResult.Message ?? "Message template could not be created.", saveResult.StatusCode);
+
+        var ownerLabels = await LoadOwnerLabelsAsync(tenantId, [template.OwnerCredentialId], ct);
+        return Result<MessageTemplateResponse>.Success(ToResponse(template, ownerLabels), 201, "Message template created.");
+    }
+
+    public async Task<Result<MessageTemplateResponse>> UpdateTemplateAsync(
+        UpdateMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = await ResolveTenantIdAsync(request.Metadata.TenantId);
+        if (!tenantResult.IsSuccess)
+            return Result<MessageTemplateResponse>.Failure(tenantResult.Message ?? "Tenant could not be resolved", tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        await EnsureTenantTemplatesAsync(tenantId, ct);
+
+        var template = await FindTemplateByIdAsync(tenantId, request.TemplateId, includeInactive: true, ct);
+        if (template is null)
+            return Result<MessageTemplateResponse>.NotFound("Message template not found.");
+
+        if (IsSystemTemplate(template))
+            return Result<MessageTemplateResponse>.Forbidden("System templates cannot be edited. Clone the template first.");
+
+        var validation = await ValidateUpdateAsync(tenantId, template, request, ct);
+        if (validation.Count > 0)
+            return Result<MessageTemplateResponse>.ValidationError(validation);
+
+        if (request.Key is not null)
+            template.Key = NormalizeKey(request.Key);
+
+        if (request.Name is not null)
+            template.Name = request.Name.Trim();
+
+        if (request.Description is not null)
+            template.Description = NormalizeNullable(request.Description);
+
+        if (request.Subject is not null)
+            template.Subject = NormalizeNullable(request.Subject);
+
+        if (request.Body is not null)
+            template.Body = request.Body.Trim();
+
+        if (request.RequiredVariables is not null)
+            template.RequiredVariablesJson = SerializeVariables(request.RequiredVariables);
+
+        if (request.IsDefault is bool isDefault)
+            template.IsDefault = isDefault;
+
+        if (request.IsEnabled is bool isEnabled)
+            template.IsEnabled = isEnabled;
+
+        template.ModifiedAt = DateTime.UtcNow;
+        template.ConcurrencyStamp = Guid.NewGuid();
+
+        dataContext.Update(template);
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<MessageTemplateResponse>.Failure(saveResult.Message ?? "Message template could not be updated.", saveResult.StatusCode);
+
+        var ownerLabels = await LoadOwnerLabelsAsync(tenantId, [template.OwnerCredentialId], ct);
+        return Result<MessageTemplateResponse>.Success(ToResponse(template, ownerLabels), "Message template updated.");
+    }
+
+    public async Task<Result<CmdResponse>> DeleteTemplateAsync(
+        DeleteMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = await ResolveTenantIdAsync(request.Metadata.TenantId);
+        if (!tenantResult.IsSuccess)
+            return Result<CmdResponse>.Failure(tenantResult.Message ?? "Tenant could not be resolved", tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        await EnsureTenantTemplatesAsync(tenantId, ct);
+
+        var template = await FindTemplateByIdAsync(tenantId, request.TemplateId, includeInactive: true, ct);
+        if (template is null)
+            return Result<CmdResponse>.NotFound("Message template not found.");
+
+        if (IsSystemTemplate(template))
+            return Result<CmdResponse>.Forbidden("System templates cannot be deleted.");
+
+        template.IsEnabled = false;
+        template.IsDeleted = true;
+        template.DeletedAt = DateTime.UtcNow;
+        template.ModifiedAt = template.DeletedAt;
+        template.ConcurrencyStamp = Guid.NewGuid();
+
+        dataContext.Update(template);
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<CmdResponse>.Failure(saveResult.Message ?? "Message template could not be deleted.", saveResult.StatusCode);
+
+        return Result<CmdResponse>.Success(new CmdResponse
+        {
+            HttpStatusCode = HttpStatusCode.OK,
+            Message = "Message template deleted."
+        });
+    }
+
+    public async Task<Result<MessageTemplateResponse>> CloneTemplateAsync(
+        CloneMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = await ResolveTenantIdAsync(request.Metadata.TenantId);
+        if (!tenantResult.IsSuccess)
+            return Result<MessageTemplateResponse>.Failure(tenantResult.Message ?? "Tenant could not be resolved", tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        await EnsureTenantTemplatesAsync(tenantId, ct);
+
+        var source = await FindTemplateByIdAsync(tenantId, request.TemplateId, includeInactive: true, ct);
+        if (source is null)
+            return Result<MessageTemplateResponse>.NotFound("Message template not found.");
+
+        var targetType = NormalizeTemplateType(request.TemplateType);
+        var key = NormalizeKey(request.Key ?? $"{source.Key}.copy");
+        var createRequest = new CreateMessageTemplateRequest
+        {
+            Metadata = request.Metadata,
+            TemplateType = targetType,
+            OwnerCredentialId = targetType == MessageTemplateTypes.User ? request.OwnerCredentialId : null,
+            Key = key,
+            Name = string.IsNullOrWhiteSpace(request.Name) ? $"{source.Name} Copy" : request.Name.Trim(),
+            Description = source.Description,
+            Subject = source.Subject,
+            Body = source.Body,
+            RequiredVariables = DeserializeVariables(source.RequiredVariablesJson),
+            IsDefault = false,
+            IsEnabled = true
+        };
+
+        return await CreateTemplateAsync(createRequest, ct);
+    }
+
+    public async Task<Result<RenderMessageTemplateResponse>> RenderTemplateAsync(
+        RenderMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = await ResolveTenantIdAsync(request.Metadata.TenantId);
+        if (!tenantResult.IsSuccess)
+            return Result<RenderMessageTemplateResponse>.Failure(tenantResult.Message ?? "Tenant could not be resolved", tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+        await EnsureTenantTemplatesAsync(tenantId, ct);
+
+        var template = request.TemplateId is Guid templateId
+            ? await FindTemplateByIdAsync(tenantId, templateId, includeInactive: false, ct)
+            : await ResolveTemplateByKeyAsync(tenantId, request.Metadata.CredentialId, request.TemplateKey, ct);
+
+        if (template is null)
+            return Result<RenderMessageTemplateResponse>.NotFound("Message template not found.");
+
+        if (template.TemplateType == MessageTemplateTypes.User &&
+            template.OwnerCredentialId is Guid ownerCredentialId &&
+            request.Metadata.CredentialId != ownerCredentialId)
+        {
+            return Result<RenderMessageTemplateResponse>.Forbidden("User template is not available to this credential.");
+        }
+
+        var renderResult = Render(template, request.TemplateVariables);
+        if (renderResult.Errors.Count > 0)
+            return Result<RenderMessageTemplateResponse>.ValidationError(renderResult.Errors);
+
+        return Result<RenderMessageTemplateResponse>.Success(new RenderMessageTemplateResponse
+        {
+            TemplateId = template.Id,
+            TemplateKey = template.Key,
+            TemplateType = template.TemplateType,
+            Subject = renderResult.Subject,
+            Body = renderResult.Body,
+            TemplateVariables = renderResult.Variables
+        });
+    }
+
+    private async Task EnsureTenantTemplatesAsync(Guid tenantId, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var templates = await dataContext.Query<MessageTemplate>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(template => template.TenantId == tenantId)
+            .Where(template => !template.IsDeleted)
+            .ToListAsync(ct);
+
+        foreach (var systemTemplate in MessagingTemplateCatalog.SystemTemplates)
+        {
+            var existing = templates.FirstOrDefault(template =>
+                template.SystemReferenceId == systemTemplate.SystemReferenceId ||
+                (template.TemplateType == MessageTemplateTypes.System &&
+                 string.Equals(template.Key, systemTemplate.Key, StringComparison.OrdinalIgnoreCase)));
+
+            if (existing is not null)
+                continue;
+
+            var seeded = new MessageTemplate
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                Key = systemTemplate.Key,
+                Name = systemTemplate.Name,
+                Description = systemTemplate.Description,
+                TemplateType = MessageTemplateTypes.System,
+                Subject = systemTemplate.Subject,
+                Body = systemTemplate.Body,
+                RequiredVariablesJson = SerializeVariables(systemTemplate.RequiredVariables),
+                IsDefault = true,
+                IsLocked = true,
+                SystemReferenceId = systemTemplate.SystemReferenceId,
+                IsEnabled = true,
+                CreatedAt = now,
+                ModifiedAt = now,
+                ConcurrencyStamp = Guid.NewGuid()
+            };
+            dataContext.Add(seeded);
+            templates.Add(seeded);
+        }
+
+        await BackfillLegacyRegistryTemplateAsync(
+            tenantId,
+            "MessagingService_Otp",
+            MessageTemplateKeys.IdentityOtp,
+            "Tenant OTP Override",
+            "Backfilled tenant override from the legacy OTP registry setting.",
+            ["Value"],
+            templates,
+            now,
+            ct);
+        await BackfillLegacyRegistryTemplateAsync(
+            tenantId,
+            "MessagingService_PasswordReset",
+            MessageTemplateKeys.IdentityPasswordReset,
+            "Tenant Password Reset Override",
+            "Backfilled tenant override from the legacy password reset registry setting.",
+            ["Token"],
+            templates,
+            now,
+            ct);
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+        {
+            logger.LogWarning("Messaging templates could not be seeded for tenant {TenantId}: {Message}", tenantId, saveResult.Message);
+        }
+    }
+
+    private async Task BackfillLegacyRegistryTemplateAsync(
+        Guid tenantId,
+        string groupName,
+        string templateKey,
+        string name,
+        string description,
+        IReadOnlyList<string> variables,
+        ICollection<MessageTemplate> existingTemplates,
+        DateTime now,
+        CancellationToken ct)
+    {
+        if (existingTemplates.Any(template =>
+                template.TemplateType == MessageTemplateTypes.Tenant &&
+                string.Equals(template.Key, templateKey, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        var legacyConfig = await dataContext.Query<RegistryConfiguration>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Include(config => config.Group)
+            .Where(config => config.TenantId == tenantId)
+            .Where(config => !config.IsDeleted)
+            .Where(config => config.Key == "MessageTemplate")
+            .Where(config => config.Group != null && config.Group.Name == groupName)
+            .FirstOrDefaultAsync(ct);
+
+        if (string.IsNullOrWhiteSpace(legacyConfig?.Value))
+            return;
+
+        var systemTemplate = MessagingTemplateCatalog.FindSystemTemplate(templateKey);
+        dataContext.Add(new MessageTemplate
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            TemplateType = MessageTemplateTypes.Tenant,
+            Key = templateKey,
+            Name = name,
+            Description = description,
+            Subject = systemTemplate?.Subject,
+            Body = legacyConfig.Value.Trim(),
+            RequiredVariablesJson = SerializeVariables(variables),
+            IsDefault = true,
+            IsLocked = false,
+            IsEnabled = true,
+            CreatedAt = now,
+            ModifiedAt = now,
+            ConcurrencyStamp = Guid.NewGuid()
+        });
+    }
+
+    private async Task<List<MessageTemplate>> LoadTemplatesAsync(
+        Guid tenantId,
+        bool includeInactive,
+        CancellationToken ct)
+    {
+        var query = dataContext.Query<MessageTemplate>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(template => template.TenantId == tenantId)
+            .Where(template => !template.IsDeleted);
+
+        if (!includeInactive)
+        {
+            query = query.Where(template => template.IsEnabled);
+        }
+
+        return await query.Take(1000).ToListAsync(ct);
+    }
+
+    private async Task<MessageTemplate?> FindTemplateByIdAsync(
+        Guid tenantId,
+        Guid templateId,
+        bool includeInactive,
+        CancellationToken ct)
+    {
+        var query = dataContext.Query<MessageTemplate>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(template => template.TenantId == tenantId)
+            .Where(template => template.Id == templateId)
+            .Where(template => !template.IsDeleted);
+
+        if (!includeInactive)
+        {
+            query = query.Where(template => template.IsEnabled);
+        }
+
+        return await query.FirstOrDefaultAsync(ct);
+    }
+
+    private async Task<MessageTemplate?> ResolveTemplateByKeyAsync(
+        Guid tenantId,
+        Guid? credentialId,
+        string? templateKey,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(templateKey))
+            return null;
+
+        var key = NormalizeKey(templateKey);
+        var templates = await dataContext.Query<MessageTemplate>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(template => template.TenantId == tenantId)
+            .Where(template => template.Key == key)
+            .Where(template => !template.IsDeleted && template.IsEnabled)
+            .ToListAsync(ct);
+
+        if (credentialId is Guid credential)
+        {
+            var userTemplate = templates.FirstOrDefault(template =>
+                template.TemplateType == MessageTemplateTypes.User &&
+                template.OwnerCredentialId == credential);
+            if (userTemplate is not null)
+                return userTemplate;
+        }
+
+        return templates.FirstOrDefault(template => template.TemplateType == MessageTemplateTypes.Tenant)
+               ?? templates.FirstOrDefault(template => template.TemplateType == MessageTemplateTypes.System);
+    }
+
+    private async Task<Dictionary<string, string[]>> ValidateCreateAsync(
+        Guid tenantId,
+        CreateMessageTemplateRequest request,
+        CancellationToken ct)
+    {
+        var errors = ValidateShape(
+            request.TemplateType,
+            request.Key,
+            request.Name,
+            request.Description,
+            request.Subject,
+            request.Body,
+            request.RequiredVariables);
+
+        var type = NormalizeTemplateType(request.TemplateType);
+        ValidateTemplateTypeScope(errors, type, request.OwnerCredentialId);
+
+        if (type == MessageTemplateTypes.System)
+            errors["TemplateType"] = ["System templates are seeded by Messaging and cannot be created through the API."];
+
+        if (!errors.ContainsKey("Key") &&
+            !errors.ContainsKey("TemplateType") &&
+            await HasDuplicateKeyAsync(tenantId, type, request.OwnerCredentialId, NormalizeKey(request.Key), exceptTemplateId: null, ct))
+        {
+            errors["Key"] = ["An active template with this key already exists in the selected scope."];
+        }
+
+        if (type == MessageTemplateTypes.User && request.OwnerCredentialId is Guid ownerCredentialId)
+        {
+            await ValidateOwnerAsync(tenantId, ownerCredentialId, errors, ct);
+        }
+
+        return errors;
+    }
+
+    private async Task<Dictionary<string, string[]>> ValidateUpdateAsync(
+        Guid tenantId,
+        MessageTemplate existing,
+        UpdateMessageTemplateRequest request,
+        CancellationToken ct)
+    {
+        var key = request.Key ?? existing.Key;
+        var name = request.Name ?? existing.Name;
+        var description = request.Description ?? existing.Description;
+        var subject = request.Subject ?? existing.Subject;
+        var body = request.Body ?? existing.Body;
+        var variables = request.RequiredVariables ?? DeserializeVariables(existing.RequiredVariablesJson);
+
+        var errors = ValidateShape(existing.TemplateType, key, name, description, subject, body, variables);
+        if (!errors.ContainsKey("Key") &&
+            await HasDuplicateKeyAsync(tenantId, existing.TemplateType, existing.OwnerCredentialId, NormalizeKey(key), existing.Id, ct))
+        {
+            errors["Key"] = ["An active template with this key already exists in the selected scope."];
+        }
+
+        return errors;
+    }
+
+    private static Dictionary<string, string[]> ValidateShape(
+        string templateType,
+        string key,
+        string name,
+        string? description,
+        string? subject,
+        string body,
+        IReadOnlyCollection<string> requiredVariables)
+    {
+        var errors = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+
+        if (!IsKnownTemplateType(templateType))
+            errors["TemplateType"] = ["Template type must be System, Tenant, or User."];
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            errors["Key"] = ["Template key is required."];
+        }
+        else
+        {
+            var normalizedKey = NormalizeKey(key);
+            if (normalizedKey.Length > MaxKeyLength)
+                errors["Key"] = [$"Template key cannot exceed {MaxKeyLength} characters."];
+            else if (normalizedKey.Any(character => !char.IsLetterOrDigit(character) && character is not '.' and not '-' and not '_'))
+                errors["Key"] = ["Template key may only contain letters, numbers, dots, dashes, and underscores."];
+        }
+
+        if (string.IsNullOrWhiteSpace(name))
+            errors["Name"] = ["Template name is required."];
+        else if (name.Trim().Length > MaxNameLength)
+            errors["Name"] = [$"Template name cannot exceed {MaxNameLength} characters."];
+
+        if (description?.Length > MaxDescriptionLength)
+            errors["Description"] = [$"Template description cannot exceed {MaxDescriptionLength} characters."];
+
+        if (subject?.Length > MaxSubjectLength)
+            errors["Subject"] = [$"Template subject cannot exceed {MaxSubjectLength} characters."];
+
+        if (string.IsNullOrWhiteSpace(body))
+            errors["Body"] = ["Template body is required."];
+        else if (body.Trim().Length > MaxBodyLength)
+            errors["Body"] = [$"Template body cannot exceed {MaxBodyLength} characters."];
+
+        var invalidVariables = requiredVariables
+            .Where(variable => string.IsNullOrWhiteSpace(variable) ||
+                               variable.Any(character => !char.IsLetterOrDigit(character) && character is not '_' and not '-' and not '.'))
+            .ToList();
+        if (invalidVariables.Count > 0)
+            errors["RequiredVariables"] = ["Required variables may only contain letters, numbers, dots, dashes, and underscores."];
+
+        return errors;
+    }
+
+    private static void ValidateTemplateTypeScope(
+        Dictionary<string, string[]> errors,
+        string templateType,
+        Guid? ownerCredentialId)
+    {
+        if (templateType == MessageTemplateTypes.User && ownerCredentialId is null)
+        {
+            errors["OwnerCredentialId"] = ["User templates require an owner credential."];
+        }
+
+        if (templateType == MessageTemplateTypes.Tenant && ownerCredentialId is not null)
+        {
+            errors["OwnerCredentialId"] = ["Tenant templates cannot have a user owner."];
+        }
+    }
+
+    private async Task ValidateOwnerAsync(
+        Guid tenantId,
+        Guid ownerCredentialId,
+        Dictionary<string, string[]> errors,
+        CancellationToken ct)
+    {
+        var exists = await dataContext.Query<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(credential => credential.TenantId == tenantId)
+            .Where(credential => credential.Id == ownerCredentialId)
+            .Where(credential => !credential.IsDeleted)
+            .AnyAsync(ct);
+
+        if (!exists)
+            errors["OwnerCredentialId"] = ["Owner credential was not found in this tenant."];
+    }
+
+    private async Task<bool> HasDuplicateKeyAsync(
+        Guid tenantId,
+        string templateType,
+        Guid? ownerCredentialId,
+        string key,
+        Guid? exceptTemplateId,
+        CancellationToken ct)
+    {
+        var query = dataContext.Query<MessageTemplate>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(template => template.TenantId == tenantId)
+            .Where(template => !template.IsDeleted)
+            .Where(template => template.IsEnabled)
+            .Where(template => template.Key == key);
+
+        if (templateType == MessageTemplateTypes.User)
+        {
+            query = query.Where(template =>
+                template.TemplateType == MessageTemplateTypes.User &&
+                template.OwnerCredentialId == ownerCredentialId);
+        }
+        else
+        {
+            query = query.Where(template =>
+                template.TemplateType == templateType &&
+                template.OwnerCredentialId == null);
+        }
+
+        if (exceptTemplateId is Guid existingId)
+        {
+            query = query.Where(template => template.Id != existingId);
+        }
+
+        return await query.AnyAsync(ct);
+    }
+
+    private TemplateRenderResult Render(
+        MessageTemplate template,
+        IReadOnlyDictionary<string, string> variables)
+    {
+        var values = new Dictionary<string, string>(variables, StringComparer.OrdinalIgnoreCase);
+        var requiredVariables = DeserializeVariables(template.RequiredVariablesJson)
+            .Concat(ExtractTokens(template.Subject))
+            .Concat(ExtractTokens(template.Body))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var missing = requiredVariables
+            .Where(variable => !values.ContainsKey(variable) || string.IsNullOrWhiteSpace(values[variable]))
+            .ToList();
+        if (missing.Count > 0)
+        {
+            return TemplateRenderResult.Invalid(new Dictionary<string, string[]>
+            {
+                ["TemplateVariables"] = [$"Missing required template variable(s): {string.Join(", ", missing)}."]
+            });
+        }
+
+        var subject = ReplaceTokens(template.Subject, values);
+        var body = ReplaceTokens(template.Body, values) ?? string.Empty;
+        if (subject?.Length > MaxSubjectLength)
+        {
+            return TemplateRenderResult.Invalid(new Dictionary<string, string[]>
+            {
+                ["Subject"] = [$"Rendered subject cannot exceed {MaxSubjectLength} characters."]
+            });
+        }
+
+        if (body.Length > MaxBodyLength)
+        {
+            return TemplateRenderResult.Invalid(new Dictionary<string, string[]>
+            {
+                ["Body"] = [$"Rendered message cannot exceed {MaxBodyLength} characters."]
+            });
+        }
+
+        return TemplateRenderResult.Valid(subject, body, values);
+    }
+
+    private static string? ReplaceTokens(string? value, IReadOnlyDictionary<string, string> variables)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        return TokenRegex.Replace(value, match =>
+        {
+            var tokenName = match.Groups[1].Value;
+            return variables.TryGetValue(tokenName, out var replacement) ? replacement : match.Value;
+        });
+    }
+
+    private static List<string> ExtractTokens(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return [];
+
+        return TokenRegex.Matches(value)
+            .Select(match => match.Groups[1].Value)
+            .Where(token => !string.IsNullOrWhiteSpace(token))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private async Task<Dictionary<Guid, string>> LoadOwnerLabelsAsync(
+        Guid tenantId,
+        IEnumerable<Guid?> ownerCredentialIds,
+        CancellationToken ct)
+    {
+        var ids = ownerCredentialIds
+            .OfType<Guid>()
+            .Distinct()
+            .ToList();
+        if (ids.Count == 0)
+            return [];
+
+        var credentials = await dataContext.Query<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Include(credential => credential.IdentityInfo)
+            .Where(credential => credential.TenantId == tenantId)
+            .Where(credential => ids.Contains(credential.Id))
+            .ToListAsync(ct);
+
+        return credentials.ToDictionary(credential => credential.Id, BuildOwnerLabel);
+    }
+
+    private static MessageTemplateResponse ToResponse(
+        MessageTemplate template,
+        IReadOnlyDictionary<Guid, string> ownerLabels) =>
+        new()
+        {
+            Id = template.Id,
+            TenantId = template.TenantId,
+            Key = template.Key,
+            Name = template.Name,
+            Description = template.Description,
+            TemplateType = template.TemplateType,
+            Subject = template.Subject,
+            Body = template.Body,
+            RequiredVariables = DeserializeVariables(template.RequiredVariablesJson),
+            OwnerCredentialId = template.OwnerCredentialId,
+            OwnerLabel = template.OwnerCredentialId is Guid ownerCredentialId
+                ? ownerLabels.GetValueOrDefault(ownerCredentialId) ?? ownerCredentialId.ToString()[..8]
+                : null,
+            IsDefault = template.IsDefault,
+            IsLocked = template.IsLocked,
+            IsEnabled = template.IsEnabled,
+            IsDeleted = template.IsDeleted,
+            SystemReferenceId = template.SystemReferenceId,
+            CreatedAt = template.CreatedAt,
+            ModifiedAt = template.ModifiedAt
+        };
+
+    private async Task<Result<Guid>> ResolveTenantIdAsync(Guid? tenantId)
+    {
+        try
+        {
+            var tenant = await tenantResolver.GetTenant(tenantId);
+            return Result<Guid>.Success(tenant.Id);
+        }
+        catch (ArgumentNullException)
+        {
+            return Result<Guid>.Failure("Tenant id is required.", 400);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result<Guid>.NotFound("Tenant could not be found.");
+        }
+    }
+
+    private static string NormalizeTemplateType(string? templateType)
+    {
+        if (string.Equals(templateType, MessageTemplateTypes.System, StringComparison.OrdinalIgnoreCase))
+            return MessageTemplateTypes.System;
+
+        if (string.Equals(templateType, MessageTemplateTypes.User, StringComparison.OrdinalIgnoreCase))
+            return MessageTemplateTypes.User;
+
+        return MessageTemplateTypes.Tenant;
+    }
+
+    private static bool IsKnownTemplateType(string? templateType) =>
+        string.IsNullOrWhiteSpace(templateType) ||
+        MessageTemplateTypes.All.Contains(templateType.Trim(), StringComparer.OrdinalIgnoreCase);
+
+    private static string NormalizeKey(string key) => key.Trim().ToLowerInvariant();
+
+    private static string? NormalizeNullable(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static bool IsSystemTemplate(MessageTemplate template) =>
+        template.IsLocked || template.TemplateType == MessageTemplateTypes.System;
+
+    private static int TemplateTypeRank(string templateType) =>
+        templateType switch
+        {
+            MessageTemplateTypes.System => 0,
+            MessageTemplateTypes.Tenant => 1,
+            MessageTemplateTypes.User => 2,
+            _ => 3
+        };
+
+    private static string SerializeVariables(IEnumerable<string> variables) =>
+        JsonSerializer.Serialize(
+            variables
+                .Where(variable => !string.IsNullOrWhiteSpace(variable))
+                .Select(variable => variable.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            JsonOptions);
+
+    private static List<string> DeserializeVariables(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json, JsonOptions) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static string BuildOwnerLabel(IdentityCredential credential)
+    {
+        if (!string.IsNullOrWhiteSpace(credential.IdentityInfo?.FullName))
+            return credential.IdentityInfo.FullName;
+
+        if (!string.IsNullOrWhiteSpace(credential.IdentityInfo?.IdentityName))
+            return credential.IdentityInfo.IdentityName;
+
+        if (!string.IsNullOrWhiteSpace(credential.UserAlias))
+            return credential.UserAlias;
+
+        if (!string.IsNullOrWhiteSpace(credential.UserName))
+            return credential.UserName;
+
+        return credential.Id.ToString()[..8];
+    }
+
+    private sealed record TemplateRenderResult(
+        bool IsSuccess,
+        string? Subject,
+        string Body,
+        Dictionary<string, string> Variables,
+        Dictionary<string, string[]> Errors)
+    {
+        public static TemplateRenderResult Valid(
+            string? subject,
+            string body,
+            Dictionary<string, string> variables) =>
+            new(true, subject, body, variables, []);
+
+        public static TemplateRenderResult Invalid(Dictionary<string, string[]> errors) =>
+            new(false, null, string.Empty, [], errors);
+    }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Api/Services/ThreadService.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Api/Services/ThreadService.cs
@@ -6,6 +6,7 @@ using Messaging.Domain.Shared.Contracts.Requests.Attachments;
 using Messaging.Domain.Shared.Contracts.Requests.Delete;
 using Messaging.Domain.Shared.Contracts.Requests.Edit;
 using Messaging.Domain.Shared.Contracts.Requests.Reactions;
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
 using Messaging.Domain.Shared.Contracts.Requests.Threads;
 using Messaging.Domain.Shared.Contracts.Responses;
 using XFramework.Core.Patterns;
@@ -15,6 +16,7 @@ namespace Messaging.Api.Services;
 public sealed class ThreadService(
     IDataContext dataContext,
     IMessagingRequestContextResolver requestContextResolver,
+    IMessagingTemplateService templateService,
     ILogger<ThreadService> logger
 ) : IThreadService
 {
@@ -1180,15 +1182,47 @@ public sealed class ThreadService(
                     return Result<CreateThreadMessageResponse>.Failure("Mentioned credentials must be active members of this thread", 400);
             }
 
+            var messageText = request.Text?.Trim();
+            RenderMessageTemplateResponse? renderedTemplate = null;
+            if (HasTemplate(request.TemplateId, request.TemplateKey))
+            {
+                var renderResult = await templateService.RenderTemplateAsync(new RenderMessageTemplateRequest
+                {
+                    Metadata = request.Metadata,
+                    TemplateId = request.TemplateId,
+                    TemplateKey = request.TemplateKey,
+                    TemplateVariables = request.TemplateVariables
+                }, ct);
+
+                if (!renderResult.IsSuccess || renderResult.Data is null)
+                {
+                    return Result<CreateThreadMessageResponse>.Failure(
+                        renderResult.Message ?? "Message template could not be rendered",
+                        renderResult.StatusCode);
+                }
+
+                renderedTemplate = renderResult.Data;
+                messageText = renderedTemplate.Body;
+            }
+
+            if (string.IsNullOrWhiteSpace(messageText))
+                return Result<CreateThreadMessageResponse>.Failure("Message text or template is required", 400);
+
             var message = new Message
             {
                 Id = Guid.NewGuid(),
                 TenantId = thread.TenantId,
                 MessageThreadId = request.ThreadId,
                 MessageThreadMemberId = senderMember.Id,
-                Text = request.Text,
+                Text = messageText,
                 ParentMessageId = request.ParentMessageId,
                 MentionedCredentialIdsJson = JsonSerializer.Serialize(mentionedCredentialIds, OutboxJsonOptions),
+                TemplateId = renderedTemplate?.TemplateId,
+                TemplateKey = renderedTemplate?.TemplateKey,
+                TemplateType = renderedTemplate?.TemplateType,
+                TemplateVariablesJson = JsonSerializer.Serialize(
+                    renderedTemplate?.TemplateVariables ?? new Dictionary<string, string>(),
+                    OutboxJsonOptions),
                 IsEnabled = true,
                 CreatedAt = DateTime.UtcNow,
                 ConcurrencyStamp = Guid.NewGuid()
@@ -2530,6 +2564,9 @@ public sealed class ThreadService(
             return [];
         }
     }
+
+    private static bool HasTemplate(Guid? templateId, string? templateKey) =>
+        templateId is Guid || !string.IsNullOrWhiteSpace(templateKey);
 
     private static bool IsAllowedAttachmentFileType(StorageFile file)
     {

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageConfiguration.cs
@@ -24,6 +24,11 @@ public class MessageConfiguration : IEntityTypeConfiguration<Message>
         entity.Property(e => e.MentionedCredentialIdsJson)
             .HasColumnType("jsonb")
             .HasDefaultValueSql("'[]'::jsonb");
+        entity.Property(e => e.TemplateKey).HasColumnType("character varying");
+        entity.Property(e => e.TemplateType).HasColumnType("character varying");
+        entity.Property(e => e.TemplateVariablesJson)
+            .HasColumnType("jsonb")
+            .HasDefaultValueSql("'{}'::jsonb");
         entity.Property(e => e.Text).HasColumnType("character varying");
 
         entity.HasIndex(e => new { e.MessageThreadId, e.CreatedAt, e.Id })
@@ -31,6 +36,9 @@ public class MessageConfiguration : IEntityTypeConfiguration<Message>
 
         entity.HasIndex(e => new { e.MessageThreadMemberId, e.CreatedAt })
             .HasDatabaseName("IX_Message_Member_CreatedAt");
+
+        entity.HasIndex(e => e.TemplateId)
+            .HasDatabaseName("IX_Message_TemplateId");
 
         entity.HasOne(d => d.MessageThread).WithMany(p => p.Messages)
             .HasForeignKey(d => d.MessageThreadId)

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageDirectConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageDirectConfiguration.cs
@@ -26,6 +26,14 @@ public class MessageDirectConfiguration : IEntityTypeConfiguration<MessageDirect
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
         entity.Property(e => e.ReceivedAt).HasColumnName("RecievedAt");
         entity.Property(e => e.Subject).HasColumnType("character varying");
+        entity.Property(e => e.TemplateKey).HasColumnType("character varying");
+        entity.Property(e => e.TemplateType).HasColumnType("character varying");
+        entity.Property(e => e.TemplateVariablesJson)
+            .HasColumnType("jsonb")
+            .HasDefaultValueSql("'{}'::jsonb");
+
+        entity.HasIndex(e => e.TemplateId)
+            .HasDatabaseName("IX_MessageDirect_TemplateId");
 
         entity.HasOne(d => d.ParentMessage).WithMany(p => p.InverseParentMessage)
             .HasForeignKey(d => d.ParentMessageId)

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageTemplateConfiguration.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Configurations/MessageTemplateConfiguration.cs
@@ -1,0 +1,55 @@
+using Messaging.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Messaging.Domain.Shared.Configurations;
+
+public sealed class MessageTemplateConfiguration : IEntityTypeConfiguration<MessageTemplate>
+{
+    public void Configure(EntityTypeBuilder<MessageTemplate> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("messagetemplate_pk");
+
+        entity.ToTable("MessageTemplate", "Messaging");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.IsEnabled)
+            .IsRequired()
+            .HasDefaultValueSql("true");
+
+        entity.Property(e => e.Key).HasColumnType("character varying").IsRequired();
+        entity.Property(e => e.Name).HasColumnType("character varying").IsRequired();
+        entity.Property(e => e.Description).HasColumnType("character varying");
+        entity.Property(e => e.TemplateType).HasColumnType("character varying").IsRequired();
+        entity.Property(e => e.Subject).HasColumnType("character varying");
+        entity.Property(e => e.Body).HasColumnType("character varying").IsRequired();
+        entity.Property(e => e.RequiredVariablesJson)
+            .HasColumnType("jsonb")
+            .HasDefaultValueSql("'[]'::jsonb");
+
+        entity.HasIndex(e => new { e.TenantId, e.TemplateType, e.Key })
+            .HasDatabaseName("IX_MessageTemplate_Tenant_Type_Key");
+
+        entity.HasIndex(e => new { e.TenantId, e.TemplateType, e.Key })
+            .IsUnique()
+            .HasDatabaseName("UX_MessageTemplate_Tenant_Type_Key_Active")
+            .HasFilter("\"IsDeleted\" = false AND \"OwnerCredentialId\" IS NULL");
+
+        entity.HasIndex(e => new { e.TenantId, e.OwnerCredentialId, e.Key })
+            .IsUnique()
+            .HasDatabaseName("UX_MessageTemplate_User_Key_Active")
+            .HasFilter("\"IsDeleted\" = false AND \"OwnerCredentialId\" IS NOT NULL");
+
+        entity.HasIndex(e => new { e.TenantId, e.TemplateType, e.ModifiedAt })
+            .HasDatabaseName("IX_MessageTemplate_Tenant_Type_ModifiedAt");
+
+        entity.HasOne(e => e.OwnerCredential)
+            .WithMany()
+            .HasForeignKey(e => e.OwnerCredentialId)
+            .HasConstraintName("messagetemplate_ownercredential_id_fk");
+    }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Constants.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Constants.cs
@@ -15,6 +15,66 @@ public static class MessageIntents
     public static readonly string Notification = nameof(Notification);
 }
 
+public static class MessageTemplateTypes
+{
+    public const string System = nameof(System);
+    public const string Tenant = nameof(Tenant);
+    public const string User = nameof(User);
+
+    public static readonly string[] All = [System, Tenant, User];
+}
+
+public static class MessageTemplateKeys
+{
+    public const string IdentityOtp = "identity.otp";
+    public const string IdentityPasswordReset = "identity.password-reset";
+    public const string MessagingGeneric = "messaging.generic";
+}
+
+public sealed record SystemMessageTemplateDefinition(
+    Guid SystemReferenceId,
+    string Key,
+    string Name,
+    string Description,
+    string? Subject,
+    string Body,
+    IReadOnlyList<string> RequiredVariables);
+
+public static class MessagingTemplateCatalog
+{
+    public static readonly IReadOnlyList<SystemMessageTemplateDefinition> SystemTemplates =
+    [
+        new(
+            new Guid("2d876ee4-a3a5-4e38-a18f-45c76c3c7801"),
+            MessageTemplateKeys.IdentityOtp,
+            "Identity OTP",
+            "Built-in one-time password template used by Identity verification messages.",
+            null,
+            "Your verification code is |Value|.",
+            ["Value"]),
+        new(
+            new Guid("8df726dc-f12c-4ce6-bdf1-52ef3169223b"),
+            MessageTemplateKeys.IdentityPasswordReset,
+            "Identity Password Reset",
+            "Built-in password reset template used by Identity recovery flows.",
+            "Password reset",
+            "Your password reset token is: |Token|. This token expires in 30 minutes.",
+            ["Token"]),
+        new(
+            new Guid("7ce67e0f-e285-4b4c-a35a-699c0c04ab6a"),
+            MessageTemplateKeys.MessagingGeneric,
+            "Generic Message",
+            "Built-in generic Messaging template for tenant application messages.",
+            null,
+            "|Message|",
+            ["Message"])
+    ];
+
+    public static SystemMessageTemplateDefinition? FindSystemTemplate(string key) =>
+        SystemTemplates.FirstOrDefault(template =>
+            string.Equals(template.Key, key, StringComparison.OrdinalIgnoreCase));
+}
+
 public static class MessageEvents
 {
     public static readonly string SmsReceived = nameof(SmsReceived);

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Message.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Message.cs
@@ -22,23 +22,35 @@ public partial class Message : BaseModel
     public string MentionedCredentialIdsJson { get; set; } = "[]";
 
     [MemoryPackOrder(5)]
-    public virtual ICollection<MessageDelivery> MessageDeliveries { get; set; } = new List<MessageDelivery>();
+    public Guid? TemplateId { get; set; }
 
     [MemoryPackOrder(6)]
-    public virtual ICollection<MessageFile> MessageFiles { get; set; } = new List<MessageFile>();
+    public string? TemplateKey { get; set; }
 
     [MemoryPackOrder(7)]
-    public virtual ICollection<MessageReaction> MessageReactions { get; set; } = new List<MessageReaction>();
+    public string? TemplateType { get; set; }
 
     [MemoryPackOrder(8)]
-    public virtual MessageThread MessageThread { get; set; } = null!;
+    public string TemplateVariablesJson { get; set; } = "{}";
 
     [MemoryPackOrder(9)]
-    public virtual MessageThreadMember MessageThreadMember { get; set; } = null!;
+    public virtual ICollection<MessageDelivery> MessageDeliveries { get; set; } = new List<MessageDelivery>();
 
     [MemoryPackOrder(10)]
-    public virtual Message? ParentMessage { get; set; }
+    public virtual ICollection<MessageFile> MessageFiles { get; set; } = new List<MessageFile>();
 
     [MemoryPackOrder(11)]
+    public virtual ICollection<MessageReaction> MessageReactions { get; set; } = new List<MessageReaction>();
+
+    [MemoryPackOrder(12)]
+    public virtual MessageThread MessageThread { get; set; } = null!;
+
+    [MemoryPackOrder(13)]
+    public virtual MessageThreadMember MessageThreadMember { get; set; } = null!;
+
+    [MemoryPackOrder(14)]
+    public virtual Message? ParentMessage { get; set; }
+
+    [MemoryPackOrder(15)]
     public virtual ICollection<Message> Replies { get; set; } = new List<Message>();
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/MessageDirect.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/MessageDirect.cs
@@ -51,17 +51,29 @@ public partial class MessageDirect : BaseModel
     public DateTime? ReceivedAt { get; set; }
 
     [MemoryPackOrder(15)]
-    public virtual ICollection<MessageDirect> InverseParentMessage { get; set; } = [];
+    public Guid? TemplateId { get; set; }
 
     [MemoryPackOrder(16)]
-    public virtual MessageDirect? ParentMessage { get; set; }
+    public string? TemplateKey { get; set; }
 
     [MemoryPackOrder(17)]
-    public virtual IdentityCredential? Recipient { get; set; }
+    public string? TemplateType { get; set; }
 
     [MemoryPackOrder(18)]
-    public virtual IdentityCredential? Sender { get; set; } = null!;
+    public string TemplateVariablesJson { get; set; } = "{}";
 
     [MemoryPackOrder(19)]
+    public virtual ICollection<MessageDirect> InverseParentMessage { get; set; } = [];
+
+    [MemoryPackOrder(20)]
+    public virtual MessageDirect? ParentMessage { get; set; }
+
+    [MemoryPackOrder(21)]
+    public virtual IdentityCredential? Recipient { get; set; }
+
+    [MemoryPackOrder(22)]
+    public virtual IdentityCredential? Sender { get; set; } = null!;
+
+    [MemoryPackOrder(23)]
     public virtual MessageType Type { get; set; } = null!;
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/MessageTemplate.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/MessageTemplate.cs
@@ -1,0 +1,43 @@
+namespace Messaging.Domain.Shared.Contracts;
+
+using Messaging.Domain.Shared;
+
+[MemoryPackable(GenerateType.CircularReference)]
+public partial class MessageTemplate : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public string Key { get; set; } = null!;
+
+    [MemoryPackOrder(1)]
+    public string Name { get; set; } = null!;
+
+    [MemoryPackOrder(2)]
+    public string? Description { get; set; }
+
+    [MemoryPackOrder(3)]
+    public string TemplateType { get; set; } = MessageTemplateTypes.Tenant;
+
+    [MemoryPackOrder(4)]
+    public string? Subject { get; set; }
+
+    [MemoryPackOrder(5)]
+    public string Body { get; set; } = null!;
+
+    [MemoryPackOrder(6)]
+    public string RequiredVariablesJson { get; set; } = "[]";
+
+    [MemoryPackOrder(7)]
+    public Guid? OwnerCredentialId { get; set; }
+
+    [MemoryPackOrder(8)]
+    public bool IsDefault { get; set; }
+
+    [MemoryPackOrder(9)]
+    public bool IsLocked { get; set; }
+
+    [MemoryPackOrder(10)]
+    public Guid? SystemReferenceId { get; set; }
+
+    [MemoryPackOrder(11)]
+    public virtual IdentityCredential? OwnerCredential { get; set; }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Requests/Create/CreateDirectMessageRequest.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Requests/Create/CreateDirectMessageRequest.cs
@@ -16,6 +16,9 @@ public partial record CreateDirectMessageRequest : RequestBase,
     public required string Recipient { get; set; } = null!;
     public string? Subject { get; set; }
     public string Intent { get; set; } = "Notification";
-    public required string Message { get; set; } = null!;
+    public string? Message { get; set; }
+    public Guid? TemplateId { get; set; }
+    public string? TemplateKey { get; set; }
+    public Dictionary<string, string> TemplateVariables { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     public bool IsScheduled { get; set; }
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Requests/Templates/MessageTemplateRequests.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Requests/Templates/MessageTemplateRequests.cs
@@ -1,0 +1,101 @@
+namespace Messaging.Domain.Shared.Contracts.Requests.Templates;
+
+using Messaging.Domain.Shared;
+
+using TCreateRequest = CreateMessageTemplateRequest;
+using TCreateResponse = CmdResponse<MessageTemplateResponse>;
+using TDeleteRequest = DeleteMessageTemplateRequest;
+using TGetRequest = GetMessageTemplateRequest;
+using TGetResponse = QueryResponse<MessageTemplateResponse>;
+using TListRequest = GetMessageTemplatesRequest;
+using TListResponse = QueryResponse<GetMessageTemplatesResponse>;
+using TRenderRequest = RenderMessageTemplateRequest;
+using TRenderResponse = QueryResponse<RenderMessageTemplateResponse>;
+using TUpdateRequest = UpdateMessageTemplateRequest;
+using TUpdateResponse = CmdResponse<MessageTemplateResponse>;
+using TCloneRequest = CloneMessageTemplateRequest;
+using TCloneResponse = CmdResponse<MessageTemplateResponse>;
+
+[MemoryPackable]
+public partial record GetMessageTemplatesRequest : RequestBase,
+    IQuery<TListResponse>,
+    IBoltRequest<TListRequest, TListResponse>
+{
+    public string? TemplateType { get; set; }
+    public Guid? OwnerCredentialId { get; set; }
+    public string? Search { get; set; }
+    public bool IncludeInactive { get; set; }
+    public int PageIndex { get; set; }
+    public int PageSize { get; set; } = 20;
+}
+
+[MemoryPackable]
+public partial record GetMessageTemplateRequest : RequestBase,
+    IQuery<TGetResponse>,
+    IBoltRequest<TGetRequest, TGetResponse>
+{
+    public Guid TemplateId { get; set; }
+}
+
+[MemoryPackable]
+public partial record CreateMessageTemplateRequest : RequestBase,
+    ICommand<TCreateResponse>,
+    IBoltRequest<TCreateRequest, TCreateResponse>
+{
+    public string TemplateType { get; set; } = MessageTemplateTypes.Tenant;
+    public string Key { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Subject { get; set; }
+    public string Body { get; set; } = string.Empty;
+    public List<string> RequiredVariables { get; set; } = [];
+    public Guid? OwnerCredentialId { get; set; }
+    public bool IsDefault { get; set; }
+    public bool IsEnabled { get; set; } = true;
+}
+
+[MemoryPackable]
+public partial record UpdateMessageTemplateRequest : RequestBase,
+    ICommand<TUpdateResponse>,
+    IBoltRequest<TUpdateRequest, TUpdateResponse>
+{
+    public Guid TemplateId { get; set; }
+    public string? Key { get; set; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public string? Subject { get; set; }
+    public string? Body { get; set; }
+    public List<string>? RequiredVariables { get; set; }
+    public bool? IsDefault { get; set; }
+    public bool? IsEnabled { get; set; }
+}
+
+[MemoryPackable]
+public partial record DeleteMessageTemplateRequest : RequestBase,
+    ICommand<CmdResponse>,
+    IBoltRequest<TDeleteRequest, CmdResponse>
+{
+    public Guid TemplateId { get; set; }
+}
+
+[MemoryPackable]
+public partial record CloneMessageTemplateRequest : RequestBase,
+    ICommand<TCloneResponse>,
+    IBoltRequest<TCloneRequest, TCloneResponse>
+{
+    public Guid TemplateId { get; set; }
+    public string TemplateType { get; set; } = MessageTemplateTypes.Tenant;
+    public Guid? OwnerCredentialId { get; set; }
+    public string? Key { get; set; }
+    public string? Name { get; set; }
+}
+
+[MemoryPackable]
+public partial record RenderMessageTemplateRequest : RequestBase,
+    IQuery<TRenderResponse>,
+    IBoltRequest<TRenderRequest, TRenderResponse>
+{
+    public Guid? TemplateId { get; set; }
+    public string? TemplateKey { get; set; }
+    public Dictionary<string, string> TemplateVariables { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Requests/Threads/CreateThreadMessageRequest.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Requests/Threads/CreateThreadMessageRequest.cs
@@ -10,8 +10,11 @@ public partial record CreateThreadMessageRequest : RequestBase,
 {
     public Guid ThreadId { get; set; }
     public Guid SenderCredentialId { get; set; }
-    public string Text { get; set; } = null!;
+    public string? Text { get; set; }
     public Guid? TypeId { get; set; }
     public Guid? ParentMessageId { get; set; }
     public List<Guid> MentionedCredentialIds { get; set; } = [];
+    public Guid? TemplateId { get; set; }
+    public string? TemplateKey { get; set; }
+    public Dictionary<string, string> TemplateVariables { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Responses/MessageTemplateResponses.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Domain.Shared/Contracts/Responses/MessageTemplateResponses.cs
@@ -1,0 +1,44 @@
+namespace Messaging.Domain.Shared.Contracts.Responses;
+
+[MemoryPackable]
+public partial record MessageTemplateResponse
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }
+    public string Key { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string TemplateType { get; set; } = string.Empty;
+    public string? Subject { get; set; }
+    public string Body { get; set; } = string.Empty;
+    public List<string> RequiredVariables { get; set; } = [];
+    public Guid? OwnerCredentialId { get; set; }
+    public string? OwnerLabel { get; set; }
+    public bool IsDefault { get; set; }
+    public bool IsLocked { get; set; }
+    public bool IsEnabled { get; set; }
+    public bool IsDeleted { get; set; }
+    public Guid? SystemReferenceId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ModifiedAt { get; set; }
+}
+
+[MemoryPackable]
+public partial record GetMessageTemplatesResponse
+{
+    public List<MessageTemplateResponse> Items { get; set; } = [];
+    public int PageIndex { get; set; }
+    public int PageSize { get; set; }
+    public int TotalCount { get; set; }
+}
+
+[MemoryPackable]
+public partial record RenderMessageTemplateResponse
+{
+    public Guid TemplateId { get; set; }
+    public string TemplateKey { get; set; } = string.Empty;
+    public string TemplateType { get; set; } = string.Empty;
+    public string? Subject { get; set; }
+    public string Body { get; set; } = string.Empty;
+    public Dictionary<string, string> TemplateVariables { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Integration/Drivers/MessagingServiceDriver.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Integration/Drivers/MessagingServiceDriver.cs
@@ -2,6 +2,7 @@ using Messaging.Domain.Shared;
 using Messaging.Domain.Shared.Contracts.Realtime;
 using Messaging.Domain.Shared.Contracts.Requests.Create;
 using Messaging.Domain.Shared.Contracts.Requests.Settings;
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
 using Messaging.Domain.Shared.Contracts.Responses;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +22,27 @@ public interface IMessagingServiceWrapper : IServiceWrapper
         CancellationToken ct = default);
     Task<CmdResponse<MessagingSettingsResponse>> UpdateMessagingSettingsAsync(
         UpdateMessagingSettingsRequest request,
+        CancellationToken ct = default);
+    Task<QueryResponse<GetMessageTemplatesResponse>> GetMessageTemplatesAsync(
+        GetMessageTemplatesRequest request,
+        CancellationToken ct = default);
+    Task<QueryResponse<MessageTemplateResponse>> GetMessageTemplateAsync(
+        GetMessageTemplateRequest request,
+        CancellationToken ct = default);
+    Task<CmdResponse<MessageTemplateResponse>> CreateMessageTemplateAsync(
+        CreateMessageTemplateRequest request,
+        CancellationToken ct = default);
+    Task<CmdResponse<MessageTemplateResponse>> UpdateMessageTemplateAsync(
+        UpdateMessageTemplateRequest request,
+        CancellationToken ct = default);
+    Task<CmdResponse> DeleteMessageTemplateAsync(
+        DeleteMessageTemplateRequest request,
+        CancellationToken ct = default);
+    Task<CmdResponse<MessageTemplateResponse>> CloneMessageTemplateAsync(
+        CloneMessageTemplateRequest request,
+        CancellationToken ct = default);
+    Task<QueryResponse<RenderMessageTemplateResponse>> RenderMessageTemplateAsync(
+        RenderMessageTemplateRequest request,
         CancellationToken ct = default);
     Task SubscribeThreadEventsAsync(
         Guid tenantId,
@@ -71,6 +93,62 @@ public sealed record MessagingServiceWrapper(
     {
         ct.ThrowIfCancellationRequested();
         return SendVoidAsync<UpdateMessagingSettingsRequest, MessagingSettingsResponse>(request);
+    }
+
+    public Task<QueryResponse<GetMessageTemplatesResponse>> GetMessageTemplatesAsync(
+        GetMessageTemplatesRequest request,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return SendAsync<GetMessageTemplatesRequest, GetMessageTemplatesResponse>(request);
+    }
+
+    public Task<QueryResponse<MessageTemplateResponse>> GetMessageTemplateAsync(
+        GetMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return SendAsync<GetMessageTemplateRequest, MessageTemplateResponse>(request);
+    }
+
+    public Task<CmdResponse<MessageTemplateResponse>> CreateMessageTemplateAsync(
+        CreateMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return SendVoidAsync<CreateMessageTemplateRequest, MessageTemplateResponse>(request);
+    }
+
+    public Task<CmdResponse<MessageTemplateResponse>> UpdateMessageTemplateAsync(
+        UpdateMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return SendVoidAsync<UpdateMessageTemplateRequest, MessageTemplateResponse>(request);
+    }
+
+    public Task<CmdResponse> DeleteMessageTemplateAsync(
+        DeleteMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return SendVoidAsync(request);
+    }
+
+    public Task<CmdResponse<MessageTemplateResponse>> CloneMessageTemplateAsync(
+        CloneMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return SendVoidAsync<CloneMessageTemplateRequest, MessageTemplateResponse>(request);
+    }
+
+    public Task<QueryResponse<RenderMessageTemplateResponse>> RenderMessageTemplateAsync(
+        RenderMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return SendAsync<RenderMessageTemplateRequest, RenderMessageTemplateResponse>(request);
     }
 
     public Task SubscribeThreadEventsAsync(

--- a/src/Modules/XFramework.Messaging/Messaging.Tests/Services/MessagingTemplateServiceTests.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Tests/Services/MessagingTemplateServiceTests.cs
@@ -1,0 +1,301 @@
+using IdentityServer.Domain.Shared.Contracts;
+using Messaging.Api.Services;
+using Messaging.Domain.Shared;
+using Messaging.Domain.Shared.Contracts;
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
+using Messaging.Tests.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using XFramework.Core.Services;
+using XFramework.Domain.Shared.BusinessObjects;
+
+namespace Messaging.Tests.Services;
+
+public sealed class MessagingTemplateServiceTests
+{
+    [Test]
+    public async Task GetTemplatesAsync_WhenNoRowsExist_SeedsSystemTemplatesOnce()
+    {
+        var tenantId = Guid.NewGuid();
+        var dataContext = new InMemoryDataContext();
+        var service = CreateService(dataContext, tenantId);
+
+        var first = await service.GetTemplatesAsync(ListRequest(tenantId));
+        var second = await service.GetTemplatesAsync(ListRequest(tenantId));
+
+        Assert.That(first.IsSuccess, Is.True, first.Message);
+        Assert.That(second.IsSuccess, Is.True, second.Message);
+        Assert.That(first.Data!.Items.Count(item => item.TemplateType == MessageTemplateTypes.System), Is.EqualTo(3));
+        Assert.That(dataContext.Set<MessageTemplate>().Count(item => item.TemplateType == MessageTemplateTypes.System), Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task UpdateTemplateAsync_WhenSystemTemplate_ReturnsForbidden()
+    {
+        var tenantId = Guid.NewGuid();
+        var dataContext = new InMemoryDataContext();
+        var service = CreateService(dataContext, tenantId);
+        var seeded = await service.GetTemplatesAsync(ListRequest(tenantId));
+        var systemTemplate = seeded.Data!.Items.Single(item => item.Key == MessageTemplateKeys.IdentityOtp);
+
+        var result = await service.UpdateTemplateAsync(new UpdateMessageTemplateRequest
+        {
+            TemplateId = systemTemplate.Id,
+            Name = "Editable OTP",
+            Metadata = Metadata(tenantId)
+        });
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.StatusCode, Is.EqualTo(403));
+    }
+
+    [Test]
+    public async Task CreateTemplateAsync_WhenDuplicateActiveTenantKey_ReturnsValidationError()
+    {
+        var tenantId = Guid.NewGuid();
+        var service = CreateService(new InMemoryDataContext(), tenantId);
+
+        var first = await service.CreateTemplateAsync(CreateTenantRequest(tenantId, "Announcements.Welcome"));
+        var second = await service.CreateTemplateAsync(CreateTenantRequest(tenantId, "announcements.welcome"));
+
+        Assert.That(first.IsSuccess, Is.True, first.Message);
+        Assert.That(second.IsSuccess, Is.False);
+        Assert.That(second.Errors, Contains.Key("Key"));
+    }
+
+    [Test]
+    public async Task CreateTemplateAsync_WhenTemplateTypeIsUnknown_ReturnsValidationError()
+    {
+        var tenantId = Guid.NewGuid();
+        var service = CreateService(new InMemoryDataContext(), tenantId);
+
+        var result = await service.CreateTemplateAsync(new CreateMessageTemplateRequest
+        {
+            TemplateType = "Organization",
+            Key = "custom.invalid",
+            Name = "Invalid",
+            Body = "Invalid",
+            Metadata = Metadata(tenantId)
+        });
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Errors, Contains.Key("TemplateType"));
+    }
+
+    [Test]
+    public async Task RenderTemplateAsync_ByKey_PrefersTenantTemplateAndReplacesTokensCaseInsensitive()
+    {
+        var tenantId = Guid.NewGuid();
+        var service = CreateService(new InMemoryDataContext(), tenantId);
+        var created = await service.CreateTemplateAsync(new CreateMessageTemplateRequest
+        {
+            TemplateType = MessageTemplateTypes.Tenant,
+            Key = MessageTemplateKeys.MessagingGeneric,
+            Name = "Tenant Generic",
+            Body = "Tenant says |Message|",
+            RequiredVariables = ["Message"],
+            Metadata = Metadata(tenantId)
+        });
+
+        var rendered = await service.RenderTemplateAsync(new RenderMessageTemplateRequest
+        {
+            TemplateKey = MessageTemplateKeys.MessagingGeneric,
+            TemplateVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["message"] = "hello"
+            },
+            Metadata = Metadata(tenantId)
+        });
+
+        Assert.That(created.IsSuccess, Is.True, created.Message);
+        Assert.That(rendered.IsSuccess, Is.True, rendered.Message);
+        Assert.That(rendered.Data!.TemplateType, Is.EqualTo(MessageTemplateTypes.Tenant));
+        Assert.That(rendered.Data.Body, Is.EqualTo("Tenant says hello"));
+    }
+
+    [Test]
+    public async Task RenderTemplateAsync_WhenRequiredVariableMissing_ReturnsValidationError()
+    {
+        var tenantId = Guid.NewGuid();
+        var service = CreateService(new InMemoryDataContext(), tenantId);
+
+        var result = await service.RenderTemplateAsync(new RenderMessageTemplateRequest
+        {
+            TemplateKey = MessageTemplateKeys.IdentityOtp,
+            Metadata = Metadata(tenantId)
+        });
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Errors, Contains.Key("TemplateVariables"));
+    }
+
+    [Test]
+    public async Task RenderTemplateAsync_WhenUserTemplateRequestedByOtherCredential_ReturnsForbidden()
+    {
+        var tenantId = Guid.NewGuid();
+        var ownerCredentialId = Guid.NewGuid();
+        var otherCredentialId = Guid.NewGuid();
+        var dataContext = new InMemoryDataContext();
+        dataContext.Seed(Credential(ownerCredentialId, tenantId), Credential(otherCredentialId, tenantId));
+        var service = CreateService(dataContext, tenantId);
+        var created = await service.CreateTemplateAsync(new CreateMessageTemplateRequest
+        {
+            TemplateType = MessageTemplateTypes.User,
+            OwnerCredentialId = ownerCredentialId,
+            Key = "quick.reply",
+            Name = "Quick Reply",
+            Body = "Thanks, |Name|",
+            RequiredVariables = ["Name"],
+            Metadata = Metadata(tenantId, ownerCredentialId)
+        });
+
+        var result = await service.RenderTemplateAsync(new RenderMessageTemplateRequest
+        {
+            TemplateId = created.Data!.Id,
+            TemplateVariables = new Dictionary<string, string> { ["Name"] = "Ava" },
+            Metadata = Metadata(tenantId, otherCredentialId)
+        });
+
+        Assert.That(created.IsSuccess, Is.True, created.Message);
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.StatusCode, Is.EqualTo(403));
+    }
+
+    [Test]
+    public async Task DeleteTemplateAsync_WhenTenantTemplate_MarksTemplateDeleted()
+    {
+        var tenantId = Guid.NewGuid();
+        var dataContext = new InMemoryDataContext();
+        var service = CreateService(dataContext, tenantId);
+        var created = await service.CreateTemplateAsync(CreateTenantRequest(tenantId, "tenant.delete"));
+
+        var result = await service.DeleteTemplateAsync(new DeleteMessageTemplateRequest
+        {
+            TemplateId = created.Data!.Id,
+            Metadata = Metadata(tenantId)
+        });
+
+        Assert.That(result.IsSuccess, Is.True, result.Message);
+        var stored = dataContext.Set<MessageTemplate>().Single(template => template.Id == created.Data.Id);
+        Assert.That(stored.IsDeleted, Is.True);
+        Assert.That(stored.IsEnabled, Is.False);
+        Assert.That(stored.DeletedAt, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task GetTemplatesAsync_BackfillsLegacyOtpRegistryTemplateAsTenantTemplate()
+    {
+        var tenantId = Guid.NewGuid();
+        var group = RegistryGroup(Guid.NewGuid(), tenantId, "MessagingService_Otp");
+        var dataContext = new InMemoryDataContext();
+        dataContext.Seed(
+            group,
+            RegistryConfig(Guid.NewGuid(), tenantId, group, "MessageTemplate", "Legacy code |Value|"));
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.GetTemplatesAsync(ListRequest(tenantId));
+
+        Assert.That(result.IsSuccess, Is.True, result.Message);
+        var backfilled = result.Data!.Items.Single(item =>
+            item.TemplateType == MessageTemplateTypes.Tenant &&
+            item.Key == MessageTemplateKeys.IdentityOtp);
+        Assert.That(backfilled.Body, Is.EqualTo("Legacy code |Value|"));
+        Assert.That(backfilled.IsDefault, Is.True);
+    }
+
+    private static MessagingTemplateService CreateService(
+        InMemoryDataContext dataContext,
+        params Guid[] tenantIds) =>
+        new(dataContext, new FakeTenantResolver(tenantIds), NullLogger<MessagingTemplateService>.Instance);
+
+    private static GetMessageTemplatesRequest ListRequest(Guid tenantId) => new()
+    {
+        IncludeInactive = true,
+        PageSize = 100,
+        Metadata = Metadata(tenantId)
+    };
+
+    private static CreateMessageTemplateRequest CreateTenantRequest(Guid tenantId, string key) => new()
+    {
+        TemplateType = MessageTemplateTypes.Tenant,
+        Key = key,
+        Name = "Tenant Template",
+        Body = "Hello |Name|",
+        RequiredVariables = ["Name"],
+        Metadata = Metadata(tenantId)
+    };
+
+    private static RequestMetadata Metadata(Guid tenantId, Guid? credentialId = null) => new()
+    {
+        TenantId = tenantId,
+        CredentialId = credentialId
+    };
+
+    private static IdentityCredential Credential(Guid id, Guid tenantId) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        UserName = $"user-{id:N}",
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private static RegistryConfigurationGroup RegistryGroup(
+        Guid id,
+        Guid tenantId,
+        string name) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        Name = name,
+        Description = name,
+        SystemReferenceId = Guid.NewGuid(),
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private static RegistryConfiguration RegistryConfig(
+        Guid id,
+        Guid tenantId,
+        RegistryConfigurationGroup group,
+        string key,
+        string value) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        GroupId = group.Id,
+        Group = group,
+        Key = key,
+        Value = value,
+        Unit = "string",
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private sealed class FakeTenantResolver(params Guid[] tenantIds) : ITenantResolver
+    {
+        private readonly HashSet<Guid> _tenantIds = tenantIds.ToHashSet();
+
+        public Task<Tenant> GetTenant(Guid? id)
+        {
+            if (id is null || id == Guid.Empty)
+                throw new ArgumentNullException(nameof(id));
+
+            if (!_tenantIds.Contains(id.Value))
+                throw new InvalidOperationException($"Tenant '{id}' could not be found.");
+
+            return Task.FromResult(new Tenant
+            {
+                Id = id.Value,
+                TenantId = id.Value,
+                Name = "Tenant",
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow,
+                ConcurrencyStamp = Guid.NewGuid()
+            });
+        }
+    }
+}

--- a/src/Modules/XFramework.Messaging/Messaging.Tests/Services/ThreadServiceSecurityTests.cs
+++ b/src/Modules/XFramework.Messaging/Messaging.Tests/Services/ThreadServiceSecurityTests.cs
@@ -4,11 +4,14 @@ using IdentityServer.Domain.Shared.Contracts;
 using Messaging.Api.Services;
 using Messaging.Domain.Shared;
 using Messaging.Domain.Shared.Contracts;
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
 using Messaging.Domain.Shared.Contracts.Requests.Threads;
+using Messaging.Domain.Shared.Contracts.Responses;
 using Messaging.Tests.Infrastructure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
+using XFramework.Core.Patterns;
 using XFramework.Domain.Shared.BusinessObjects;
 
 namespace Messaging.Tests.Services;
@@ -273,10 +276,56 @@ public sealed class ThreadServiceSecurityTests
         Assert.That(mentions, Is.EquivalentTo(new[] { mentionedCredentialId }));
     }
 
-    private static ThreadService CreateService(InMemoryDataContext dataContext) =>
+    [Test]
+    public async Task CreateThreadMessageAsync_WithTemplate_StoresRenderedTextAndTemplateAuditFields()
+    {
+        var tenantId = Guid.NewGuid();
+        var threadId = Guid.NewGuid();
+        var callerCredentialId = Guid.NewGuid();
+        var callerMemberId = Guid.NewGuid();
+        var templateId = Guid.NewGuid();
+        var dataContext = new InMemoryDataContext();
+        dataContext.Seed(
+            Thread(threadId, tenantId),
+            Member(callerMemberId, threadId, callerCredentialId, tenantId));
+        var service = CreateService(
+            dataContext,
+            new TestMessagingTemplateService(new RenderMessageTemplateResponse
+            {
+                TemplateId = templateId,
+                TemplateKey = "tenant.notice",
+                TemplateType = MessageTemplateTypes.Tenant,
+                Body = "Rendered notice",
+                TemplateVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Name"] = "Ava"
+                }
+            }));
+
+        var result = await service.CreateThreadMessageAsync(new CreateThreadMessageRequest
+        {
+            ThreadId = threadId,
+            TemplateId = templateId,
+            TemplateVariables = new Dictionary<string, string> { ["Name"] = "Ava" },
+            Metadata = Metadata(callerCredentialId, tenantId)
+        });
+
+        Assert.That(result.IsSuccess, Is.True, result.Message);
+        var message = dataContext.Set<Message>().Single();
+        Assert.That(message.Text, Is.EqualTo("Rendered notice"));
+        Assert.That(message.TemplateId, Is.EqualTo(templateId));
+        Assert.That(message.TemplateKey, Is.EqualTo("tenant.notice"));
+        Assert.That(message.TemplateType, Is.EqualTo(MessageTemplateTypes.Tenant));
+        Assert.That(message.TemplateVariablesJson, Does.Contain("Ava"));
+    }
+
+    private static ThreadService CreateService(
+        InMemoryDataContext dataContext,
+        IMessagingTemplateService? templateService = null) =>
         new(
             dataContext,
             new MessagingRequestContextResolver(new HttpContextAccessor()),
+            templateService ?? new TestMessagingTemplateService(),
             NullLogger<ThreadService>.Instance);
 
     private static RequestMetadata Metadata(Guid credentialId, Guid tenantId) => new()
@@ -399,4 +448,45 @@ public sealed class ThreadServiceSecurityTests
         CreatedAt = DateTime.UtcNow,
         ConcurrencyStamp = Guid.NewGuid()
     };
+
+    private sealed class TestMessagingTemplateService(
+        RenderMessageTemplateResponse? renderResponse = null) : IMessagingTemplateService
+    {
+        public Task<Result<GetMessageTemplatesResponse>> GetTemplatesAsync(
+            GetMessageTemplatesRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<GetMessageTemplatesResponse>.Failure("Template service is not configured for this test.", 501));
+
+        public Task<Result<MessageTemplateResponse>> GetTemplateAsync(
+            GetMessageTemplateRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<MessageTemplateResponse>.Failure("Template service is not configured for this test.", 501));
+
+        public Task<Result<MessageTemplateResponse>> CreateTemplateAsync(
+            CreateMessageTemplateRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<MessageTemplateResponse>.Failure("Template service is not configured for this test.", 501));
+
+        public Task<Result<MessageTemplateResponse>> UpdateTemplateAsync(
+            UpdateMessageTemplateRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<MessageTemplateResponse>.Failure("Template service is not configured for this test.", 501));
+
+        public Task<Result<CmdResponse>> DeleteTemplateAsync(
+            DeleteMessageTemplateRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<CmdResponse>.Failure("Template service is not configured for this test.", 501));
+
+        public Task<Result<MessageTemplateResponse>> CloneTemplateAsync(
+            CloneMessageTemplateRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<MessageTemplateResponse>.Failure("Template service is not configured for this test.", 501));
+
+        public Task<Result<RenderMessageTemplateResponse>> RenderTemplateAsync(
+            RenderMessageTemplateRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(renderResponse is null
+                ? Result<RenderMessageTemplateResponse>.Failure("Template service is not configured for this test.", 501)
+                : Result<RenderMessageTemplateResponse>.Success(renderResponse));
+    }
 }

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/MessagingSettingsShell.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/MessagingSettingsShell.razor
@@ -65,9 +65,16 @@ else
                 </aside>
 
                 <section class="messaging-settings-content">
-                    <MessagingSettingsEditor Title="@CurrentSection.Title"
-                                             Description="@CurrentSection.Description"
-                                             SectionKey="@CurrentSection.SectionKey" />
+                    @if (CurrentSection.SectionKey == MessagingSettingsCatalog.TemplatesSectionKey)
+                    {
+                        <MessagingTemplateLibrary />
+                    }
+                    else
+                    {
+                        <MessagingSettingsEditor Title="@CurrentSection.Title"
+                                                 Description="@CurrentSection.Description"
+                                                 SectionKey="@CurrentSection.SectionKey" />
+                    }
                 </section>
             </div>
         </div>
@@ -86,7 +93,7 @@ else
     [
         new(MessagingSettingsCatalog.ChatSectionKey, "Chat Controls", "Thread, direct-message, read-state, typing, and presence defaults.", "message-circle", "/messaging/settings/chat"),
         new(MessagingSettingsCatalog.PolicySectionKey, "Policy", "Retention, attachment, rate-limit, and moderation policy values.", "shield-check", "/messaging/settings/policy"),
-        new(MessagingSettingsCatalog.TemplatesSectionKey, "Templates", "Identity message templates and direct-message transport defaults.", "file-text", "/messaging/settings/templates")
+        new(MessagingSettingsCatalog.TemplatesSectionKey, "Templates", "System, tenant, and user message templates.", "file-text", "/messaging/settings/templates")
     ];
 
     private MessagingControlPanelGuardResult? _guard;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/MessagingTemplateLibrary.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Messaging/MessagingTemplateLibrary.razor
@@ -1,0 +1,735 @@
+@using System.Globalization
+@implements IDisposable
+
+@if (_loading)
+{
+    <CenteredSpinner />
+}
+else
+{
+    <div class="messaging-template-library space-y-6">
+        <div class="messaging-settings-editor-heading">
+            <div>
+                <BbTypographyH3>Templates</BbTypographyH3>
+                <BbTypographyMuted>System defaults, tenant templates, and user template audit records.</BbTypographyMuted>
+            </div>
+            <div class="xf-page-actions">
+                <BbButton OnClick="@OpenCreateSheet">
+                    <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                    Create Tenant Template
+                </BbButton>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@RefreshTemplates" Disabled="@_refreshing">
+                    @if (_refreshing)
+                    {
+                        <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                    }
+                    else
+                    {
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                    }
+                    Refresh
+                </BbButton>
+            </div>
+        </div>
+
+        @if (_error is not null)
+        {
+            <BbAlert Variant="AlertVariant.Danger">
+                <BbAlertTitle>Templates Unavailable</BbAlertTitle>
+                <BbAlertDescription>@_error</BbAlertDescription>
+            </BbAlert>
+        }
+        else
+        {
+            <div class="messaging-template-metrics" aria-label="Messaging template counts">
+                <span><strong>@_systemCount</strong> System</span>
+                <span><strong>@_tenantCount</strong> Tenant</span>
+                <span><strong>@_userCount</strong> User</span>
+                <span><strong>@_inactiveCount</strong> Inactive</span>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Template Library</BbCardTitle>
+                    <BbCardDescription>@_templates.Count template(s) loaded for this tenant.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    @if (_templates.Count == 0)
+                    {
+                        <BbEmpty Title="No templates found" Description="Messaging will seed system templates when the template service is reachable." />
+                    }
+                    else
+                    {
+                        <BbDataGrid Items="@_templates"
+                                    ShowPagination="true"
+                                    InitialPageSize="20"
+                                    OnRowClick="@((MessageTemplateResponse item) => OpenTemplateSheet(item))"
+                                    Class="cursor-pointer">
+                            <Columns>
+                                <BbDataGridTemplateColumn Title="Type" Sortable="true" Filterable="true" FilterBy="@(item => item.TemplateType)">
+                                    <ChildContent Context="item">
+                                        <StatusBadge Text="@item.TemplateType" Status="@TemplateTypeStatus(item.TemplateType)" />
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Template" Sortable="true" Filterable="true" FilterBy="@(item => $"{item.Name} {item.Key}")">
+                                    <ChildContent Context="item">
+                                        <div class="messaging-template-name-cell">
+                                            <strong>@item.Name</strong>
+                                            <span>@item.Key</span>
+                                        </div>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Owner" Sortable="true" Filterable="true" FilterBy="@(item => item.OwnerLabel ?? "Tenant")">
+                                    <ChildContent Context="item">@(item.OwnerLabel ?? "Tenant")</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Status" Sortable="true" Filterable="true" FilterBy="@(item => item.IsEnabled ? "Enabled" : "Disabled")">
+                                    <ChildContent Context="item">
+                                        <StatusBadge Text="@(item.IsEnabled ? "Enabled" : "Disabled")" Status="@(item.IsEnabled ? "active" : "inactive")" />
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Default" Sortable="true" Filterable="true" FilterBy="@(item => item.IsDefault)">
+                                    <ChildContent Context="item">
+                                        @if (item.IsDefault)
+                                        {
+                                            <StatusBadge Text="Default" Status="active" />
+                                        }
+                                        else
+                                        {
+                                            <span class="text-muted-foreground">Standard</span>
+                                        }
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Updated" Sortable="true" Filterable="true" FilterBy="@(item => item.ModifiedAt ?? item.CreatedAt)">
+                                    <ChildContent Context="item">@FormatDate(item.ModifiedAt ?? item.CreatedAt)</ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Preview" Filterable="true" FilterBy="@(item => Preview(item.Body, 120))">
+                                    <ChildContent Context="item">
+                                        <span class="messaging-template-preview">@Preview(item.Body, 120)</span>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                        </BbDataGrid>
+                    }
+                </BbCardContent>
+            </BbCard>
+        }
+    </div>
+}
+
+<BbSheet Open="@_sheetOpen" OpenChanged="@OnSheetOpenChanged">
+    <BbSheetContent Side="SheetSide.Right" Class="messaging-template-sheet">
+        <BbSheetHeader>
+            <BbSheetTitle>@SheetTitle</BbSheetTitle>
+            <BbSheetDescription>@SheetDescription</BbSheetDescription>
+        </BbSheetHeader>
+
+        @if (_selected is not null || _creating)
+        {
+            <div class="messaging-template-sheet-body">
+                @if (_validationErrors.Count > 0)
+                {
+                    <BbAlert Variant="AlertVariant.Warning">
+                        <BbAlertTitle>Review Template</BbAlertTitle>
+                        <BbAlertDescription>@string.Join(" ", _validationErrors)</BbAlertDescription>
+                    </BbAlert>
+                }
+
+                @if (IsReadOnly)
+                {
+                    <BbAlert Variant="AlertVariant.Info">
+                        <BbAlertTitle>@ReadOnlyTitle</BbAlertTitle>
+                        <BbAlertDescription>@ReadOnlyDescription</BbAlertDescription>
+                    </BbAlert>
+                }
+
+                <div class="messaging-template-editor-grid">
+                    <BbFormFieldInput TValue="string"
+                                      Value="@_form.Key"
+                                      ValueChanged="@OnKeyChanged"
+                                      UpdateTiming="UpdateTiming.Immediate"
+                                      Label="Key"
+                                      Placeholder="identity.otp"
+                                      Required="true"
+                                      Disabled="@IsReadOnly" />
+                    <BbFormFieldInput TValue="string"
+                                      Value="@_form.Name"
+                                      ValueChanged="@OnNameChanged"
+                                      UpdateTiming="UpdateTiming.Immediate"
+                                      Label="Name"
+                                      Placeholder="Template name"
+                                      Required="true"
+                                      Disabled="@IsReadOnly" />
+                    <BbFormFieldInput TValue="string"
+                                      Value="@_form.Subject"
+                                      ValueChanged="@OnSubjectChanged"
+                                      UpdateTiming="UpdateTiming.Immediate"
+                                      Label="Subject"
+                                      Placeholder="Optional subject"
+                                      Disabled="@IsReadOnly" />
+                    <div class="messaging-template-switches">
+                        <BbFormFieldSwitch Checked="@_form.IsEnabled"
+                                           CheckedChanged="@OnEnabledChanged"
+                                           Label="Enabled"
+                                           Disabled="@IsReadOnly" />
+                        <BbFormFieldSwitch Checked="@_form.IsDefault"
+                                           CheckedChanged="@OnDefaultChanged"
+                                           Label="Default"
+                                           Disabled="@IsReadOnly" />
+                    </div>
+                    <div class="messaging-template-editor-full">
+                        <BbFormFieldInput TValue="string"
+                                          Value="@_form.Description"
+                                          ValueChanged="@OnDescriptionChanged"
+                                          UpdateTiming="UpdateTiming.Immediate"
+                                          Label="Description"
+                                          Placeholder="Describe when this template is used"
+                                          Disabled="@IsReadOnly" />
+                    </div>
+                    <div class="messaging-template-editor-full">
+                        <BbFormFieldTagInput Tags="@_form.RequiredVariables"
+                                             TagsChanged="@OnRequiredVariablesChanged"
+                                             Label="Required Variables"
+                                             Placeholder="Add variable"
+                                             MaxTags="20"
+                                             MaxTagLength="64"
+                                             AllowDuplicates="false"
+                                             Clearable="true"
+                                             Disabled="@IsReadOnly" />
+                    </div>
+                    <div class="messaging-template-editor-full">
+                        <BbFormFieldTextarea Value="@_form.Body"
+                                             ValueChanged="@OnBodyChanged"
+                                             UpdateTiming="UpdateTiming.Immediate"
+                                             Label="Body"
+                                             Placeholder="Use |TokenName| placeholders for variables"
+                                             Required="true"
+                                             MaxLength="4000"
+                                             ShowCharacterCount="true"
+                                             Disabled="@IsReadOnly"
+                                             InputClass="messaging-template-body-input" />
+                    </div>
+                </div>
+
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>Template Context</BbCardTitle>
+                        <BbCardDescription>Token style and audit details.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <div class="xf-detail-field-grid">
+                            <div>
+                                <BbTypographyMuted>Type</BbTypographyMuted>
+                                <StatusBadge Text="@_form.TemplateType" Status="@TemplateTypeStatus(_form.TemplateType)" />
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Owner</BbTypographyMuted>
+                                <BbTypographyP>@(_selected?.OwnerLabel ?? "Tenant")</BbTypographyP>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Created</BbTypographyMuted>
+                                <BbTypographyP>@(_selected is null ? "New template" : FormatDate(_selected.CreatedAt))</BbTypographyP>
+                            </div>
+                            <div>
+                                <BbTypographyMuted>Updated</BbTypographyMuted>
+                                <BbTypographyP>@(_selected is null ? "Not saved" : FormatDate(_selected.ModifiedAt ?? _selected.CreatedAt))</BbTypographyP>
+                            </div>
+                        </div>
+                        <div class="messaging-template-token-help">
+                            <span>Use tokens such as</span>
+                            <BbBadge Variant="BadgeVariant.Outline">|Value|</BbBadge>
+                            <BbBadge Variant="BadgeVariant.Outline">|Token|</BbBadge>
+                            <BbBadge Variant="BadgeVariant.Outline">|Message|</BbBadge>
+                            <span>and add each required token name without pipes.</span>
+                        </div>
+                    </BbCardContent>
+                </BbCard>
+            </div>
+        }
+
+        <BbSheetFooter Class="messaging-template-sheet-footer">
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@CloseSheet">Close</BbButton>
+            @if (_selected is { TemplateType: MessageTemplateTypes.System })
+            {
+                <BbButton OnClick="@CloneSelectedTemplate" Disabled="@_saving">
+                    <LucideIcon Name="copy" class="mr-2 h-4 w-4" />
+                    Clone
+                </BbButton>
+            }
+            else if (_selected is { TemplateType: MessageTemplateTypes.Tenant })
+            {
+                <BbButton Variant="ButtonVariant.Destructive" OnClick="@DeleteSelectedTemplate" Disabled="@_saving">
+                    <LucideIcon Name="trash-2" class="mr-2 h-4 w-4" />
+                    Delete
+                </BbButton>
+                <BbButton OnClick="@SaveTemplate" Disabled="@(_saving || !_dirty)">
+                    <LucideIcon Name="save" class="mr-2 h-4 w-4" />
+                    Save
+                </BbButton>
+            }
+            else if (_creating)
+            {
+                <BbButton OnClick="@SaveTemplate" Disabled="@_saving">
+                    <LucideIcon Name="save" class="mr-2 h-4 w-4" />
+                    Create
+                </BbButton>
+            }
+        </BbSheetFooter>
+    </BbSheetContent>
+</BbSheet>
+
+@code {
+    [Inject] private MessagingControlPanelTemplateService TemplateService { get; set; } = default!;
+    [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
+
+    private readonly TemplateForm _form = new();
+    private List<MessageTemplateResponse> _templates = [];
+    private List<string> _validationErrors = [];
+    private MessageTemplateResponse? _selected;
+    private bool _loading = true;
+    private bool _refreshing;
+    private bool _saving;
+    private bool _dirty;
+    private bool _creating;
+    private bool _sheetOpen;
+    private string? _error;
+
+    private int _systemCount => _templates.Count(x => x.TemplateType == MessageTemplateTypes.System);
+    private int _tenantCount => _templates.Count(x => x.TemplateType == MessageTemplateTypes.Tenant);
+    private int _userCount => _templates.Count(x => x.TemplateType == MessageTemplateTypes.User);
+    private int _inactiveCount => _templates.Count(x => !x.IsEnabled);
+    private bool IsReadOnly => !_creating && _selected?.TemplateType != MessageTemplateTypes.Tenant;
+    private string SheetTitle => _creating ? "Create Tenant Template" : _selected?.Name ?? "Template";
+    private string SheetDescription => _creating
+        ? "Create a configurable tenant template for server-side Messaging rendering."
+        : _selected?.Key ?? "Review template details.";
+    private string ReadOnlyTitle => _selected?.TemplateType == MessageTemplateTypes.System
+        ? "System Template"
+        : "User Template";
+    private string ReadOnlyDescription => _selected?.TemplateType == MessageTemplateTypes.System
+        ? "System templates are seeded and locked. Clone one to create a configurable tenant override."
+        : "User templates are tenant app records. ControlPanel shows them for audit in this pass.";
+
+    protected override async Task OnInitializedAsync()
+    {
+        TenantFilter.OnChanged += OnTenantFilterChanged;
+        await LoadTemplates();
+    }
+
+    private void OnTenantFilterChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            CloseSheet();
+            await LoadTemplates();
+            StateHasChanged();
+        });
+    }
+
+    private async Task RefreshTemplates()
+    {
+        _refreshing = true;
+        try
+        {
+            await LoadTemplates(showFeedback: true);
+        }
+        finally
+        {
+            _refreshing = false;
+        }
+    }
+
+    private async Task LoadTemplates(bool showFeedback = false)
+    {
+        _loading = !showFeedback;
+        _error = null;
+
+        try
+        {
+            var result = await TemplateService.GetTemplatesAsync();
+            if (!result.IsSuccess || result.Templates is null)
+            {
+                _templates = [];
+                _error = result.Message;
+                if (showFeedback)
+                {
+                    ToastService.Error("Messaging templates could not be refreshed.", "Templates Unavailable");
+                }
+
+                return;
+            }
+
+            _templates = result.Templates.Items;
+            if (showFeedback)
+            {
+                ToastService.Success("Messaging templates refreshed.", "Templates Refreshed");
+            }
+        }
+        catch
+        {
+            _templates = [];
+            _error = "Messaging templates could not be loaded. Check service health and tenant module state.";
+            if (showFeedback)
+            {
+                ToastService.Error("Messaging templates could not be refreshed.", "Templates Unavailable");
+            }
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void OpenCreateSheet()
+    {
+        _creating = true;
+        _selected = null;
+        _dirty = false;
+        _validationErrors = [];
+        _form.SetDefaults();
+        _sheetOpen = true;
+    }
+
+    private void OpenTemplateSheet(MessageTemplateResponse template)
+    {
+        _creating = false;
+        _selected = template;
+        _dirty = false;
+        _validationErrors = [];
+        _form.Load(template);
+        _sheetOpen = true;
+    }
+
+    private void OnSheetOpenChanged(bool open)
+    {
+        _sheetOpen = open;
+        if (!open)
+        {
+            _validationErrors = [];
+            _dirty = false;
+            _creating = false;
+            _selected = null;
+        }
+    }
+
+    private void CloseSheet() => OnSheetOpenChanged(false);
+
+    private async Task SaveTemplate()
+    {
+        _validationErrors = ValidateForm();
+        if (_validationErrors.Count > 0)
+        {
+            ToastService.Warning("Review the template before saving.", "Validation Required");
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var result = _creating
+                ? await TemplateService.CreateTemplateAsync(new CreateMessageTemplateRequest
+                {
+                    TemplateType = MessageTemplateTypes.Tenant,
+                    Key = _form.Key,
+                    Name = _form.Name,
+                    Description = _form.Description,
+                    Subject = _form.Subject,
+                    Body = _form.Body,
+                    RequiredVariables = _form.RequiredVariables,
+                    IsDefault = _form.IsDefault,
+                    IsEnabled = _form.IsEnabled
+                })
+                : await TemplateService.UpdateTemplateAsync(new UpdateMessageTemplateRequest
+                {
+                    TemplateId = _selected!.Id,
+                    Key = _form.Key,
+                    Name = _form.Name,
+                    Description = _form.Description,
+                    Subject = _form.Subject,
+                    Body = _form.Body,
+                    RequiredVariables = _form.RequiredVariables,
+                    IsDefault = _form.IsDefault,
+                    IsEnabled = _form.IsEnabled
+                });
+
+            if (!result.IsSuccess)
+            {
+                _validationErrors = [result.Message];
+                ToastService.Error("Messaging template could not be saved.", "Save Failed");
+                return;
+            }
+
+            ToastService.Success(result.Message, _creating ? "Template Created" : "Template Saved");
+            await LoadTemplates(showFeedback: false);
+
+            if (result.Template is not null)
+            {
+                OpenTemplateSheet(result.Template);
+            }
+            else
+            {
+                CloseSheet();
+            }
+        }
+        catch
+        {
+            _validationErrors = ["Messaging template could not be saved. Check validation and service health."];
+            ToastService.Error("Messaging template could not be saved.", "Save Failed");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task CloneSelectedTemplate()
+    {
+        if (_selected is null)
+        {
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var result = await TemplateService.CloneTemplateAsync(new CloneMessageTemplateRequest
+            {
+                TemplateId = _selected.Id,
+                TemplateType = MessageTemplateTypes.Tenant,
+                Key = _selected.Key,
+                Name = $"{_selected.Name} Tenant"
+            });
+
+            if (!result.IsSuccess)
+            {
+                _validationErrors = [result.Message];
+                ToastService.Error("Messaging template could not be cloned.", "Clone Failed");
+                return;
+            }
+
+            ToastService.Success(result.Message, "Template Cloned");
+            await LoadTemplates(showFeedback: false);
+            if (result.Template is not null)
+            {
+                OpenTemplateSheet(result.Template);
+            }
+        }
+        catch
+        {
+            ToastService.Error("Messaging template could not be cloned.", "Clone Failed");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task DeleteSelectedTemplate()
+    {
+        if (_selected is null)
+        {
+            return;
+        }
+
+        if (!await DialogService.Confirm(
+                "Delete Messaging Template",
+                $"Delete tenant template '{_selected.Name}'? Existing messages keep their rendered content and audit fields.",
+                new ConfirmDialogOptions { Destructive = true }))
+        {
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var result = await TemplateService.DeleteTemplateAsync(_selected.Id);
+            if (!result.IsSuccess)
+            {
+                ToastService.Error("Messaging template could not be deleted.", "Delete Failed");
+                return;
+            }
+
+            ToastService.Success(result.Message, "Template Deleted");
+            CloseSheet();
+            await LoadTemplates(showFeedback: false);
+        }
+        catch
+        {
+            ToastService.Error("Messaging template could not be deleted.", "Delete Failed");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private List<string> ValidateForm()
+    {
+        var errors = new List<string>();
+        if (string.IsNullOrWhiteSpace(_form.Key))
+        {
+            errors.Add("Key is required.");
+        }
+        else if (_form.Key.Length > 128)
+        {
+            errors.Add("Key cannot exceed 128 characters.");
+        }
+        else if (_form.Key.Any(character => !char.IsLetterOrDigit(character) && character is not '.' and not '-' and not '_'))
+        {
+            errors.Add("Key may only contain letters, numbers, dots, dashes, and underscores.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_form.Name))
+        {
+            errors.Add("Name is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_form.Body))
+        {
+            errors.Add("Body is required.");
+        }
+        else if (_form.Body.Length > 4000)
+        {
+            errors.Add("Body cannot exceed 4,000 characters.");
+        }
+
+        if (_form.RequiredVariables.Any(variable =>
+                string.IsNullOrWhiteSpace(variable) ||
+                variable.Any(character => !char.IsLetterOrDigit(character) && character is not '_' and not '-' and not '.')))
+        {
+            errors.Add("Required variables may only contain letters, numbers, dots, dashes, and underscores.");
+        }
+
+        return errors;
+    }
+
+    private void MarkDirty() => _dirty = true;
+
+    private Task OnKeyChanged(string? value)
+    {
+        _form.Key = value ?? string.Empty;
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
+    private Task OnNameChanged(string? value)
+    {
+        _form.Name = value ?? string.Empty;
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
+    private Task OnSubjectChanged(string? value)
+    {
+        _form.Subject = value;
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
+    private Task OnDescriptionChanged(string? value)
+    {
+        _form.Description = value;
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
+    private Task OnBodyChanged(string? value)
+    {
+        _form.Body = value ?? string.Empty;
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
+    private Task OnRequiredVariablesChanged()
+    {
+        _form.RequiredVariables = _form.RequiredVariables
+            .Select(variable => variable.Trim())
+            .Where(variable => variable.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
+    private Task OnEnabledChanged(bool value)
+    {
+        _form.IsEnabled = value;
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
+    private Task OnDefaultChanged(bool value)
+    {
+        _form.IsDefault = value;
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
+    private static string TemplateTypeStatus(string templateType) =>
+        templateType switch
+        {
+            MessageTemplateTypes.System => "pending",
+            MessageTemplateTypes.Tenant => "active",
+            MessageTemplateTypes.User => "info",
+            _ => "inactive"
+        };
+
+    private static string Preview(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "No template body";
+        }
+
+        var normalized = value.ReplaceLineEndings(" ").Trim();
+        return normalized.Length <= maxLength ? normalized : $"{normalized[..maxLength]}...";
+    }
+
+    private static string FormatDate(DateTime? value) =>
+        value?.ToString("g", CultureInfo.CurrentCulture) ?? "N/A";
+
+    public void Dispose()
+    {
+        TenantFilter.OnChanged -= OnTenantFilterChanged;
+    }
+
+    private sealed class TemplateForm
+    {
+        public string TemplateType { get; set; } = MessageTemplateTypes.Tenant;
+        public string Key { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public string? Subject { get; set; }
+        public string Body { get; set; } = string.Empty;
+        public List<string> RequiredVariables { get; set; } = [];
+        public bool IsDefault { get; set; }
+        public bool IsEnabled { get; set; } = true;
+
+        public void SetDefaults()
+        {
+            TemplateType = MessageTemplateTypes.Tenant;
+            Key = string.Empty;
+            Name = string.Empty;
+            Description = null;
+            Subject = null;
+            Body = string.Empty;
+            RequiredVariables = [];
+            IsDefault = false;
+            IsEnabled = true;
+        }
+
+        public void Load(MessageTemplateResponse template)
+        {
+            TemplateType = template.TemplateType;
+            Key = template.Key;
+            Name = template.Name;
+            Description = template.Description;
+            Subject = template.Subject;
+            Body = template.Body;
+            RequiredVariables = template.RequiredVariables.ToList();
+            IsDefault = template.IsDefault;
+            IsEnabled = template.IsEnabled;
+        }
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Components/_Imports.razor
+++ b/src/Presentation/ControlPanel.Server/Components/_Imports.razor
@@ -32,6 +32,8 @@
 @using global::Inventario.Integration.Drivers
 @using global::Messaging.Domain.Shared
 @using global::Messaging.Domain.Shared.Contracts
+@using global::Messaging.Domain.Shared.Contracts.Requests.Templates
+@using global::Messaging.Domain.Shared.Contracts.Responses
 @using global::Messaging.Integration.Drivers
 @using global::Wallets.Domain.Shared.Contracts
 @using global::Wallets.Domain.Shared.Contracts.Requests

--- a/src/Presentation/ControlPanel.Server/Program.cs
+++ b/src/Presentation/ControlPanel.Server/Program.cs
@@ -110,6 +110,7 @@ builder.Services.AddScoped<TenantModuleFeatureDefinitionResolver>();
 builder.Services.AddScoped<MessagingControlPanelGuard>();
 builder.Services.AddScoped<MessagingControlPanelReadService>();
 builder.Services.AddScoped<MessagingControlPanelSettingsService>();
+builder.Services.AddScoped<MessagingControlPanelTemplateService>();
 builder.Services.AddScoped<NavigationHistoryService>();
 builder.Services.AddScoped<CommunityControlPanelAccessService>();
 builder.Services.AddScoped<WalletsAdminBackendContractService>();

--- a/src/Presentation/ControlPanel.Server/Services/MessagingControlPanelTemplateService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/MessagingControlPanelTemplateService.cs
@@ -1,0 +1,164 @@
+using Messaging.Domain.Shared.Contracts.Requests.Templates;
+using Messaging.Domain.Shared.Contracts.Responses;
+using Messaging.Integration.Drivers;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Responses;
+
+namespace ControlPanel.Server.Services;
+
+public sealed class MessagingControlPanelTemplateService(
+    IMessagingServiceWrapper messaging,
+    RequestMetadata metadata,
+    TenantFilterService tenantFilter)
+{
+    public async Task<MessagingTemplatesLoadResult> GetTemplatesAsync(CancellationToken ct = default)
+    {
+        if (tenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            return MessagingTemplatesLoadResult.Failure("Select a tenant before loading Messaging templates.");
+        }
+
+        var response = await messaging.GetMessageTemplatesAsync(
+            new GetMessageTemplatesRequest
+            {
+                Metadata = BuildMetadata(tenantId),
+                IncludeInactive = true,
+                PageSize = 500
+            },
+            ct);
+
+        return response is { IsSuccess: true, Response: not null }
+            ? MessagingTemplatesLoadResult.Success(response.Response)
+            : MessagingTemplatesLoadResult.Failure(NormalizeFailureMessage(
+                response.Message,
+                "Messaging templates could not be loaded."));
+    }
+
+    public async Task<MessagingTemplateMutationResult> CreateTemplateAsync(
+        CreateMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        if (tenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            return MessagingTemplateMutationResult.Failure("Select a tenant before creating a Messaging template.");
+        }
+
+        request.Metadata = BuildMetadata(tenantId);
+        var response = await messaging.CreateMessageTemplateAsync(request, ct);
+        return ToMutationResult(response, "Messaging template created.");
+    }
+
+    public async Task<MessagingTemplateMutationResult> UpdateTemplateAsync(
+        UpdateMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        if (tenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            return MessagingTemplateMutationResult.Failure("Select a tenant before updating a Messaging template.");
+        }
+
+        request.Metadata = BuildMetadata(tenantId);
+        var response = await messaging.UpdateMessageTemplateAsync(request, ct);
+        return ToMutationResult(response, "Messaging template updated.");
+    }
+
+    public async Task<MessagingTemplateMutationResult> CloneTemplateAsync(
+        CloneMessageTemplateRequest request,
+        CancellationToken ct = default)
+    {
+        if (tenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            return MessagingTemplateMutationResult.Failure("Select a tenant before cloning a Messaging template.");
+        }
+
+        request.Metadata = BuildMetadata(tenantId);
+        var response = await messaging.CloneMessageTemplateAsync(request, ct);
+        return ToMutationResult(response, "Messaging template cloned.");
+    }
+
+    public async Task<MessagingTemplateMutationResult> DeleteTemplateAsync(
+        Guid templateId,
+        CancellationToken ct = default)
+    {
+        if (tenantFilter.SelectedTenantId is not Guid tenantId)
+        {
+            return MessagingTemplateMutationResult.Failure("Select a tenant before deleting a Messaging template.");
+        }
+
+        var response = await messaging.DeleteMessageTemplateAsync(
+            new DeleteMessageTemplateRequest
+            {
+                Metadata = BuildMetadata(tenantId),
+                TemplateId = templateId
+            },
+            ct);
+
+        return response.IsSuccess
+            ? MessagingTemplateMutationResult.Success(null, response.Message ?? "Messaging template deleted.")
+            : MessagingTemplateMutationResult.Failure(NormalizeFailureMessage(
+                response.Message,
+                "Messaging template could not be deleted."));
+    }
+
+    private MessagingTemplateMutationResult ToMutationResult(
+        CmdResponse<MessageTemplateResponse> response,
+        string successMessage) =>
+        response is { IsSuccess: true, Response: not null }
+            ? MessagingTemplateMutationResult.Success(response.Response, response.Message ?? successMessage)
+            : MessagingTemplateMutationResult.Failure(NormalizeFailureMessage(
+                response.Message,
+                "Messaging template could not be saved."));
+
+    private RequestMetadata BuildMetadata(Guid tenantId) => new()
+    {
+        TenantId = tenantId,
+        CredentialId = metadata.CredentialId,
+        SessionId = metadata.SessionId,
+        RequestId = Guid.NewGuid(),
+        Name = metadata.Name,
+        DeviceName = metadata.DeviceName,
+        DeviceAgent = metadata.DeviceAgent,
+        IpAddress = metadata.IpAddress
+    };
+
+    private static string NormalizeFailureMessage(string? message, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return fallback;
+        }
+
+        return string.Equals(message, "NotFound", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(message, "NotImplemented", StringComparison.OrdinalIgnoreCase)
+            ? "Messaging templates service is unavailable. Check Messaging service health and Bolt handler registration."
+            : message;
+    }
+}
+
+public sealed record MessagingTemplatesLoadResult(
+    bool IsSuccess,
+    GetMessageTemplatesResponse? Templates,
+    string Message)
+{
+    public static MessagingTemplatesLoadResult Success(
+        GetMessageTemplatesResponse templates,
+        string message = "Messaging templates loaded.") =>
+        new(true, templates, message);
+
+    public static MessagingTemplatesLoadResult Failure(string message) =>
+        new(false, null, message);
+}
+
+public sealed record MessagingTemplateMutationResult(
+    bool IsSuccess,
+    MessageTemplateResponse? Template,
+    string Message)
+{
+    public static MessagingTemplateMutationResult Success(
+        MessageTemplateResponse? template,
+        string message) =>
+        new(true, template, message);
+
+    public static MessagingTemplateMutationResult Failure(string message) =>
+        new(false, null, message);
+}

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -485,6 +485,79 @@
     min-height: 8rem;
 }
 
+.messaging-template-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    color: var(--muted-foreground);
+    font-size: 0.875rem;
+}
+
+.messaging-template-metrics span {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.35rem;
+}
+
+.messaging-template-name-cell {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.messaging-template-name-cell span,
+.messaging-template-preview {
+    color: var(--muted-foreground);
+    font-size: 0.875rem;
+}
+
+.messaging-template-sheet {
+    width: min(100vw, 48rem);
+}
+
+.messaging-template-sheet-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow-y: auto;
+    padding: 1rem 0;
+}
+
+.messaging-template-editor-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+}
+
+.messaging-template-editor-full {
+    min-width: 0;
+}
+
+.messaging-template-switches {
+    display: grid;
+    gap: 0.75rem;
+    align-content: start;
+}
+
+.messaging-template-body-input {
+    min-height: 12rem;
+}
+
+.messaging-template-token-help {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem;
+    margin-top: 1rem;
+    color: var(--muted-foreground);
+    font-size: 0.875rem;
+}
+
+.messaging-template-sheet-footer {
+    gap: 0.5rem;
+}
+
 .xf-detail-header {
     display: flex;
     align-items: center;
@@ -584,6 +657,14 @@
         flex-direction: row;
         align-items: center;
         justify-content: space-between;
+    }
+
+    .messaging-template-editor-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .messaging-template-editor-full {
+        grid-column: 1 / -1;
     }
 
 }


### PR DESCRIPTION
## Summary
- Add tenant-scoped Messaging template library with System, Tenant, and User template types.
- Add template list/detail/create/update/delete/clone/render APIs and wrapper methods.
- Render selected templates server-side for thread/direct messages and persist template audit fields.
- Replace Messaging settings templates form with a ControlPanel template grid and editor sheet.

## Verification
- dotnet build src/Modules/XFramework.Messaging/Messaging.Api/Messaging.Api.csproj -m:1 /nr:false
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false
- dotnet test src/Modules/XFramework.Messaging/Messaging.Tests/Messaging.Tests.csproj -m:1 /nr:false