### PR TITLE
[codex] Redesign POS cashier for touchscreen

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Pages/POS/Cashier.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/POS/Cashier.razor
@@ -19,284 +19,357 @@ else if (!_moduleEnabled)
 else
 {
     <FadeInContent>
-        <div class="space-y-6">
-            <div class="xf-page-header">
+        <div class="pos-cashier-page">
+            <div class="xf-page-header pos-cashier-header">
                 <div>
                     <BbTypographyH3>Cashier</BbTypographyH3>
-                    <BbTypographyMuted>Checkout uses Inventario catalog and Wallets ledger posting.</BbTypographyMuted>
+                    <BbTypographyMuted>@CartItemCount item(s) | @Total.ToString("N2") total</BbTypographyMuted>
                 </div>
-                <div class="xf-page-actions">
+                <div class="xf-page-actions pos-cashier-header-actions">
                     @if (_cartsEnabled)
                     {
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="@SuspendCart" Disabled="@(_savingCart || !_cart.Any())">
-                            <LucideIcon Name="pause" class="mr-2 h-4 w-4" />
-                            Suspend Cart
+                        <BbButton Size="ButtonSize.Large" Variant="ButtonVariant.Outline" OnClick="@OpenHeldCartsDialog">
+                            <LucideIcon Name="clock" class="mr-2 h-4 w-4" />
+                            Held Carts
+                            @if (_suspendedCarts.Count > 0)
+                            {
+                                <span class="pos-button-count">@_suspendedCarts.Count</span>
+                            }
                         </BbButton>
                     }
-                    <BbButton Variant="ButtonVariant.Destructive" OnClick="@ConfirmClearCurrentCart" Disabled="@(!_cart.Any())">
+                    <BbButton Size="ButtonSize.Large" Variant="ButtonVariant.Outline" OnClick="@OpenSaleDetailsDialog">
+                        <LucideIcon Name="clipboard-list" class="mr-2 h-4 w-4" />
+                        Sale Details
+                    </BbButton>
+                    <BbButton Size="ButtonSize.Large" Variant="ButtonVariant.Destructive" OnClick="@ConfirmClearCurrentCart" Disabled="@(!_cart.Any())">
                         <LucideIcon Name="x" class="mr-2 h-4 w-4" />
                         Clear
                     </BbButton>
-                    <BbButton Variant="ButtonVariant.Outline" OnClick="@Reload">
+                    <BbButton Size="ButtonSize.Large" Variant="ButtonVariant.Outline" OnClick="@Reload">
                         <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
                         Refresh
                     </BbButton>
                 </div>
             </div>
 
-            <div class="grid gap-6 xl:grid-cols-2">
-                <div class="space-y-6">
-                    <BbCard>
-                        <BbCardHeader>
-                            <BbCardTitle>Catalog</BbCardTitle>
-                            <BbCardDescription>Search sellable products from Inventario.</BbCardDescription>
-                        </BbCardHeader>
-                        <BbCardContent>
-                            <div class="xf-filter-actions">
-                                <BbInput @bind-Value="_catalogSearch" Placeholder="Search SKU, product, variant, or brand" />
-                                <BbButton OnClick="@SearchCatalog" Disabled="@_searching">
-                                    <LucideIcon Name="search" class="mr-2 h-4 w-4" />
-                                    Search
-                                </BbButton>
-                            </div>
-                            <div class="mt-4">
-                                <BbDataGrid Items="@_catalogItems" ShowPagination="true" InitialPageSize="10">
-                                    <Columns>
-                                        <BbDataGridPropertyColumn Property="@(x => x.DisplayName)" Title="Item" Sortable="true" Filterable="true" />
-                                        <BbDataGridPropertyColumn Property="@(x => x.SKU)" Title="SKU" Sortable="true" Filterable="true" />
-                                        <BbDataGridTemplateColumn Title="Price" Sortable="true" Filterable="true" FilterBy="@(item => item.Price)">
-                                            <ChildContent Context="item">@item.Price.ToString("N2")</ChildContent>
-                                        </BbDataGridTemplateColumn>
-                                        <BbDataGridTemplateColumn Title="Status" Filterable="true" FilterBy="@(item => item.IsAvailable)">
-                                            <ChildContent Context="item">
-                                                <StatusBadge Text="@(item.IsAvailable ? "Available" : "Unavailable")"
-                                                             Status="@(item.IsAvailable ? "active" : "inactive")" />
-                                            </ChildContent>
-                                        </BbDataGridTemplateColumn>
-                                        <BbDataGridTemplateColumn Title="Actions">
-                                            <ChildContent Context="item">
-                                                <BbButton Size="ButtonSize.Small" OnClick="@(() => AddToCart(item))" Disabled="@(!item.IsAvailable)">
-                                                    Add
-                                                </BbButton>
-                                            </ChildContent>
-                                        </BbDataGridTemplateColumn>
-                                    </Columns>
-                                    <EmptyTemplate>
-                                        <BbEmpty Title="No catalog items" Description="Search Inventario sellable products to add items." />
-                                    </EmptyTemplate>
-                                </BbDataGrid>
-                            </div>
-                        </BbCardContent>
-                    </BbCard>
+            <div class="pos-cashier-shell">
+                <section class="pos-catalog-panel">
+                    <div class="pos-catalog-toolbar">
+                        <div class="pos-search-field">
+                            <BbInput id="pos-catalog-search"
+                                     @bind-Value="_catalogSearch"
+                                     Placeholder="Scan barcode or search SKU, product, variant, or brand"
+                                     Class="pos-search-input"
+                                     @onkeydown="@HandleCatalogKeyDown" />
+                        </div>
+                        <BbButton Size="ButtonSize.Large" OnClick="@(() => SearchCatalog())" Disabled="@_searching" Class="pos-search-button">
+                            <LucideIcon Name="search" class="mr-2 h-5 w-5" />
+                            Search
+                        </BbButton>
+                    </div>
 
-                    <BbCard>
-                        <BbCardHeader>
-                            <BbCardTitle>Cart</BbCardTitle>
-                            <BbCardDescription>@_cart.Count line(s)</BbCardDescription>
-                        </BbCardHeader>
-                        <BbCardContent>
-                            <BbDataGrid Items="@_cart" ShowPagination="false">
-                                <Columns>
-                                    <BbDataGridPropertyColumn Property="@(x => x.DisplayName)" Title="Item" Filterable="true" />
-                                    <BbDataGridTemplateColumn Title="Qty" Sortable="true" Filterable="true" FilterBy="@(item => item.Quantity)">
-                                        <ChildContent Context="item">
-                                            <div class="flex items-center gap-2">
-                                                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => ChangeQuantity(item, -1))">-</BbButton>
-                                                <span class="font-mono">@item.Quantity.ToString("N0")</span>
-                                                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="@(() => ChangeQuantity(item, 1))">+</BbButton>
-                                            </div>
-                                        </ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                    <BbDataGridTemplateColumn Title="Unit" Filterable="true" FilterBy="@(item => item.UnitPrice)">
-                                        <ChildContent Context="item">@item.UnitPrice.ToString("N2")</ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                    <BbDataGridTemplateColumn Title="Total" Filterable="true" FilterBy="@(item => item.LineTotal)">
-                                        <ChildContent Context="item">@item.LineTotal.ToString("N2")</ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                    <BbDataGridTemplateColumn Title="Actions">
-                                        <ChildContent Context="item">
-                                            <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Destructive" OnClick="@(() => RemoveFromCart(item))">Remove</BbButton>
-                                    </ChildContent>
-                                </BbDataGridTemplateColumn>
-                            </Columns>
+                    <div class="pos-category-strip" aria-label="Catalog categories">
+                        <BbButton Size="ButtonSize.Large"
+                                  Variant="@CategoryButtonVariant(null)"
+                                  Class="pos-category-chip"
+                                  OnClick="@(() => SelectCategory(null))">
+                            All
+                        </BbButton>
+                        @foreach (var category in _categories)
+                        {
+                            <BbButton Size="ButtonSize.Large"
+                                      Variant="@CategoryButtonVariant(category.Id)"
+                                      Class="pos-category-chip"
+                                      OnClick="@(() => SelectCategory(category.Id))">
+                                @category.Name
+                            </BbButton>
+                        }
+                    </div>
+
+                    <BbDataView TItem="PosCatalogItemResponse"
+                                Data="@_catalogItems"
+                                Layout="DataViewLayout.Grid"
+                                ShowToolbar="false"
+                                ShowPagination="true"
+                                InitialPageSize="24"
+                                GridColumnMinWidth="12rem"
+                                Class="pos-catalog-view"
+                                GridClass="pos-product-grid"
+                                IsLoading="@_searching">
+                        <Fields>
+                            <BbDataViewGridTemplate TItem="PosCatalogItemResponse" Context="item">
+                                <BbButton Variant="ButtonVariant.Outline"
+                                          Class="pos-product-tile"
+                                          OnClick="@(() => AddToCart(item))"
+                                          Disabled="@(!item.IsAvailable)">
+                                    <span class="pos-product-media">
+                                        @if (!string.IsNullOrWhiteSpace(item.Image))
+                                        {
+                                            <img src="@item.Image" alt="@item.DisplayName" />
+                                        }
+                                        else
+                                        {
+                                            <LucideIcon Name="package" class="pos-product-icon" />
+                                        }
+                                    </span>
+                                    <span class="pos-product-body">
+                                        <span class="pos-product-name">@item.DisplayName</span>
+                                        <span class="pos-product-meta">@FormatProductMeta(item)</span>
+                                        <span class="pos-product-footer">
+                                            <span class="pos-product-price">@item.Price.ToString("N2")</span>
+                                            <span class="@AvailabilityClass(item)">@AvailabilityText(item)</span>
+                                        </span>
+                                    </span>
+                                </BbButton>
+                            </BbDataViewGridTemplate>
+                        </Fields>
+                        <LoadingTemplate>
+                            <div class="pos-catalog-empty">
+                                <BbSpinner />
+                            </div>
+                        </LoadingTemplate>
+                        <EmptyTemplate>
+                            <BbEmpty Title="No catalog items" Description="Scan or search Inventario sellable products." />
+                        </EmptyTemplate>
+                    </BbDataView>
+                </section>
+
+                <aside class="pos-cart-panel">
+                    <div class="pos-checkout-panel">
+                        @if (!string.IsNullOrWhiteSpace(_activeCartNumber))
+                        {
+                            <BbAlert>
+                                <BbAlertTitle>Draft @_activeCartNumber</BbAlertTitle>
+                                <BbAlertDescription>Checkout or suspend to keep the queue moving.</BbAlertDescription>
+                            </BbAlert>
+                        }
+
+                        <XfEntityPicker TItem="PosRegister"
+                                        @bind-Value="_selectedRegisterId"
+                                        Items="@_registers"
+                                        Label="Register"
+                                        Placeholder="Select register"
+                                        SearchPlaceholder="Search registers..."
+                                        EmptyMessage="No POS registers found."
+                                        ValueSelector="@GetRegisterValue"
+                                        TextSelector="@GetRegisterLabel"
+                                        SearchTextSelector="@GetRegisterSearchText"
+                                        AdvancedColumns="@RegisterAdvancedColumns"
+                                        AdvancedSearchScope="Searches register name, code, default warehouse, default location, enabled state, and register id."
+                                        AdvancedSearchTitle="Find Register"
+                                        AdvancedSearchDescription="Select the register for this checkout." />
+
+                        <div class="pos-payment-block">
+                            <BbLabel>Payment</BbLabel>
+                            <BbRadioGroup TValue="PosPaymentMethod" @bind-Value="_paymentMethod" Class="pos-payment-options">
+                                <label class="pos-payment-option" for="pos-payment-cash">
+                                    <BbRadioGroupItem TValue="PosPaymentMethod" Value="@PosPaymentMethod.CashDrawer" id="pos-payment-cash" />
+                                    <span>
+                                        <strong>Cash Drawer</strong>
+                                        <small>Post to register cash drawer wallet</small>
+                                    </span>
+                                </label>
+                                <label class="pos-payment-option" for="pos-payment-wallet">
+                                    <BbRadioGroupItem TValue="PosPaymentMethod" Value="@PosPaymentMethod.WalletTransfer" id="pos-payment-wallet" />
+                                    <span>
+                                        <strong>Wallet Transfer</strong>
+                                        <small>Move funds from customer wallet</small>
+                                    </span>
+                                </label>
+                            </BbRadioGroup>
+                        </div>
+
+                        @if (IsWalletPayment)
+                        {
+                            <XfEntityPicker TItem="IdentityCredential"
+                                            @bind-Value="_selectedCustomerCredentialId"
+                                            Items="@_credentials"
+                                            Label="Customer Credential"
+                                            Placeholder="Select customer"
+                                            SearchPlaceholder="Search credentials..."
+                                            EmptyMessage="No credentials found."
+                                            ValueSelector="@GetCredentialValue"
+                                            TextSelector="@GetCredentialLabel"
+                                            SearchTextSelector="@GetCredentialSearchText"
+                                            AdvancedColumns="@CredentialAdvancedColumns"
+                                            AdvancedSearchScope="Searches customer credential username, alias, online state, last seen date, device, location, and credential id."
+                                            AdvancedSearchTitle="Find Customer Credential"
+                                            AdvancedSearchDescription="Select the customer wallet source." />
+                        }
+
+                        <div class="pos-adjustments">
+                            <BbFormFieldCurrencyInput @bind-Value="_discountAmount" Label="Discount" ShowSymbol="false" Min="0" />
+                            <BbFormFieldCurrencyInput @bind-Value="_taxAmount" Label="Tax" ShowSymbol="false" Min="0" />
+                        </div>
+
+                        @if (IsCashPayment)
+                        {
+                            <div class="pos-cash-panel">
+                                <BbFormFieldCurrencyInput @bind-Value="_cashTenderedAmount" Label="Cash Tendered" ShowSymbol="false" Min="0" />
+                                <div class="pos-change-due">
+                                    <span>Change Due</span>
+                                    <strong>@ChangeDue.ToString("N2")</strong>
+                                </div>
+                            </div>
+                        }
+                    </div>
+
+                    <div class="pos-cart-list">
+                        <div class="pos-cart-title-row">
+                            <div>
+                                <h2>Cart</h2>
+                                <span>@CartItemCount item(s)</span>
+                            </div>
+                            @if (_cartsEnabled)
+                            {
+                                <BbButton Size="ButtonSize.Large" Variant="ButtonVariant.Outline" OnClick="@SuspendCart" Disabled="@(_savingCart || !_cart.Any())">
+                                    <LucideIcon Name="pause" class="mr-2 h-4 w-4" />
+                                    Suspend
+                                </BbButton>
+                            }
+                        </div>
+
+                        <BbDataView TItem="CartLine"
+                                    Data="@_cart"
+                                    Layout="DataViewLayout.List"
+                                    ShowToolbar="false"
+                                    ShowPagination="false"
+                                    Class="pos-cart-view"
+                                    ListClass="pos-cart-lines">
+                            <Fields>
+                                <BbDataViewListTemplate TItem="CartLine" Context="line">
+                                    <div class="pos-cart-line">
+                                        <div class="pos-cart-line-main">
+                                            <strong>@line.DisplayName</strong>
+                                            <span>@line.UnitPrice.ToString("N2") each</span>
+                                        </div>
+                                        <div class="pos-qty-stepper" aria-label="Quantity controls">
+                                            <BbButton Size="ButtonSize.IconLarge" Variant="ButtonVariant.Outline" OnClick="@(() => ChangeQuantity(line, -1))" aria-label="Decrease quantity">
+                                                <LucideIcon Name="minus" class="h-4 w-4" />
+                                            </BbButton>
+                                            <span class="pos-qty-value">@FormatQuantity(line.Quantity)</span>
+                                            <BbButton Size="ButtonSize.IconLarge" Variant="ButtonVariant.Outline" OnClick="@(() => ChangeQuantity(line, 1))" aria-label="Increase quantity">
+                                                <LucideIcon Name="plus" class="h-4 w-4" />
+                                            </BbButton>
+                                        </div>
+                                        <div class="pos-cart-line-total">@line.LineTotal.ToString("N2")</div>
+                                        <BbButton Size="ButtonSize.IconLarge" Variant="ButtonVariant.Destructive" OnClick="@(() => RemoveFromCart(line))" aria-label="Remove item">
+                                            <LucideIcon Name="trash-2" class="h-4 w-4" />
+                                        </BbButton>
+                                    </div>
+                                </BbDataViewListTemplate>
+                            </Fields>
                             <EmptyTemplate>
                                 <BbEmpty Title="Cart is empty" Description="Add catalog items before checkout." />
                             </EmptyTemplate>
