### PR TITLE
Fix service token RSA signing cache

### DIFF
--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityService.cs
@@ -53,7 +53,11 @@ public sealed class ServiceIdentityService(
 
         var key = new RsaSecurityKey(rsa)
         {
-            KeyId = signingKey.KeyId
+            KeyId = signingKey.KeyId,
+            CryptoProviderFactory = new CryptoProviderFactory
+            {
+                CacheSignatureProviders = false
+            }
         };
 
         var now = DateTime.UtcNow;


### PR DESCRIPTION
﻿## Summary
- Disable IdentityModel signature-provider caching for the per-request RSA used to issue service tokens
- Fixes `ObjectDisposedException: RSAOpenSsl` when IdentityServer writes service-token JWTs after a cached provider references a disposed RSA instance

## Validation
- `dotnet build src/Modules/XFramework.IdentityServer/IdentityServer.Api/IdentityServer.Api.csproj -m:1 /nr:false`

## Runtime Context
- Xeon Dev Portal login failed after the Portal rename because IdentityServer returned 500 for `IssueServiceTokenRequest`.
- IdentityServer logs showed `Cannot access a disposed object. Object name: 'System.Security.Cryptography.RSAOpenSsl'.` during `JwtSecurityTokenHandler.WriteToken`.
