### PR TITLE
Fix Attendance session context selection

### DIFF
--- a/src/Modules/XFramework.Attendance/Attendance.Api/Services/AttendanceService.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Services/AttendanceService.cs
@@ -271,7 +271,14 @@ public sealed class AttendanceService(AppDbContext db, ILogger<AttendanceService
             .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == request.ContextId && item.IsActive, ct);
 
         if (context is null)
+        {
+            logger.LogWarning(
+                "Attendance context {ContextId} was not found for tenant {TenantId} while creating session {SessionName}.",
+                request.ContextId,
+                tenantId,
+                request.Name);
             return Result<AttendanceSessionResponse>.NotFound("Attendance context was not found");
+        }
 
         if (request.PolicyId.HasValue && !await PolicyExistsAsync(tenantId, request.PolicyId.Value, ct))
             return Result<AttendanceSessionResponse>.NotFound("Attendance policy was not found");

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Attendance/Sessions.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Attendance/Sessions.razor
@@ -352,9 +352,20 @@ else
             return;
         }
 
-        if (!Guid.TryParse(_form.ContextId, out var contextId))
+        if (!Guid.TryParse(_form.ContextId, out var contextId) || contextId == Guid.Empty)
         {
             ToastService.Warning("Select an attendance context.", "Validation");
+            return;
+        }
+
+        var selectedContext = _contextOptions.FirstOrDefault(context => context.Id == contextId);
+        if (selectedContext is null)
+        {
+            Logger.LogWarning(
+                "Attendance session creation blocked because context {ContextId} is not available for tenant {TenantId}.",
+                contextId,
+                tenantId);
+            ToastService.Warning("Select a valid attendance context for the active tenant.", "Validation");
             return;
         }
 
@@ -407,8 +418,17 @@ else
             }
             else
             {
-                Logger.LogWarning("Attendance session creation failed with status {StatusCode}", response.HttpStatusCode);
-                ToastService.Error("Attendance session could not be created.", "Attendance");
+                var message = string.IsNullOrWhiteSpace(response.Message)
+                    ? "Attendance session could not be created."
+                    : response.Message;
+
+                Logger.LogWarning(
+                    "Attendance session creation failed with status {StatusCode}: {Message}. TenantId: {TenantId}. ContextId: {ContextId}.",
+                    response.HttpStatusCode,
+                    response.Message,
+                    tenantId,
+                    contextId);
+                ToastService.Error(message, "Attendance");
             }
         }
         catch (Exception ex)

--- a/src/Presentation/ControlPanel.Server/Services/AttendanceControlPanelReadService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/AttendanceControlPanelReadService.cs
@@ -1,12 +1,20 @@
 using Attendance.Domain.Shared.Contracts;
+using Attendance.Domain.Shared.Contracts.Requests;
+using Attendance.Domain.Shared.Contracts.Responses;
 using Attendance.Domain.Shared.Enums;
+using Attendance.Integration.Drivers;
 using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.EntityFrameworkCore;
+using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
 
 namespace ControlPanel.Server.Services;
 
