### PR TITLE
Fix tenant management scope

### DIFF
--- a/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Layout/MainLayout.razor
@@ -143,10 +143,13 @@
                                     <LucideIcon Name="settings" class="mr-2 h-4 w-4" />
                                     Tenant Settings
                                 </BbButton>
-                                <BbButton Variant="ButtonVariant.Outline" OnClick="@ManageTenants" Class="profile-menu-button">
-                                    <LucideIcon Name="building-2" class="mr-2 h-4 w-4" />
-                                    Manage Tenants
-                                </BbButton>
+                                @if (_canManageTenants)
+                                {
+                                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ManageTenants" Class="profile-menu-button">
+                                        <LucideIcon Name="building-2" class="mr-2 h-4 w-4" />
+                                        Manage Tenants
+                                    </BbButton>
+                                }
                                 <BbButton Variant="ButtonVariant.Ghost" OnClick="@Logout" Class="profile-menu-button">
                                     <LucideIcon Name="log-out" class="mr-2 h-4 w-4" />
                                     Sign Out
@@ -196,11 +199,13 @@
     private Guid? _breadcrumbWalletId;
     private string? _breadcrumbWalletLabel;
     private bool _profileMenuOpen;
+    private bool _canManageTenants;
 
     private string _selectedTenantName => TenantFilter.SelectedTenantName ?? "";
     private string ActiveTenantLabel => string.IsNullOrWhiteSpace(_selectedTenantName) ? "All Tenants" : _selectedTenantName;
     private string CurrentPath => new Uri(Nav.Uri).AbsolutePath.TrimEnd('/');
     private bool IsTenantListRoute => string.Equals(CurrentPath, "/identity/tenants", StringComparison.OrdinalIgnoreCase);
+    private bool IsManageTenantsRoute => IsTenantListRoute || TryGetTenantDetailRoute(out _, out _);
     private bool HasActiveTenant => Guid.TryParse(_selectedTenantId, out _);
     private string TenantSettingsTitle => HasActiveTenant ? "Open active tenant settings" : "Select a tenant to open tenant settings";
     private string SidebarClass => "app-sidebar shrink-0 border-r bg-sidebar text-sidebar-foreground"
@@ -349,12 +354,14 @@
             return;
         }
 
+        _canManageTenants = ControlPanelAccess.CanManageTenants(user);
         _userName = user.Identity.Name ?? "";
         _displayName = user.FindFirst(ControlPanelAuthClaims.DisplayName)?.Value
             ?? user.Identity.Name
             ?? "Administrator";
         _userInitials = BuildInitials(_displayName);
 
+        await EnsureManageTenantsRouteUsesAllTenants();
         await RefreshBreadcrumbEntityLabels();
     }
 