-                        </BbDataGrid>
-                    </BbCardContent>
-                </BbCard>
-                </div>
+                        </BbDataView>
+                    </div>
 
-                <div class="space-y-6">
-                    <BbCard>
-                        <BbCardHeader>
-                            <BbCardTitle>Checkout</BbCardTitle>
-                            <BbCardDescription>Select register and tender.</BbCardDescription>
-                        </BbCardHeader>
-                        <BbCardContent>
-                            <div class="grid gap-4">
-                                @if (!string.IsNullOrWhiteSpace(_activeCartNumber))
-                                {
-                                    <BbAlert>
-                                        <BbAlertTitle>Draft @_activeCartNumber</BbAlertTitle>
-                                        <BbAlertDescription>Changes will be saved before suspend or checkout.</BbAlertDescription>
-                                    </BbAlert>
-                                }
-
-                                <div class="grid gap-3 md:grid-cols-2">
-                                    <div class="grid gap-2">
-                                        <BbLabel>Customer Label</BbLabel>
-                                        <BbInput @bind-Value="_customerLabel" Placeholder="Name, queue number, or note" />
-                                    </div>
-                                    <div class="grid gap-2">
-                                        <BbLabel>Cart Notes</BbLabel>
-                                        <BbInput @bind-Value="_cartNotes" Placeholder="Optional cashier note" />
-                                    </div>
-                                </div>
-
-                                <XfEntityPicker TItem="PosRegister"
-                                                @bind-Value="_selectedRegisterId"
-                                                Items="@_registers"
-                                                Label="Register"
-                                                Placeholder="Select register"
-                                                SearchPlaceholder="Search registers..."
-                                                EmptyMessage="No POS registers found."
-                                                ValueSelector="@GetRegisterValue"
-                                                TextSelector="@GetRegisterLabel"
-                                                SearchTextSelector="@GetRegisterSearchText"
-                                                AdvancedColumns="@RegisterAdvancedColumns"
-                                                AdvancedSearchScope="Searches register name, code, default warehouse, default location, enabled state, and register id."
-                                                AdvancedSearchTitle="Find Register"
-                                                AdvancedSearchDescription="Select the register for this checkout." />
-
-                                <BbFormFieldSelect TValue="string" @bind-Value="PaymentMethodValue" Label="Payment">
-                                    <BbSelectItem Value="@PosPaymentMethod.CashDrawer.ToString()">Cash Drawer</BbSelectItem>
-                                    <BbSelectItem Value="@PosPaymentMethod.WalletTransfer.ToString()">Wallet Transfer</BbSelectItem>
-                                </BbFormFieldSelect>
-
-                                @if (_paymentMethod == PosPaymentMethod.WalletTransfer)
-                                {
-                                    <XfEntityPicker TItem="IdentityCredential"
-                                                    @bind-Value="_selectedCustomerCredentialId"
-                                                    Items="@_credentials"
-                                                    Label="Customer Credential"
-                                                    Placeholder="Select customer"
-                                                    SearchPlaceholder="Search credentials..."
-                                                    EmptyMessage="No credentials found."
-                                                    ValueSelector="@GetCredentialValue"
-                                                    TextSelector="@GetCredentialLabel"
-                                                    SearchTextSelector="@GetCredentialSearchText"
-                                                    AdvancedColumns="@CredentialAdvancedColumns"
-                                                    AdvancedSearchScope="Searches customer credential username, alias, online state, last seen date, device, location, and credential id."
-                                                    AdvancedSearchTitle="Find Customer Credential"
-                                                    AdvancedSearchDescription="Select the customer wallet source." />
-                                }
-
-                                <div class="grid gap-3 md:grid-cols-2">
-                                    <BbFormFieldCurrencyInput @bind-Value="_discountAmount" Label="Discount" ShowSymbol="false" Min="0" />
-                                    <BbFormFieldCurrencyInput @bind-Value="_taxAmount" Label="Tax" ShowSymbol="false" Min="0" />
-                                </div>
-
-                                <div class="grid gap-2 rounded border p-4">
-                                    <div class="flex justify-between">
-                                        <span>Subtotal</span>
-                                        <span class="font-mono">@Subtotal.ToString("N2")</span>
-                                    </div>
-                                    <div class="flex justify-between">
-                                        <span>Discount</span>
-                                        <span class="font-mono">-@_discountAmount.ToString("N2")</span>
-                                    </div>
-                                    <div class="flex justify-between">
-                                        <span>Tax</span>
-                                        <span class="font-mono">@_taxAmount.ToString("N2")</span>
-                                    </div>
-                                    <div class="flex justify-between text-lg font-semibold">
-                                        <span>Total</span>
-                                        <span class="font-mono">@Total.ToString("N2")</span>
-                                    </div>
-                                </div>
-
-                                <div class="grid gap-2 md:grid-cols-2">
-                                    @if (_cartsEnabled)
-                                    {
-                                        <BbButton Variant="ButtonVariant.Outline" OnClick="@SuspendCart" Disabled="@(_savingCart || !_cart.Any())">
-                                            <LucideIcon Name="pause" class="mr-2 h-4 w-4" />
-                                            Suspend Cart
-                                        </BbButton>
-                                    }
-                                    <BbButton OnClick="@Checkout" Disabled="@(_checkingOut || !_cart.Any())">
-                                        <LucideIcon Name="receipt" class="mr-2 h-4 w-4" />
-                                        Checkout
-                                    </BbButton>
-                                </div>
-                            </div>
-                        </BbCardContent>
-                    </BbCard>
+                    <div class="pos-total-bar">
+                        <div class="pos-total-lines">
+                            <div><span>Subtotal</span><strong>@Subtotal.ToString("N2")</strong></div>
+                            <div><span>Discount</span><strong>-@_discountAmount.ToString("N2")</strong></div>
+                            <div><span>Tax</span><strong>@_taxAmount.ToString("N2")</strong></div>
+                        </div>
+                        <div class="pos-grand-total">
+                            <span>Total</span>
+                            <strong>@Total.ToString("N2")</strong>
+                        </div>
+                        <BbButton Size="ButtonSize.Large" OnClick="@Checkout" Disabled="@(!CanCheckout)" Class="pos-checkout-action">
+                            <LucideIcon Name="receipt" class="mr-2 h-5 w-5" />
+                            Checkout
+                        </BbButton>
+                    </div>
 
                     @if (_lastReceipt is not null)
                     {
-                        <BbCard>
-                            <BbCardHeader>
-                                <BbCardTitle>Receipt @_lastReceipt.SaleNumber</BbCardTitle>
-                                <BbCardDescription>@_lastReceipt.Status</BbCardDescription>
-                            </BbCardHeader>
-                            <BbCardContent>
-                                <div class="grid gap-2 text-sm">
-                                    <div class="flex justify-between"><span>Total</span><span>@_lastReceipt.TotalAmount.ToString("N2")</span></div>
-                                    <div class="flex justify-between"><span>Lines</span><span>@_lastReceipt.Lines.Count</span></div>
-                                    @if (!string.IsNullOrWhiteSpace(_lastReceipt.FailureReason))
-                                    {
-                                        <BbAlert Variant="AlertVariant.Warning">
-                                            <BbAlertTitle>Recovery needed</BbAlertTitle>
-                                            <BbAlertDescription>@_lastReceipt.FailureReason</BbAlertDescription>
-                                        </BbAlert>
-                                    }
-                                </div>
-                            </BbCardContent>
-                        </BbCard>
+                        <div class="pos-receipt-panel">
+                            <div>
+                                <strong>Receipt @_lastReceipt.SaleNumber</strong>
+                                <span>@_lastReceipt.Status | @_lastReceipt.TotalAmount.ToString("N2")</span>
+                            </div>
+                            @if (!string.IsNullOrWhiteSpace(_lastReceipt.FailureReason))
+                            {
+                                <BbAlert Variant="AlertVariant.Warning">
+                                    <BbAlertTitle>Recovery needed</BbAlertTitle>
+                                    <BbAlertDescription>@_lastReceipt.FailureReason</BbAlertDescription>
+                                </BbAlert>
+                            }
+                            <BbButton Size="ButtonSize.Large" Variant="ButtonVariant.Outline" OnClick="@StartNewSale">
+                                <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
+                                New Sale
+                            </BbButton>
+                        </div>
                     }
