### PR TITLE
Fix Portal bootstrap tenant compatibility

### DIFF
--- a/src/Presentation/XFramework.Portal/Services/PortalAuthService.cs
+++ b/src/Presentation/XFramework.Portal/Services/PortalAuthService.cs
@@ -32,12 +32,7 @@ public sealed class PortalAuthService(
         var options = new PortalAuthOptions();
         configuration.GetSection(PortalAuthOptions.BootstrapAdminSectionName).Bind(options);
 
-        var tenant = await dataContext.Query<Tenant>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => !x.IsDeleted)
-            .Where(x => x.Name == options.TenantName)
-            .FirstOrDefaultAsync(ct);
+        var tenant = await FindBootstrapTenantAsync(options, ct);
 
         if (tenant is null)
         {
@@ -139,6 +134,30 @@ public sealed class PortalAuthService(
 
     private static bool IsSuperUserRole(Guid roleTypeId) =>
         roleTypeId == PortalBootstrapConstants.AdminRoleTypeId;
+
+    private async Task<Tenant?> FindBootstrapTenantAsync(PortalAuthOptions options, CancellationToken ct)
+    {
+        var tenant = await dataContext.Query<Tenant>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => !x.IsDeleted)
+            .Where(x => x.Id == PortalBootstrapConstants.AdminTenantId)
+            .FirstOrDefaultAsync(ct);
+
+        if (tenant is not null)
+        {
+            return tenant;
+        }
+
+        var lookupNames = PortalBootstrapConstants.BuildAdminTenantLookupNames(options.TenantName);
+        return await dataContext.Query<Tenant>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => !x.IsDeleted)
+            .Where(x => lookupNames.Contains(x.Name))
+            .OrderBy(x => x.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+    }
 }
 
 public sealed record PortalLoginResult(bool IsSuccess, string? Error, ClaimsPrincipal? Principal)

--- a/src/Presentation/XFramework.Portal/Services/PortalBootstrapConstants.cs
+++ b/src/Presentation/XFramework.Portal/Services/PortalBootstrapConstants.cs
@@ -13,5 +13,13 @@ internal static class PortalBootstrapConstants
     public static readonly Guid DefaultAuthorizeById = new("934ce9b2-6513-411b-a32f-5dc74f61975c");
     public static readonly Guid AdminRoleGroupSystemReferenceId = new("1208681c-a202-453b-95f2-f0cbf682f9dd");
     public static readonly Guid RegistryGroupSystemReferenceId = new("35ab856b-7f99-4d2e-ac46-e5093bb27b59");
+    public static readonly string[] LegacyAdminTenantNames = ["XFramework Admin"];
+
+    public static string[] BuildAdminTenantLookupNames(string tenantName) =>
+        LegacyAdminTenantNames
+            .Append(tenantName)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 }
 

--- a/src/Presentation/XFramework.Portal/Services/PortalBootstrapSeeder.cs
+++ b/src/Presentation/XFramework.Portal/Services/PortalBootstrapSeeder.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using IdentityServer.Domain.Shared;
 using IdentityServer.Domain.Shared.Contracts;
+using IdentityServer.Domain.Shared.Contracts.Requests;
+using IdentityServer.Integration.Drivers;
 using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Domain.Shared.Enums;
