### PR TITLE
Fix IdentityServer tenant creation wrapper path

### DIFF
--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Tenants/Create/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Tenants/Create/Endpoint.cs
@@ -1,0 +1,40 @@
+using FluentValidation;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Tenants.Create;
+
+public static class CreateTenantEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/tenants", Tags = ["Tenants"],
+        Summary = "Create a tenant",
+        Description = "Creates a tenant through the IdentityServer admin workflow.",
+        ExcludeFromOpenApi = true)]
+    public static async Task<Result<Tenant>> Handle(
+        CreateTenantRequest request,
+        IAuthService authService,
+        CancellationToken ct)
+    {
+        return await authService.CreateTenantAsync(request, ct);
+    }
+}
+
+public class CreateTenantRequestValidator : AbstractValidator<CreateTenantRequest>
+{
+    public CreateTenantRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Tenant name is required");
+
+        RuleFor(x => x.Version)
+            .GreaterThan(0).WithMessage("Version must be greater than zero");
+
+        RuleFor(x => x.Status)
+            .Must(status => status is null or >= 0 and <= 3)
+            .WithMessage("Tenant status is invalid");
+
+        RuleFor(x => x.ParentTenantId)
+            .Must(parentTenantId => parentTenantId is null || parentTenantId != Guid.Empty)
+            .WithMessage("Parent tenant is invalid");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/AuthService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/AuthService.cs
@@ -71,6 +71,73 @@ public sealed class AuthService : IAuthService
         _logger = logger;
     }
 
