### PR TITLE
[codex] Fix xeon dev compose validation env

### DIFF
--- a/.github/workflows/deploy-xeon-dev-service.yml
+++ b/.github/workflows/deploy-xeon-dev-service.yml
@@ -45,6 +45,7 @@ jobs:
       DB_PASSWORD: compose-validation-placeholder
       JWT_SECRET: compose-validation-placeholder
       BOLT_SIGNATURE: compose-validation-placeholder
+      SERVICE_IDENTITY_DEVELOPMENT_SECRET: compose-validation-placeholder
       COMMUNICATIONS_TRUSTED_METADATA_SECRET: compose-validation-placeholder
       SERVICE_NAME: ${{ inputs.service }}
       HEALTH_URL: ${{ inputs.health_url }}

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -50,6 +50,7 @@ jobs:
       DB_PASSWORD: compose-validation-placeholder
       JWT_SECRET: compose-validation-placeholder
       BOLT_SIGNATURE: compose-validation-placeholder
+      SERVICE_IDENTITY_DEVELOPMENT_SECRET: compose-validation-placeholder
       COMMUNICATIONS_TRUSTED_METADATA_SECRET: compose-validation-placeholder
 
     steps:


### PR DESCRIPTION
﻿## Summary
- Add the missing `SERVICE_IDENTITY_DEVELOPMENT_SECRET` placeholder to Xeon dev deploy workflow env blocks.
- Keeps `docker compose config` validation aligned with `docker-compose.yml`, which requires this variable for service identity client secrets.

## Validation
- Parsed changed workflow YAML successfully.
- `docker-compose -f docker-compose.yml config --quiet`
- `git diff --check`
