### PR TITLE
[codex] Fix POS ControlPanel UI rules

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/NavMenu.razor
@@ -53,10 +53,15 @@
     </SidebarSection>
 }
 
-@if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos))
+@if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "registers")
+     || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "sales")
+     || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "returns"))
 {
     <SidebarSection GroupId="pos" Title="POS" Icon="scan-barcode">
-        <SidebarNavItem Href="/pos/cashier" Label="Cashier" Icon="shopping-cart" />
+        @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "sales"))
+        {
+            <SidebarNavItem Href="/pos/cashier" Label="Cashier" Icon="shopping-cart" />
+        }
         @if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "registers"))
         {
             <SidebarNavItem Href="/pos/registers" Label="Registers" Icon="store" />

--- a/src/Presentation/ControlPanel.Server/Components/Pages/POS/Cashier.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/POS/Cashier.razor
@@ -26,11 +26,14 @@ else
                     <BbTypographyMuted>Checkout uses Inventario catalog and Wallets ledger posting.</BbTypographyMuted>
                 </div>
                 <div class="xf-page-actions">
-                    <BbButton Variant="ButtonVariant.Outline" OnClick="@SuspendCart" Disabled="@(_savingCart || !_cart.Any())">
-                        <LucideIcon Name="pause" class="mr-2 h-4 w-4" />
-                        Suspend Cart
-                    </BbButton>
-                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ClearCurrentCart" Disabled="@(!_cart.Any())">
+                    @if (_cartsEnabled)
+                    {
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="@SuspendCart" Disabled="@(_savingCart || !_cart.Any())">
+                            <LucideIcon Name="pause" class="mr-2 h-4 w-4" />
+                            Suspend Cart
+                        </BbButton>
+                    }
+                    <BbButton Variant="ButtonVariant.Destructive" OnClick="@ConfirmClearCurrentCart" Disabled="@(!_cart.Any())">
                         <LucideIcon Name="x" class="mr-2 h-4 w-4" />
                         Clear
                     </BbButton>
@@ -41,7 +44,7 @@ else
                 </div>
             </div>
 
-            <div class="grid gap-6 xl:grid-cols-[1.3fr_1fr]">
+            <div class="grid gap-6 xl:grid-cols-2">
                 <div class="space-y-6">
                     <BbCard>
                         <BbCardHeader>
@@ -49,7 +52,7 @@ else
                             <BbCardDescription>Search sellable products from Inventario.</BbCardDescription>
                         </BbCardHeader>
                         <BbCardContent>
-                            <div class="grid gap-3 md:grid-cols-[1fr_auto]">
+                            <div class="xf-filter-actions">
                                 <BbInput @bind-Value="_catalogSearch" Placeholder="Search SKU, product, variant, or brand" />
                                 <BbButton OnClick="@SearchCatalog" Disabled="@_searching">
                                     <LucideIcon Name="search" class="mr-2 h-4 w-4" />
@@ -78,6 +81,9 @@ else
                                             </ChildContent>
                                         </BbDataGridTemplateColumn>
                                     </Columns>
+                                    <EmptyTemplate>
+                                        <BbEmpty Title="No catalog items" Description="Search Inventario sellable products to add items." />
+                                    </EmptyTemplate>
                                 </BbDataGrid>
                             </div>
                         </BbCardContent>
@@ -110,12 +116,15 @@ else
                                     <BbDataGridTemplateColumn Title="Actions">
                                         <ChildContent Context="item">
                                             <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Destructive" OnClick="@(() => RemoveFromCart(item))">Remove</BbButton>
-                                        </ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                </Columns>
-                            </BbDataGrid>
-                        </BbCardContent>
-                    </BbCard>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="Cart is empty" Description="Add catalog items before checkout." />
+                            </EmptyTemplate>
+                        </BbDataGrid>
+                    </BbCardContent>
+                </BbCard>
                 </div>
 
                 <div class="space-y-6">
@@ -155,43 +164,15 @@ else
                                                 ValueSelector="@GetRegisterValue"
                                                 TextSelector="@GetRegisterLabel"
                                                 SearchTextSelector="@GetRegisterSearchText"
+                                                AdvancedColumns="@RegisterAdvancedColumns"
+                                                AdvancedSearchScope="Searches register name, code, default warehouse, default location, enabled state, and register id."
                                                 AdvancedSearchTitle="Find Register"
                                                 AdvancedSearchDescription="Select the register for this checkout." />
 
-                                <div class="grid gap-2">
-                                    <BbLabel>Payment</BbLabel>
-                                    <div class="flex flex-wrap gap-2">
-                                        @if (_paymentMethod == PosPaymentMethod.CashDrawer)
-                                        {
-                                            <BbButton OnClick="@(() => _paymentMethod = PosPaymentMethod.CashDrawer)">
-                                                <LucideIcon Name="banknote" class="mr-2 h-4 w-4" />
-                                                Cash Drawer
-                                            </BbButton>
-                                        }
-                                        else
-                                        {
-                                            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _paymentMethod = PosPaymentMethod.CashDrawer)">
-                                                <LucideIcon Name="banknote" class="mr-2 h-4 w-4" />
-                                                Cash Drawer
-                                            </BbButton>
-                                        }
-
-                                        @if (_paymentMethod == PosPaymentMethod.WalletTransfer)
-                                        {
-                                            <BbButton OnClick="@(() => _paymentMethod = PosPaymentMethod.WalletTransfer)">
-                                                <LucideIcon Name="wallet" class="mr-2 h-4 w-4" />
-                                                Wallet Transfer
-                                            </BbButton>
-                                        }
-                                        else
-                                        {
-                                            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _paymentMethod = PosPaymentMethod.WalletTransfer)">
-                                                <LucideIcon Name="wallet" class="mr-2 h-4 w-4" />
-                                                Wallet Transfer
-                                            </BbButton>
-                                        }
-                                    </div>
-                                </div>
+                                <BbFormFieldSelect TValue="string" @bind-Value="PaymentMethodValue" Label="Payment">
+                                    <BbSelectItem Value="@PosPaymentMethod.CashDrawer.ToString()">Cash Drawer</BbSelectItem>
+                                    <BbSelectItem Value="@PosPaymentMethod.WalletTransfer.ToString()">Wallet Transfer</BbSelectItem>
+                                </BbFormFieldSelect>
 
                                 @if (_paymentMethod == PosPaymentMethod.WalletTransfer)
                                 {
@@ -205,6 +186,8 @@ else
                                                     ValueSelector="@GetCredentialValue"
                                                     TextSelector="@GetCredentialLabel"
                                                     SearchTextSelector="@GetCredentialSearchText"
+                                                    AdvancedColumns="@CredentialAdvancedColumns"
+                                                    AdvancedSearchScope="Searches customer credential username, alias, online state, last seen date, device, location, and credential id."
                                                     AdvancedSearchTitle="Find Customer Credential"
                                                     AdvancedSearchDescription="Select the customer wallet source." />
                                 }