@@ -520,6 +527,12 @@
 
     private async Task RestoreTenantSelection()
     {
+        if (_canManageTenants && IsManageTenantsRoute)
+        {
+            await SetAllTenantsActive();
+            return;
+        }
+
         var selectedTenantId = TenantFilter.SelectedTenantId;
         var storedTenantId = await ReadStoredTenantId();
 
@@ -597,6 +610,13 @@
 
     private async Task OnTenantSelectionChanged(string? value)
     {
+        if (_canManageTenants && IsManageTenantsRoute)
+        {
+            await SetAllTenantsActive();
+            _profileMenuOpen = false;
+            return;
+        }
+
         _selectedTenantId = string.IsNullOrWhiteSpace(value) ? AllTenantsValue : value;
 
         if (Guid.TryParse(_selectedTenantId, out var tenantId))
@@ -625,10 +645,37 @@
         Nav.NavigateTo($"/identity/tenants/{tenantId}/configurations");
     }
 
-    private void ManageTenants()
+    private async Task ManageTenants()
     {
+        if (!_canManageTenants)
+        {
+            return;
+        }
+
         _profileMenuOpen = false;
+        await SetAllTenantsActive();
         Nav.NavigateTo("/identity/tenants");
+    }
+
+    private async Task EnsureManageTenantsRouteUsesAllTenants()
+    {
+        if (!_canManageTenants || !IsManageTenantsRoute)
+        {
+            return;
+        }
+
+        await SetAllTenantsActive();
+    }
+
+    private async Task SetAllTenantsActive()
+    {
+        _selectedTenantId = AllTenantsValue;
+        if (TenantFilter.SelectedTenantId is not null || !string.IsNullOrWhiteSpace(TenantFilter.SelectedTenantName))
+        {
+            TenantFilter.Clear();
+        }
+
+        await ClearStoredTenantId();
     }
 
     private void Logout()
@@ -843,6 +890,7 @@
     {
         _ = InvokeAsync(async () =>
         {
+            await EnsureManageTenantsRouteUsesAllTenants();
             UpdateActiveSidebarGroup();
             _contentRenderKey++;
             await RefreshBreadcrumbEntityLabels();

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/TenantDetail.razor
@@ -4,7 +4,18 @@
 
 <PageTitle>Tenant Detail - Control Panel</PageTitle>
 
-@if (_loading)
+@if (!_accessChecked)
+{
+    <CenteredSpinner />
+}
+else if (!_canManageTenants)
+{
+    <BbAlert Variant="AlertVariant.Danger">
+        <BbAlertTitle>Tenant Management Restricted</BbAlertTitle>
+        <BbAlertDescription>Only super users can manage tenant details.</BbAlertDescription>
+    </BbAlert>
+}
+else if (_loading)
 {
     <CenteredSpinner />
 }
@@ -525,11 +536,14 @@ else
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
     [Inject] private TenantModuleFeatureDefinitionResolver ModuleFeatureDefinitionResolver { get; set; } = default!;
+    [CascadingParameter] private Task<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>? AuthenticationStateTask { get; set; }
 
     private Tenant? _tenant;
     private bool _loading;
     private bool _saving;
     private bool _outsideTenantContext;
+    private bool _accessChecked;
+    private bool _canManageTenants;
     private Guid? _loadedId;
     private EditableForm<Tenant>? _editableForm;
 
@@ -588,6 +602,12 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        await ResolveAccess();
+        if (!_canManageTenants)
+        {
+            return;
+        }
+
         if (!IsValidSection(Section))
         {
             Navigation.NavigateTo($"/identity/tenants/{Id}", replace: true);
@@ -603,6 +623,19 @@ else
         await LoadTenant();
     }
 
+    private async Task ResolveAccess()
+    {
+        if (AuthenticationStateTask is null)
+        {
+            _accessChecked = true;
+            return;
+        }
+
+        var authState = await AuthenticationStateTask;
+        _canManageTenants = ControlPanelAccess.CanManageTenants(authState.User);
+        _accessChecked = true;
+    }
+
     private void OnTenantFilterChanged()
     {
         _ = InvokeAsync(async () =>
@@ -614,10 +647,17 @@ else
 
     private async Task LoadTenant()
     {
+        if (!_canManageTenants)
+        {
+            _tenant = null;
+            ClearDetailData();
+            return;
+        }
+
         _loading = true;
         try
         {
-            _outsideTenantContext = TenantFilter.SelectedTenantId is Guid tenantId && tenantId != Id;
+            _outsideTenantContext = !_canManageTenants && TenantFilter.SelectedTenantId is Guid tenantId && tenantId != Id;
             if (_outsideTenantContext)
             {
                 _tenant = null;

--- a/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
+++ b/src/Presentation/ControlPanel.Server/Components/Pages/Identity/Tenants.razor
@@ -2,6 +2,19 @@
 
 <PageTitle>Tenant Management - Control Panel</PageTitle>
 
+@if (!_accessChecked)
+{
+    <CenteredSpinner />
+}
+else if (!_canManageTenants)
+{
+    <BbAlert Variant="AlertVariant.Danger">
+        <BbAlertTitle>Tenant Management Restricted</BbAlertTitle>
+        <BbAlertDescription>Only super users can manage tenants.</BbAlertDescription>
+    </BbAlert>
+}
+else
+{
 <div class="space-y-6">
 
     @* -- Header -- *@
@@ -106,86 +119,90 @@
     </FadeInContent>
     }
 </div>
+}
 
-@* -- Create Tenant Dialog -- *@
-<BbDialog Open="@_tenantDialogOpen" OpenChanged="@(v => _tenantDialogOpen = v)">
-    <BbDialogContent TrapFocus="false">
-        <BbDialogHeader>
-            <BbDialogTitle>Create Tenant</BbDialogTitle>
-            <BbDialogDescription>Fill in the details for the new tenant.</BbDialogDescription>
-        </BbDialogHeader>
-        <div class="grid gap-4 py-4">
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_tenantForm.Name"
-                              Label="Name"
-                              Placeholder="Tenant name"
-                              Required="true" />
-            <BbFormFieldInput TValue="string"
-                              @bind-Value="_tenantForm.Description"
-                              Label="Description"
-                              Placeholder="Brief description" />
-            <div class="grid grid-cols-2 gap-4">
+@if (_canManageTenants)
+{
+    @* -- Create Tenant Dialog -- *@
+    <BbDialog Open="@_tenantDialogOpen" OpenChanged="@(v => _tenantDialogOpen = v)">
+        <BbDialogContent TrapFocus="false">
+            <BbDialogHeader>
+                <BbDialogTitle>Create Tenant</BbDialogTitle>
+                <BbDialogDescription>Fill in the details for the new tenant.</BbDialogDescription>
+            </BbDialogHeader>
+            <div class="grid gap-4 py-4">
                 <BbFormFieldInput TValue="string"
-                                  @bind-Value="_tenantForm.VersionString"
-                                  Label="Version"
-                                  Placeholder="1.0" />
-                <BbFormFieldSelect TValue="string"
-                                   @bind-Value="_tenantForm.StatusString"
-                                   Label="Status">
-                    <BbSelectItem Value="0">Pending</BbSelectItem>
-                    <BbSelectItem Value="1">Active</BbSelectItem>
-                    <BbSelectItem Value="2">Suspended</BbSelectItem>
-                    <BbSelectItem Value="3">Inactive</BbSelectItem>
-                </BbFormFieldSelect>
+                                  @bind-Value="_tenantForm.Name"
+                                  Label="Name"
+                                  Placeholder="Tenant name"
+                                  Required="true" />
+                <BbFormFieldInput TValue="string"
+                                  @bind-Value="_tenantForm.Description"
+                                  Label="Description"
+                                  Placeholder="Brief description" />
+                <div class="grid grid-cols-2 gap-4">
+                    <BbFormFieldInput TValue="string"
+                                      @bind-Value="_tenantForm.VersionString"
+                                      Label="Version"
+                                      Placeholder="1.0" />
+                    <BbFormFieldSelect TValue="string"
+                                       @bind-Value="_tenantForm.StatusString"
+                                       Label="Status">
+                        <BbSelectItem Value="0">Pending</BbSelectItem>
+                        <BbSelectItem Value="1">Active</BbSelectItem>
+                        <BbSelectItem Value="2">Suspended</BbSelectItem>
+                        <BbSelectItem Value="3">Inactive</BbSelectItem>
+                    </BbFormFieldSelect>
+                </div>
+                <div class="grid grid-cols-2 gap-4">
+                    <BbFormFieldInput TValue="string"
+                                      @bind-Value="_tenantForm.ExpirationString"
+                                      Label="Expiration Date"
+                                      Placeholder="YYYY-MM-DD" />
+                    <BbFormFieldInput TValue="string"
+                                      @bind-Value="_tenantForm.AvailabilityString"
+                                      Label="Availability Date"
+                                      Placeholder="YYYY-MM-DD" />
+                </div>
+                <XfEntityPicker TItem="Tenant"
+                                  Value="@_tenantForm.ParentTenantIdString"
+                                  ValueChanged="@(value => _tenantForm.ParentTenantIdString = value ?? "")"
+                                  Label="Parent Tenant"
+                                  Items="@_tenants"
+                                  ValueSelector="@GetTenantPickerValue"
+                                  TextSelector="@GetTenantLabel"
+                                  SearchTextSelector="@GetTenantSearchText"
+                                  AdvancedColumns="@TenantAdvancedColumns"
+                                  AdvancedFilters="@TenantAdvancedFilters"
+                                  AdvancedSearchScope="Searches tenant name, description, status, version, expiration, enabled state, and created date."
+                                  SearchPlaceholder="Search tenants..."
+                                  EmptyMessage="No tenants found."
+                                  AllowClear="true"
+                                  ClearText="No parent tenant"
+                                  ShowCreate="false"
+                                  AdvancedSearchTitle="Find Parent Tenant"
+                                  AdvancedSearchDescription="Search existing tenants to use as the parent tenant."
+                                  Placeholder="Optional - leave blank for root tenant" />
             </div>
-            <div class="grid grid-cols-2 gap-4">
-                <BbFormFieldInput TValue="string"
-                                  @bind-Value="_tenantForm.ExpirationString"
-                                  Label="Expiration Date"
-                                  Placeholder="YYYY-MM-DD" />
-                <BbFormFieldInput TValue="string"
-                                  @bind-Value="_tenantForm.AvailabilityString"
-                                  Label="Availability Date"
-                                  Placeholder="YYYY-MM-DD" />
-            </div>
-            <XfEntityPicker TItem="Tenant"
-                              Value="@_tenantForm.ParentTenantIdString"
-                              ValueChanged="@(value => _tenantForm.ParentTenantIdString = value ?? "")"
-                              Label="Parent Tenant"
-                              Items="@_tenants"
-                              ValueSelector="@GetTenantPickerValue"
-                              TextSelector="@GetTenantLabel"
-                              SearchTextSelector="@GetTenantSearchText"
-                              AdvancedColumns="@TenantAdvancedColumns"
-                              AdvancedFilters="@TenantAdvancedFilters"
-                              AdvancedSearchScope="Searches tenant name, description, status, version, expiration, enabled state, and created date."
-                              SearchPlaceholder="Search tenants..."
-                              EmptyMessage="No tenants found."
-                              AllowClear="true"
-                              ClearText="No parent tenant"
-                              ShowCreate="false"
-                              AdvancedSearchTitle="Find Parent Tenant"
-                              AdvancedSearchDescription="Search existing tenants to use as the parent tenant."
-                              Placeholder="Optional - leave blank for root tenant" />
-        </div>
-        <BbDialogFooter>
-            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _tenantDialogOpen = false)">Cancel</BbButton>
-            <BbButton OnClick="@CreateTenant" Disabled="@_saving">
-                @if (_saving)
-                {
-                    <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
-                }
-                Create
-            </BbButton>
-        </BbDialogFooter>
-    </BbDialogContent>
-</BbDialog>
+            <BbDialogFooter>
+                <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _tenantDialogOpen = false)">Cancel</BbButton>
+                <BbButton OnClick="@CreateTenant" Disabled="@_saving">
+                    @if (_saving)
+                    {
+                        <LucideIcon Name="loader-2" class="mr-2 h-4 w-4 animate-spin" />
+                    }
+                    Create
+                </BbButton>
+            </BbDialogFooter>
+        </BbDialogContent>
+    </BbDialog>
 
-@* -- Delete Tenant Confirmation -- *@
-<ConfirmDeleteDialog Open="@_deleteDialogOpen"
-                     OpenChanged="@(v => _deleteDialogOpen = v)"
-                     Message="@($"This will soft-delete the tenant \"{_deletingTenant?.Name}\". The tenant and its data will be marked as deleted.")"
-                     OnConfirm="@ConfirmDeleteTenant" />
+    @* -- Delete Tenant Confirmation -- *@
+    <ConfirmDeleteDialog Open="@_deleteDialogOpen"
+                         OpenChanged="@(v => _deleteDialogOpen = v)"
+                         Message="@($"This will soft-delete the tenant \"{_deletingTenant?.Name}\". The tenant and its data will be marked as deleted.")"
+                         OnConfirm="@ConfirmDeleteTenant" />
+}
 
 @code {
     [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
@@ -193,11 +210,14 @@
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ToastService ToastService { get; set; } = default!;
     [Inject] private TenantFilterService TenantFilter { get; set; } = default!;
+    [CascadingParameter] private Task<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>? AuthenticationStateTask { get; set; }
 
     // -- Tenant list state --
     private List<Tenant> _tenants = [];
     private bool _saving;
     private bool _loading;
+    private bool _accessChecked;
+    private bool _canManageTenants;
 
     // -- Tenant create dialog --
     private bool _tenantDialogOpen;
@@ -211,7 +231,26 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ResolveAccess();
+        if (!_canManageTenants)
+        {
+            return;
+        }
+
         await LoadTenants();
+    }
+
+    private async Task ResolveAccess()
+    {
+        if (AuthenticationStateTask is null)
+        {
+            _accessChecked = true;
+            return;
+        }
+
+        var authState = await AuthenticationStateTask;
+        _canManageTenants = ControlPanelAccess.CanManageTenants(authState.User);
+        _accessChecked = true;
     }
 
     private async Task LoadTenants()

--- a/src/Presentation/ControlPanel.Server/Services/ControlPanelAccess.cs
+++ b/src/Presentation/ControlPanel.Server/Services/ControlPanelAccess.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+
+namespace ControlPanel.Server.Services;
+
+public static class ControlPanelAccess
+{
+    public static bool CanManageTenants(ClaimsPrincipal? user)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return false;
+        }
+
+        if (bool.TryParse(user.FindFirst(ControlPanelAuthClaims.IsSuperUser)?.Value, out var isSuperUser)
+            && isSuperUser)
+        {
+            return true;
+        }
+
+        return Guid.TryParse(user.FindFirst(ControlPanelAuthClaims.RoleTypeId)?.Value, out var roleTypeId)
+            && roleTypeId == ControlPanelBootstrapConstants.AdminRoleTypeId;
+    }
+}

--- a/src/Presentation/ControlPanel.Server/Services/ControlPanelAuthClaims.cs
+++ b/src/Presentation/ControlPanel.Server/Services/ControlPanelAuthClaims.cs
@@ -6,6 +6,7 @@ public static class ControlPanelAuthClaims
     public const string CredentialId = "credentialId";
     public const string TenantId = "tenantId";
     public const string RoleTypeId = "roleTypeId";
+    public const string IsSuperUser = "isSuperUser";
     public const string SessionId = "sessionId";
     public const string DisplayName = "displayName";
 }

--- a/src/Presentation/ControlPanel.Server/Services/ControlPanelAuthService.cs
+++ b/src/Presentation/ControlPanel.Server/Services/ControlPanelAuthService.cs
@@ -124,7 +124,8 @@ public sealed class ControlPanelAuthService(
             new(ControlPanelAuthClaims.IdentityId, identityId.ToString()),
             new(ControlPanelAuthClaims.CredentialId, credentialId.ToString()),
             new(ControlPanelAuthClaims.TenantId, tenantId.ToString()),
-            new(ControlPanelAuthClaims.RoleTypeId, roleTypeId.ToString())
+            new(ControlPanelAuthClaims.RoleTypeId, roleTypeId.ToString()),
+            new(ControlPanelAuthClaims.IsSuperUser, IsSuperUserRole(roleTypeId).ToString())
         };
 
         if (response.SessionId is { } sessionId)
@@ -135,6 +136,9 @@ public sealed class ControlPanelAuthService(
         var identity = new ClaimsIdentity(claims, ControlPanelAuthDefaults.AuthenticationScheme);
         return new ClaimsPrincipal(identity);
     }
+
+    private static bool IsSuperUserRole(Guid roleTypeId) =>
+        roleTypeId == ControlPanelBootstrapConstants.AdminRoleTypeId;
 }
 
 public sealed record ControlPanelLoginResult(bool IsSuccess, string? Error, ClaimsPrincipal? Principal)


### PR DESCRIPTION
## Summary
- Clear active tenant scope to All Tenants when super users enter Manage Tenants routes
- Hide Manage Tenants profile action unless the signed-in user can manage tenants
- Guard tenant list and tenant detail pages against direct access by non-super users

## Tests
- dotnet build src/Presentation/ControlPanel.Server/ControlPanel.Server.csproj -m:1 /nr:false