### PR TITLE
[codex] Fix Notifications test constructor

### DIFF
--- a/src/Modules/XFramework.Notifications/Notifications.Tests/Services/NotificationServiceTests.cs
+++ b/src/Modules/XFramework.Notifications/Notifications.Tests/Services/NotificationServiceTests.cs
@@ -277,7 +277,7 @@ public sealed class NotificationServiceTests
     }
 
     private static NotificationService CreateService(AppDbContext db) =>
-        new(db, NullLogger<NotificationService>.Instance);
+        new(db, NullLogger<NotificationService>.Instance, new ConfigurationBuilder().Build());
 
     private static void EnableChannels(
         AppDbContext db,


### PR DESCRIPTION
## Summary
- Update `NotificationServiceTests` to pass the required `IConfiguration` dependency to `NotificationService`.
- Fixes the develop `Publish NuGet Packages` build failure caused by the stale test constructor.

## Validation
- `dotnet test src\Modules\XFramework.Notifications\Notifications.Tests\Notifications.Tests.csproj --logger "console;verbosity=minimal" -m:1 /nr:false`
- `dotnet build XFramework.slnx -c Release -p:XFrameworkVersion=1.0.1-dev.local -p:BoltVersion=1.0.0-dev.local -m:1 /nr:false`
- `git diff --check`