@@ -234,10 +217,13 @@ else
                                 </div>
 
                                 <div class="grid gap-2 md:grid-cols-2">
-                                    <BbButton Variant="ButtonVariant.Outline" OnClick="@SuspendCart" Disabled="@(_savingCart || !_cart.Any())">
-                                        <LucideIcon Name="pause" class="mr-2 h-4 w-4" />
-                                        Suspend Cart
-                                    </BbButton>
+                                    @if (_cartsEnabled)
+                                    {
+                                        <BbButton Variant="ButtonVariant.Outline" OnClick="@SuspendCart" Disabled="@(_savingCart || !_cart.Any())">
+                                            <LucideIcon Name="pause" class="mr-2 h-4 w-4" />
+                                            Suspend Cart
+                                        </BbButton>
+                                    }
                                     <BbButton OnClick="@Checkout" Disabled="@(_checkingOut || !_cart.Any())">
                                         <LucideIcon Name="receipt" class="mr-2 h-4 w-4" />
                                         Checkout
@@ -270,37 +256,43 @@ else
                         </BbCard>
                     }
 
-                    <BbCard>
-                        <BbCardHeader>
-                            <BbCardTitle>Suspended Carts</BbCardTitle>
-                            <BbCardDescription>@_suspendedCarts.Count cart(s) waiting</BbCardDescription>
-                        </BbCardHeader>
-                        <BbCardContent>
-                            <BbDataGrid Items="@_suspendedCarts" ShowPagination="true" InitialPageSize="8">
-                                <Columns>
-                                    <BbDataGridPropertyColumn Property="@(x => x.CartNumber)" Title="Cart" Sortable="true" Filterable="true" />
-                                    <BbDataGridPropertyColumn Property="@(x => x.CustomerLabel)" Title="Customer" Sortable="true" Filterable="true" />
-                                    <BbDataGridTemplateColumn Title="Total" Sortable="true" Filterable="true" FilterBy="@(item => item.TotalAmount)">
-                                        <ChildContent Context="item">@item.TotalAmount.ToString("N2")</ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                    <BbDataGridPropertyColumn Property="@(x => x.SuspendedAt)" Title="Suspended" Sortable="true" Filterable="true" />
-                                    <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
-                                    <BbDataGridTemplateColumn Title="Actions">
-                                        <ChildContent Context="item">
-                                            <div class="flex flex-wrap gap-1">
-                                                <BbButton Size="ButtonSize.Small" OnClick="@(() => ResumeCart(item))" Disabled="@_actingOnCart">
-                                                    Resume
-                                                </BbButton>
-                                                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Destructive" OnClick="@(() => CancelDraftCart(item))" Disabled="@_actingOnCart">
-                                                    Cancel
-                                                </BbButton>
-                                            </div>
-                                        </ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                </Columns>
-                            </BbDataGrid>
-                        </BbCardContent>
-                    </BbCard>
+                    @if (_cartsEnabled)
+                    {
+                        <BbCard>
+                            <BbCardHeader>
+                                <BbCardTitle>Suspended Carts</BbCardTitle>
+                                <BbCardDescription>@_suspendedCarts.Count cart(s) waiting</BbCardDescription>
+                            </BbCardHeader>
+                            <BbCardContent>
+                                <BbDataGrid Items="@_suspendedCarts" ShowPagination="true" InitialPageSize="8">
+                                    <Columns>
+                                        <BbDataGridPropertyColumn Property="@(x => x.CartNumber)" Title="Cart" Sortable="true" Filterable="true" />
+                                        <BbDataGridPropertyColumn Property="@(x => x.CustomerLabel)" Title="Customer" Sortable="true" Filterable="true" />
+                                        <BbDataGridTemplateColumn Title="Total" Sortable="true" Filterable="true" FilterBy="@(item => item.TotalAmount)">
+                                            <ChildContent Context="item">@item.TotalAmount.ToString("N2")</ChildContent>
+                                        </BbDataGridTemplateColumn>
+                                        <BbDataGridPropertyColumn Property="@(x => x.SuspendedAt)" Title="Suspended" Sortable="true" Filterable="true" />
+                                        <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
+                                        <BbDataGridTemplateColumn Title="Actions">
+                                            <ChildContent Context="item">
+                                                <div class="flex flex-wrap gap-1">
+                                                    <BbButton Size="ButtonSize.Small" OnClick="@(() => ResumeCart(item))" Disabled="@_actingOnCart">
+                                                        Resume
+                                                    </BbButton>
+                                                    <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Destructive" OnClick="@(() => CancelDraftCart(item))" Disabled="@_actingOnCart">
+                                                        Cancel
+                                                    </BbButton>
+                                                </div>
+                                            </ChildContent>
+                                        </BbDataGridTemplateColumn>
+                                    </Columns>
+                                    <EmptyTemplate>
+                                        <BbEmpty Title="No suspended carts" Description="Suspended customer carts will appear here." />
+                                    </EmptyTemplate>
+                                </BbDataGrid>
+                            </BbCardContent>
+                        </BbCard>
+                    }
                 </div>
             </div>
         </div>
