### PR TITLE
Fix Attendance deployed session flow

### DIFF
--- a/src/Modules/XFramework.Attendance/Attendance.Api/Program.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Program.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using IdentityServer.Domain.Shared.Contracts;
 using Attendance.Api.Generated;
+using Bolt.Client;
 using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
 using XFramework.Core.Health;
@@ -22,6 +23,8 @@ builder.Services.AddXFrameworkRateLimiting();
 
 var app = (WebApplication)builder.Build();
 
+RegisterGeneratedBoltHandlers(app);
+
 app.UseCorrelationId();
 app.UseXFrameworkRateLimiting();
 app.UseTenantModuleFeatureGate(options =>
@@ -34,5 +37,14 @@ app.MapApiDocumentation();
 
 app.Run();
 
-public partial class Program;
+static void RegisterGeneratedBoltHandlers(WebApplication app)
+{
+    var client = app.Services.GetRequiredService<BoltClient>();
+    var logger = app.Services.GetRequiredService<ILoggerFactory>()
+        .CreateLogger("Attendance.GeneratedBoltHandlers");
+    var scopeFactory = app.Services.GetRequiredService<IServiceScopeFactory>();
 
+    BoltHandlerRegistry.RegisterAll(client, logger, scopeFactory);
+}
+
+public partial class Program;

--- a/src/Presentation/ControlPanel.Server/Services/AttendanceControlPanelReadService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/AttendanceControlPanelReadService.cs
@@ -61,8 +61,7 @@ public sealed class AttendanceControlPanelReadService(IDataContext dataContext)
         var query = dataContext.Query<AttendanceSession>()
             .IgnoreQueryFilters()
             .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .Where(x => x.StartsAt >= fromUtc && x.StartsAt <= toUtc);
+            .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (contextId is Guid selectedContextId)
         {
@@ -76,10 +75,19 @@ public sealed class AttendanceControlPanelReadService(IDataContext dataContext)
 
         var sessions = await query
             .OrderByDescending(x => x.StartsAt)
-            .Take(500)
+            .Take(2000)
             .ToListAsync(cancellationToken);
 
+        var from = NormalizeUtc(fromUtc);
+        var to = NormalizeUtc(toUtc);
+
         return sessions
+            .Where(session =>
+            {
+                var startsAt = NormalizeUtc(session.StartsAt);
+                return startsAt >= from && startsAt <= to;
+            })
+            .Take(500)
             .Select(session =>
                 new AttendanceSessionRow(
                     session.Id,
@@ -88,8 +96,8 @@ public sealed class AttendanceControlPanelReadService(IDataContext dataContext)
                     LabelOrFallback(session.ContextId, contexts, "Context"),
                     session.Name,
                     session.Code,
-                    session.StartsAt,
-                    session.EndsAt,
+                    NormalizeUtc(session.StartsAt),
+                    NormalizeUtc(session.EndsAt),
                     session.TimeZoneId,
                     session.Status))
             .ToList();
@@ -489,6 +497,13 @@ public sealed class AttendanceControlPanelReadService(IDataContext dataContext)
         ?? Normalize(credential.UserName)
         ?? Normalize(credential.UserAlias)
         ?? credential.Id.ToString();
+
+    private static DateTime NormalizeUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+    };
 
     private static Guid[] NormalizeIds(IEnumerable<Guid?> ids) =>
         ids.Where(x => x.HasValue)

--- a/src/Tests/ControlPanel.E2ETests/AttendanceControlPanelContractTests.cs
+++ b/src/Tests/ControlPanel.E2ETests/AttendanceControlPanelContractTests.cs
@@ -105,7 +105,26 @@ public sealed class AttendanceControlPanelContractTests
         service.Should().Contain("x.TenantId == tenantId");
         service.Should().Contain("BuildCredentialLabel");
         service.Should().Contain("AttendanceRecordStatus.Absent");
+        service.Should().Contain("NormalizeUtc(fromUtc)");
+        service.Should().NotContain("x.StartsAt >= fromUtc");
         service.Should().NotContain("SaveChangesAsync(");
+    }
+
+    [Test]
+    public void AttendanceApi_RegistersGeneratedBoltHandlersAtStartup()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var programPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.Attendance",
+            "Attendance.Api",
+            "Program.cs");
+        var program = File.ReadAllText(programPath);
+
+        program.Should().Contain("BoltHandlerRegistry.RegisterAll");
+        program.Should().Contain("CreateLogger(\"Attendance.GeneratedBoltHandlers\")");
     }
 
     private static string ReadAttendancePageSource()


### PR DESCRIPTION
﻿## Summary
- explicitly register generated Attendance Bolt handlers at API startup
- avoid remote DateTime predicates in the ControlPanel Attendance session list read
- add ControlPanel contract coverage for the production startup/read-service behavior

## Verification
- dotnet build src/Modules/XFramework.Attendance/Attendance.Api/Attendance.Api.csproj -m:1 /nr:false
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false
- dotnet test src/Tests/ControlPanel.E2ETests/ControlPanel.E2ETests.csproj --filter "TestCategory=Module:Attendance" --logger "console;verbosity=minimal" -m:1 /nr:false