-
-                    @if (_cartsEnabled)
-                    {
-                        <BbCard>
-                            <BbCardHeader>
-                                <BbCardTitle>Suspended Carts</BbCardTitle>
-                                <BbCardDescription>@_suspendedCarts.Count cart(s) waiting</BbCardDescription>
-                            </BbCardHeader>
-                            <BbCardContent>
-                                <BbDataGrid Items="@_suspendedCarts" ShowPagination="true" InitialPageSize="8">
-                                    <Columns>
-                                        <BbDataGridPropertyColumn Property="@(x => x.CartNumber)" Title="Cart" Sortable="true" Filterable="true" />
-                                        <BbDataGridPropertyColumn Property="@(x => x.CustomerLabel)" Title="Customer" Sortable="true" Filterable="true" />
-                                        <BbDataGridTemplateColumn Title="Total" Sortable="true" Filterable="true" FilterBy="@(item => item.TotalAmount)">
-                                            <ChildContent Context="item">@item.TotalAmount.ToString("N2")</ChildContent>
-                                        </BbDataGridTemplateColumn>
-                                        <BbDataGridPropertyColumn Property="@(x => x.SuspendedAt)" Title="Suspended" Sortable="true" Filterable="true" />
-                                        <BbDataGridPropertyColumn Property="@(x => x.ExpiresAt)" Title="Expires" Sortable="true" Filterable="true" />
-                                        <BbDataGridTemplateColumn Title="Actions">
-                                            <ChildContent Context="item">
-                                                <div class="flex flex-wrap gap-1">
-                                                    <BbButton Size="ButtonSize.Small" OnClick="@(() => ResumeCart(item))" Disabled="@_actingOnCart">
-                                                        Resume
-                                                    </BbButton>
-                                                    <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Destructive" OnClick="@(() => CancelDraftCart(item))" Disabled="@_actingOnCart">
-                                                        Cancel
-                                                    </BbButton>
-                                                </div>
-                                            </ChildContent>
-                                        </BbDataGridTemplateColumn>
-                                    </Columns>
-                                    <EmptyTemplate>
-                                        <BbEmpty Title="No suspended carts" Description="Suspended customer carts will appear here." />
-                                    </EmptyTemplate>
-                                </BbDataGrid>
-                            </BbCardContent>
-                        </BbCard>
-                    }
-                </div>
+                </aside>
             </div>
         </div>
     </FadeInContent>