@@ -314,6 +306,7 @@ else
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private RequestMetadata RequestMetadata { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
 
     private readonly List<CartLine> _cart = [];
     private List<PosRegister> _registers = [];
@@ -323,6 +316,7 @@ else
     private bool _loading = true;
     private bool _hasTenant;
     private bool _moduleEnabled;
+    private bool _cartsEnabled;
     private bool _searching;
     private bool _checkingOut;
     private bool _savingCart;
@@ -342,6 +336,15 @@ else
 
     private decimal Subtotal => _cart.Sum(line => line.LineTotal);
     private decimal Total => Subtotal - _discountAmount + _taxAmount;
+    private string PaymentMethodValue
+    {
+        get => _paymentMethod.ToString();
+        set
+        {
+            if (Enum.TryParse<PosPaymentMethod>(value, out var method))
+                _paymentMethod = method;
+        }
+    }
 
     protected override void OnInitialized()
     {
@@ -360,7 +363,8 @@ else
         {
             await ModuleNavigation.EnsureLoadedAsync();
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
-            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos);
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "sales");
+            _cartsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "carts");
             _registers = [];
             _credentials = [];
             _suspendedCarts = [];
@@ -384,7 +388,8 @@ else
                     .ToListAsync();
 
                 _selectedRegisterId ??= _registers.FirstOrDefault()?.Id.ToString();
-                await LoadSuspendedCarts();
+                if (_cartsEnabled)
+                    await LoadSuspendedCarts();
             }
         }
         catch