+    #region Tenant Administration
+
+    /// <inheritdoc />
+    public async Task<Result<Tenant>> CreateTenantAsync(
+        CreateTenantRequest request,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var name = request.Name?.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return Result<Tenant>.Failure("Tenant name is required", 400);
+            }
+
+            if (request.ParentTenantId is { } parentTenantId)
+            {
+                var parentExists = await _dataContext.Query<Tenant>()
+                    .IgnoreQueryFilters()
+                    .Where(tenant => tenant.Id == parentTenantId)
+                    .Where(tenant => !tenant.IsDeleted)
+                    .AnyAsync(ct);
+
+                if (!parentExists)
+                {
+                    return Result<Tenant>.NotFound("Parent tenant not found");
+                }
+            }
+
+            var tenantId = Guid.NewGuid();
+            var tenant = new Tenant
+            {
+                Id = tenantId,
+                TenantId = tenantId,
+                Name = name,
+                Description = request.Description,
+                Version = request.Version > 0 ? request.Version : 1.0m,
+                Status = request.Status ?? 1,
+                Expiration = request.Expiration,
+                AvailabilityDate = request.AvailabilityDate,
+                ParentTenantId = request.ParentTenantId,
+                CreatedAt = DateTime.UtcNow,
+                IsEnabled = true,
+                ConcurrencyStamp = Guid.NewGuid()
+            };
+
+            _dataContext.Add(tenant);
+            var saveResult = await _dataContext.SaveChangesAsync(ct);
+            if (!saveResult.IsSuccess)
+            {
+                _logger.OperationFailed("CreateTenant", "Tenant", tenant.Id, saveResult.Message ?? string.Empty, null);
+                return Result<Tenant>.Failure("Tenant could not be created", saveResult.StatusCode);
+            }
+
+            _logger.EntityCreated("Tenant", tenant.Id);
+
+            return Result<Tenant>.Success(tenant);
+        }
+        catch (Exception ex)
+        {
+            _logger.OperationFailed("CreateTenant", "Tenant", Guid.Empty, ex.Message, ex);
+            return Result<Tenant>.Failure("Tenant could not be created", 500);
+        }
+    }
+
+    #endregion
+
     #region Credential Management
 
     /// <inheritdoc />

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/IAuthService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/IAuthService.cs
@@ -9,6 +9,16 @@ namespace IdentityServer.Api.Services;
 public interface IAuthService
 {
     /// <summary>
+    /// Creates a tenant through the IdentityServer admin workflow.
+    /// </summary>
+    /// <param name="request">Tenant creation request</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing the created tenant</returns>
+    Task<Result<Tenant>> CreateTenantAsync(
+        CreateTenantRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Creates a new identity credential with BCrypt password hashing (workFactor 11).
     /// </summary>
     /// <param name="request">The credential creation request containing username, password, and identity info</param>

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Requests/CreateTenantRequest.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Requests/CreateTenantRequest.cs
@@ -1,0 +1,17 @@
+namespace IdentityServer.Domain.Shared.Contracts.Requests;
+
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record CreateTenantRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<CreateTenantRequest, TResponse>
+{
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public short? Status { get; set; }
+    public DateTime? Expiration { get; set; }
+    public DateTime? AvailabilityDate { get; set; }
+    public Guid? ParentTenantId { get; set; }
+    public decimal Version { get; set; } = 1.0m;
+}

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
@@ -189,6 +189,7 @@
 
 @code {
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
+    [Inject] private IIdentityServerServiceWrapper IdentityServer { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
@@ -260,39 +261,21 @@
 
         try
         {
-            var tenantId = Guid.NewGuid();
-            var tenant = new Tenant
+            var request = new CreateTenantRequest
             {
-                Id = tenantId,
-                TenantId = tenantId,
                 Name = _tenantForm.Name,
                 Description = _tenantForm.Description,
                 Version = decimal.TryParse(_tenantForm.VersionString, out var v) ? v : 1.0m,
                 Status = short.TryParse(_tenantForm.StatusString, out var s) ? s : (short)1,
                 Expiration = DateTime.TryParse(_tenantForm.ExpirationString, out var exp) ? exp : null,
                 AvailabilityDate = DateTime.TryParse(_tenantForm.AvailabilityString, out var avail) ? avail : null,
-                ParentTenantId = Guid.TryParse(_tenantForm.ParentTenantIdString, out var pid) ? pid : null,
-                CreatedAt = DateTime.UtcNow,
-                IsEnabled = true
+                ParentTenantId = Guid.TryParse(_tenantForm.ParentTenantIdString, out var pid) ? pid : null
             };
 
-            DataContext.Add(tenant);
-            var result = await DataContext.SaveChangesAsync();
+            var result = await IdentityServer.CreateTenant(request);
 
             if (result.IsSuccess)
             {
-                var createdTenant = await DataContext.Query<Tenant>()
-                    .IgnoreQueryFilters()
-                    .NoCache()
-                    .Where(x => x.Id == tenantId)
-                    .FirstOrDefaultAsync();
-
-                if (createdTenant is null || createdTenant.IsDeleted)
-                {
-                    ToastService.Warning("Tenant save completed, but the tenant could not be reloaded.", "Reload needed");
-                    return;
-                }
-
                 ToastService.Success("Tenant created successfully.", "Tenant saved");
                 _tenantDialogOpen = false;
                 await LoadTenants();

--- a/src/Tests/ControlPanel.E2ETests/IdentityServerControlPanelContractTests.cs
+++ b/src/Tests/ControlPanel.E2ETests/IdentityServerControlPanelContractTests.cs
@@ -161,6 +161,7 @@ public sealed class IdentityServerControlPanelContractTests
         var pagesRoot = GetIdentityPagesRoot();
         var userDetail = File.ReadAllText(Path.Combine(pagesRoot, "UserDetail.razor"));
         var credentials = File.ReadAllText(Path.Combine(pagesRoot, "Credentials.razor"));
+        var tenants = File.ReadAllText(Path.Combine(pagesRoot, "Tenants.razor"));
 
         userDetail.Should().Contain("[Inject] private IIdentityServerServiceWrapper IdentityServer");
         userDetail.Should().Contain("IdentityServer.CreateCredential(new CreateCredentialRequest");
@@ -170,6 +171,11 @@ public sealed class IdentityServerControlPanelContractTests
         credentials.Should().Contain("[Inject] private IIdentityServerServiceWrapper IdentityServer");
         credentials.Should().Contain("IdentityServer.UploadCredentialAvatar(new UploadCredentialAvatarRequest");
         credentials.Should().Contain("IdentityServer.RemoveCredentialAvatar(new RemoveCredentialAvatarRequest");
+        tenants.Should().Contain("[Inject] private IIdentityServerServiceWrapper IdentityServer");
+        tenants.Should().Contain("new CreateTenantRequest");
+        tenants.Should().Contain("IdentityServer.CreateTenant(request)");
+        tenants.Should().NotContain("DataContext.Add(tenant)");
+        tenants.Should().NotContain("TenantId = tenantId");
         userDetail.Should().NotContain("BCrypt.Net.BCrypt.HashPassword");
         userDetail.Should().NotContain("DataContext.Add(credential)");
         userDetail.Should().NotContain("DataContext.Update(session)");

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
@@ -21,6 +21,38 @@ namespace IdentityServer.IntegrationTests.Tests;
 public sealed class WrapperCoverageTests : IntegrationTestBase
 {
     [Test]
+    public async Task CreateTenant_WithValidData_CreatesTenantWithServerGeneratedIdentity()
+    {
+        var tenantName = $"Wrapper Tenant {Guid.NewGuid():N}";
+
+        var result = await IntegrationTestFixture.ServiceWrapper.CreateTenant(new CreateTenantRequest
+        {
+            Name = tenantName,
+            Description = "Created through direct wrapper coverage",
+            Version = 1.25m,
+            Status = 1,
+            ParentTenantId = IntegrationTestFixture.TestTenantId,
+            Metadata = CreateMetadata()
+        });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        result.IsSuccess.Should().BeTrue();
+
+        await using var db = CreateDbContext();
+        var tenant = await db.Set<Tenant>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Name == tenantName);
+
+        tenant.Should().NotBeNull();
+        tenant!.Id.Should().NotBeEmpty();
+        tenant.TenantId.Should().Be(tenant.Id);
+        tenant.ParentTenantId.Should().Be(IntegrationTestFixture.TestTenantId);
+        tenant.Version.Should().Be(1.25m);
+        tenant.Status.Should().Be(1);
+        tenant.IsEnabled.Should().BeTrue();
+    }
+
+    [Test]
     public async Task CreateCredential_WithValidData_HashesPasswordAndCreatesCredential()
     {
         var info = await SeedIdentityInfo();


### PR DESCRIPTION
## Summary
- Add an IdentityServer `CreateTenantRequest` wrapper path and Bolt endpoint for tenant creation.
- Move ControlPanel tenant creation off direct `IDataContext.Add(tenant)` and onto `IIdentityServerServiceWrapper.CreateTenant`.
- Add ControlPanel contract coverage and direct IdentityServer wrapper coverage for the new tenant create path.

## Testing
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false`
- `dotnet test src/Tests/ControlPanel.E2ETests/ControlPanel.E2ETests.csproj --filter TestCategory=Area:ControlPanelContract --logger console;verbosity=minimal -m:1 /nr:false`
- `dotnet test src/Tests/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj --filter TestCategory=Area:Wrappers --logger console;verbosity=minimal -m:1 /nr:false`