+
+    <BbDialog Open="@_saleDetailsOpen" OpenChanged="@(value => _saleDetailsOpen = value)">
+        <BbDialogContent TrapFocus="false" Class="xf-dialog-wide">
+            <BbDialogHeader>
+                <BbDialogTitle>Sale Details</BbDialogTitle>
+                <BbDialogDescription>Optional customer and cashier notes for the active sale.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="pos-dialog-fields">
+                <div>
+                    <BbLabel>Customer Label</BbLabel>
+                    <BbInput @bind-Value="_customerLabel" Placeholder="Name, queue number, or note" />
+                </div>
+                <div>
+                    <BbLabel>Cart Notes</BbLabel>
+                    <BbTextarea @bind-Value="_cartNotes" Placeholder="Optional cashier note" />
+                </div>
+            </div>
+            <BbDialogFooter>
+                <BbButton Size="ButtonSize.Large" OnClick="@CloseSaleDetailsDialog">Done</BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
+
+    @if (_cartsEnabled)
+    {
+        <BbDialog Open="@_heldCartsOpen" OpenChanged="@(value => _heldCartsOpen = value)">
+            <BbDialogContent TrapFocus="false" Class="xf-dialog-wide pos-held-carts-dialog">
+                <BbDialogHeader>
+                    <BbDialogTitle>Held Carts</BbDialogTitle>
+                    <BbDialogDescription>@_suspendedCarts.Count suspended customer cart(s).</BbDialogDescription>
+                </BbDialogHeader>
+                <BbDataView TItem="PosCartSummaryResponse"
+                            Data="@_suspendedCarts"
+                            Layout="DataViewLayout.List"
+                            ShowToolbar="false"
+                            ShowPagination="true"
+                            InitialPageSize="8"
+                            Class="pos-held-carts-view"
+                            ListClass="pos-held-carts-list">
+                    <Fields>
+                        <BbDataViewListTemplate TItem="PosCartSummaryResponse" Context="cart">
+                            <div class="pos-held-cart-row">
+                                <div class="pos-held-cart-main">
+                                    <strong>@cart.CartNumber</strong>
+                                    <span>@HeldCartCustomer(cart) | @cart.TotalAmount.ToString("N2")</span>
+                                    <small>Suspended @FormatDateTime(cart.SuspendedAt) | Expires @FormatDateTime(cart.ExpiresAt)</small>
+                                </div>
+                                <div class="pos-held-cart-actions">
+                                    <BbButton Size="ButtonSize.Large" OnClick="@(() => ResumeCart(cart))" Disabled="@_actingOnCart">
+                                        Resume
+                                    </BbButton>
+                                    <BbButton Size="ButtonSize.Large" Variant="ButtonVariant.Destructive" OnClick="@(() => CancelDraftCart(cart))" Disabled="@_actingOnCart">
+                                        Cancel
+                                    </BbButton>
+                                </div>
+                            </div>
+                        </BbDataViewListTemplate>
+                    </Fields>
+                    <EmptyTemplate>
+                        <BbEmpty Title="No held carts" Description="Suspended customer carts will appear here." />
+                    </EmptyTemplate>
+                </BbDataView>
+            </BbDialogContent>
+        </BbDialog>
+    }
 }
 
 @code {
@@ -307,10 +380,12 @@ else
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private RequestMetadata RequestMetadata { get; set; } = default!;
     [Inject] private DialogService DialogService { get; set; } = default!;
+    [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
 
     private readonly List<CartLine> _cart = [];
     private List<PosRegister> _registers = [];
     private List<IdentityCredential> _credentials = [];
+    private List<ProductCategory> _categories = [];
     private List<PosCatalogItemResponse> _catalogItems = [];
     private List<PosCartSummaryResponse> _suspendedCarts = [];
     private bool _loading = true;
@@ -321,30 +396,30 @@ else
     private bool _checkingOut;
     private bool _savingCart;
     private bool _actingOnCart;
+    private bool _heldCartsOpen;
+    private bool _saleDetailsOpen;
     private string _catalogSearch = "";
     private string? _selectedRegisterId;
     private string? _selectedCustomerCredentialId;
     private string _customerLabel = "";
     private string _cartNotes = "";
+    private Guid? _selectedCategoryId;
     private Guid? _activeCartId;
     private Guid? _activeCartConcurrencyStamp;
     private string? _activeCartNumber;
     private decimal _discountAmount;
     private decimal _taxAmount;
+    private decimal _cashTenderedAmount;
     private PosPaymentMethod _paymentMethod = PosPaymentMethod.CashDrawer;
     private PosSaleReceiptResponse? _lastReceipt;
 
     private decimal Subtotal => _cart.Sum(line => line.LineTotal);
     private decimal Total => Subtotal - _discountAmount + _taxAmount;
-    private string PaymentMethodValue
-    {
-        get => _paymentMethod.ToString();
-        set
-        {
-            if (Enum.TryParse<PosPaymentMethod>(value, out var method))
-                _paymentMethod = method;
-        }
-    }
+    private decimal ChangeDue => Math.Max(0, _cashTenderedAmount - Total);
+    private decimal CartItemCount => _cart.Sum(line => line.Quantity);
+    private bool IsCashPayment => _paymentMethod == PosPaymentMethod.CashDrawer;
+    private bool IsWalletPayment => _paymentMethod == PosPaymentMethod.WalletTransfer;
+    private bool CanCheckout => !_checkingOut && _cart.Any() && Total >= 0;
 
     protected override void OnInitialized()
     {
@@ -367,6 +442,7 @@ else
             _cartsEnabled = ModuleNavigation.IsFeatureEnabled(TenantModuleFeatureKeys.Pos, "carts");
             _registers = [];
             _credentials = [];
+            _categories = [];
             _suspendedCarts = [];
 
             if (_hasTenant && _moduleEnabled && TenantFilter.SelectedTenantId is Guid tenantId)
@@ -385,6 +461,14 @@ else
                     .Where(item => item.TenantId == tenantId && !item.IsDeleted && item.IsEnabled)
                     .OrderBy(item => item.UserName)
                     .Take(200)
+                    .ToListAsync();
+
+                _categories = await DataContext.Query<ProductCategory>()
+                    .IgnoreQueryFilters()
+                    .NoCache()
+                    .Where(item => item.TenantId == tenantId && !item.IsDeleted)
+                    .OrderBy(item => item.Name)
+                    .Take(80)
                     .ToListAsync();
 
                 _selectedRegisterId ??= _registers.FirstOrDefault()?.Id.ToString();
@@ -424,7 +508,7 @@ else
             ToastService.Show(response.Message ?? "Could not load suspended carts.");
     }
 
-    private async Task SearchCatalog()
+    private async Task SearchCatalog(bool addExactSkuToCart = true)
     {
         if (TenantFilter.SelectedTenantId is not Guid)
         {
@@ -435,32 +519,72 @@ else
         _searching = true;
         try
         {
+            var searchText = _catalogSearch.Trim();
             var response = await POS.SearchPosCatalog(new SearchPosCatalogRequest
             {
                 Metadata = BuildMetadata(),
-                Search = _catalogSearch,
+                Search = searchText,
+                CategoryId = _selectedCategoryId,
                 Page = 1,
                 PageSize = 50
             });
 
             _catalogItems = response.Response ?? [];
             if (!response.IsSuccess)
+            {
                 ToastService.Show(response.Message ?? "Catalog search failed.");
+                return;
+            }
+
+            if (addExactSkuToCart && !string.IsNullOrWhiteSpace(searchText))
+                AddExactSkuMatchToCart(searchText);
         }
         finally
         {
             _searching = false;
+            await FocusCatalogSearchAsync();
         }
+    }
+
+    private async Task SelectCategory(Guid? categoryId)
+    {
+        if (_selectedCategoryId == categoryId)
+            return;
+
+        _selectedCategoryId = categoryId;
+        await SearchCatalog(false);
+    }
+
+    private async Task HandleCatalogKeyDown(KeyboardEventArgs args)
+    {
+        if (args.Key == "Enter")
+            await SearchCatalog();
+    }
+
+    private void AddExactSkuMatchToCart(string searchText)
+    {
+        var matches = _catalogItems
+            .Where(item => item.IsAvailable && string.Equals(item.SKU, searchText, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count != 1)
+            return;
+
+        AddToCart(matches[0]);
+        _catalogSearch = "";
+        ToastService.Show("Item added to cart.");
     }
 
     private void AddToCart(PosCatalogItemResponse item)
     {
+        _lastReceipt = null;
         var existing = _cart.FirstOrDefault(line =>
             line.ProductId == item.ProductId &&
             line.ProductVariationId == item.ProductVariationId);
         if (existing is not null)
         {
-            existing.Quantity++;
+            SetQuantity(existing, existing.Quantity + 1);
+            _ = InvokeAsync(FocusCatalogSearchAsync);
             return;
         }
 
@@ -472,14 +596,24 @@ else
             UnitPrice = item.Price,
             Quantity = 1
         });
+        _ = InvokeAsync(FocusCatalogSearchAsync);
     }
 
-    private void ChangeQuantity(CartLine line, int delta)
+    private void ChangeQuantity(CartLine line, decimal delta)
     {
-        line.Quantity = Math.Max(1, line.Quantity + delta);
+        SetQuantity(line, line.Quantity + delta);
     }
 
-    private void RemoveFromCart(CartLine line) => _cart.Remove(line);
+    private static void SetQuantity(CartLine line, decimal quantity)
+    {
+        line.Quantity = Math.Max(1, quantity);
+    }
+
+    private void RemoveFromCart(CartLine line)
+    {
+        _lastReceipt = null;
+        _cart.Remove(line);
+    }
 
     private async Task SuspendCart()
     {
@@ -547,6 +681,7 @@ else
             ToastService.Show("Cart suspended.");
             ClearCurrentCart();
             await LoadSuspendedCarts();
+            _heldCartsOpen = true;
         }
         finally
         {
@@ -585,6 +720,7 @@ else
             }
 
             ApplyCart(response.Response);
+            _heldCartsOpen = false;
             if (response.Response.Warnings.Count > 0)
                 ToastService.Show(response.Response.Warnings[0]);
             else
@@ -684,7 +820,7 @@ else
         }
 
         Guid? customerCredentialId = null;
-        if (_paymentMethod == PosPaymentMethod.WalletTransfer)
+        if (IsWalletPayment)
         {
             if (!Guid.TryParse(_selectedCustomerCredentialId, out var parsedCustomer))
             {
@@ -784,6 +920,7 @@ else
 
     private void ApplyCart(PosCartResponse cart)
     {
+        _lastReceipt = null;
         _activeCartId = cart.Id;
         _activeCartConcurrencyStamp = cart.ConcurrencyStamp;
         _activeCartNumber = cart.CartNumber;
@@ -793,6 +930,7 @@ else
         _cartNotes = cart.Notes ?? "";
         _discountAmount = cart.DiscountAmount;
         _taxAmount = cart.TaxAmount;
+        _cashTenderedAmount = 0;
 
         _cart.Clear();
         foreach (var line in cart.Lines.OrderBy(item => item.LineNumber))
@@ -821,6 +959,7 @@ else
         _selectedCustomerCredentialId = null;
         _discountAmount = 0;
         _taxAmount = 0;
+        _cashTenderedAmount = 0;
     }
 
     private async Task ConfirmClearCurrentCart()
@@ -836,8 +975,25 @@ else
             return;
         }
 
+        _lastReceipt = null;
         ClearCurrentCart();
     }
+
+    private void StartNewSale()
+    {
+        _lastReceipt = null;
+        ClearCurrentCart();
+        _ = InvokeAsync(FocusCatalogSearchAsync);
+    }
+
+    private void OpenHeldCartsDialog()
+    {
+        if (_cartsEnabled)
+            _heldCartsOpen = true;
+    }
+
+    private void OpenSaleDetailsDialog() => _saleDetailsOpen = true;
+    private void CloseSaleDetailsDialog() => _saleDetailsOpen = false;
 
     private bool TryResolveRegister(out Guid registerId)
     {
@@ -863,6 +1019,21 @@ else
             ? customerCredentialId
             : null;
 
+    private async Task FocusCatalogSearchAsync()
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("eval", "document.getElementById('pos-catalog-search')?.focus();");
+        }
+        catch (JSException)
+        {
+            // Focus is an ergonomic enhancement; checkout behavior must not depend on it.
+        }
+    }
+
+    private ButtonVariant CategoryButtonVariant(Guid? categoryId) =>
+        _selectedCategoryId == categoryId ? ButtonVariant.Default : ButtonVariant.Outline;
+
     private RequestMetadata BuildMetadata() => new()
     {
         TenantId = TenantFilter.SelectedTenantId,
@@ -883,6 +1054,31 @@ else
         string.IsNullOrWhiteSpace(credential.UserName) ? credential.Id.ToString()[..8] : credential.UserName;
     private static string GetCredentialSearchText(IdentityCredential credential) =>
         $"{credential.UserName} {credential.UserAlias}";
+
+    private static string FormatProductMeta(PosCatalogItemResponse item)
+    {
+        var parts = new[] { item.SKU, item.Brand, item.CategoryName }
+            .Where(value => !string.IsNullOrWhiteSpace(value));
+
+        return string.Join(" | ", parts);
+    }
+
+    private static string AvailabilityText(PosCatalogItemResponse item)
+    {
+        if (!item.IsAvailable)
+            return "Unavailable";
+
+        return item.AvailableQuantity.HasValue
+            ? $"{FormatQuantity(item.AvailableQuantity.Value)} available"
+            : "Available";
+    }
+
+    private static string AvailabilityClass(PosCatalogItemResponse item) =>
+        item.IsAvailable ? "pos-product-status pos-product-status-ready" : "pos-product-status pos-product-status-offline";
+
+    private static string FormatQuantity(decimal value) => value % 1 == 0 ? value.ToString("N0") : value.ToString("N2");
+    private static string HeldCartCustomer(PosCartSummaryResponse cart) =>
+        string.IsNullOrWhiteSpace(cart.CustomerLabel) ? "Walk-in customer" : cart.CustomerLabel;
 
     private static IReadOnlyList<XfEntityPickerColumn<PosRegister>> RegisterAdvancedColumns =>
     [
@@ -907,7 +1103,7 @@ else
 
     private static string ShortId(Guid id) => id.ToString()[..8];
     private static string FormatBoolean(bool value) => value ? "Yes" : "No";
-    private static string FormatDateTime(DateTime? value) => value?.ToString("yyyy-MM-dd") ?? "-";
+    private static string FormatDateTime(DateTime? value) => value?.ToString("yyyy-MM-dd HH:mm") ?? "-";
 
     public void Dispose()
     {

--- a/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
+++ b/src/Presentation/ControlPanel.Server/wwwroot/css/app.css
@@ -1,6 +1,511 @@
 /*! tailwindcss v4.1.16 | MIT License | https://tailwindcss.com */
 @layer properties{@supports (((-webkit-hyphens:none)) and (not (margin-trim:inline))) or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-space-y-reverse:0;--tw-space-x-reverse:0;--tw-border-style:solid;--tw-leading:initial;--tw-font-weight:initial;--tw-tracking:initial;--tw-shadow:0 0 #0000;--tw-shadow-color:initial;--tw-shadow-alpha:100%;--tw-inset-shadow:0 0 #0000;--tw-inset-shadow-color:initial;--tw-inset-shadow-alpha:100%;--tw-ring-color:initial;--tw-ring-shadow:0 0 #0000;--tw-inset-ring-color:initial;--tw-inset-ring-shadow:0 0 #0000;--tw-ring-inset:initial;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-offset-shadow:0 0 #0000}}}@layer theme{:root,:host{--font-mono:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;--color-yellow-500:oklch(79.5% .184 86.047);--color-green-500:oklch(72.3% .219 149.579);--color-blue-500:oklch(62.3% .214 259.815);--color-black:#000;--spacing:.25rem;--container-sm:24rem;--container-md:28rem;--container-lg:32rem;--container-3xl:48rem;--text-sm:.875rem;--text-sm--line-height:calc(1.25/.875);--text-base:1rem;--text-base--line-height:calc(1.5/1);--text-lg:1.125rem;--text-lg--line-height:calc(1.75/1.125);--text-xl:1.25rem;--text-xl--line-height:calc(1.75/1.25);--text-3xl:1.875rem;--text-3xl--line-height:calc(2.25/1.875);--text-4xl:2.25rem;--text-4xl--line-height:calc(2.5/2.25);--text-5xl:3rem;--text-5xl--line-height:1;--font-weight-normal:400;--font-weight-medium:500;--font-weight-semibold:600;--font-weight-bold:700;--tracking-tight:-.025em;--radius-xl:.75rem;--animate-spin:spin 1s linear infinite;--default-transition-duration:.15s;--default-transition-timing-function:cubic-bezier(.4,0,.2,1);--default-mono-font-family:var(--font-mono)}}@layer base{*,:after,:before,::backdrop{box-sizing:border-box;border:0 solid;margin:0;padding:0}::file-selector-button{box-sizing:border-box;border:0 solid;margin:0;padding:0}html,:host{-webkit-text-size-adjust:100%;tab-size:4;font-feature-settings:normal;font-variation-settings:normal;-webkit-tap-highlight-color:transparent;font-family:Inter,ui-sans-serif,system-ui,sans-serif;line-height:1.5}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,samp,pre{font-family:var(--default-mono-font-family,ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace);font-feature-settings:var(--default-mono-font-feature-settings,normal);font-variation-settings:var(--default-mono-font-variation-settings,normal);font-size:1em}small{font-size:80%}sub,sup{vertical-align:baseline;font-size:75%;line-height:0;position:relative}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}:-moz-focusring{outline:auto}progress{vertical-align:baseline}summary{display:list-item}ol,ul,menu{list-style:none}img,svg,video,canvas,audio,iframe,embed,object{vertical-align:middle;display:block}img,video{max-width:100%;height:auto}button,input,select,optgroup,textarea{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}::file-selector-button{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}:where(select:is([multiple],[size])) optgroup{font-weight:bolder}:where(select:is([multiple],[size])) optgroup option{padding-inline-start:20px}::file-selector-button{margin-inline-end:4px}::placeholder{opacity:1}@supports (not ((-webkit-appearance:-apple-pay-button))) or (contain-intrinsic-size:1px){::placeholder{color:currentColor}@supports (color:color-mix(in lab, red, red)){::placeholder{color:color-mix(in oklab,currentcolor 50%,transparent)}}}textarea{resize:vertical}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-date-and-time-value{min-height:1lh;text-align:inherit}::-webkit-datetime-edit{display:inline-flex}::-webkit-datetime-edit-fields-wrapper{padding:0}::-webkit-datetime-edit{padding-block:0}::-webkit-datetime-edit-year-field{padding-block:0}::-webkit-datetime-edit-month-field{padding-block:0}::-webkit-datetime-edit-day-field{padding-block:0}::-webkit-datetime-edit-hour-field{padding-block:0}::-webkit-datetime-edit-minute-field{padding-block:0}::-webkit-datetime-edit-second-field{padding-block:0}::-webkit-datetime-edit-millisecond-field{padding-block:0}::-webkit-datetime-edit-meridiem-field{padding-block:0}::-webkit-calendar-picker-indicator{line-height:1}:-moz-ui-invalid{box-shadow:none}button,input:where([type=button],[type=reset],[type=submit]){appearance:button}::file-selector-button{appearance:button}::-webkit-inner-spin-button{height:auto}::-webkit-outer-spin-button{height:auto}[hidden]:where(:not([hidden=until-found])){display:none!important}}@layer components;@layer utilities{.sr-only{clip-path:inset(50%);white-space:nowrap;border-width:0;width:1px;height:1px;margin:-1px;padding:0;position:absolute;overflow:hidden}.fixed{position:fixed}.relative{position:relative}.static{position:static}.sticky{position:sticky}.top-0{top:calc(var(--spacing)*0)}.top-20{top:calc(var(--spacing)*20)}.right-0{right:calc(var(--spacing)*0)}.bottom-0{bottom:calc(var(--spacing)*0)}.left-0{left:calc(var(--spacing)*0)}.z-50{z-index:50}.container{width:100%}@media (min-width:40rem){.container{max-width:40rem}}@media (min-width:48rem){.container{max-width:48rem}}@media (min-width:64rem){.container{max-width:64rem}}@media (min-width:80rem){.container{max-width:80rem}}@media (min-width:96rem){.container{max-width:96rem}}.mx-auto{margin-inline:auto}.my-4{margin-block:calc(var(--spacing)*4)}.my-6{margin-block:calc(var(--spacing)*6)}.mt-2{margin-top:calc(var(--spacing)*2)}.mt-4{margin-top:calc(var(--spacing)*4)}.mr-1{margin-right:calc(var(--spacing)*1)}.mr-2{margin-right:calc(var(--spacing)*2)}.mr-4{margin-right:calc(var(--spacing)*4)}.mr-6{margin-right:calc(var(--spacing)*6)}.mb-2{margin-bottom:calc(var(--spacing)*2)}.mb-3{margin-bottom:calc(var(--spacing)*3)}.ml-2{margin-left:calc(var(--spacing)*2)}.block{display:block}.flex{display:flex}.grid{display:grid}.hidden{display:none}.table{display:table}.h-4{height:calc(var(--spacing)*4)}.h-5{height:calc(var(--spacing)*5)}.h-10{height:calc(var(--spacing)*10)}.h-12{height:calc(var(--spacing)*12)}.h-14{height:calc(var(--spacing)*14)}.h-\[125px\]{height:125px}.min-h-\[100px\]{min-height:100px}.min-h-\[400px\]{min-height:400px}.min-h-screen{min-height:100vh}.w-4\/5{width:80%}.w-9{width:calc(var(--spacing)*9)}.w-12{width:calc(var(--spacing)*12)}.w-14{width:calc(var(--spacing)*14)}.w-\[100px\]{width:100px}.w-\[200px\]{width:200px}.w-\[250px\]{width:250px}.w-full{width:100%}.max-w-3xl{max-width:var(--container-3xl)}.max-w-lg{max-width:var(--container-lg)}.max-w-md{max-width:var(--container-md)}.max-w-sm{max-width:var(--container-sm)}.min-w-0{min-width:calc(var(--spacing)*0)}.flex-1{flex:1}.shrink-0{flex-shrink:0}.caption-bottom{caption-side:bottom}.animate-spin{animation:var(--animate-spin)}.grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.flex-col{flex-direction:column}.flex-wrap{flex-wrap:wrap}.items-center{align-items:center}.justify-between{justify-content:space-between}.justify-center{justify-content:center}.justify-end{justify-content:flex-end}.gap-2{gap:calc(var(--spacing)*2)}.gap-4{gap:calc(var(--spacing)*4)}.gap-8{gap:calc(var(--spacing)*8)}:where(.space-y-0\.5>:not(:last-child)){--tw-space-y-reverse:0;margin-block-start:calc(calc(var(--spacing)*.5)*var(--tw-space-y-reverse));margin-block-end:calc(calc(var(--spacing)*.5)*calc(1 - var(--tw-space-y-reverse)))}:where(.space-y-1>:not(:last-child)){--tw-space-y-reverse:0;margin-block-start:calc(calc(var(--spacing)*1)*var(--tw-space-y-reverse));margin-block-end:calc(calc(var(--spacing)*1)*calc(1 - var(--tw-space-y-reverse)))}:where(.space-y-2>:not(:last-child)){--tw-space-y-reverse:0;margin-block-start:calc(calc(var(--spacing)*2)*var(--tw-space-y-reverse));margin-block-end:calc(calc(var(--spacing)*2)*calc(1 - var(--tw-space-y-reverse)))}:where(.space-y-3>:not(:last-child)){--tw-space-y-reverse:0;margin-block-start:calc(calc(var(--spacing)*3)*var(--tw-space-y-reverse));margin-block-end:calc(calc(var(--spacing)*3)*calc(1 - var(--tw-space-y-reverse)))}:where(.space-y-4>:not(:last-child)){--tw-space-y-reverse:0;margin-block-start:calc(calc(var(--spacing)*4)*var(--tw-space-y-reverse));margin-block-end:calc(calc(var(--spacing)*4)*calc(1 - var(--tw-space-y-reverse)))}:where(.space-y-6>:not(:last-child)){--tw-space-y-reverse:0;margin-block-start:calc(calc(var(--spacing)*6)*var(--tw-space-y-reverse));margin-block-end:calc(calc(var(--spacing)*6)*calc(1 - var(--tw-space-y-reverse)))}:where(.space-y-8>:not(:last-child)){--tw-space-y-reverse:0;margin-block-start:calc(calc(var(--spacing)*8)*var(--tw-space-y-reverse));margin-block-end:calc(calc(var(--spacing)*8)*calc(1 - var(--tw-space-y-reverse)))}:where(.space-x-2>:not(:last-child)){--tw-space-x-reverse:0;margin-inline-start:calc(calc(var(--spacing)*2)*var(--tw-space-x-reverse));margin-inline-end:calc(calc(var(--spacing)*2)*calc(1 - var(--tw-space-x-reverse)))}:where(.space-x-4>:not(:last-child)){--tw-space-x-reverse:0;margin-inline-start:calc(calc(var(--spacing)*4)*var(--tw-space-x-reverse));margin-inline-end:calc(calc(var(--spacing)*4)*calc(1 - var(--tw-space-x-reverse)))}:where(.space-x-6>:not(:last-child)){--tw-space-x-reverse:0;margin-inline-start:calc(calc(var(--spacing)*6)*var(--tw-space-x-reverse));margin-inline-end:calc(calc(var(--spacing)*6)*calc(1 - var(--tw-space-x-reverse)))}.overflow-auto{overflow:auto}.rounded{border-radius:.25rem}.rounded-full{border-radius:3.40282e38px}.rounded-lg{border-radius:var(--radius)}.rounded-md{border-radius:calc(var(--radius) - 2px)}.rounded-xl{border-radius:var(--radius-xl)}.border{border-style:var(--tw-border-style);border-width:1px}.border-t{border-top-style:var(--tw-border-style);border-top-width:1px}.border-b{border-bottom-style:var(--tw-border-style);border-bottom-width:1px}.bg-accent{background-color:var(--accent)}.bg-background{background-color:var(--background)}.bg-blue-500{background-color:var(--color-blue-500)}.bg-destructive{background-color:var(--destructive)}.bg-green-500{background-color:var(--color-green-500)}.bg-muted,.bg-muted\/50{background-color:var(--muted)}@supports (color:color-mix(in lab, red, red)){.bg-muted\/50{background-color:color-mix(in oklab,var(--muted)50%,transparent)}}.bg-primary{background-color:var(--primary)}.bg-yellow-500{background-color:var(--color-yellow-500)}.p-0{padding:calc(var(--spacing)*0)}.p-2{padding:calc(var(--spacing)*2)}.p-4{padding:calc(var(--spacing)*4)}.px-1{padding-inline:calc(var(--spacing)*1)}.px-2{padding-inline:calc(var(--spacing)*2)}.px-3{padding-inline:calc(var(--spacing)*3)}.px-4{padding-inline:calc(var(--spacing)*4)}.py-2{padding-block:calc(var(--spacing)*2)}.py-4{padding-block:calc(var(--spacing)*4)}.py-6{padding-block:calc(var(--spacing)*6)}.py-10{padding-block:calc(var(--spacing)*10)}.pb-2{padding-bottom:calc(var(--spacing)*2)}.pb-4{padding-bottom:calc(var(--spacing)*4)}.text-center{text-align:center}.text-left{text-align:left}.text-right{text-align:right}.align-middle{vertical-align:middle}.font-mono{font-family:var(--font-mono)}.font-sans{font-family:Inter,ui-sans-serif,system-ui,sans-serif}.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}.text-4xl{font-size:var(--text-4xl);line-height:var(--tw-leading,var(--text-4xl--line-height))}.text-base{font-size:var(--text-base);line-height:var(--tw-leading,var(--text-base--line-height))}.text-lg{font-size:var(--text-lg);line-height:var(--tw-leading,var(--text-lg--line-height))}.text-sm{font-size:var(--text-sm);line-height:var(--tw-leading,var(--text-sm--line-height))}.text-xl{font-size:var(--text-xl);line-height:var(--tw-leading,var(--text-xl--line-height))}.leading-none{--tw-leading:1;line-height:1}.font-bold{--tw-font-weight:var(--font-weight-bold);font-weight:var(--font-weight-bold)}.font-medium{--tw-font-weight:var(--font-weight-medium);font-weight:var(--font-weight-medium)}.font-normal{--tw-font-weight:var(--font-weight-normal);font-weight:var(--font-weight-normal)}.font-semibold{--tw-font-weight:var(--font-weight-semibold);font-weight:var(--font-weight-semibold)}.tracking-tight{--tw-tracking:var(--tracking-tight);letter-spacing:var(--tracking-tight)}.text-black{color:var(--color-black)}.text-destructive-foreground{color:var(--destructive-foreground)}.text-foreground,.text-foreground\/60{color:var(--foreground)}@supports (color:color-mix(in lab, red, red)){.text-foreground\/60{color:color-mix(in oklab,var(--foreground)60%,transparent)}}.text-muted-foreground{color:var(--muted-foreground)}.text-primary{color:var(--primary)}.text-primary-foreground{color:var(--primary-foreground)}.underline{text-decoration-line:underline}.underline-offset-4{text-underline-offset:4px}.antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.shadow-sm{--tw-shadow:0 1px 3px 0 var(--tw-shadow-color,#0000001a),0 1px 2px -1px var(--tw-shadow-color,#0000001a);box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow),var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow)}.ring{--tw-ring-shadow:var(--tw-ring-inset,)0 0 0 calc(1px + var(--tw-ring-offset-width))var(--tw-ring-color,currentcolor);box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow),var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow)}.transition-colors{transition-property:color,background-color,border-color,outline-color,text-decoration-color,fill,stroke,--tw-gradient-from,--tw-gradient-via,--tw-gradient-to;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}@media (hover:hover){.hover\:bg-accent:hover{background-color:var(--accent)}.hover\:bg-blue-500\/80:hover{background-color:#3080ffcc}@supports (color:color-mix(in lab, red, red)){.hover\:bg-blue-500\/80:hover{background-color:color-mix(in oklab,var(--color-blue-500)80%,transparent)}}.hover\:bg-green-500\/80:hover{background-color:#00c758cc}@supports (color:color-mix(in lab, red, red)){.hover\:bg-green-500\/80:hover{background-color:color-mix(in oklab,var(--color-green-500)80%,transparent)}}.hover\:bg-muted\/50:hover{background-color:var(--muted)}@supports (color:color-mix(in lab, red, red)){.hover\:bg-muted\/50:hover{background-color:color-mix(in oklab,var(--muted)50%,transparent)}}.hover\:bg-yellow-500\/80:hover{background-color:#edb200cc}@supports (color:color-mix(in lab, red, red)){.hover\:bg-yellow-500\/80:hover{background-color:color-mix(in oklab,var(--color-yellow-500)80%,transparent)}}.hover\:text-foreground\/80:hover{color:var(--foreground)}@supports (color:color-mix(in lab, red, red)){.hover\:text-foreground\/80:hover{color:color-mix(in oklab,var(--foreground)80%,transparent)}}}@media (min-width:40rem){.sm\:max-w-\[425px\]{max-width:425px}.sm\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.sm\:text-5xl{font-size:var(--text-5xl);line-height:var(--tw-leading,var(--text-5xl--line-height))}}@media (min-width:48rem){.md\:h-14{height:calc(var(--spacing)*14)}.md\:flex-row{flex-direction:row}.md\:py-0{padding-block:calc(var(--spacing)*0)}}@media (min-width:64rem){.lg\:w-64{width:calc(var(--spacing)*64)}.lg\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.lg\:flex-row{flex-direction:row}}.\[\&_tr\]\:border-b tr{border-bottom-style:var(--tw-border-style);border-bottom-width:1px}.\[\&_tr\:last-child\]\:border-0 tr:last-child{border-style:var(--tw-border-style);border-width:0}.\[\&\>tr\]\:last\:border-b-0>tr:last-child{border-bottom-style:var(--tw-border-style);border-bottom-width:0}}.container{width:100%;margin-left:auto;margin-right:auto;padding-left:1rem;padding-right:1rem}@media (min-width:640px){.container{max-width:640px}}@media (min-width:768px){.container{max-width:768px}}@media (min-width:1024px){.container{max-width:1024px}}@media (min-width:1280px){.container{max-width:1280px}}@media (min-width:1536px){.container{max-width:1536px}}@property --tw-space-y-reverse{syntax:"*";inherits:false;initial-value:0}@property --tw-space-x-reverse{syntax:"*";inherits:false;initial-value:0}@property --tw-border-style{syntax:"*";inherits:false;initial-value:solid}@property --tw-leading{syntax:"*";inherits:false}@property --tw-font-weight{syntax:"*";inherits:false}@property --tw-tracking{syntax:"*";inherits:false}@property --tw-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-shadow-color{syntax:"*";inherits:false}@property --tw-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-inset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-shadow-color{syntax:"*";inherits:false}@property --tw-inset-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-ring-color{syntax:"*";inherits:false}@property --tw-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-ring-color{syntax:"*";inherits:false}@property --tw-inset-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-ring-inset{syntax:"*";inherits:false}@property --tw-ring-offset-width{syntax:"<length>";inherits:false;initial-value:0}@property --tw-ring-offset-color{syntax:"*";inherits:false;initial-value:#fff}@property --tw-ring-offset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@keyframes spin{to{transform:rotate(360deg)}}
 
+.pos-cashier-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-width: 0;
+}
+
+.pos-cashier-header {
+    align-items: center;
+}
+
+.pos-cashier-header-actions {
+    gap: 0.75rem;
+}
+
+.pos-button-count {
+    display: inline-flex;
+    min-width: 1.5rem;
+    height: 1.5rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: var(--primary);
+    color: var(--primary-foreground);
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.pos-cashier-shell {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(24rem, 30rem);
+    gap: 1rem;
+    align-items: start;
+    min-width: 0;
+}
+
+.pos-catalog-panel,
+.pos-cart-panel,
+.pos-checkout-panel,
+.pos-cart-list,
+.pos-total-bar,
+.pos-receipt-panel {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--card);
+    color: var(--card-foreground);
+}
+
+.pos-catalog-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-width: 0;
+    min-height: calc(100dvh - 12rem);
+    padding: 1rem;
+}
+
+.pos-catalog-toolbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.pos-search-field {
+    min-width: 0;
+}
+
+.pos-search-input {
+    min-height: 3.5rem !important;
+    width: 100% !important;
+    font-size: 1rem !important;
+}
+
+.pos-search-button,
+.pos-touch-action {
+    min-height: 3.5rem !important;
+}
+
+.pos-category-strip {
+    display: flex;
+    gap: 0.5rem;
+    min-width: 0;
+    overflow-x: auto;
+    padding-bottom: 0.125rem;
+}
+
+.pos-category-chip {
+    min-height: 3rem !important;
+    flex: 0 0 auto;
+}
+
+.pos-catalog-view {
+    min-width: 0;
+}
+
+.pos-product-grid {
+    gap: 0.75rem !important;
+}
+
+.pos-product-tile {
+    display: grid !important;
+    grid-template-columns: 4rem minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: stretch !important;
+    justify-content: stretch !important;
+    min-height: 8.5rem !important;
+    width: 100% !important;
+    padding: 0.75rem !important;
+    text-align: left !important;
+    white-space: normal !important;
+}
+
+.pos-product-media {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 4rem;
+    min-height: 4rem;
+    border-radius: var(--radius);
+    background: color-mix(in oklab, var(--muted) 70%, transparent);
+    overflow: hidden;
+}
+
+.pos-product-media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.pos-product-icon {
+    width: 1.75rem;
+    height: 1.75rem;
+    color: var(--muted-foreground);
+}
+
+.pos-product-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 0;
+}
+
+.pos-product-name {
+    color: var(--foreground);
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.pos-product-meta {
+    min-height: 1.25rem;
+    color: var(--muted-foreground);
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
+}
+
+.pos-product-footer {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-top: auto;
+    min-width: 0;
+}
+
+.pos-product-price {
+    font-family: var(--font-mono);
+    font-size: 1.125rem;
+    font-weight: 800;
+}
+
+.pos-product-status {
+    border-radius: 999px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.pos-product-status-ready {
+    background: color-mix(in oklab, var(--primary) 15%, transparent);
+    color: var(--primary);
+}
+
+.pos-product-status-offline {
+    background: color-mix(in oklab, var(--destructive) 18%, transparent);
+    color: var(--destructive);
+}
+
+.pos-catalog-empty {
+    display: flex;
+    min-height: 16rem;
+    align-items: center;
+    justify-content: center;
+}
+
+.pos-cart-panel {
+    position: sticky;
+    top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-height: calc(100dvh - 8rem);
+    min-width: 0;
+    overflow: auto;
+    padding: 1rem;
+}
+
+.pos-checkout-panel,
+.pos-cart-list,
+.pos-total-bar,
+.pos-receipt-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+}
+
+.pos-payment-block,
+.pos-dialog-fields > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.pos-payment-options {
+    display: grid !important;
+    gap: 0.5rem !important;
+}
+
+.pos-payment-option {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    min-height: 4.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.75rem;
+    cursor: pointer;
+}
+
+.pos-payment-option strong,
+.pos-payment-option small {
+    display: block;
+}
+
+.pos-payment-option small {
+    color: var(--muted-foreground);
+    font-size: 0.8125rem;
+}
+
+.pos-adjustments {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.pos-cash-panel {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: flex-end;
+}
+
+.pos-change-due {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 8rem;
+    min-height: 3.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.75rem;
+}
+
+.pos-change-due span {
+    color: var(--muted-foreground);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.pos-change-due strong {
+    font-family: var(--font-mono);
+    font-size: 1.25rem;
+}
+
+.pos-cart-title-row,
+.pos-cart-line,
+.pos-held-cart-row,
+.pos-held-cart-actions {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.pos-cart-title-row,
+.pos-held-cart-row {
+    justify-content: space-between;
+}
+
+.pos-cart-title-row h2 {
+    font-size: 1.125rem;
+    font-weight: 800;
+    line-height: 1.2;
+}
+
+.pos-cart-title-row span {
+    color: var(--muted-foreground);
+    font-size: 0.875rem;
+}
+
+.pos-cart-view,
+.pos-cart-lines,
+.pos-held-carts-view,
+.pos-held-carts-list {
+    min-width: 0;
+}
+
+.pos-cart-lines,
+.pos-held-carts-list {
+    display: grid !important;
+    gap: 0.75rem !important;
+}
+
+.pos-cart-line,
+.pos-held-cart-row {
+    min-width: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: color-mix(in oklab, var(--background) 70%, transparent);
+    padding: 0.75rem;
+}
+
+.pos-cart-line {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+}
+
+.pos-cart-line-main {
+    min-width: 0;
+}
+
+.pos-cart-line-main strong,
+.pos-cart-line-main span {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.pos-cart-line-main span,
+.pos-held-cart-main span,
+.pos-held-cart-main small {
+    color: var(--muted-foreground);
+    font-size: 0.8125rem;
+}
+
+.pos-qty-stepper {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.pos-qty-value {
+    display: inline-flex;
+    min-width: 3rem;
+    min-height: 2.75rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.pos-cart-line-total {
+    min-width: 5.5rem;
+    font-family: var(--font-mono);
+    font-weight: 800;
+    text-align: right;
+}
+
+.pos-total-lines {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.pos-total-lines div,
+.pos-grand-total {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.pos-total-lines span {
+    color: var(--muted-foreground);
+}
+
+.pos-total-lines strong,
+.pos-grand-total strong {
+    font-family: var(--font-mono);
+}
+
+.pos-grand-total {
+    align-items: baseline;
+    border-top: 1px solid var(--border);
+    padding-top: 0.75rem;
+}
+
+.pos-grand-total span {
+    font-size: 1rem;
+    font-weight: 800;
+}
+
+.pos-grand-total strong {
+    font-size: 2rem;
+    line-height: 1.1;
+}
+
+.pos-checkout-action {
+    min-height: 4rem !important;
+    width: 100% !important;
+    font-size: 1.125rem !important;
+    font-weight: 800 !important;
+}
+
+.pos-receipt-panel > div:first-child,
+.pos-held-cart-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.pos-receipt-panel span {
+    color: var(--muted-foreground);
+    font-size: 0.875rem;
+}
+
+.pos-dialog-fields {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.pos-held-carts-dialog {
+    max-height: min(42rem, calc(100dvh - 4rem));
+}
+
+@media (max-width: 1100px) {
+    .pos-cashier-shell {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .pos-cart-panel {
+        position: static;
+        max-height: none;
+    }
+
+    .pos-total-bar {
+        position: sticky;
+        bottom: 0;
+        z-index: 20;
+        box-shadow: 0 -0.5rem 1.5rem color-mix(in oklab, var(--background) 70%, transparent);
+    }
+}
+
+@media (max-width: 720px) {
+    .pos-catalog-toolbar,
+    .pos-adjustments,
+    .pos-cash-panel,
+    .pos-dialog-fields {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .pos-search-button {
+        width: 100% !important;
+    }
+
+    .pos-product-tile {
+        grid-template-columns: 3.5rem minmax(0, 1fr);
+    }
+
+    .pos-product-media {
+        width: 3.5rem;
+    }
+
+    .pos-cart-line {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .pos-cart-line-total {
+        grid-column: 1 / -1;
+        text-align: left;
+    }
+
+    .pos-held-cart-row,
+    .pos-held-cart-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+}
+
 :root {
     --xf-header-bg: color-mix(in oklab, var(--background) 78%, transparent);
     --xf-scrollbar-track: transparent;

--- a/src/Tests/POS.IntegrationTests/ControlPanelContractTests.cs
+++ b/src/Tests/POS.IntegrationTests/ControlPanelContractTests.cs
@@ -17,12 +17,19 @@ public sealed class ControlPanelContractTests
         "Returns.razor"
     ];
 
+    private static readonly string[] PosTabularPages =
+    [
+        "Registers.razor",
+        "Sales.razor",
+        "Returns.razor"
+    ];
+
     [Test]
     public void PosPages_TabularSurfaces_UseFilteredBlazorBlueprintDataGrids()
     {
         var pagesRoot = GetPosPagesRoot();
 
-        foreach (var page in PosPages)
+        foreach (var page in PosTabularPages)
         {
             var text = File.ReadAllText(Path.Combine(pagesRoot, page));
 
@@ -34,6 +41,62 @@ public sealed class ControlPanelContractTests
                 @"<BbDataGridTemplateColumn\b[^>]*Title=""Actions""[^>]*Filterable=""true""",
                 $"{page} should not expose filters on command/action columns");
         }
+    }
+
+    [Test]
+    public void PosCashier_UsesTouchFirstBlueprintDataViewsAndLayout()
+    {
+        var pagesRoot = GetPosPagesRoot();
+        var cashier = File.ReadAllText(Path.Combine(pagesRoot, "Cashier.razor"));
+
+        cashier.Should().NotContain("<table", "cashier touch surfaces should not use raw tables");
+        cashier.Should().NotContain("<BbDataGrid", "cashier product/cart surfaces are touch workflows, not tabular reports");
+        cashier.Should().Contain("<BbDataView TItem=\"PosCatalogItemResponse\"");
+        cashier.Should().Contain("<BbDataView TItem=\"CartLine\"");
+        cashier.Should().Contain("<BbDataView TItem=\"PosCartSummaryResponse\"");
+        cashier.Should().Contain("Layout=\"DataViewLayout.Grid\"");
+        cashier.Should().Contain("GridColumnMinWidth=\"12rem\"");
+        cashier.Should().Contain("<BbRadioGroup TValue=\"PosPaymentMethod\" @bind-Value=\"_paymentMethod\"");
+        cashier.Should().Contain("<BbDialog Open=\"@_saleDetailsOpen\"");
+        cashier.Should().Contain("<BbDialog Open=\"@_heldCartsOpen\"");
+        cashier.Should().Contain("ButtonSize.Large");
+        cashier.Should().Contain("ButtonSize.IconLarge");
+        cashier.Should().Contain("pos-cashier-shell");
+        cashier.Should().Contain("pos-product-tile");
+        cashier.Should().Contain("pos-cart-panel");
+        cashier.Should().Contain("pos-total-bar");
+        cashier.Should().Contain("CategoryId = _selectedCategoryId");
+        cashier.Should().Contain("DataContext.Query<ProductCategory>()");
+        cashier.Should().NotContain("grid-cols-[");
+    }
+
+    [Test]
+    public void PosCashier_CssDefinesTouchLayoutContracts()
+    {
+        var css = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "src",
+            "Presentation",
+            "ControlPanel.Server",
+            "wwwroot",
+            "css",
+            "app.css"));
+
+        var requiredClasses = new[]
+        {
+            "pos-cashier-shell",
+            "pos-catalog-panel",
+            "pos-cart-panel",
+            "pos-checkout-panel",
+            "pos-product-grid",
+            "pos-product-tile",
+            "pos-cart-line",
+            "pos-total-bar",
+            "pos-checkout-action"
+        };
+
+        foreach (var cssClass in requiredClasses)
+            css.Should().Contain($".{cssClass}", $"{cssClass} is part of the cashier touch layout contract");
     }
 
     [Test]
@@ -152,7 +215,8 @@ public sealed class ControlPanelContractTests
         var sales = File.ReadAllText(Path.Combine(pagesRoot, "Sales.razor"));
         var returns = File.ReadAllText(Path.Combine(pagesRoot, "Returns.razor"));
 
-        cashier.Should().Contain("<BbFormFieldSelect TValue=\"string\" @bind-Value=\"PaymentMethodValue\" Label=\"Payment\">");
+        cashier.Should().Contain("<BbRadioGroup TValue=\"PosPaymentMethod\" @bind-Value=\"_paymentMethod\"");
+        cashier.Should().Contain("BbFormFieldCurrencyInput @bind-Value=\"_cashTenderedAmount\"");
         returns.Should().Contain("<BbFormFieldSelect TValue=\"string\" @bind-Value=\"RefundMethodValue\" Label=\"Refund Method\">");
         cashier.Should().NotContain("grid-cols-[");
         returns.Should().NotContain("@if (_refundMethod == PosPaymentMethod.CashDrawer)");
@@ -160,6 +224,7 @@ public sealed class ControlPanelContractTests
 
         cashier.Should().Contain("ConfirmClearCurrentCart");
         cashier.Should().Contain("Cancel Suspended Cart");
+        cashier.Should().Contain("Held Carts");
         sales.Should().Contain("Cancel POS Sale");
         (cashier + sales).Should().Contain("new ConfirmDialogOptions { Destructive = true }");
     }


### PR DESCRIPTION
## Summary
- Redesign the ControlPanel POS cashier into a touch-first two-pane register workspace.
- Replace cashier catalog/cart/held-cart grids with Blueprint DataView tile/list surfaces.
- Add POS-specific responsive CSS, category chips, scanner-friendly search, cash tender/change due, sale details dialog, and held carts dialog.
- Update POS ControlPanel contract tests to enforce the cashier touch layout while preserving BbDataGrid requirements for tabular POS pages.

## Validation
- `dotnet test src/Tests/POS.IntegrationTests/POS.IntegrationTests.csproj --filter TestCategory=Area:ControlPanelContract --no-restore`
- `dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false --no-restore`

## Notes
- Local browser smoke was blocked because ControlPanel startup retried Bolt Hub at `ws://xeon-dev:7000/bolt/ws` and never reached the HTTP listener.