### PR TITLE
Avoid Portal bootstrap updates for existing seed rows

### DIFF
--- a/src/Presentation/XFramework.Portal/Services/PortalBootstrapSeeder.cs
+++ b/src/Presentation/XFramework.Portal/Services/PortalBootstrapSeeder.cs
@@ -118,14 +118,6 @@ public sealed class PortalBootstrapSeeder(
 
         if (group is not null)
         {
-            if (group.Name != "Administrators" || group.Description != "Portal administrator roles")
-            {
-                group.Name = "Administrators";
-                group.Description = "Portal administrator roles";
-                group.ModifiedAt = now;
-                dataContext.Update(group);
-            }
-
             return group;
         }
 
@@ -158,39 +150,6 @@ public sealed class PortalBootstrapSeeder(
 
         if (roleType is not null)
         {
-            var changed = false;
-            if (roleType.Name != "Portal Super Admin")
-            {
-                roleType.Name = "Portal Super Admin";
-                changed = true;
-            }
-
-            if (roleType.GroupId != groupId)
-            {
-                roleType.GroupId = groupId;
-                changed = true;
-            }
-
-            if (roleType.RoleLevel != 100)
-            {
-                roleType.RoleLevel = 100;
-                changed = true;
-            }
-
-            if (!roleType.IsEnabled || roleType.IsDeleted)
-            {
-                roleType.IsEnabled = true;
-                roleType.IsDeleted = false;
-                roleType.DeletedAt = null;
-                changed = true;
-            }
-
-            if (changed)
-            {
-                roleType.ModifiedAt = now;
-                dataContext.Update(roleType);
-            }
-
             return roleType;
         }
 
@@ -265,12 +224,6 @@ public sealed class PortalBootstrapSeeder(
                 ConcurrencyStamp = Guid.NewGuid()
             };
             dataContext.Add(group);
-        }
-        else if (group.Description != "Portal authentication defaults")
-        {
-            group.Description = "Portal authentication defaults";
-            group.ModifiedAt = now;
-            dataContext.Update(group);
         }
 
         var config = await dataContext.Query<RegistryConfiguration>()
@@ -361,21 +314,6 @@ public sealed class PortalBootstrapSeeder(
 
         if (credential is not null)
         {
-            if (!credential.IsEnabled || credential.PasswordByte is not { Length: > 0 })
-            {
-                credential.IsEnabled = true;
-                credential.IsDeleted = false;
-                credential.DeletedAt = null;
-                credential.ModifiedAt = now;
-
-                if (credential.PasswordByte is not { Length: > 0 })
-                {
-                    credential.PasswordByte = HashPassword(options.Password!);
-                }
-
-                dataContext.Update(credential);
-            }
-
             return credential;
         }
 
@@ -407,16 +345,6 @@ public sealed class PortalBootstrapSeeder(
 
         if (role is not null)
         {
-            if (!role.IsEnabled || role.RoleExpiration <= now)
-            {
-                role.IsEnabled = true;
-                role.IsDeleted = false;
-                role.DeletedAt = null;
-                role.RoleExpiration = now.AddYears(50);
-                role.ModifiedAt = now;
-                dataContext.Update(role);
-            }
-
             return;
         }
 


### PR DESCRIPTION
﻿## Summary
- Stop Portal bootstrap seeding from updating existing role group, role type, registry group, credential, or role rows
- Keep existing seeded rows read-compatible with the remote Portal data context, which does not register those bootstrap entities for remote mutation
- Preserve create behavior for missing seed rows

## Validation
- `dotnet build src/Presentation/XFramework.Portal/XFramework.Portal.csproj -m:1 /nr:false`
- `dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --filter TestCategory=Area:PortalContract -m:1 /nr:false --logger "console;verbosity=minimal"`

## Runtime Context
- After PR #340, Xeon Dev login compatibility was fixed but startup logs still showed failed remote mutation attempts for existing `IdentityRoleTypeGroup` bootstrap rows.