-public sealed class AttendanceControlPanelReadService(IDataContext dataContext)
+public sealed class AttendanceControlPanelReadService(
+    IDataContext dataContext,
+    IAttendanceServiceWrapper attendance,
+    RequestMetadata requestMetadata,
+    ILogger<AttendanceControlPanelReadService> logger)
 {
     public async Task<IReadOnlyList<AttendanceContextRow>> LoadContextRowsAsync(
         Guid tenantId,
@@ -355,17 +363,41 @@ public sealed class AttendanceControlPanelReadService(IDataContext dataContext)
         Guid tenantId,
         CancellationToken cancellationToken = default)
     {
-        var contexts = await dataContext.Query<AttendanceContext>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.IsActive)
-            .OrderBy(x => x.Name)
-            .Take(500)
-            .ToListAsync(cancellationToken);
+        var response = await attendance.GetAttendanceContexts(new GetAttendanceContextsRequest
+        {
+            TenantId = tenantId,
+            IsActive = true,
+            Page = 1,
+            PageSize = 500,
+            Metadata = BuildMetadata(tenantId)
+        });
 
-        return contexts
+        if (!response.IsSuccess || response.Response is null)
+        {
+            logger.LogWarning(
+                "Attendance context options could not be loaded for tenant {TenantId}. Status: {StatusCode}. Message: {Message}",
+                tenantId,
+                response.HttpStatusCode,
+                response.Message);
+            return [];
+        }
+
+        var options = response.Response.Items
+            .Where(context => context.Id != Guid.Empty)
+            .OrderBy(context => context.Name)
             .Select(context => new AttendanceContextOption(context.Id, ContextLabel(context), context.ContextType, context.IsActive))
             .ToList();
+
+        var emptyIdCount = response.Response.Items.Count - options.Count;
+        if (emptyIdCount > 0)
+        {
+            logger.LogWarning(
+                "Attendance context options response for tenant {TenantId} contained {EmptyIdCount} context(s) with an empty ID.",
+                tenantId,
+                emptyIdCount);
+        }
+
+        return options;
     }
 
     public async Task<IReadOnlyDictionary<Guid, string>> LoadCredentialLabelsAsync(
@@ -473,8 +505,24 @@ public sealed class AttendanceControlPanelReadService(IDataContext dataContext)
 
     public static string ShortId(Guid? id) => id is Guid value ? value.ToString("N")[..8] : "N/A";
 
-    private static string ContextLabel(AttendanceContext context) =>
-        string.IsNullOrWhiteSpace(context.Code) ? context.Name : $"{context.Code} - {context.Name}";
+    private RequestMetadata BuildMetadata(Guid tenantId) => new()
+    {
+        TenantId = tenantId,
+        CredentialId = requestMetadata.CredentialId,
+        SessionId = requestMetadata.SessionId,
+        RequestId = Guid.NewGuid(),
+        Name = requestMetadata.Name ?? "ControlPanel",
+        DeviceName = requestMetadata.DeviceName,
+        DeviceAgent = requestMetadata.DeviceAgent,
+        IpAddress = requestMetadata.IpAddress
+    };
+
+    private static string ContextLabel(AttendanceContext context) => ContextLabel(context.Name, context.Code);
+
+    private static string ContextLabel(AttendanceContextResponse context) => ContextLabel(context.Name, context.Code);
+
+    private static string ContextLabel(string name, string? code) =>
+        string.IsNullOrWhiteSpace(code) ? name : $"{code} - {name}";
 
     private static string DisplayNameForParticipant(AttendanceParticipant participant) =>
         Normalize(participant.DisplayName) ?? $"Credential {ShortId(participant.CredentialId)}";

--- a/src/Tests/ControlPanel.E2ETests/AttendanceControlPanelContractTests.cs
+++ b/src/Tests/ControlPanel.E2ETests/AttendanceControlPanelContractTests.cs
@@ -97,6 +97,8 @@ public sealed class AttendanceControlPanelContractTests
         var service = File.ReadAllText(servicePath);
 
         service.Should().Contain("IDataContext dataContext");
+        service.Should().Contain("IAttendanceServiceWrapper attendance");
+        service.Should().Contain("attendance.GetAttendanceContexts(new GetAttendanceContextsRequest");
         service.Should().Contain("dataContext.Query<AttendanceContext>()");
         service.Should().Contain("dataContext.Query<AttendanceSession>()");
         service.Should().Contain("dataContext.Query<AttendanceParticipant>()");
@@ -106,6 +108,7 @@ public sealed class AttendanceControlPanelContractTests
         service.Should().Contain("BuildCredentialLabel");
         service.Should().Contain("AttendanceRecordStatus.Absent");
         service.Should().Contain("NormalizeUtc(fromUtc)");
+        service.Should().Contain("context.Id != Guid.Empty");
         service.Should().NotContain("x.StartsAt >= fromUtc");
         service.Should().NotContain("SaveChangesAsync(");
     }


### PR DESCRIPTION
﻿## Summary
- load Attendance context picker options through the Attendance wrapper instead of the generic remote entity query
- block empty or unavailable context IDs before creating a session
- surface/log the Attendance module failure message with tenant/context IDs when session creation fails

## Verification
- dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj
- dotnet test src\Tests\ControlPanel.E2ETests\ControlPanel.E2ETests.csproj --filter "FullyQualifiedName~AttendanceControlPanelContractTests"
- dotnet build src\Modules\XFramework.Attendance\Attendance.Api\Attendance.Api.csproj
