### PR TITLE
Add Inventario POS catalog wrapper surface

### DIFF
--- a/src/Modules/XFramework.Inventario/AGENTS.md
+++ b/src/Modules/XFramework.Inventario/AGENTS.md
@@ -79,6 +79,7 @@ Inventario is not the owner of identities, tenant membership, payments, wallet b
 - Direct remote mutation is acceptable only for intentionally allowlisted simple catalog/admin entities and only when no richer wrapper request exists.
 - Keep wrapper completeness coverage current. When adding a new `IBoltRequest`, add a direct `IInventarioServiceWrapper` integration test and keep `WrapperCoverageCompletenessTests` green.
 - Do not assume HTTP health means wrapper health. Bolt handler registration and generated wrapper routing must be covered by integration tests for wrapper changes.
+- POS and sales modules must consume Inventario through wrappers, not cross-module writes. Use `SearchSellableProducts`, `GetSellableProduct`, and `GetProductVariations` for POS catalog line selection, then use the reservation, stock movement, balance, and movement query wrappers with stable `ReferenceType`/`ReferenceId` values for inventory effects and follow-up reads. Do not add POS-owned sale, payment, tax, or receipt behavior to Inventario.
 
 ## Feature Gates And Tenant Modules
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/GetProductVariations/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/GetProductVariations/Endpoint.cs
@@ -1,0 +1,20 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Products;
+
+namespace Inventario.Api.Features.Catalog.GetProductVariations;
+
+public static class GetProductVariationsEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/catalog/products/{productId:guid}/variations", Tags = ["Inventario Catalog"],
+        Summary = "Get product variations",
+        Description = "Returns enabled sellable variants for one product.")]
+    public static Task<Result<List<SellableProductVariationItem>>> Handle(
+        GetProductVariationsRequest request,
+        ProductService productService,
+        CancellationToken ct) =>
+        productService.GetProductVariationsAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/GetProductVariations/GetProductVariationsValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/GetProductVariations/GetProductVariationsValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+
+namespace Inventario.Api.Features.Catalog.GetProductVariations;
+
+public sealed class GetProductVariationsValidator : AbstractValidator<GetProductVariationsRequest>
+{
+    public GetProductVariationsValidator()
+    {
+        RuleFor(x => x.ProductId).NotEmpty().WithMessage("Product is required.");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/GetSellableProduct/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/GetSellableProduct/Endpoint.cs
@@ -1,0 +1,20 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Products;
+
+namespace Inventario.Api.Features.Catalog.GetSellableProduct;
+
+public static class GetSellableProductEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/catalog/sellable-products/{productId:guid}", Tags = ["Inventario Catalog"],
+        Summary = "Get sellable product",
+        Description = "Returns POS-friendly product catalog details and enabled variants.")]
+    public static Task<Result<SellableProductDetail>> Handle(
+        GetSellableProductRequest request,
+        ProductService productService,
+        CancellationToken ct) =>
+        productService.GetSellableProductAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/GetSellableProduct/GetSellableProductValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/GetSellableProduct/GetSellableProductValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+
+namespace Inventario.Api.Features.Catalog.GetSellableProduct;
+
+public sealed class GetSellableProductValidator : AbstractValidator<GetSellableProductRequest>
+{
+    public GetSellableProductValidator()
+    {
+        RuleFor(x => x.ProductId).NotEmpty().WithMessage("Product is required.");
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/SearchSellableProducts/Endpoint.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Catalog/SearchSellableProducts/Endpoint.cs
@@ -1,0 +1,20 @@
+using XFramework.Core.Patterns;
+using XFramework.Integration.Attributes;
+using XFramework.Inventario.Api.Services;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Products;
+
+namespace Inventario.Api.Features.Catalog.SearchSellableProducts;
+
+public static class SearchSellableProductsEndpoint
+{
+    [BoltHandler]
+    [MapGet("/api/inventario/catalog/sellable-products", Tags = ["Inventario Catalog"],
+        Summary = "Search sellable products",
+        Description = "Returns POS-friendly product and variant catalog rows for line selection.")]
+    public static Task<Result<List<SellableProductCatalogItem>>> Handle(
+        SearchSellableProductsRequest request,
+        ProductService productService,
+        CancellationToken ct) =>
+        productService.SearchSellableProductsAsync(request, ct);
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
@@ -1,13 +1,16 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using XFramework.Core.Loggers;
 using XFramework.Core.Observability;
 using XFramework.Core.Patterns;
 using XFramework.Core.Services.Caching;
+using XFramework.Domain.Contexts;
 using XFramework.Domain.Shared.Contracts.Requests;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Domain.Shared.Contracts;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Products;
 using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace XFramework.Inventario.Api.Services;
@@ -18,17 +21,20 @@ namespace XFramework.Inventario.Api.Services;
 public class ProductService
 {
     private readonly IDataContext _dataContext;
+    private readonly AppDbContext _db;
     private readonly ICacheService _cacheService;
     private readonly ILogger<ProductService> _logger;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     public ProductService(
         IDataContext dataContext,
+        AppDbContext db,
         ICacheService cacheService,
         ILogger<ProductService> logger,
         IHttpContextAccessor httpContextAccessor)
     {
         _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
         _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
@@ -283,6 +289,168 @@ public class ProductService
         }
     }
 
+    public async Task<Result<List<SellableProductCatalogItem>>> SearchSellableProductsAsync(
+        SearchSellableProductsRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<SellableProductCatalogItem>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+
+        try
+        {
+            if (!request.IncludeBaseProducts && !request.IncludeVariants)
+                return Result<List<SellableProductCatalogItem>>.Success([]);
+
+            var page = request.Page <= 0 ? 1 : request.Page;
+            var pageSize = request.PageSize <= 0 ? 20 : Math.Min(request.PageSize, 100);
+            var productQuery = BuildSellableProductQuery(tenantId, request.CategoryId, request.IsAvailable);
+            IQueryable<SellableProductCatalogItem>? rows = null;
+
+            if (request.IncludeBaseProducts)
+                rows = BuildBaseCatalogRows(productQuery);
+
+            if (request.IncludeVariants)
+            {
+                var variantRows = BuildVariantCatalogRows(productQuery, tenantId);
+                rows = rows is null ? variantRows : rows.Concat(variantRows);
+            }
+
+            if (rows is null)
+                return Result<List<SellableProductCatalogItem>>.Success([]);
+
+            var search = NormalizeSearch(request.Search);
+            if (search is not null)
+            {
+                rows = rows.Where(x =>
+                    x.ProductName.ToLower().Contains(search) ||
+                    (x.SKU != null && x.SKU.ToLower().Contains(search)) ||
+                    (x.Brand != null && x.Brand.ToLower().Contains(search)) ||
+                    (x.VariantName != null && x.VariantName.ToLower().Contains(search)) ||
+                    (x.VariantTypeName != null && x.VariantTypeName.ToLower().Contains(search)));
+            }
+
+            var items = await rows
+                .OrderBy(x => x.ProductName)
+                .ThenBy(x => x.ProductVariationId.HasValue)
+                .ThenBy(x => x.VariantTypeName)
+                .ThenBy(x => x.VariantName)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(ct);
+
+            _logger.EntityQueryCompleted(items.Count, "SellableProductCatalog");
+            return Result<List<SellableProductCatalogItem>>.Success(items);
+        }
+        catch (Exception ex)
+        {
+            _logger.OperationFailed("Search", "SellableProductCatalog", Guid.Empty, ex.Message, ex);
+            return Result<List<SellableProductCatalogItem>>.Failure(
+                "An error occurred searching sellable products",
+                500);
+        }
+    }
+
+    public async Task<Result<SellableProductDetail>> GetSellableProductAsync(
+        GetSellableProductRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<SellableProductDetail>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+
+        try
+        {
+            var product = await BuildSellableProductQuery(tenantId, categoryId: null, isAvailable: null)
+                .Where(p => p.Id == request.ProductId)
+                .Select(p => new
+                {
+                    p.Id,
+                    Name = p.Name ?? string.Empty,
+                    p.Description,
+                    p.SKU,
+                    p.Brand,
+                    p.Image,
+                    p.CategoryId,
+                    CategoryName = p.Category != null ? p.Category.Name : null,
+                    p.IsAvailable,
+                    p.Price
+                })
+                .FirstOrDefaultAsync(ct);
+
+            if (product is null)
+            {
+                _logger.EntityNotFound("Product", request.ProductId);
+                return Result<SellableProductDetail>.NotFound("Product not found");
+            }
+
+            var variations = await BuildSellableVariationItemsQuery(tenantId, request.ProductId)
+                .OrderBy(x => x.VariantTypeName)
+                .ThenBy(x => x.VariantName)
+                .ToListAsync(ct);
+
+            return Result<SellableProductDetail>.Success(new SellableProductDetail(
+                product.Id,
+                product.Name,
+                product.Description,
+                product.SKU,
+                product.Brand,
+                product.Image,
+                product.CategoryId,
+                product.CategoryName,
+                product.IsAvailable,
+                product.Price,
+                variations));
+        }
+        catch (Exception ex)
+        {
+            _logger.OperationFailed("Retrieve", "SellableProduct", request.ProductId, ex.Message, ex);
+            return Result<SellableProductDetail>.Failure(
+                "An error occurred retrieving the sellable product",
+                500);
+        }
+    }
+
+    public async Task<Result<List<SellableProductVariationItem>>> GetProductVariationsAsync(
+        GetProductVariationsRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantResult = GetCurrentTenantId(request);
+        if (!tenantResult.IsSuccess)
+            return Result<List<SellableProductVariationItem>>.Failure(tenantResult.Message!, tenantResult.StatusCode);
+
+        var tenantId = tenantResult.Data;
+
+        try
+        {
+            var productExists = await BuildSellableProductQuery(tenantId, categoryId: null, isAvailable: null)
+                .AnyAsync(p => p.Id == request.ProductId, ct);
+            if (!productExists)
+            {
+                _logger.EntityNotFound("Product", request.ProductId);
+                return Result<List<SellableProductVariationItem>>.NotFound("Product not found");
+            }
+
+            var variations = await BuildSellableVariationItemsQuery(tenantId, request.ProductId)
+                .OrderBy(x => x.VariantTypeName)
+                .ThenBy(x => x.VariantName)
+                .ToListAsync(ct);
+
+            return Result<List<SellableProductVariationItem>>.Success(variations);
+        }
+        catch (Exception ex)
+        {
+            _logger.OperationFailed("List", "ProductVariation", request.ProductId, ex.Message, ex);
+            return Result<List<SellableProductVariationItem>>.Failure(
+                "An error occurred retrieving product variations",
+                500);
+        }
+    }
+
     /// <summary>
     /// Updates an existing product
     /// </summary>
@@ -439,8 +607,116 @@ public class ProductService
     private static string BuildProductListCachePrefix(Guid tenantId) =>
         $"products:list:{tenantId}:";
 
+    private IQueryable<Product> BuildSellableProductQuery(
+        Guid tenantId,
+        Guid? categoryId,
+        bool? isAvailable)
+    {
+        var query = _db.Set<Product>()
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(p => p.TenantId == tenantId && !p.IsDeleted && p.IsEnabled);
+
+        if (categoryId.HasValue)
+            query = query.Where(p => p.CategoryId == categoryId.Value);
+
+        if (isAvailable.HasValue)
+            query = query.Where(p => p.IsAvailable == isAvailable.Value);
+
+        return query;
+    }
+
+    private static IQueryable<SellableProductCatalogItem> BuildBaseCatalogRows(
+        IQueryable<Product> products) =>
+        products.Select(product => new SellableProductCatalogItem(
+            product.Id,
+            null,
+            product.Name ?? string.Empty,
+            product.Name ?? string.Empty,
+            null,
+            null,
+            null,
+            product.SKU,
+            product.Brand,
+            product.Image,
+            product.CategoryId,
+            product.Category != null ? product.Category.Name : null,
+            product.IsAvailable,
+            product.Price));
+
+    private IQueryable<SellableProductCatalogItem> BuildVariantCatalogRows(
+        IQueryable<Product> products,
+        Guid tenantId)
+    {
+        var variations = _db.Set<ProductVariation>()
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(v => v.TenantId == tenantId && !v.IsDeleted && v.IsEnabled);
+        var variationTypes = _db.Set<ProductVariationType>()
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(t => t.TenantId == tenantId && !t.IsDeleted);
+
+        return
+            from product in products
+            join variation in variations on product.Id equals variation.ProductId
+            join variationType in variationTypes
+                on variation.ProductVariationTypeId equals (Guid?)variationType.Id into variationTypeJoin
+            from variationType in variationTypeJoin.DefaultIfEmpty()
+            select new SellableProductCatalogItem(
+                product.Id,
+                variation.Id,
+                (product.Name ?? string.Empty) + " - " + (variation.Name ?? string.Empty),
+                product.Name ?? string.Empty,
+                variation.Name,
+                variation.ProductVariationTypeId,
+                variationType != null ? variationType.Name : variation.VariationType,
+                product.SKU,
+                product.Brand,
+                product.Image,
+                product.CategoryId,
+                product.Category != null ? product.Category.Name : null,
+                product.IsAvailable,
+                variation.Price);
+    }
+
+    private IQueryable<SellableProductVariationItem> BuildSellableVariationItemsQuery(
+        Guid tenantId,
+        Guid productId)
+    {
+        var products = BuildSellableProductQuery(tenantId, categoryId: null, isAvailable: null)
+            .Where(p => p.Id == productId);
+        var variations = _db.Set<ProductVariation>()
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(v => v.TenantId == tenantId && !v.IsDeleted && v.IsEnabled);
+        var variationTypes = _db.Set<ProductVariationType>()
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(t => t.TenantId == tenantId && !t.IsDeleted);
+
+        return
+            from product in products
+            join variation in variations on product.Id equals variation.ProductId
+            join variationType in variationTypes
+                on variation.ProductVariationTypeId equals (Guid?)variationType.Id into variationTypeJoin
+            from variationType in variationTypeJoin.DefaultIfEmpty()
+            select new SellableProductVariationItem(
+                variation.Id,
+                product.Id,
+                variation.ProductVariationTypeId,
+                variationType != null ? variationType.Name : variation.VariationType,
+                variation.Name ?? string.Empty,
+                variation.Price,
+                product.Price,
+                variation.Price - product.Price);
+    }
+
     private static string? NormalizeSku(string? sku) =>
         string.IsNullOrWhiteSpace(sku) ? null : sku.Trim();
+
+    private static string? NormalizeSearch(string? search) =>
+        string.IsNullOrWhiteSpace(search) ? null : search.Trim().ToLowerInvariant();
 }
 
 /// <summary>

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/GetProductVariationsRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/GetProductVariationsRequest.cs
@@ -1,0 +1,17 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Products;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+
+using TRequest = GetProductVariationsRequest;
+using TResponse = QueryResponse<List<SellableProductVariationItem>>;
+
+[MemoryPackable]
+public partial record GetProductVariationsRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid ProductId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/GetSellableProductRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/GetSellableProductRequest.cs
@@ -1,0 +1,17 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Products;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+
+using TRequest = GetSellableProductRequest;
+using TResponse = QueryResponse<SellableProductDetail>;
+
+[MemoryPackable]
+public partial record GetSellableProductRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public Guid ProductId { get; init; }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/SearchSellableProductsRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Products/SearchSellableProductsRequest.cs
@@ -1,0 +1,23 @@
+using Bolt.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Inventario.Domain.Shared.Contracts.Responses.Products;
+
+namespace XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+
+using TRequest = SearchSellableProductsRequest;
+using TResponse = QueryResponse<List<SellableProductCatalogItem>>;
+
+[MemoryPackable]
+public partial record SearchSellableProductsRequest : RequestBase,
+    IQuery<TResponse>,
+    IBoltRequest<TRequest, TResponse>
+{
+    public string? Search { get; init; }
+    public Guid? CategoryId { get; init; }
+    public bool? IsAvailable { get; init; } = true;
+    public bool IncludeBaseProducts { get; init; } = true;
+    public bool IncludeVariants { get; init; } = true;
+    public int Page { get; init; } = 1;
+    public int PageSize { get; init; } = 20;
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Responses/Products/SellableProductCatalogResponses.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Responses/Products/SellableProductCatalogResponses.cs
@@ -1,0 +1,43 @@
+namespace XFramework.Inventario.Domain.Shared.Contracts.Responses.Products;
+
+[MemoryPackable]
+public partial record SellableProductCatalogItem(
+    Guid ProductId,
+    Guid? ProductVariationId,
+    string DisplayName,
+    string ProductName,
+    string? VariantName,
+    Guid? ProductVariationTypeId,
+    string? VariantTypeName,
+    string? SKU,
+    string? Brand,
+    string? Image,
+    Guid CategoryId,
+    string? CategoryName,
+    bool IsAvailable,
+    decimal Price);
+
+[MemoryPackable]
+public partial record SellableProductDetail(
+    Guid ProductId,
+    string Name,
+    string? Description,
+    string? SKU,
+    string? Brand,
+    string? Image,
+    Guid CategoryId,
+    string? CategoryName,
+    bool IsAvailable,
+    decimal Price,
+    List<SellableProductVariationItem> Variations);
+
+[MemoryPackable]
+public partial record SellableProductVariationItem(
+    Guid ProductVariationId,
+    Guid ProductId,
+    Guid? ProductVariationTypeId,
+    string? VariantTypeName,
+    string VariantName,
+    decimal Price,
+    decimal BaseProductPrice,
+    decimal PriceDelta);

--- a/src/Tests/Inventario.IntegrationTests/Tests/WrapperContractCoverageTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/WrapperContractCoverageTests.cs
@@ -7,6 +7,7 @@ using XFramework.Inventario.Domain.Shared.Contracts.Requests.Purchasing;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Variations;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Warehouses;
 using XFramework.Inventario.Domain.Shared.Enums;
 using XFramework.TestInfrastructure;
@@ -72,6 +73,197 @@ public sealed class WrapperContractCoverageTests : InventarioTestBase
         updated.Brand.Should().Be("Updated Wrapper Brand");
         updated.Description.Should().Be("Updated through wrapper coverage");
         updated.IsAvailable.Should().BeFalse();
+    }
+
+    [Test]
+    [Category(TestCategories.Catalog)]
+    public async Task SellableCatalogWrappers_SearchGetAndVariations_ReturnPosCatalogRows()
+    {
+        await using var db = CreateDbContext();
+        var category = await TestInventarioSeed.SeedCategory(db);
+        var otherCategory = await TestInventarioSeed.SeedCategory(db);
+        var sku = UniqueCode("POS");
+        var product = await TestInventarioSeed.SeedProduct(
+            db,
+            categoryId: category.Id,
+            sku: sku,
+            name: $"POS Wrapper Product {sku}");
+        product.Brand = $"POS Brand {sku}";
+        product.Price = 42m;
+        product.Image = "pos-wrapper-product.png";
+
+        var unavailableSku = UniqueCode("OFF");
+        var unavailable = await TestInventarioSeed.SeedProduct(
+            db,
+            categoryId: category.Id,
+            sku: unavailableSku,
+            name: $"Unavailable POS Product {unavailableSku}");
+        unavailable.IsAvailable = false;
+
+        var otherProduct = await TestInventarioSeed.SeedProduct(
+            db,
+            categoryId: otherCategory.Id,
+            sku: UniqueCode("OTHER"),
+            name: "Other category POS product");
+        var otherTenantId = Guid.NewGuid();
+        var otherTenantCategory = await TestInventarioSeed.SeedCategory(db, otherTenantId);
+        var otherTenantProduct = await TestInventarioSeed.SeedProduct(
+            db,
+            otherTenantId,
+            otherTenantCategory.Id,
+            sku: UniqueCode("XTPOS"),
+            name: "Other tenant POS product");
+
+        db.Set<Product>().UpdateRange(product, unavailable);
+        await db.SaveChangesAsync();
+
+        var typeName = $"POS Flavor {Guid.NewGuid():N}";
+        var createType = await InventarioIntegrationTestFixture.ServiceWrapper.CreateProductVariationType(
+            new CreateProductVariationTypeRequest
+            {
+                Metadata = CreateMetadata(),
+                Name = typeName
+            });
+        createType.IsSuccess.Should().BeTrue(createType.Message);
+
+        await using var typeDb = CreateDbContext();
+        var persistedType = await typeDb.Set<ProductVariationType>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Name == typeName);
+
+        var variantName = $"Vanilla {Guid.NewGuid():N}";
+        var createVariant = await InventarioIntegrationTestFixture.ServiceWrapper.CreateProductVariation(
+            new CreateProductVariationRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = product.Id,
+                ProductVariationTypeId = persistedType.Id,
+                Name = variantName,
+                Price = 49.75m
+            });
+        createVariant.IsSuccess.Should().BeTrue(createVariant.Message);
+
+        await using var variationDb = CreateDbContext();
+        var variation = await variationDb.Set<ProductVariation>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.ProductId == product.Id && x.Name == variantName);
+
+        var searchBySku = await InventarioIntegrationTestFixture.ServiceWrapper.SearchSellableProducts(
+            new SearchSellableProductsRequest
+            {
+                Metadata = CreateMetadata(),
+                Search = sku,
+                IncludeVariants = false
+            });
+        searchBySku.IsSuccess.Should().BeTrue(searchBySku.Message);
+        searchBySku.Response.Should().ContainSingle(x =>
+            x.ProductId == product.Id &&
+            x.ProductVariationId == null &&
+            x.SKU == sku &&
+            x.Price == product.Price);
+
+        var searchByBrand = await InventarioIntegrationTestFixture.ServiceWrapper.SearchSellableProducts(
+            new SearchSellableProductsRequest
+            {
+                Metadata = CreateMetadata(),
+                Search = product.Brand,
+                IncludeVariants = false
+            });
+        searchByBrand.IsSuccess.Should().BeTrue(searchByBrand.Message);
+        searchByBrand.Response.Should().Contain(x => x.ProductId == product.Id);
+
+        var searchByVariant = await InventarioIntegrationTestFixture.ServiceWrapper.SearchSellableProducts(
+            new SearchSellableProductsRequest
+            {
+                Metadata = CreateMetadata(),
+                Search = variantName,
+                IncludeBaseProducts = false
+            });
+        searchByVariant.IsSuccess.Should().BeTrue(searchByVariant.Message);
+        searchByVariant.Response.Should().ContainSingle(x =>
+            x.ProductId == product.Id &&
+            x.ProductVariationId == variation.Id &&
+            x.VariantTypeName == typeName &&
+            x.Price == variation.Price);
+
+        var searchByVariantType = await InventarioIntegrationTestFixture.ServiceWrapper.SearchSellableProducts(
+            new SearchSellableProductsRequest
+            {
+                Metadata = CreateMetadata(),
+                Search = typeName,
+                IncludeBaseProducts = false
+            });
+        searchByVariantType.IsSuccess.Should().BeTrue(searchByVariantType.Message);
+        searchByVariantType.Response.Should().ContainSingle(x => x.ProductVariationId == variation.Id);
+
+        var categorySearch = await InventarioIntegrationTestFixture.ServiceWrapper.SearchSellableProducts(
+            new SearchSellableProductsRequest
+            {
+                Metadata = CreateMetadata(),
+                CategoryId = category.Id,
+                IncludeVariants = false,
+                PageSize = 100
+            });
+        categorySearch.IsSuccess.Should().BeTrue(categorySearch.Message);
+        categorySearch.Response.Should().Contain(x => x.ProductId == product.Id);
+        categorySearch.Response.Should().NotContain(x => x.ProductId == otherProduct.Id);
+
+        var otherTenantSearch = await InventarioIntegrationTestFixture.ServiceWrapper.SearchSellableProducts(
+            new SearchSellableProductsRequest
+            {
+                Metadata = CreateMetadata(),
+                Search = otherTenantProduct.SKU,
+                IncludeVariants = false
+            });
+        otherTenantSearch.IsSuccess.Should().BeTrue(otherTenantSearch.Message);
+        otherTenantSearch.Response.Should().BeEmpty();
+
+        var unavailableDefault = await InventarioIntegrationTestFixture.ServiceWrapper.SearchSellableProducts(
+            new SearchSellableProductsRequest
+            {
+                Metadata = CreateMetadata(),
+                Search = unavailableSku,
+                IncludeVariants = false
+            });
+        unavailableDefault.IsSuccess.Should().BeTrue(unavailableDefault.Message);
+        unavailableDefault.Response.Should().BeEmpty();
+
+        var unavailableExplicit = await InventarioIntegrationTestFixture.ServiceWrapper.SearchSellableProducts(
+            new SearchSellableProductsRequest
+            {
+                Metadata = CreateMetadata(),
+                Search = unavailableSku,
+                IsAvailable = false,
+                IncludeVariants = false
+            });
+        unavailableExplicit.IsSuccess.Should().BeTrue(unavailableExplicit.Message);
+        unavailableExplicit.Response.Should().ContainSingle(x =>
+            x.ProductId == unavailable.Id &&
+            x.IsAvailable == false);
+
+        var detail = await InventarioIntegrationTestFixture.ServiceWrapper.GetSellableProduct(
+            new GetSellableProductRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = product.Id
+            });
+        detail.IsSuccess.Should().BeTrue(detail.Message);
+        detail.Response.Should().NotBeNull();
+        detail.Response!.ProductId.Should().Be(product.Id);
+        detail.Response.Variations.Should().ContainSingle(x =>
+            x.ProductVariationId == variation.Id &&
+            x.Price == variation.Price &&
+            x.BaseProductPrice == product.Price);
+
+        var variations = await InventarioIntegrationTestFixture.ServiceWrapper.GetProductVariations(
+            new GetProductVariationsRequest
+            {
+                Metadata = CreateMetadata(),
+                ProductId = product.Id
+            });
+        variations.IsSuccess.Should().BeTrue(variations.Message);
+        variations.Response.Should().ContainSingle(x => x.ProductVariationId == variation.Id);
+        variations.Response.Should().NotContain(x => x.ProductId == otherProduct.Id);
     }
 
     [Test]


### PR DESCRIPTION
﻿## Summary
- Add wrapper-callable Inventario sellable catalog requests for future POS product and variant selection.
- Add generated Bolt handler endpoints for sellable product search, detail, and variation lookup.
- Extend ProductService with tenant-scoped POS catalog read projections and add wrapper coverage.
- Document the POS integration rule in the Inventario module agent guide.

## Verification
- `dotnet build src\Modules\XFramework.Inventario\Inventario.Api\Inventario.Api.csproj -m:1 /nr:false /p:NuGetAuditLevel=critical` passed.
- `dotnet build src\Tests\Inventario.IntegrationTests\Inventario.IntegrationTests.csproj -m:1 /nr:false /p:NuGetAuditLevel=critical` passed.
- Manual wrapper completeness scan reports no missing Inventario wrapper coverage across 43 IBoltRequest contracts.

## Notes
- Standard build/test commands without `/p:NuGetAuditLevel=critical` are currently blocked by existing NU1903 on Microsoft.OpenApi 2.0.0.
- Runtime wrapper tests compiled but did not execute locally: local Docker was unavailable; xeon-dev Docker tunnel worked, then the Inventario fixture timed out waiting for Bolt health at `http://localhost:17200/health/live` before any test method ran.
