### PR TITLE
[codex] Fix POS DbContext registration

### DIFF
--- a/src/Modules/XFramework.POS/POS.Api/Installers/DbInstaller.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Installers/DbInstaller.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using XFramework.Core.DataContext;
+using XFramework.Domain.Interceptors;
+using XFramework.Domain.Shared.Interfaces;
+
+namespace POS.Api.Installers;
+
+public class DbInstaller : IInstaller
+{
+    public virtual void InstallServices<TApp>(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment)
+    {
+        services.AddHttpContextAccessor();
+        services.AddScoped<AuditInterceptor>();
+
+        services.AddDbContext<DbContext, AppDbContext>((serviceProvider, options) => options
+            .UseNpgsql(string.IsNullOrEmpty(configuration["DefaultDatabaseConnection"])
+                ? configuration.GetConnectionString("DefaultDatabaseConnection")
+                : configuration["DefaultDatabaseConnection"],
+                npgsqlOptions => npgsqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery))
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.BoolWithDefaultWarning))
+            .AddInterceptors(serviceProvider.GetRequiredService<AuditInterceptor>()));
+
+        services.AddServerDataContext<AppDbContext>();
+    }
+}


### PR DESCRIPTION
## Summary
- Add the missing POS API `DbInstaller` so POS registers `DbContext`/`AppDbContext` and `ServerDataContext<AppDbContext>` like the other modules.
- Restores dependency resolution for feature-gate/readiness services in the POS container.

## Validation
- `dotnet build src\Modules\XFramework.POS\POS.Api\POS.Api.csproj -m:1 /nr:false`
- `git diff --check`