@@ -9,13 +11,14 @@ namespace XFramework.Portal.Services;
 
 public sealed class PortalBootstrapSeeder(
     IDataContext dataContext,
+    IIdentityServerServiceWrapper identityServer,
     RequestMetadata requestMetadata,
     ILogger<PortalBootstrapSeeder> logger)
 {
     public async Task SeedAsync(PortalAuthOptions options, CancellationToken ct)
     {
         var now = DateTime.UtcNow;
-        var tenant = await EnsureTenant(options, now, ct);
+        var tenant = await EnsureTenant(options, ct);
 
         requestMetadata.TenantId = tenant.Id;
 
@@ -39,7 +42,7 @@ public sealed class PortalBootstrapSeeder(
             credential.Id);
     }
 
-    private async Task<Tenant> EnsureTenant(PortalAuthOptions options, DateTime now, CancellationToken ct)
+    private async Task<Tenant> EnsureTenant(PortalAuthOptions options, CancellationToken ct)
     {
         var tenant = await dataContext.Query<Tenant>()
             .IgnoreQueryFilters()
@@ -48,58 +51,54 @@ public sealed class PortalBootstrapSeeder(
             .OrderBy(x => x.CreatedAt)
             .FirstOrDefaultAsync(ct);
 
-        tenant ??= await dataContext.Query<Tenant>()
+        if (tenant is not null)
+        {
+            return tenant;
+        }
+
+        var lookupNames = PortalBootstrapConstants.BuildAdminTenantLookupNames(options.TenantName);
+        tenant = await dataContext.Query<Tenant>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => lookupNames.Contains(x.Name))
+            .OrderBy(x => x.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (tenant is not null)
+        {
+            return tenant;
+        }
+
+        var createResult = await identityServer.CreateTenant(new CreateTenantRequest
+        {
+            Name = options.TenantName,
+            Description = "Portal bootstrap administration tenant",
+            Status = 1,
+            Version = 1.0m,
+            Metadata = new RequestMetadata
+            {
+                Name = "Portal",
+                RequestId = Guid.NewGuid()
+            }
+        });
+
+        if (!createResult.IsSuccess)
+        {
+            throw new InvalidOperationException($"Portal bootstrap admin tenant could not be created: {createResult.Message}");
+        }
+
+        tenant = await dataContext.Query<Tenant>()
             .IgnoreQueryFilters()
             .NoCache()
             .Where(x => x.Name == options.TenantName)
             .OrderBy(x => x.CreatedAt)
             .FirstOrDefaultAsync(ct);
 
-        if (tenant is not null)
+        if (tenant is null)
         {
-            var changed = false;
-            if (!tenant.IsEnabled || tenant.IsDeleted)
-            {
-                tenant.IsEnabled = true;
-                tenant.IsDeleted = false;
-                tenant.DeletedAt = null;
-                changed = true;
-            }
-
-            if (tenant.Name != options.TenantName)
-            {
-                tenant.Name = options.TenantName;
-                changed = true;
-            }
-
-            if (tenant.Description != "Portal bootstrap administration tenant")
-            {
-                tenant.Description = "Portal bootstrap administration tenant";
-                changed = true;
-            }
-
-            if (changed)
-            {
-                tenant.ModifiedAt = now;
-                dataContext.Update(tenant);
-            }
-
-            return tenant;
+            throw new InvalidOperationException("Portal bootstrap admin tenant was created but could not be loaded.");
         }
 
-        tenant = new Tenant
-        {
-            Id = PortalBootstrapConstants.AdminTenantId,
-            TenantId = PortalBootstrapConstants.AdminTenantId,
-            Name = options.TenantName,
-            Description = "Portal bootstrap administration tenant",
-            Status = 1,
-            Version = 1.0m,
-            IsEnabled = true,
-            CreatedAt = now,
-            ConcurrencyStamp = Guid.NewGuid()
-        };
-        dataContext.Add(tenant);
         return tenant;
     }
 


### PR DESCRIPTION
﻿## Summary
- Resolve Portal bootstrap admin tenant by stable bootstrap tenant ID first, then by the new Portal tenant name and the legacy `XFramework Admin` tenant name
- Avoid direct `Tenant` mutations through Portal remote `IDataContext`, because Tenant is query-only for this surface on Xeon Dev
- Use the existing IdentityServer `CreateTenant` wrapper only if the bootstrap tenant is missing

## Validation
- `dotnet build src/Presentation/XFramework.Portal/XFramework.Portal.csproj -m:1 /nr:false`
- `dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --filter TestCategory=Area:PortalContract -m:1 /nr:false --logger "console;verbosity=minimal"`
- Active ControlPanel static scan remains clean

## Runtime Context
- Xeon Dev browser validation after the rename reached `Sign in - Portal` but login failed with `Portal admin tenant is not seeded yet.`
- `xframework-portal` logs showed the seeder failing on direct Tenant mutation: `Entity type 'Tenant' is not registered for remote mutation.`
