### PR TITLE
Fix notification durability migrations

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260627094000_AddNotificationCorrelationUniqueness.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260627094000_AddNotificationCorrelationUniqueness.cs
@@ -1,9 +1,13 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using XFramework.Domain.Contexts;
 
 #nullable disable
 
 namespace XFramework.Domain.Migrations;
 
+[DbContext(typeof(AppDbContext))]
+[Migration("20260627094000_AddNotificationCorrelationUniqueness")]
 public partial class AddNotificationCorrelationUniqueness : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/Kernel/XFramework.Domain/Migrations/20260627154745_AddNotificationSmsDeliveryDurability.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260627154745_AddNotificationSmsDeliveryDurability.cs
@@ -18,58 +18,6 @@ namespace XFramework.Domain.Migrations
                 name: "SmsGateway");
 
             migrationBuilder.CreateTable(
-                name: "NotificationInboxItem",
-                schema: "Notifications",
-                columns: table => new
-                {
-                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
-                    RecipientCredentialId = table.Column<Guid>(type: "uuid", nullable: false),
-                    SourceCredentialId = table.Column<Guid>(type: "uuid", nullable: true),
-                    TemplateKey = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
-                    Title = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
-                    Body = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
-                    DeliveryChannels = table.Column<int>(type: "integer", nullable: false),
-                    CorrelationId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
-                    DataJson = table.Column<string>(type: "text", nullable: true),
-                    IsRead = table.Column<bool>(type: "boolean", nullable: false),
-                    ReadAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
-                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
-                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
-                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
-                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("notificationinboxitem_pk", x => x.ID);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "NotificationPreference",
-                schema: "Notifications",
-                columns: table => new
-                {
-                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
-                    CredentialId = table.Column<Guid>(type: "uuid", nullable: false),
-                    EnabledChannels = table.Column<int>(type: "integer", nullable: false),
-                    DisabledTemplateKeys = table.Column<string>(type: "text", nullable: true),
-                    DigestEnabled = table.Column<bool>(type: "boolean", nullable: false),
-                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
-                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
-                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
-                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
-                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("notificationpreference_pk", x => x.ID);
-                });
-
-            migrationBuilder.CreateTable(
                 name: "NotificationProviderSetting",
                 schema: "Notifications",
                 columns: table => new
@@ -169,40 +117,6 @@ namespace XFramework.Domain.Migrations
                     table.PrimaryKey("notificationdeliveryjob_pk", x => x.ID);
                     table.ForeignKey(
                         name: "notificationdeliveryjob_inboxitem_id_fk",
-                        column: x => x.NotificationInboxItemId,
-                        principalSchema: "Notifications",
-                        principalTable: "NotificationInboxItem",
-                        principalColumn: "ID",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "NotificationDeliveryStatus",
-                schema: "Notifications",
-                columns: table => new
-                {
-                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
-                    NotificationInboxItemId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Channel = table.Column<int>(type: "integer", nullable: false),
-                    Status = table.Column<int>(type: "integer", nullable: false),
-                    ProviderMessageId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
-                    ErrorCode = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
-                    ErrorMessage = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
-                    AttemptNumber = table.Column<int>(type: "integer", nullable: false),
-                    RecordedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
-                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
-                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
-                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
-                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
-                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("notificationdeliverystatus_pk", x => x.ID);
-                    table.ForeignKey(
-                        name: "notificationdeliverystatus_inboxitem_id_fk",
                         column: x => x.NotificationInboxItemId,
                         principalSchema: "Notifications",
                         principalTable: "NotificationInboxItem",
@@ -327,40 +241,6 @@ namespace XFramework.Domain.Migrations
                 column: "NotificationInboxItemId");
 
             migrationBuilder.CreateIndex(
-                name: "ux_notificationdeliverystatus_tenant_item_channel",
-                schema: "Notifications",
-                table: "NotificationDeliveryStatus",
-                columns: new[] { "TenantId", "NotificationInboxItemId", "Channel" },
-                unique: true);
-
-            migrationBuilder.CreateIndex(
-                name: "ix_notificationinboxitem_tenant_correlation",
-                schema: "Notifications",
-                table: "NotificationInboxItem",
-                columns: new[] { "TenantId", "CorrelationId" },
-                unique: true,
-                filter: "\"CorrelationId\" IS NOT NULL");
-
-            migrationBuilder.CreateIndex(
-                name: "ix_notificationinboxitem_tenant_recipient_read_created",
-                schema: "Notifications",
-                table: "NotificationInboxItem",
-                columns: new[] { "TenantId", "RecipientCredentialId", "IsRead", "CreatedAt" });
-
-            migrationBuilder.CreateIndex(
-                name: "ix_notificationinboxitem_tenant_template",
-                schema: "Notifications",
-                table: "NotificationInboxItem",
-                columns: new[] { "TenantId", "TemplateKey" });
-
-            migrationBuilder.CreateIndex(
-                name: "ux_notificationpreference_tenant_credential",
-                schema: "Notifications",
-                table: "NotificationPreference",
-                columns: new[] { "TenantId", "CredentialId" },
-                unique: true);
-
-            migrationBuilder.CreateIndex(
                 name: "ux_notificationprovidersetting_tenant_channel_key",
                 schema: "Notifications",
                 table: "NotificationProviderSetting",
@@ -404,16 +284,13 @@ namespace XFramework.Domain.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropIndex(
+                name: "IX_NotificationDeliveryStatus_NotificationInboxItemId",
+                schema: "Notifications",
+                table: "NotificationDeliveryStatus");
+
             migrationBuilder.DropTable(
                 name: "NotificationDeliveryAttempt",
-                schema: "Notifications");
-
-            migrationBuilder.DropTable(
-                name: "NotificationDeliveryStatus",
-                schema: "Notifications");
-
-            migrationBuilder.DropTable(
-                name: "NotificationPreference",
                 schema: "Notifications");
 
             migrationBuilder.DropTable(
@@ -431,10 +308,6 @@ namespace XFramework.Domain.Migrations
             migrationBuilder.DropTable(
                 name: "SmsOutboundJob",
                 schema: "SmsGateway");
-
-            migrationBuilder.DropTable(
-                name: "NotificationInboxItem",
-                schema: "Notifications");
 
         }
     }


### PR DESCRIPTION
## Summary
- make `20260627094000_AddNotificationCorrelationUniqueness` discoverable by EF migrations
- fix `20260627154745_AddNotificationSmsDeliveryDurability` so it no longer recreates baseline Notifications tables and indexes
- keep the durability migration scoped to provider settings, delivery jobs/attempts, SMS queue artifacts, and the additional delivery-status FK index

## Deployment finding
The aggregate xeon-dev deploy for PR #319 failed because the live database already has the Notifications baseline tables from `20260617000000_AddNotificationsBaseline`, but `AddNotificationSmsDeliveryDurability` was trying to create those tables again. The correlation uniqueness migration also lacked EF migration metadata and was not listed as pending.

## Verification
- dotnet build src/Kernel/XFramework.Domain/XFramework.Domain.csproj --verbosity minimal /nr:false
- dotnet build src/Tools/XFramework.MigrationRunner/XFramework.MigrationRunner.csproj --verbosity minimal /nr:false
- dotnet ef migrations list includes `20260627094000_AddNotificationCorrelationUniqueness`
- stale Messaging-name scan clean outside historical EF migration filenames