@@ -400,6 +405,12 @@ else
 
     private async Task LoadSuspendedCarts()
     {
+        if (!_cartsEnabled)
+        {
+            _suspendedCarts = [];
+            return;
+        }
+
         var response = await POS.SearchPosCarts(new SearchPosCartsRequest
         {
             Metadata = BuildMetadata(),
@@ -472,6 +483,12 @@ else
 
     private async Task SuspendCart()
     {
+        if (!_cartsEnabled)
+        {
+            ToastService.Show("POS carts feature is not enabled.");
+            return;
+        }
+
         if (!TryResolveRegister(out var registerId) || !TryResolveCashier(out var cashierCredentialId))
             return;
 
@@ -539,6 +556,12 @@ else
 
     private async Task ResumeCart(PosCartSummaryResponse cart)
     {
+        if (!_cartsEnabled)
+        {
+            ToastService.Show("POS carts feature is not enabled.");
+            return;
+        }
+
         if (_cart.Any() && _activeCartId != cart.Id)
         {
             ToastService.Show("Suspend or clear the current cart before resuming another cart.");
@@ -577,6 +600,20 @@ else
 
     private async Task CancelDraftCart(PosCartSummaryResponse cart)
     {
+        if (!_cartsEnabled)
+        {
+            ToastService.Show("POS carts feature is not enabled.");
+            return;
+        }
+
+        if (!await DialogService.Confirm(
+                "Cancel Suspended Cart",
+                $"Cancel suspended cart {cart.CartNumber} and remove it from the queue?",
+                new ConfirmDialogOptions { Destructive = true }))
+        {
+            return;
+        }
+
         _actingOnCart = true;
         try
         {
@@ -633,6 +670,12 @@ else
     {
         if (!TryResolveRegister(out var registerId) || !TryResolveCashier(out var cashierCredentialId))
             return;
+
+        if (_activeCartId.HasValue && !_cartsEnabled)
+        {
+            ToastService.Show("POS carts feature is not enabled.");
+            return;
+        }
 
         if (Total < 0)
         {
@@ -780,6 +823,22 @@ else
         _taxAmount = 0;
     }
 
+    private async Task ConfirmClearCurrentCart()
+    {
+        if (!_cart.Any())
+            return;
+
+        if (!await DialogService.Confirm(
+                "Clear Cart",
+                "Discard all items and customer details from the active cart?",
+                new ConfirmDialogOptions { Destructive = true }))
+        {
+            return;
+        }
+
+        ClearCurrentCart();
+    }
+
     private bool TryResolveRegister(out Guid registerId)
     {
         if (Guid.TryParse(_selectedRegisterId, out registerId))
@@ -824,6 +883,31 @@ else
         string.IsNullOrWhiteSpace(credential.UserName) ? credential.Id.ToString()[..8] : credential.UserName;
     private static string GetCredentialSearchText(IdentityCredential credential) =>
         $"{credential.UserName} {credential.UserAlias}";
+
+    private static IReadOnlyList<XfEntityPickerColumn<PosRegister>> RegisterAdvancedColumns =>
+    [
+        new("Name", register => register.Name),
+        new("Code", register => register.Code),
+        new("Warehouse", register => ShortId(register.DefaultWarehouseId)),
+        new("Location", register => ShortId(register.DefaultLocationId)),
+        new("Enabled", register => FormatBoolean(register.IsEnabled)),
+        new("Register", register => ShortId(register.Id))
+    ];
+
+    private static IReadOnlyList<XfEntityPickerColumn<IdentityCredential>> CredentialAdvancedColumns =>
+    [
+        new("Username", credential => credential.UserName ?? credential.UserAlias),
+        new("Alias", credential => credential.UserAlias),
+        new("Online", credential => FormatBoolean(credential.IsOnline)),
+        new("Last Seen", credential => FormatDateTime(credential.LastSeen)),
+        new("Device", credential => credential.Device),
+        new("Location", credential => credential.Location),
+        new("Credential", credential => ShortId(credential.Id))
+    ];
+
+    private static string ShortId(Guid id) => id.ToString()[..8];
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDateTime(DateTime? value) => value?.ToString("yyyy-MM-dd") ?? "-";
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/POS/Registers.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/POS/Registers.razor
@@ -63,6 +63,9 @@ else
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
                         </Columns>
+                        <EmptyTemplate>
+                            <BbEmpty Title="No POS registers" Description="Create a register before using cashier checkout." />
+                        </EmptyTemplate>
                     </BbDataGrid>
                 </BbCardContent>
             </BbCard>
@@ -92,6 +95,8 @@ else
                                 ValueSelector="@GetCredentialValue"
                                 TextSelector="@GetCredentialLabel"
                                 SearchTextSelector="@GetCredentialSearchText"
+                                AdvancedColumns="@CredentialAdvancedColumns"
+                                AdvancedSearchScope="Searches credential name, username, alias, online state, last seen date, and credential id."
                                 AdvancedSearchTitle="Find Merchant Credential"
                                 AdvancedSearchDescription="Select the merchant credential used for Wallets transfers." />
                 <XfEntityPicker TItem="Wallet"
@@ -104,6 +109,8 @@ else
                                 ValueSelector="@GetWalletValue"
                                 TextSelector="@GetWalletLabel"
                                 SearchTextSelector="@GetWalletSearchText"
+                                AdvancedColumns="@WalletAdvancedColumns"
+                                AdvancedSearchScope="Searches wallet account number, credential, wallet type, status, balance, available balance, and created date."
                                 AdvancedSearchTitle="Find Cash Drawer Wallet"
                                 AdvancedSearchDescription="Select the Wallets ledger account for cash drawer movement." />
             </div>
@@ -118,6 +125,8 @@ else
                                 ValueSelector="@GetWalletTypeValue"
                                 TextSelector="@GetWalletTypeLabel"
                                 SearchTextSelector="@GetWalletTypeSearchText"
+                                AdvancedColumns="@WalletTypeAdvancedColumns"
+                                AdvancedSearchScope="Searches wallet type code, name, currency, type, transfer rules, and description."
                                 AdvancedSearchTitle="Find Wallet Type"
                                 AdvancedSearchDescription="Select the wallet type used for POS payments." />
                 <XfEntityPicker TItem="Wallets.Domain.Shared.Contracts.CurrencyType"
@@ -130,6 +139,8 @@ else
                                 ValueSelector="@GetCurrencyValue"
                                 TextSelector="@GetCurrencyLabel"
                                 SearchTextSelector="@GetCurrencySearchText"
+                                AdvancedColumns="@CurrencyAdvancedColumns"
+                                AdvancedSearchScope="Searches currency ISO code, name, type, tenant scope, and description."
                                 AdvancedSearchTitle="Find Currency"
                                 AdvancedSearchDescription="Select the checkout currency." />
             </div>
@@ -145,6 +156,8 @@ else
                                 ValueSelector="@GetWarehouseValue"
                                 TextSelector="@GetWarehouseLabel"
                                 SearchTextSelector="@GetWarehouseSearchText"
+                                AdvancedColumns="@WarehouseAdvancedColumns"
+                                AdvancedSearchScope="Searches warehouse code, name, city, region, country, default flag, and created date."
                                 AdvancedSearchTitle="Find Warehouse"
                                 AdvancedSearchDescription="Select the default source warehouse." />
                 <XfEntityPicker TItem="InventoryLocation"
@@ -157,6 +170,8 @@ else
                                 ValueSelector="@GetLocationValue"
                                 TextSelector="@GetLocationLabel"
                                 SearchTextSelector="@GetLocationSearchText"
+                                AdvancedColumns="@LocationAdvancedColumns"
+                                AdvancedSearchScope="Searches location code, name, warehouse, type, pickable flag, and description."
                                 AdvancedSearchTitle="Find Location"
                                 AdvancedSearchDescription="Select the default stock location." />
             </div>
@@ -211,8 +226,7 @@ else
         {
             await ModuleNavigation.EnsureLoadedAsync();
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
-            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "registers")
-                || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos);
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "registers");
 
             _registers = [];
             if (!_hasTenant || !_moduleEnabled || TenantFilter.SelectedTenantId is not Guid tenantId)
@@ -381,6 +395,87 @@ else
     private static string GetLocationValue(InventoryLocation item) => item.Id.ToString();
     private static string GetLocationLabel(InventoryLocation item) => string.IsNullOrWhiteSpace(item.Code) ? item.Name : $"{item.Name} ({item.Code})";
     private static string GetLocationSearchText(InventoryLocation item) => $"{item.Name} {item.Code} {item.Description}";
+
+    private IReadOnlyList<XfEntityPickerColumn<IdentityCredential>> CredentialAdvancedColumns =>
+    [
+        new("Name", item => item.IdentityInfo?.FullName ?? item.IdentityInfo?.IdentityName ?? item.UserName ?? item.UserAlias),
+        new("Username", item => item.UserName ?? item.UserAlias),
+        new("Online", item => FormatBoolean(item.IsOnline)),
+        new("Last Seen", item => FormatDateTime(item.LastSeen)),
+        new("Credential", item => ShortId(item.Id))
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<Wallet>> WalletAdvancedColumns =>
+    [
+        new("Account", item => string.IsNullOrWhiteSpace(item.AccountNumber) ? ShortId(item.Id) : item.AccountNumber),
+        new("Credential", item => GetCredentialLabelById(item.CredentialId)),
+        new("Type", item => GetWalletTypeName(item.WalletTypeId)),
+        new("Status", item => item.Status.ToString()),
+        new("Balance", item => FormatDecimal(item.Balance)),
+        new("Available", item => FormatDecimal(item.AvailableBalance)),
+        new("Created", item => FormatDateTime(item.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<Wallets.Domain.Shared.Contracts.WalletType>> WalletTypeAdvancedColumns =>
+    [
+        new("Code", item => item.Code),
+        new("Name", item => item.Name),
+        new("Currency", item => GetCurrencyName(item.CurrencyTypeId)),
+        new("Type", item => item.Type.ToString()),
+        new("Min Transfer", item => FormatDecimal(item.MinTransferRule)),
+        new("Max Transfer", item => FormatDecimal(item.MaxTransferRule)),
+        new("Description", item => item.Desc)
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<Wallets.Domain.Shared.Contracts.CurrencyType>> CurrencyAdvancedColumns =>
+    [
+        new("ISO", item => item.CurrencyIsoCode3),
+        new("Name", item => item.Name),
+        new("Type", item => item.Type?.ToString()),
+        new("Scope", item => item.TenantId == Guid.Empty ? "Global" : "Tenant"),
+        new("Description", item => item.Description)
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<Warehouse>> WarehouseAdvancedColumns =>
+    [
+        new("Code", item => item.Code),
+        new("Name", item => item.Name),
+        new("City", item => item.City),
+        new("Region", item => item.Region),
+        new("Country", item => item.CountryCode),
+        new("Default", item => FormatBoolean(item.IsDefault)),
+        new("Created", item => FormatDateTime(item.CreatedAt))
+    ];
+
+    private IReadOnlyList<XfEntityPickerColumn<InventoryLocation>> LocationAdvancedColumns =>
+    [
+        new("Code", item => item.Code),
+        new("Name", item => item.Name),
+        new("Warehouse", item => GetWarehouseName(item.WarehouseId)),
+        new("Type", item => item.LocationType.ToString()),
+        new("Pickable", item => FormatBoolean(item.IsPickable)),
+        new("Description", item => item.Description)
+    ];
+
+    private string GetCredentialLabelById(Guid credentialId) =>
+        _credentials.FirstOrDefault(item => item.Id == credentialId) is { } credential
+            ? GetCredentialLabel(credential)
+            : ShortId(credentialId);
+
+    private string GetWalletTypeName(Guid? walletTypeId) =>
+        walletTypeId is Guid id
+            ? _walletTypes.FirstOrDefault(item => item.Id == id)?.Name ?? ShortId(id)
+            : "-";
+
+    private string GetCurrencyName(Guid? currencyId) =>
+        currencyId is Guid id
+            ? _currencies.FirstOrDefault(item => item.Id == id)?.CurrencyIsoCode3 ?? ShortId(id)
+            : "-";
+
+    private static string ShortId(Guid id) => id.ToString()[..8];
+    private static string FormatBoolean(bool value) => value ? "Yes" : "No";
+    private static string FormatDateTime(DateTime? value) => value?.ToString("yyyy-MM-dd") ?? "-";
+    private static string FormatDecimal(decimal? value) => value?.ToString("N2") ?? "-";
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/POS/Returns.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/POS/Returns.razor
@@ -62,6 +62,9 @@ else
                             </BbDataGridTemplateColumn>
                             <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
                         </Columns>
+                        <EmptyTemplate>
+                            <BbEmpty Title="No POS returns" Description="Return and refund records will appear here." />
+                        </EmptyTemplate>
                     </BbDataGrid>
                 </BbCardContent>
             </BbCard>
@@ -76,7 +79,7 @@ else
             <BbDialogDescription>Select a completed sale and the quantities to return.</BbDialogDescription>
         </BbDialogHeader>
         <div class="grid gap-4 py-4">
-            <XfEntityPicker TItem="PosSale"
+            <XfEntityPicker TItem="PosSaleSummaryResponse"
                             Value="@_selectedSaleId"
                             ValueChanged="@OnSaleChanged"
                             Items="@_completedSales"
@@ -87,43 +90,15 @@ else
                             ValueSelector="@GetSaleValue"
                             TextSelector="@GetSaleLabel"
                             SearchTextSelector="@GetSaleSearchText"
+                            AdvancedColumns="@SaleAdvancedColumns"
+                            AdvancedSearchScope="Searches sale number, register, total, status, created date, completed date, and sale id."
                             AdvancedSearchTitle="Find Original Sale"
                             AdvancedSearchDescription="Select the completed sale for this return." />
 
-            <div class="grid gap-2">
-                <BbLabel>Refund Method</BbLabel>
-                <div class="flex flex-wrap gap-2">
-                    @if (_refundMethod == PosPaymentMethod.CashDrawer)
-                    {
-                        <BbButton OnClick="@(() => _refundMethod = PosPaymentMethod.CashDrawer)">
-                            <LucideIcon Name="banknote" class="mr-2 h-4 w-4" />
-                            Cash Drawer
-                        </BbButton>
-                    }
-                    else
-                    {
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _refundMethod = PosPaymentMethod.CashDrawer)">
-                            <LucideIcon Name="banknote" class="mr-2 h-4 w-4" />
-                            Cash Drawer
-                        </BbButton>
-                    }
-
-                    @if (_refundMethod == PosPaymentMethod.WalletTransfer)
-                    {
-                        <BbButton OnClick="@(() => _refundMethod = PosPaymentMethod.WalletTransfer)">
-                            <LucideIcon Name="wallet" class="mr-2 h-4 w-4" />
-                            Wallet Transfer
-                        </BbButton>
-                    }
-                    else
-                    {
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _refundMethod = PosPaymentMethod.WalletTransfer)">
-                            <LucideIcon Name="wallet" class="mr-2 h-4 w-4" />
-                            Wallet Transfer
-                        </BbButton>
-                    }
-                </div>
-            </div>
+            <BbFormFieldSelect TValue="string" @bind-Value="RefundMethodValue" Label="Refund Method">
+                <BbSelectItem Value="@PosPaymentMethod.CashDrawer.ToString()">Cash Drawer</BbSelectItem>
+                <BbSelectItem Value="@PosPaymentMethod.WalletTransfer.ToString()">Wallet Transfer</BbSelectItem>
+            </BbFormFieldSelect>
 
             <BbDataGrid Items="@_returnLines" ShowPagination="false">
                 <Columns>
@@ -145,6 +120,9 @@ else
                         <ChildContent Context="item">@item.RefundAmount.ToString("N2")</ChildContent>
                     </BbDataGridTemplateColumn>
                 </Columns>
+                <EmptyTemplate>
+                    <BbEmpty Title="No returnable lines" Description="Select a completed sale with line items." />
+                </EmptyTemplate>
             </BbDataGrid>
             <BbFormFieldInput TValue="string" @bind-Value="_reason" Label="Reason" />
         </div>
@@ -165,8 +143,8 @@ else
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private RequestMetadata RequestMetadata { get; set; } = default!;
 
-    private List<PosReturn> _returns = [];
-    private List<PosSale> _completedSales = [];
+    private List<PosReturnSummaryResponse> _returns = [];
+    private List<PosSaleSummaryResponse> _completedSales = [];
     private List<PosRegister> _registers = [];
     private List<ReturnLineForm> _returnLines = [];
     private bool _loading = true;
@@ -177,6 +155,16 @@ else
     private string? _selectedSaleId;
     private string _reason = "";
     private PosPaymentMethod _refundMethod = PosPaymentMethod.CashDrawer;
+
+    private string RefundMethodValue
+    {
+        get => _refundMethod.ToString();
+        set
+        {
+            if (Enum.TryParse<PosPaymentMethod>(value, out var method))
+                _refundMethod = method;
+        }
+    }
 
     protected override void OnInitialized()
     {
@@ -204,8 +192,7 @@ else
         {
             await ModuleNavigation.EnsureLoadedAsync();
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
-            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "returns")
-                || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos);
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "returns");
             _returns = [];
             _completedSales = [];
             _registers = [];
@@ -217,16 +204,26 @@ else
                 .Where(item => item.TenantId == tenantId && !item.IsDeleted)
                 .Take(200)
                 .ToListAsync();
-            _completedSales = await DataContext.Query<PosSale>().IgnoreQueryFilters().NoCache()
-                .Where(item => item.TenantId == tenantId && !item.IsDeleted && item.Status == PosSaleStatus.Completed)
-                .OrderByDescending(item => item.CreatedAt)
-                .Take(200)
-                .ToListAsync();
-            _returns = await DataContext.Query<PosReturn>().IgnoreQueryFilters().NoCache()
-                .Where(item => item.TenantId == tenantId && !item.IsDeleted)
-                .OrderByDescending(item => item.CreatedAt)
-                .Take(250)
-                .ToListAsync();
+            var completedSalesResponse = await POS.SearchPosSales(new SearchPosSalesRequest
+            {
+                Metadata = BuildMetadata(),
+                Status = PosSaleStatus.Completed,
+                Page = 1,
+                PageSize = 100
+            });
+            _completedSales = completedSalesResponse.Response ?? [];
+            if (!completedSalesResponse.IsSuccess)
+                ToastService.Show(completedSalesResponse.Message ?? "Could not load completed POS sales.");
+
+            var returnsResponse = await POS.SearchPosReturns(new SearchPosReturnsRequest
+            {
+                Metadata = BuildMetadata(),
+                Page = 1,
+                PageSize = 100
+            });
+            _returns = returnsResponse.Response ?? [];
+            if (!returnsResponse.IsSuccess)
+                ToastService.Show(returnsResponse.Message ?? "Could not load POS returns.");
         }
         catch
         {
@@ -263,13 +260,19 @@ else
         if (TenantFilter.SelectedTenantId is not Guid tenantId)
             return;
 
-        var lines = await DataContext.Query<PosSaleLine>().IgnoreQueryFilters().NoCache()
-            .Where(item => item.TenantId == tenantId && item.SaleId == saleId && !item.IsDeleted)
-            .OrderBy(item => item.LineNumber)
-            .Take(100)
-            .ToListAsync();
+        var response = await POS.GetPosSale(new GetPosSaleRequest
+        {
+            Metadata = BuildMetadata(),
+            Id = saleId
+        });
 
-        _returnLines = lines.Select(line => new ReturnLineForm
+        if (!response.IsSuccess || response.Response is null)
+        {
+            ToastService.Show(response.Message ?? "Could not load sale lines.");
+            return;
+        }
+
+        _returnLines = response.Response.Lines.OrderBy(line => line.LineNumber).Select(line => new ReturnLineForm
         {
             SaleLineId = line.Id,
             ProductName = string.IsNullOrWhiteSpace(line.VariantName) ? line.ProductName : $"{line.ProductName} - {line.VariantName}",
@@ -347,9 +350,9 @@ else
 
     private string GetSaleNumber(Guid saleId) => _completedSales.FirstOrDefault(item => item.Id == saleId)?.SaleNumber ?? saleId.ToString()[..8];
     private string GetRegisterName(Guid registerId) => _registers.FirstOrDefault(item => item.Id == registerId)?.Name ?? registerId.ToString()[..8];
-    private static string GetSaleValue(PosSale item) => item.Id.ToString();
-    private static string GetSaleLabel(PosSale item) => $"{item.SaleNumber} - {item.TotalAmount:N2}";
-    private static string GetSaleSearchText(PosSale item) => $"{item.SaleNumber} {item.TotalAmount:N2} {item.CreatedAt:yyyy-MM-dd}";
+    private static string GetSaleValue(PosSaleSummaryResponse item) => item.Id.ToString();
+    private static string GetSaleLabel(PosSaleSummaryResponse item) => $"{item.SaleNumber} - {item.TotalAmount:N2}";
+    private string GetSaleSearchText(PosSaleSummaryResponse item) => $"{item.SaleNumber} {GetRegisterName(item.RegisterId)} {item.TotalAmount:N2} {item.CreatedAt:yyyy-MM-dd}";
     private static string GetReturnStatusBadge(PosReturnStatus status) =>
         status switch
         {
@@ -357,6 +360,17 @@ else
             PosReturnStatus.Failed => "warning",
             _ => "pending"
         };
+
+    private IReadOnlyList<XfEntityPickerColumn<PosSaleSummaryResponse>> SaleAdvancedColumns =>
+    [
+        new("Receipt", item => item.SaleNumber),
+        new("Register", item => GetRegisterName(item.RegisterId)),
+        new("Total", item => item.TotalAmount.ToString("N2")),
+        new("Status", item => item.Status.ToString()),
+        new("Created", item => item.CreatedAt.ToString("yyyy-MM-dd")),
+        new("Completed", item => item.CompletedAt?.ToString("yyyy-MM-dd") ?? "-"),
+        new("Sale", item => item.Id.ToString()[..8])
+    ];
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/Components/Pages/POS/Sales.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/POS/Sales.razor
@@ -81,6 +81,9 @@ else
                                 </ChildContent>
                             </BbDataGridTemplateColumn>
                         </Columns>
+                        <EmptyTemplate>
+                            <BbEmpty Title="No POS sales" Description="Completed and recoverable checkout records will appear here." />
+                        </EmptyTemplate>
                     </BbDataGrid>
                 </BbCardContent>
             </BbCard>
@@ -95,8 +98,9 @@ else
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private RequestMetadata RequestMetadata { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = default!;
 
-    private List<PosSale> _sales = [];
+    private List<PosSaleSummaryResponse> _sales = [];
     private List<PosRegister> _registers = [];
     private bool _loading = true;
     private bool _acting;
@@ -120,8 +124,7 @@ else
         {
             await ModuleNavigation.EnsureLoadedAsync();
             _hasTenant = TenantFilter.SelectedTenantId is Guid;
-            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "sales")
-                || ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos);
+            _moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "sales");
             _sales = [];
             _registers = [];
 
@@ -132,11 +135,16 @@ else
                 .Where(item => item.TenantId == tenantId && !item.IsDeleted)
                 .Take(200)
                 .ToListAsync();
-            _sales = await DataContext.Query<PosSale>().IgnoreQueryFilters().NoCache()
-                .Where(item => item.TenantId == tenantId && !item.IsDeleted)
-                .OrderByDescending(item => item.CreatedAt)
-                .Take(250)
-                .ToListAsync();
+            var salesResponse = await POS.SearchPosSales(new SearchPosSalesRequest
+            {
+                Metadata = BuildMetadata(),
+                Page = 1,
+                PageSize = 100
+            });
+
+            _sales = salesResponse.Response ?? [];
+            if (!salesResponse.IsSuccess)
+                ToastService.Show(salesResponse.Message ?? "Could not load POS sales.");
         }
         catch
         {
@@ -151,6 +159,14 @@ else
 
     private async Task CancelSale(Guid saleId)
     {
+        if (!await DialogService.Confirm(
+                "Cancel POS Sale",
+                "Cancel this sale and stop its recovery workflow?",
+                new ConfirmDialogOptions { Destructive = true }))
+        {
+            return;
+        }
+
         _acting = true;
         try
         {

--- a/src/Tests/POS.IntegrationTests/ControlPanelContractTests.cs
+++ b/src/Tests/POS.IntegrationTests/ControlPanelContractTests.cs
@@ -29,6 +29,7 @@ public sealed class ControlPanelContractTests
             text.Should().NotContain("<table", $"{page} should use BlazorBlueprint data grids instead of raw tables");
             text.Should().Contain("<BbDataGrid", $"{page} should use BbDataGrid for list/report tabular records");
             text.Should().Contain("Filterable=\"true\"", $"{page} should expose native filtering on useful columns");
+            text.Should().Contain("<EmptyTemplate>", $"{page} should expose explicit grid empty states");
             text.Should().NotMatchRegex(
                 @"<BbDataGridTemplateColumn\b[^>]*Title=""Actions""[^>]*Filterable=""true""",
                 $"{page} should not expose filters on command/action columns");
@@ -73,9 +74,17 @@ public sealed class ControlPanelContractTests
     }
 
     [Test]
-    public void PosPages_HideWhenTenantFeatureIsUnavailable()
+    public void PosPages_UseExactTenantSubFeatureGates()
     {
         var pagesRoot = GetPosPagesRoot();
+        var layoutRoot = Path.Combine(
+            FindRepositoryRoot().FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "Components",
+            "Layout");
+        var navMenu = File.ReadAllText(Path.Combine(layoutRoot, "NavMenu.razor"));
 
         foreach (var page in PosPages)
         {
@@ -84,7 +93,23 @@ public sealed class ControlPanelContractTests
             text.Should().Contain("_moduleEnabled");
             text.Should().Contain("ModuleUnavailable");
             text.Should().Contain("TenantModuleFeatureKeys.Pos");
+            text.Should().NotContain("|| ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos)");
         }
+
+        navMenu.Should().Contain("Href=\"/pos/cashier\"");
+        navMenu.Should().Contain("ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, \"sales\")");
+        navMenu.Should().Contain("ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, \"registers\")");
+        navMenu.Should().Contain("ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, \"returns\")");
+        navMenu.Should().NotContain("@if (ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos))");
+
+        File.ReadAllText(Path.Combine(pagesRoot, "Cashier.razor"))
+            .Should().Contain("_moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, \"sales\");");
+        File.ReadAllText(Path.Combine(pagesRoot, "Registers.razor"))
+            .Should().Contain("_moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, \"registers\");");
+        File.ReadAllText(Path.Combine(pagesRoot, "Sales.razor"))
+            .Should().Contain("_moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, \"sales\");");
+        File.ReadAllText(Path.Combine(pagesRoot, "Returns.razor"))
+            .Should().Contain("_moduleEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, \"returns\");");
     }
 
     [Test]
@@ -100,6 +125,72 @@ public sealed class ControlPanelContractTests
         text.Should().Contain("XfEntityPicker TItem=\"InventoryLocation\"");
         text.Should().NotContain("TValue=\"Guid\"");
         text.Should().NotContain("raw GUID");
+    }
+
+    [Test]
+    public void PosPages_UseWrapperReadsWherePosContractsExist()
+    {
+        var pagesRoot = GetPosPagesRoot();
+        var sales = File.ReadAllText(Path.Combine(pagesRoot, "Sales.razor"));
+        var returns = File.ReadAllText(Path.Combine(pagesRoot, "Returns.razor"));
+
+        sales.Should().Contain("POS.SearchPosSales(new SearchPosSalesRequest");
+        sales.Should().NotContain("DataContext.Query<PosSale>()");
+
+        returns.Should().Contain("POS.SearchPosSales(new SearchPosSalesRequest");
+        returns.Should().Contain("POS.SearchPosReturns(new SearchPosReturnsRequest");
+        returns.Should().Contain("POS.GetPosSale(new GetPosSaleRequest");
+        returns.Should().NotContain("DataContext.Query<PosReturn>()");
+        returns.Should().NotContain("DataContext.Query<PosSaleLine>()");
+    }
+
+    [Test]
+    public void PosPages_UseBlueprintControlsAndConfirmDestructiveActions()
+    {
+        var pagesRoot = GetPosPagesRoot();
+        var cashier = File.ReadAllText(Path.Combine(pagesRoot, "Cashier.razor"));
+        var sales = File.ReadAllText(Path.Combine(pagesRoot, "Sales.razor"));
+        var returns = File.ReadAllText(Path.Combine(pagesRoot, "Returns.razor"));
+
+        cashier.Should().Contain("<BbFormFieldSelect TValue=\"string\" @bind-Value=\"PaymentMethodValue\" Label=\"Payment\">");
+        returns.Should().Contain("<BbFormFieldSelect TValue=\"string\" @bind-Value=\"RefundMethodValue\" Label=\"Refund Method\">");
+        cashier.Should().NotContain("grid-cols-[");
+        returns.Should().NotContain("@if (_refundMethod == PosPaymentMethod.CashDrawer)");
+        cashier.Should().NotContain("@if (_paymentMethod == PosPaymentMethod.CashDrawer)");
+
+        cashier.Should().Contain("ConfirmClearCurrentCart");
+        cashier.Should().Contain("Cancel Suspended Cart");
+        sales.Should().Contain("Cancel POS Sale");
+        (cashier + sales).Should().Contain("new ConfirmDialogOptions { Destructive = true }");
+    }
+
+    [Test]
+    public void PosEntityPickers_DefineAdvancedSearchColumnsAndScope()
+    {
+        var pagesRoot = GetPosPagesRoot();
+        var registers = File.ReadAllText(Path.Combine(pagesRoot, "Registers.razor"));
+        var cashier = File.ReadAllText(Path.Combine(pagesRoot, "Cashier.razor"));
+        var returns = File.ReadAllText(Path.Combine(pagesRoot, "Returns.razor"));
+
+        Regex.Matches(registers, "AdvancedColumns=\"@").Count.Should().BeGreaterThanOrEqualTo(6);
+        Regex.Matches(registers, "AdvancedSearchScope=").Count.Should().BeGreaterThanOrEqualTo(6);
+        Regex.Matches(cashier, "AdvancedColumns=\"@").Count.Should().BeGreaterThanOrEqualTo(2);
+        Regex.Matches(cashier, "AdvancedSearchScope=").Count.Should().BeGreaterThanOrEqualTo(2);
+        Regex.Matches(returns, "AdvancedColumns=\"@").Count.Should().BeGreaterThanOrEqualTo(1);
+        Regex.Matches(returns, "AdvancedSearchScope=").Count.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public void PosCashier_SuspendedCartUiAndActions_RequireCartsFeature()
+    {
+        var text = File.ReadAllText(Path.Combine(GetPosPagesRoot(), "Cashier.razor"));
+
+        text.Should().Contain("_cartsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, \"carts\");");
+        text.Should().Contain("@if (_cartsEnabled)");
+        text.Should().Contain("POS.SearchPosCarts(new SearchPosCartsRequest");
+        text.Should().Contain("POS.SuspendPosCart(new SuspendPosCartRequest");
+        text.Should().Contain("POS.ResumePosCart(new ResumePosCartRequest");
+        text.Should().Contain("POS.CancelPosCart(new CancelPosCartRequest");
     }
 
     private static IEnumerable<string> FindDirectPosMutations(string page, string text)


### PR DESCRIPTION
﻿## Summary
- tighten POS ControlPanel nav and direct-route gates to exact POS subfeatures
- add destructive confirmations, explicit grid empty states, and Blueprint select controls for POS payment/refund choices
- add advanced entity picker columns/scopes and use POS wrapper reads for Sales/Returns where contracts exist

## Validation
- `dotnet test src\Tests\POS.IntegrationTests\POS.IntegrationTests.csproj --filter "TestCategory=Area:ControlPanelContract" --no-restore`
- `dotnet build src\Presentation\ControlPanel.Server\ControlPanel.Server.csproj -m:1 /nr:false`
