### PR TITLE
[codex] Harden POS production flows

### DIFF
--- a/src/Kernel/XFramework.Domain/Migrations/20260703161537_POSProductionHardening.Designer.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260703161537_POSProductionHardening.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XFramework.Domain.Contexts;
@@ -11,9 +12,11 @@ using XFramework.Domain.Contexts;
 namespace XFramework.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703161537_POSProductionHardening")]
+    partial class POSProductionHardening
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kernel/XFramework.Domain/Migrations/20260703161537_POSProductionHardening.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260703161537_POSProductionHardening.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class POSProductionHardening : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "IdempotencyKey",
+                schema: "Inventario",
+                table: "Reservation",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RequestHash",
+                schema: "POS",
+                table: "PosSale",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RequestHash",
+                schema: "POS",
+                table: "PosReturn",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Inventario_Reservation_Tenant_Idempotency_Active",
+                schema: "Inventario",
+                table: "Reservation",
+                columns: new[] { "TenantId", "IdempotencyKey" },
+                unique: true,
+                filter: "\"IsDeleted\" = false AND \"IdempotencyKey\" IS NOT NULL AND \"IdempotencyKey\" <> ''");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_Inventario_Reservation_Tenant_Idempotency_Active",
+                schema: "Inventario",
+                table: "Reservation");
+
+            migrationBuilder.DropColumn(
+                name: "IdempotencyKey",
+                schema: "Inventario",
+                table: "Reservation");
+
+            migrationBuilder.DropColumn(
+                name: "RequestHash",
+                schema: "POS",
+                table: "PosSale");
+
+            migrationBuilder.DropColumn(
+                name: "RequestHash",
+                schema: "POS",
+                table: "PosReturn");
+        }
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityService.cs
@@ -2,17 +2,24 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Security;
 
 namespace IdentityServer.Api.Services;
 
 public sealed class ServiceIdentityService(
     IDataContext dataContext,
     IConfiguration configuration,
-    ILogger<ServiceIdentityService> logger)
+    ILogger<ServiceIdentityService> logger,
+    IHttpContextAccessor? httpContextAccessor = null,
+    ITrustedServiceInvocationResolver? serviceInvocationResolver = null,
+    IHostEnvironment? hostEnvironment = null)
     : IServiceIdentityService
 {
     private const string Algorithm = "RS256";
@@ -124,6 +131,10 @@ public sealed class ServiceIdentityService(
         RotateServiceSigningKeyRequest request,
         CancellationToken ct = default)
     {
+        var adminResult = await EnsureSigningKeyAdminAsync(request.Metadata, ct);
+        if (!adminResult.IsSuccess)
+            return Result<ServiceSigningKeyResponse>.Failure(adminResult.Message!, adminResult.StatusCode);
+
         var key = await RotateSigningKeyCoreAsync(request.Reason ?? request.Metadata?.Name ?? "manual", ct);
         return Result<ServiceSigningKeyResponse>.Success(ToResponse(key));
     }
@@ -132,6 +143,10 @@ public sealed class ServiceIdentityService(
         RetireServiceSigningKeyRequest request,
         CancellationToken ct = default)
     {
+        var adminResult = await EnsureSigningKeyAdminAsync(request.Metadata, ct);
+        if (!adminResult.IsSuccess)
+            return Result<ServiceSigningKeyResponse>.Failure(adminResult.Message!, adminResult.StatusCode);
+
         if (string.IsNullOrWhiteSpace(request.KeyId))
             return Result<ServiceSigningKeyResponse>.Failure("KeyId is required", 400);
 
@@ -212,6 +227,14 @@ public sealed class ServiceIdentityService(
         var devSecret = configuration["ServiceIdentity:DevelopmentClientSecret"];
         if (!string.IsNullOrWhiteSpace(devSecret) && XFrameworkServiceNames.All.Contains(clientId))
         {
+            if (!AllowsDevelopmentClientFallback())
+            {
+                logger.LogWarning(
+                    "Service identity development client-secret fallback rejected outside a development-style environment. ClientId={ClientId}",
+                    clientId);
+                return null;
+            }
+
             return new ServiceClientDefinition(
                 clientId,
                 devSecret,
@@ -224,6 +247,42 @@ public sealed class ServiceIdentityService(
 
     private string ResolveIssuer() =>
         configuration["ServiceIdentity:Issuer"] ?? XFrameworkServiceNames.IdentityServer;
+
+    private async Task<Result> EnsureSigningKeyAdminAsync(
+        RequestMetadata? metadata,
+        CancellationToken ct)
+    {
+        var user = httpContextAccessor?.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated == true && user.IsInRole("SuperAdmin"))
+            return Result.Success();
+
+        if (serviceInvocationResolver is not null)
+        {
+            var invocation = await serviceInvocationResolver.ResolveAsync(
+                metadata,
+                configuration["BoltConfiguration:ClientName"] ?? XFrameworkServiceNames.IdentityServer,
+                [XFrameworkServiceScopes.IdentityAdmin],
+                requireTenant: false,
+                ct: ct);
+
+            if (invocation.IsSuccess)
+                return Result.Success();
+
+            return Result.Failure(
+                invocation.Error ?? "Trusted identity.admin service metadata is required for service signing key administration",
+                invocation.StatusCode);
+        }
+
+        return Result.Forbidden("Service signing key administration requires SuperAdmin or trusted identity.admin service metadata");
+    }
+
+    private bool AllowsDevelopmentClientFallback()
+    {
+        if (hostEnvironment?.IsDevelopment() == true)
+            return true;
+
+        return configuration.GetValue<bool>("ServiceIdentity:AllowDevelopmentClientSecretFallback");
+    }
 
     private static ServiceSigningKeyResponse ToResponse(ServiceSigningKey key) => new()
     {

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reservations/Reserve/ReserveInventoryValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Reservations/Reserve/ReserveInventoryValidator.cs
@@ -12,6 +12,7 @@ public sealed class ReserveInventoryValidator : AbstractValidator<ReserveInvento
         RuleFor(x => x.LocationId).NotEmpty();
         RuleFor(x => x.Quantity).GreaterThan(0);
         RuleFor(x => x.ReferenceType).MaximumLength(100);
+        RuleFor(x => x.IdempotencyKey).MaximumLength(200);
         RuleFor(x => x.UnitOfMeasure).MaximumLength(20);
         RuleFor(x => x.Reason).MaximumLength(500);
         RuleFor(x => x.ExpiredLotOverrideReason)

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
@@ -60,6 +60,27 @@ public sealed class ReservationService(
         if (request.Quantity <= 0)
             return Result<Reservation>.Failure("Reservation quantity must be greater than zero.", 400);
 
+        var idempotencyKey = NormalizeOptional(request.IdempotencyKey);
+        if (idempotencyKey is not null)
+        {
+            var existingReservation = await dataContext.Query<Reservation>()
+                .IgnoreQueryFilters()
+                .Include(x => x.Allocations)
+                .Where(x =>
+                    x.TenantId == tenantResult.Data &&
+                    x.IdempotencyKey == idempotencyKey &&
+                    !x.IsDeleted)
+                .FirstOrDefaultAsync(ct);
+
+            if (existingReservation is not null)
+            {
+                if (!ReferencesSameReservation(existingReservation, request))
+                    return Result<Reservation>.Conflict("Reservation idempotency key was reused with a different payload.");
+
+                return Result<Reservation>.Success(existingReservation, "Reservation replayed.");
+            }
+        }
+
         var reservationId = Guid.NewGuid();
         var allocationsResult = await allocationService.ReserveAsync(tenantResult.Data, reservationId, request, ct);
         if (!allocationsResult.IsSuccess)
@@ -82,6 +103,7 @@ public sealed class ReservationService(
             ReferenceId = request.ReferenceId,
             ReservedAt = now,
             ExpiresAt = request.ExpiresAt,
+            IdempotencyKey = idempotencyKey,
             IsEnabled = true,
             CreatedAt = now,
             ConcurrencyStamp = Guid.NewGuid(),
@@ -286,4 +308,13 @@ public sealed class ReservationService(
 
     private static string? NormalizeOptional(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static bool ReferencesSameReservation(Reservation reservation, ReserveInventoryRequest request) =>
+        reservation.ProductId == request.ProductId &&
+        reservation.ProductVariationId == request.ProductVariationId &&
+        reservation.WarehouseId == request.WarehouseId &&
+        reservation.LocationId == request.LocationId &&
+        reservation.Quantity == request.Quantity &&
+        string.Equals(reservation.ReferenceType, NormalizeOptional(request.ReferenceType), StringComparison.Ordinal) &&
+        reservation.ReferenceId == request.ReferenceId;
 }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ReservationConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ReservationConfiguration.cs
@@ -15,10 +15,15 @@ public class ReservationConfiguration : IEntityTypeConfiguration<Reservation>
         entity.Property(e => e.Quantity).HasPrecision(18, 4);
         entity.Property(e => e.Status).HasDefaultValue(ReservationStatus.Active);
         entity.Property(e => e.ReferenceType).HasMaxLength(100);
+        entity.Property(e => e.IdempotencyKey).HasMaxLength(200);
         entity.Property(e => e.ReservedAt).HasDefaultValueSql("now()");
 
         entity.HasIndex(e => new { e.TenantId, e.ProductId, e.ProductVariationId, e.Status });
         entity.HasIndex(e => new { e.TenantId, e.ReferenceType, e.ReferenceId });
+        entity.HasIndex(e => new { e.TenantId, e.IdempotencyKey })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false AND \"IdempotencyKey\" IS NOT NULL AND \"IdempotencyKey\" <> ''")
+            .HasDatabaseName("UX_Inventario_Reservation_Tenant_Idempotency_Active");
         entity.HasIndex(e => e.ExpiresAt);
 
         entity.HasOne(e => e.Product)

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reservations/ReserveInventoryRequest.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Requests/Reservations/ReserveInventoryRequest.cs
@@ -22,6 +22,7 @@ public partial record ReserveInventoryRequest : RequestBase,
     public string? UnitOfMeasure { get; init; }
     public string? ReferenceType { get; init; }
     public Guid? ReferenceId { get; init; }
+    public string? IdempotencyKey { get; init; }
     public string? Reason { get; init; }
     public bool AllowExpiredLotOverride { get; init; }
     public string? ExpiredLotOverrideReason { get; init; }

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Reservation.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Reservation.cs
@@ -51,6 +51,8 @@ public partial class Reservation : BaseModel
     public DateTime? ReleasedAt { get; set; }
     [MemoryPackOrder(12)]
     public DateTime? FulfilledAt { get; set; }
+    [MemoryPackOrder(13)]
+    public string? IdempotencyKey { get; set; }
     [MemoryPackIgnore]
     public List<ReservationAllocation> Allocations { get; set; } = [];
 }

--- a/src/Modules/XFramework.POS/POS.Api/Features/PosEndpoints.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Features/PosEndpoints.cs
@@ -249,3 +249,16 @@ public static class SearchPosReturnsEndpoint
         CancellationToken ct) =>
         service.SearchAsync(request, ct);
 }
+
+public static class RetryPosReturnEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/pos/returns/{returnId:guid}/retry", Tags = ["POS Returns"],
+        Summary = "Retry POS return",
+        Description = "Retries recoverable inventory posting or refund failures for a POS return.")]
+    public static Task<Result<PosReturnResponse>> Handle(
+        RetryPosReturnRequest request,
+        PosReturnsService service,
+        CancellationToken ct) =>
+        service.RetryAsync(request, ct);
+}

--- a/src/Modules/XFramework.POS/POS.Api/Features/PosValidators.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Features/PosValidators.cs
@@ -138,7 +138,7 @@ public sealed class CheckoutPosCartValidator : AbstractValidator<CheckoutPosCart
     public CheckoutPosCartValidator()
     {
         RuleFor(x => x.CartId).NotEmpty();
-        RuleFor(x => x.IdempotencyKey).MaximumLength(160).When(x => !string.IsNullOrWhiteSpace(x.IdempotencyKey));
+        RuleFor(x => x.IdempotencyKey).NotEmpty().MaximumLength(160);
         RuleFor(x => x.Payment).NotNull();
         RuleFor(x => x.Payment.Amount).GreaterThanOrEqualTo(0);
         RuleFor(x => x.Payment.Method).IsInEnum();
@@ -156,6 +156,7 @@ public sealed class CheckoutPosSaleValidator : AbstractValidator<CheckoutPosSale
         RuleFor(x => x.CashierCredentialId).NotEmpty();
         RuleFor(x => x.DiscountAmount).GreaterThanOrEqualTo(0);
         RuleFor(x => x.TaxAmount).GreaterThanOrEqualTo(0);
+        RuleFor(x => x.IdempotencyKey).NotEmpty().MaximumLength(160);
         RuleFor(x => x.Lines).NotEmpty();
         RuleFor(x => x.Payment).NotNull();
         RuleFor(x => x.Payment.Amount).GreaterThanOrEqualTo(0);
@@ -214,6 +215,7 @@ public sealed class CreatePosReturnValidator : AbstractValidator<CreatePosReturn
         RuleFor(x => x.CashierCredentialId).NotEmpty();
         RuleFor(x => x.RefundMethod).IsInEnum();
         RuleFor(x => x.Reason).MaximumLength(500).When(x => !string.IsNullOrWhiteSpace(x.Reason));
+        RuleFor(x => x.IdempotencyKey).NotEmpty().MaximumLength(160);
         RuleFor(x => x.Lines).NotEmpty();
         RuleForEach(x => x.Lines).ChildRules(line =>
         {
@@ -238,4 +240,10 @@ public sealed class SearchPosReturnsValidator : AbstractValidator<SearchPosRetur
         RuleFor(x => x.PageSize).InclusiveBetween(1, 100);
         RuleFor(x => x.Status).IsInEnum().When(x => x.Status.HasValue);
     }
+}
+
+public sealed class RetryPosReturnValidator : AbstractValidator<RetryPosReturnRequest>
+{
+    public RetryPosReturnValidator() =>
+        RuleFor(x => x.ReturnId).NotEmpty();
 }

--- a/src/Modules/XFramework.POS/POS.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Installers/ServicesInstaller.cs
@@ -13,6 +13,7 @@ public sealed class ServicesInstaller : IInstaller
     {
         services.AddTenantResolver();
         services.AddTenantModuleFeatures();
+        services.AddScoped<IPosRequestContextResolver, PosRequestContextResolver>();
         services.AddScoped<PosRegisterService>();
         services.AddScoped<PosCatalogService>();
         services.AddScoped<PosCartService>();

--- a/src/Modules/XFramework.POS/POS.Api/Program.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Program.cs
@@ -30,6 +30,10 @@ app.UseCorrelationId();
 app.UseXFrameworkRateLimiting();
 app.UseTenantModuleFeatureGate(options =>
 {
+    options.RequireFeature(TenantModuleFeatureKeys.PosRegisters, "/api/pos/registers");
+    options.RequireFeature(TenantModuleFeatureKeys.PosSales, "/api/pos/catalog");
+    options.RequireFeature(TenantModuleFeatureKeys.PosSales, "/api/pos/sales");
+    options.RequireFeature(TenantModuleFeatureKeys.PosReturns, "/api/pos/returns");
     options.RequireFeature(TenantModuleFeatureKeys.PosCarts, "/api/pos/carts");
     options.RequireFeature(TenantModuleFeatureKeys.Pos, "/api/pos");
 });

--- a/src/Modules/XFramework.POS/POS.Api/Services/IPosRequestContextResolver.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/IPosRequestContextResolver.cs
@@ -1,0 +1,173 @@
+using System.Security.Claims;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Security;
+
+namespace POS.Api.Services;
+
+public sealed record PosRequestContext(
+    Guid TenantId,
+    Guid? ActorCredentialId,
+    RequestMetadata Metadata,
+    bool IsPrivilegedActor,
+    bool IsTrustedInternal,
+    string? TrustedServiceName = null);
+
+public interface IPosRequestContextResolver
+{
+    Result<PosRequestContext> Resolve(RequestBase request, Guid? requestCredentialId = null);
+}
+
+public sealed class PosRequestContextResolver(
+    IHttpContextAccessor httpContextAccessor,
+    IConfiguration configuration,
+    ITrustedServiceInvocationResolver? serviceInvocationResolver = null)
+    : IPosRequestContextResolver
+{
+    public Result<PosRequestContext> Resolve(RequestBase request, Guid? requestCredentialId = null)
+    {
+        request.Metadata ??= new RequestMetadata();
+
+        var httpContext = httpContextAccessor.HttpContext;
+        var user = httpContext?.User;
+        var isAuthenticatedUser = user?.Identity?.IsAuthenticated == true;
+        var trustedInvocation = isAuthenticatedUser ? null : ResolveTrustedServerMetadata(request.Metadata);
+        var isTrustedInternal = trustedInvocation is not null;
+
+        var tenantId = TryGetClaimGuid(user, "tenant_id", "tenantId", "TenantId", "tid", "tenant")
+            ?? TryGetItemGuid(httpContext, "TenantId")
+            ?? trustedInvocation?.TenantId;
+
+        if (tenantId is null || tenantId == Guid.Empty)
+            return Result<PosRequestContext>.Failure("Tenant context is required", 400);
+
+        if (request.Metadata.TenantId is { } suppliedTenantId &&
+            suppliedTenantId != Guid.Empty &&
+            suppliedTenantId != tenantId.Value)
+        {
+            return Result<PosRequestContext>.Forbidden("Request tenant does not match trusted tenant context");
+        }
+
+        var actorCredentialId = TryGetClaimGuid(user, "credential_id", "credentialId", "CredentialId", ClaimTypes.NameIdentifier, "sub")
+            ?? TryGetItemGuid(httpContext, "CredentialId")
+            ?? trustedInvocation?.ActorCredentialId
+            ?? (isTrustedInternal ? request.Metadata.CredentialId : null);
+
+        var isPrivilegedActor = isTrustedInternal || IsAdmin(user) || TryGetItemBool(httpContext, "POSPrivilegedActor");
+
+        if (request.Metadata.CredentialId is { } suppliedCredentialId &&
+            suppliedCredentialId != Guid.Empty &&
+            actorCredentialId.HasValue &&
+            suppliedCredentialId != actorCredentialId.Value &&
+            !isPrivilegedActor)
+        {
+            return Result<PosRequestContext>.Forbidden("Request credential does not match trusted actor context");
+        }
+
+        if (requestCredentialId is { } targetCredentialId &&
+            actorCredentialId is { } actorId &&
+            actorId != targetCredentialId &&
+            !isPrivilegedActor)
+        {
+            return Result<PosRequestContext>.Forbidden("Actor cannot operate as the requested POS credential");
+        }
+
+        if (requestCredentialId.HasValue && actorCredentialId is null && !isPrivilegedActor)
+            return Result<PosRequestContext>.Forbidden("Actor credential is required for POS cashier operations");
+
+        var sanitizedMetadata = SanitizeMetadata(request.Metadata, tenantId.Value, actorCredentialId, trustedInvocation?.Metadata);
+        request.Metadata = sanitizedMetadata;
+
+        return Result<PosRequestContext>.Success(new(
+            tenantId.Value,
+            actorCredentialId,
+            sanitizedMetadata,
+            isPrivilegedActor,
+            isTrustedInternal,
+            trustedInvocation?.CallerClientId));
+    }
+
+    private TrustedServiceInvocation? ResolveTrustedServerMetadata(RequestMetadata? metadata)
+    {
+        if (serviceInvocationResolver is null)
+            return null;
+
+        var result = serviceInvocationResolver.ResolveAsync(
+                metadata,
+                configuration["BoltConfiguration:ClientName"] ?? XFrameworkServiceNames.Pos,
+                [XFrameworkServiceScopes.BoltService],
+                requireTenant: true)
+            .GetAwaiter()
+            .GetResult();
+
+        return result.IsSuccess ? result.Invocation : null;
+    }
+
+    private static RequestMetadata SanitizeMetadata(
+        RequestMetadata source,
+        Guid tenantId,
+        Guid? actorCredentialId,
+        RequestMetadata? trustedMetadata)
+    {
+        return new RequestMetadata
+        {
+            SessionId = source.SessionId ?? trustedMetadata?.SessionId,
+            TenantId = tenantId,
+            CredentialId = actorCredentialId ?? source.CredentialId ?? trustedMetadata?.CredentialId,
+            Name = source.Name ?? trustedMetadata?.Name,
+            DeviceName = source.DeviceName ?? trustedMetadata?.DeviceName,
+            DeviceAgent = source.DeviceAgent ?? trustedMetadata?.DeviceAgent,
+            IpAddress = source.IpAddress ?? trustedMetadata?.IpAddress,
+            RequestId = source.RequestId ?? trustedMetadata?.RequestId ?? Guid.NewGuid(),
+            ActorAccessToken = source.ActorAccessToken ?? trustedMetadata?.ActorAccessToken,
+            ServiceAccessToken = source.ServiceAccessToken ?? trustedMetadata?.ServiceAccessToken
+        };
+    }
+
+    private static Guid? TryGetClaimGuid(ClaimsPrincipal? user, params string[] claimTypes)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+            return null;
+
+        foreach (var claimType in claimTypes)
+        {
+            var value = user.Claims.FirstOrDefault(c =>
+                string.Equals(c.Type, claimType, StringComparison.OrdinalIgnoreCase))?.Value;
+            if (Guid.TryParse(value, out var id) && id != Guid.Empty)
+                return id;
+        }
+
+        return null;
+    }
+
+    private static Guid? TryGetItemGuid(HttpContext? context, string key)
+    {
+        if (context?.Items.TryGetValue(key, out var value) != true)
+            return null;
+
+        return value switch
+        {
+            Guid id when id != Guid.Empty => id,
+            string text when Guid.TryParse(text, out var id) && id != Guid.Empty => id,
+            _ => null
+        };
+    }
+
+    private static bool TryGetItemBool(HttpContext? context, string key)
+    {
+        if (context?.Items.TryGetValue(key, out var value) != true)
+            return false;
+
+        return value switch
+        {
+            bool flag => flag,
+            string text when bool.TryParse(text, out var flag) => flag,
+            _ => false
+        };
+    }
+
+    private static bool IsAdmin(ClaimsPrincipal? user) =>
+        user?.IsInRole("Admin") == true || user?.IsInRole("SuperAdmin") == true;
+}

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosCartService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosCartService.cs
@@ -15,6 +15,7 @@ public sealed class PosCartService(
     AppDbContext db,
     IInventarioServiceWrapper inventario,
     PosSalesService salesService,
+    IPosRequestContextResolver contextResolver,
     ILogger<PosCartService> logger)
 {
     private static readonly TimeSpan CartTtl = TimeSpan.FromHours(24);
@@ -23,8 +24,11 @@ public sealed class PosCartService(
         CreatePosCartRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosCartResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request, request.CashierCredentialId);
+        if (!contextResult.IsSuccess)
+            return Result<PosCartResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         var idempotencyKey = PosServiceHelpers.NormalizeOptional(request.IdempotencyKey) ?? string.Empty;
         if (!string.IsNullOrWhiteSpace(idempotencyKey))
@@ -68,7 +72,7 @@ public sealed class PosCartService(
         var lineResult = await BuildCartLinesAsync(
             cart.Id,
             tenantId,
-            request.Metadata,
+            contextResult.Data.Metadata,
             register,
             cart.WarehouseId,
             cart.LocationId,
@@ -95,8 +99,11 @@ public sealed class PosCartService(
         UpdatePosCartRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosCartResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosCartResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         await ExpireDueCartsAsync(tenantId, ct);
         var cart = await LoadCartAsync(tenantId, request.Id, tracking: true, ct);
@@ -130,7 +137,7 @@ public sealed class PosCartService(
         var lineResult = await BuildCartLinesAsync(
             cart.Id,
             tenantId,
-            request.Metadata,
+            contextResult.Data.Metadata,
             register,
             cart.WarehouseId,
             cart.LocationId,
@@ -158,15 +165,18 @@ public sealed class PosCartService(
         GetPosCartRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosCartResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosCartResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         await ExpireDueCartsAsync(tenantId, ct);
         var cart = await LoadCartAsync(tenantId, request.Id, tracking: false, ct);
         if (cart is null)
             return Result<PosCartResponse>.NotFound("POS cart was not found");
 
-        var warnings = await BuildCatalogWarningsAsync(cart, request.Metadata);
+        var warnings = await BuildCatalogWarningsAsync(cart, contextResult.Data.Metadata);
         return Result<PosCartResponse>.Success(PosServiceHelpers.ToCartResponse(cart, warnings));
     }
 
@@ -174,8 +184,11 @@ public sealed class PosCartService(
         SearchPosCartsRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<List<PosCartSummaryResponse>>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<List<PosCartSummaryResponse>>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         await ExpireDueCartsAsync(tenantId, ct);
         var (page, pageSize) = PosServiceHelpers.NormalizePage(request.Page, request.PageSize);
@@ -223,8 +236,11 @@ public sealed class PosCartService(
         SuspendPosCartRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosCartResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosCartResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         await ExpireDueCartsAsync(tenantId, ct);
         var cart = await LoadCartAsync(tenantId, request.CartId, tracking: true, ct);
@@ -254,8 +270,11 @@ public sealed class PosCartService(
         ResumePosCartRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosCartResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosCartResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         await ExpireDueCartsAsync(tenantId, ct);
         var cart = await LoadCartAsync(tenantId, request.CartId, tracking: true, ct);
@@ -277,7 +296,7 @@ public sealed class PosCartService(
         cart.ConcurrencyStamp = Guid.NewGuid();
 
         await db.SaveChangesAsync(ct);
-        var warnings = await BuildCatalogWarningsAsync(cart, request.Metadata);
+        var warnings = await BuildCatalogWarningsAsync(cart, contextResult.Data.Metadata);
         return Result<PosCartResponse>.Success(PosServiceHelpers.ToCartResponse(cart, warnings), "POS cart resumed");
     }
 
@@ -285,8 +304,11 @@ public sealed class PosCartService(
         CancelPosCartRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosCartResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosCartResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         await ExpireDueCartsAsync(tenantId, ct);
         var cart = await LoadCartAsync(tenantId, request.CartId, tracking: true, ct);
@@ -316,8 +338,11 @@ public sealed class PosCartService(
         CheckoutPosCartRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosSaleReceiptResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosSaleReceiptResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         await ExpireDueCartsAsync(tenantId, ct);
         var cart = await LoadCartAsync(tenantId, request.CartId, tracking: true, ct);

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosCatalogService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosCatalogService.cs
@@ -1,19 +1,48 @@
 using Inventario.Integration.Drivers;
+using Microsoft.EntityFrameworkCore;
+using POS.Domain.Shared.Contracts;
 using POS.Domain.Shared.Contracts.Requests;
 using POS.Domain.Shared.Contracts.Responses;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Contexts;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
+using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
 
 namespace POS.Api.Services;
 
-public sealed class PosCatalogService(IInventarioServiceWrapper inventario)
+public sealed class PosCatalogService(
+    IInventarioServiceWrapper inventario,
+    AppDbContext db,
+    IPosRequestContextResolver contextResolver)
 {
     public async Task<Result<List<PosCatalogItemResponse>>> SearchAsync(
         SearchPosCatalogRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out _))
-            return Result<List<PosCatalogItemResponse>>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<List<PosCatalogItemResponse>>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var context = contextResult.Data!;
+        var warehouseId = request.WarehouseId;
+        var locationId = request.LocationId;
+
+        if (request.RegisterId is { } registerId)
+        {
+            var register = await db.Set<PosRegister>()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(item =>
+                    item.TenantId == context.TenantId &&
+                    item.Id == registerId &&
+                    !item.IsDeleted,
+                    ct);
+
+            if (register is null)
+                return Result<List<PosCatalogItemResponse>>.NotFound("POS register was not found");
+
+            warehouseId ??= register.DefaultWarehouseId;
+            locationId ??= register.DefaultLocationId;
+        }
 
         var response = await inventario.SearchSellableProducts(new SearchSellableProductsRequest
         {
@@ -24,7 +53,7 @@ public sealed class PosCatalogService(IInventarioServiceWrapper inventario)
             IncludeVariants = request.IncludeVariants,
             Page = request.Page,
             PageSize = request.PageSize,
-            Metadata = request.Metadata
+            Metadata = context.Metadata
         });
 
         if (!response.IsSuccess)
@@ -49,6 +78,39 @@ public sealed class PosCatalogService(IInventarioServiceWrapper inventario)
                 Price = item.Price
             })
             .ToList() ?? [];
+
+        if (warehouseId.HasValue || locationId.HasValue)
+        {
+            var availableItems = new List<PosCatalogItemResponse>(items.Count);
+            foreach (var item in items)
+            {
+                var balanceResponse = await inventario.GetStockBalances(new GetStockBalancesRequest
+                {
+                    ProductId = item.ProductId,
+                    ProductVariationId = item.ProductVariationId,
+                    WarehouseId = warehouseId,
+                    LocationId = locationId,
+                    Metadata = context.Metadata
+                });
+
+                if (!balanceResponse.IsSuccess)
+                    return Result<List<PosCatalogItemResponse>>.Failure(
+                        balanceResponse.Message ?? "Inventario stock balance lookup failed",
+                        (int)balanceResponse.HttpStatusCode);
+
+                var availableQuantity = balanceResponse.Response?.Sum(balance => balance.AvailableQuantity);
+                var enrichedItem = item with
+                {
+                    AvailableQuantity = availableQuantity,
+                    IsAvailable = item.IsAvailable && availableQuantity.GetValueOrDefault() > 0
+                };
+
+                if (request.IsAvailable != true || enrichedItem.IsAvailable)
+                    availableItems.Add(enrichedItem);
+            }
+
+            items = availableItems;
+        }
 
         return Result<List<PosCatalogItemResponse>>.Success(items);
     }

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosRegisterService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosRegisterService.cs
@@ -2,19 +2,25 @@ using Microsoft.EntityFrameworkCore;
 using POS.Domain.Shared.Contracts;
 using POS.Domain.Shared.Contracts.Requests;
 using POS.Domain.Shared.Contracts.Responses;
+using IdentityServer.Domain.Shared.Contracts;
+using Wallets.Domain.Shared.Contracts;
 using XFramework.Core.Patterns;
 using XFramework.Domain.Contexts;
+using XFramework.Inventario.Domain.Shared.Contracts;
 
 namespace POS.Api.Services;
 
-public sealed class PosRegisterService(AppDbContext db)
+public sealed class PosRegisterService(AppDbContext db, IPosRequestContextResolver contextResolver)
 {
     public async Task<Result<PosRegisterResponse>> GetAsync(
         GetPosRegisterRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosRegisterResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosRegisterResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         var register = await db.Set<PosRegister>()
             .AsNoTracking()
@@ -33,8 +39,22 @@ public sealed class PosRegisterService(AppDbContext db)
         CreatePosRegisterRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosRegisterResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosRegisterResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
+        var referenceValidation = await ValidateRegisterReferencesAsync(
+            tenantId,
+            request.MerchantCredentialId,
+            request.CashDrawerWalletId,
+            request.WalletTypeId,
+            request.CurrencyId,
+            request.DefaultWarehouseId,
+            request.DefaultLocationId,
+            ct);
+        if (!referenceValidation.IsSuccess)
+            return Result<PosRegisterResponse>.Failure(referenceValidation.Message!, referenceValidation.StatusCode);
 
         var normalizedCode = PosServiceHelpers.NormalizeOptional(request.Code);
         if (normalizedCode is not null)
@@ -82,8 +102,11 @@ public sealed class PosRegisterService(AppDbContext db)
         UpdatePosRegisterRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosRegisterResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosRegisterResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var tenantId = contextResult.Data!.TenantId;
 
         var register = await db.Set<PosRegister>()
             .AsTracking()
@@ -95,6 +118,18 @@ public sealed class PosRegisterService(AppDbContext db)
 
         if (register is null)
             return Result<PosRegisterResponse>.NotFound("POS register was not found");
+
+        var referenceValidation = await ValidateRegisterReferencesAsync(
+            tenantId,
+            request.MerchantCredentialId,
+            request.CashDrawerWalletId,
+            request.WalletTypeId,
+            request.CurrencyId,
+            request.DefaultWarehouseId,
+            request.DefaultLocationId,
+            ct);
+        if (!referenceValidation.IsSuccess)
+            return Result<PosRegisterResponse>.Failure(referenceValidation.Message!, referenceValidation.StatusCode);
 
         var normalizedCode = PosServiceHelpers.NormalizeOptional(request.Code);
         if (normalizedCode is not null)
@@ -129,5 +164,65 @@ public sealed class PosRegisterService(AppDbContext db)
         return Result<PosRegisterResponse>.Success(
             PosServiceHelpers.ToRegisterResponse(register),
             "POS register updated");
+    }
+
+    private async Task<Result> ValidateRegisterReferencesAsync(
+        Guid tenantId,
+        Guid merchantCredentialId,
+        Guid cashDrawerWalletId,
+        Guid walletTypeId,
+        Guid currencyId,
+        Guid warehouseId,
+        Guid locationId,
+        CancellationToken ct)
+    {
+        var merchantExists = await db.Set<IdentityCredential>()
+            .AsNoTracking()
+            .AnyAsync(item => item.TenantId == tenantId && item.Id == merchantCredentialId && !item.IsDeleted, ct);
+        if (!merchantExists)
+            return Result.NotFound("Merchant credential was not found for this tenant");
+
+        var walletType = await db.Set<WalletType>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == walletTypeId && !item.IsDeleted, ct);
+        if (walletType is null)
+            return Result.NotFound("Wallet type was not found for this tenant");
+
+        if (walletType.CurrencyTypeId.HasValue && walletType.CurrencyTypeId.Value != currencyId)
+            return Result.Conflict("Wallet type currency does not match the POS register currency");
+
+        var currencyExists = await db.Set<CurrencyType>()
+            .AsNoTracking()
+            .AnyAsync(item => item.TenantId == tenantId && item.Id == currencyId && !item.IsDeleted, ct);
+        if (!currencyExists)
+            return Result.NotFound("Currency was not found for this tenant");
+
+        var cashDrawerWallet = await db.Set<Wallet>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == cashDrawerWalletId && !item.IsDeleted, ct);
+        if (cashDrawerWallet is null)
+            return Result.NotFound("Cash drawer wallet was not found for this tenant");
+
+        if (cashDrawerWallet.WalletTypeId.HasValue && cashDrawerWallet.WalletTypeId.Value != walletTypeId)
+            return Result.Conflict("Cash drawer wallet type does not match the POS register wallet type");
+
+        var warehouseExists = await db.Set<Warehouse>()
+            .AsNoTracking()
+            .AnyAsync(item => item.TenantId == tenantId && item.Id == warehouseId && !item.IsDeleted, ct);
+        if (!warehouseExists)
+            return Result.NotFound("Warehouse was not found for this tenant");
+
+        var locationExists = await db.Set<InventoryLocation>()
+            .AsNoTracking()
+            .AnyAsync(item =>
+                item.TenantId == tenantId &&
+                item.Id == locationId &&
+                item.WarehouseId == warehouseId &&
+                !item.IsDeleted,
+                ct);
+        if (!locationExists)
+            return Result.NotFound("Location was not found in the selected warehouse for this tenant");
+
+        return Result.Success();
     }
 }

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosReturnsService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosReturnsService.cs
@@ -1,3 +1,5 @@
+using System.Data;
+using Inventario.Integration.Drivers;
 using Microsoft.EntityFrameworkCore;
 using POS.Domain.Shared.Contracts;
 using POS.Domain.Shared.Contracts.Requests;
@@ -11,38 +13,48 @@ using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.Enums;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Stock;
 using XFramework.Inventario.Domain.Shared.Enums;
-using Inventario.Integration.Drivers;
 
 namespace POS.Api.Services;
 
 public sealed class PosReturnsService(
     AppDbContext db,
     IInventarioServiceWrapper inventario,
-    IWalletsServiceWrapper wallets)
+    IWalletsServiceWrapper wallets,
+    IPosRequestContextResolver contextResolver)
 {
     public async Task<Result<PosReturnResponse>> CreateAsync(
         CreatePosReturnRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosReturnResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request, request.CashierCredentialId);
+        if (!contextResult.IsSuccess)
+            return Result<PosReturnResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
 
-        var idempotencyKey = PosServiceHelpers.NormalizeOptional(request.IdempotencyKey)
-            ?? $"POS.Return.{Guid.NewGuid():N}";
+        var idempotencyKey = PosServiceHelpers.NormalizeOptional(request.IdempotencyKey) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+            return Result<PosReturnResponse>.Failure("Return idempotency key is required", 400);
 
-        var replay = await LoadReturnByIdempotencyAsync(tenantId, idempotencyKey, ct);
+        var context = contextResult.Data!;
+        var requestHash = PosServiceHelpers.BuildReturnRequestHash(request);
+        var replay = await LoadReturnByIdempotencyAsync(context.TenantId, idempotencyKey, tracking: true, ct);
         if (replay is not null)
-            return Result<PosReturnResponse>.Success(PosServiceHelpers.ToReturnResponse(replay), "POS return replayed");
+        {
+            if (!string.Equals(replay.RequestHash, requestHash, StringComparison.Ordinal))
+                return Result<PosReturnResponse>.Conflict("Return idempotency key was reused with a different payload");
+
+            return await ExecuteReturnWorkflowAsync(replay, context.Metadata, ct, replayed: true);
+        }
 
         if (request.Lines.Count == 0)
             return Result<PosReturnResponse>.Failure("At least one return line is required", 400);
 
+        await using var transaction = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct);
         var sale = await db.Set<PosSale>()
             .AsTracking()
             .Include(item => item.Register)
             .Include(item => item.Lines)
             .FirstOrDefaultAsync(item =>
-                item.TenantId == tenantId &&
+                item.TenantId == context.TenantId &&
                 item.Id == request.SaleId &&
                 !item.IsDeleted,
                 ct);
@@ -57,7 +69,7 @@ public sealed class PosReturnsService(
         var posReturn = new PosReturn
         {
             Id = Guid.NewGuid(),
-            TenantId = tenantId,
+            TenantId = context.TenantId,
             ReturnNumber = string.Empty,
             SaleId = sale.Id,
             RegisterId = sale.RegisterId,
@@ -69,12 +81,15 @@ public sealed class PosReturnsService(
             WalletTypeId = sale.WalletTypeId,
             Reason = PosServiceHelpers.NormalizeOptional(request.Reason),
             IdempotencyKey = idempotencyKey,
+            RequestHash = requestHash,
             CreatedAt = now,
             ConcurrencyStamp = Guid.NewGuid(),
-            IsEnabled = true
+            IsEnabled = true,
+            Sale = sale,
+            Register = sale.Register
         };
         posReturn.ReturnNumber = PosServiceHelpers.NewReturnNumber(now, posReturn.Id);
-        posReturn.Lines = await BuildReturnLinesAsync(posReturn, sale, request, tenantId, ct);
+        posReturn.Lines = await BuildReturnLinesAsync(posReturn, sale, request, context.TenantId, ct);
 
         if (posReturn.Lines.Count != request.Lines.Count)
             return Result<PosReturnResponse>.Failure("One or more return lines are invalid", 400);
@@ -85,44 +100,47 @@ public sealed class PosReturnsService(
 
         db.Set<PosReturn>().Add(posReturn);
         await db.SaveChangesAsync(ct);
+        await transaction.CommitAsync(ct);
 
-        var inventoryResult = await PostReturnInventoryAsync(posReturn, request.Metadata);
-        if (!inventoryResult.IsSuccess)
+        return await ExecuteReturnWorkflowAsync(posReturn, context.Metadata, ct, replayed: false);
+    }
+
+    public async Task<Result<PosReturnResponse>> RetryAsync(
+        RetryPosReturnRequest request,
+        CancellationToken ct)
+    {
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosReturnResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
+
+        var posReturn = await LoadReturnAsync(contextResult.Data!.TenantId, request.ReturnId, tracking: true, ct);
+        if (posReturn is null)
+            return Result<PosReturnResponse>.NotFound("POS return was not found");
+
+        if (posReturn.Status == PosReturnStatus.Completed)
+            return Result<PosReturnResponse>.Success(PosServiceHelpers.ToReturnResponse(posReturn), "POS return already completed");
+
+        if (posReturn.Status is not PosReturnStatus.Pending
+            and not PosReturnStatus.InventoryPostFailed
+            and not PosReturnStatus.InventoryPosted
+            and not PosReturnStatus.RefundFailed
+            and not PosReturnStatus.Failed)
         {
-            posReturn.Status = PosReturnStatus.Failed;
-            posReturn.FailureReason = inventoryResult.Message;
-            await db.SaveChangesAsync(ct);
-            return Result<PosReturnResponse>.Success(PosServiceHelpers.ToReturnResponse(posReturn), inventoryResult.Message);
+            return Result<PosReturnResponse>.Conflict("POS return is not in a retryable state");
         }
 
-        posReturn.Status = PosReturnStatus.InventoryPosted;
-        await db.SaveChangesAsync(ct);
-
-        var refundResult = await RefundAsync(posReturn, sale.Register, request.Metadata);
-        if (!refundResult.IsSuccess)
-        {
-            posReturn.Status = PosReturnStatus.Failed;
-            posReturn.FailureReason = refundResult.Message;
-            await db.SaveChangesAsync(ct);
-            return Result<PosReturnResponse>.Success(PosServiceHelpers.ToReturnResponse(posReturn), refundResult.Message);
-        }
-
-        posReturn.Status = PosReturnStatus.Completed;
-        posReturn.CompletedAt = DateTime.UtcNow;
-        posReturn.FailureReason = null;
-        await db.SaveChangesAsync(ct);
-
-        return Result<PosReturnResponse>.Success(PosServiceHelpers.ToReturnResponse(posReturn), 201, "POS return completed");
+        return await ExecuteReturnWorkflowAsync(posReturn, contextResult.Data.Metadata, ct, replayed: true);
     }
 
     public async Task<Result<PosReturnResponse>> GetAsync(
         GetPosReturnRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosReturnResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosReturnResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
 
-        var posReturn = await LoadReturnAsync(tenantId, request.Id, false, ct);
+        var posReturn = await LoadReturnAsync(contextResult.Data!.TenantId, request.Id, false, ct);
         return posReturn is null
             ? Result<PosReturnResponse>.NotFound("POS return was not found")
             : Result<PosReturnResponse>.Success(PosServiceHelpers.ToReturnResponse(posReturn));
@@ -132,9 +150,11 @@ public sealed class PosReturnsService(
         SearchPosReturnsRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<List<PosReturnSummaryResponse>>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<List<PosReturnSummaryResponse>>.Failure(contextResult.Message!, contextResult.StatusCode);
 
+        var tenantId = contextResult.Data!.TenantId;
         var (page, pageSize) = PosServiceHelpers.NormalizePage(request.Page, request.PageSize);
         IQueryable<PosReturn> query = db.Set<PosReturn>()
             .AsNoTracking()
@@ -171,6 +191,51 @@ public sealed class PosReturnsService(
 
         return Result<List<PosReturnSummaryResponse>>.Success(
             items.Select(PosServiceHelpers.ToReturnSummaryResponse).ToList());
+    }
+
+    private async Task<Result<PosReturnResponse>> ExecuteReturnWorkflowAsync(
+        PosReturn posReturn,
+        RequestMetadata metadata,
+        CancellationToken ct,
+        bool replayed)
+    {
+        if (posReturn.Status is PosReturnStatus.Pending or PosReturnStatus.InventoryPostFailed or PosReturnStatus.Failed)
+        {
+            var inventoryResult = await PostReturnInventoryAsync(posReturn, metadata, ct);
+            if (!inventoryResult.IsSuccess)
+            {
+                posReturn.Status = PosReturnStatus.InventoryPostFailed;
+                posReturn.FailureReason = inventoryResult.Message;
+                await db.SaveChangesAsync(ct);
+                return Result<PosReturnResponse>.Success(PosServiceHelpers.ToReturnResponse(posReturn), inventoryResult.Message);
+            }
+
+            posReturn.Status = PosReturnStatus.InventoryPosted;
+            posReturn.FailureReason = null;
+            await db.SaveChangesAsync(ct);
+        }
+
+        if (posReturn.Status is PosReturnStatus.InventoryPosted or PosReturnStatus.RefundFailed)
+        {
+            var refundResult = await RefundAsync(posReturn, posReturn.Register, metadata);
+            if (!refundResult.IsSuccess)
+            {
+                posReturn.Status = PosReturnStatus.RefundFailed;
+                posReturn.FailureReason = refundResult.Message;
+                await db.SaveChangesAsync(ct);
+                return Result<PosReturnResponse>.Success(PosServiceHelpers.ToReturnResponse(posReturn), refundResult.Message);
+            }
+
+            posReturn.Status = PosReturnStatus.Completed;
+            posReturn.CompletedAt = DateTime.UtcNow;
+            posReturn.FailureReason = null;
+            await db.SaveChangesAsync(ct);
+        }
+
+        var response = PosServiceHelpers.ToReturnResponse(posReturn);
+        return replayed
+            ? Result<PosReturnResponse>.Success(response, "POS return replay completed")
+            : Result<PosReturnResponse>.Success(response, 201, "POS return completed");
     }
 
     private async Task<List<PosReturnLine>> BuildReturnLinesAsync(
@@ -228,10 +293,14 @@ public sealed class PosReturnsService(
 
     private async Task<Result> PostReturnInventoryAsync(
         PosReturn posReturn,
-        RequestMetadata metadata)
+        RequestMetadata metadata,
+        CancellationToken ct)
     {
-        foreach (var line in posReturn.Lines)
+        foreach (var line in posReturn.Lines.OrderBy(item => item.CreatedAt))
         {
+            if (!string.IsNullOrWhiteSpace(line.InventoryMovementReferenceNumber))
+                continue;
+
             var idempotencyKey = $"POS.ReturnLine.{line.Id:N}";
             var response = await inventario.PostStockMovement(new PostStockMovementRequest
             {
@@ -252,11 +321,13 @@ public sealed class PosReturnsService(
             if (!response.IsSuccess)
             {
                 line.FailureReason = response.Message ?? "Inventory return posting failed";
+                await db.SaveChangesAsync(ct);
                 return Result.Failure(line.FailureReason, (int)response.HttpStatusCode);
             }
 
             line.InventoryMovementReferenceNumber = idempotencyKey;
             line.FailureReason = null;
+            await db.SaveChangesAsync(ct);
         }
 
         return Result.Success();
@@ -267,7 +338,8 @@ public sealed class PosReturnsService(
         PosRegister register,
         RequestMetadata metadata)
     {
-        var reference = PosServiceHelpers.ReturnRefundReference(posReturn);
+        var reference = PosServiceHelpers.NormalizeOptional(posReturn.RefundReferenceNumber)
+            ?? PosServiceHelpers.ReturnRefundReference(posReturn);
         posReturn.RefundReferenceNumber = reference;
 
         if (posReturn.RefundMethod == PosPaymentMethod.CashDrawer)
@@ -320,6 +392,7 @@ public sealed class PosReturnsService(
     {
         var query = db.Set<PosReturn>()
             .Include(item => item.Sale)
+            .Include(item => item.Register)
             .Include(item => item.Lines)
             .Where(item => item.TenantId == tenantId && item.Id == returnId && !item.IsDeleted);
 
@@ -332,14 +405,17 @@ public sealed class PosReturnsService(
     private async Task<PosReturn?> LoadReturnByIdempotencyAsync(
         Guid tenantId,
         string idempotencyKey,
+        bool tracking,
         CancellationToken ct) =>
-        await db.Set<PosReturn>()
-            .AsNoTracking()
+        await (tracking
+                ? db.Set<PosReturn>().AsTracking()
+                : db.Set<PosReturn>().AsNoTracking())
             .Include(item => item.Sale)
+            .Include(item => item.Register)
             .Include(item => item.Lines)
             .FirstOrDefaultAsync(item =>
-                item.TenantId == tenantId &&
-                item.IdempotencyKey == idempotencyKey &&
-                !item.IsDeleted,
+                    item.TenantId == tenantId &&
+                    item.IdempotencyKey == idempotencyKey &&
+                    !item.IsDeleted,
                 ct);
 }

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosSalesService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosSalesService.cs
@@ -19,30 +19,40 @@ public sealed class PosSalesService(
     AppDbContext db,
     IInventarioServiceWrapper inventario,
     IWalletsServiceWrapper wallets,
+    IPosRequestContextResolver contextResolver,
     ILogger<PosSalesService> logger)
 {
     public async Task<Result<PosSaleReceiptResponse>> CheckoutAsync(
         CheckoutPosSaleRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosSaleReceiptResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request, request.CashierCredentialId);
+        if (!contextResult.IsSuccess)
+            return Result<PosSaleReceiptResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
 
         var idempotencyKey = PosServiceHelpers.NormalizeOptional(request.IdempotencyKey)
-            ?? $"POS.Checkout.{Guid.NewGuid():N}";
+            ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+            return Result<PosSaleReceiptResponse>.Failure("Checkout idempotency key is required", 400);
 
-        var replay = await LoadSaleByIdempotencyAsync(tenantId, idempotencyKey, ct);
+        var context = contextResult.Data!;
+        var tenantId = context.TenantId;
+        var requestHash = PosServiceHelpers.BuildSaleRequestHash(request);
+
+        var replay = await LoadSaleByIdempotencyAsync(tenantId, idempotencyKey, tracking: true, ct);
         if (replay is not null)
-            return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(replay), "POS sale replayed");
+        {
+            if (!string.Equals(replay.RequestHash, requestHash, StringComparison.Ordinal))
+                return Result<PosSaleReceiptResponse>.Conflict("Checkout idempotency key was reused with a different payload");
 
-        var register = await db.Set<PosRegister>()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(item =>
-                item.TenantId == tenantId &&
-                item.Id == request.RegisterId &&
-                item.IsEnabled &&
-                !item.IsDeleted,
-                ct);
+            var replayRegister = await LoadRegisterAsync(tenantId, replay.RegisterId, ct);
+            if (replayRegister is null)
+                return Result<PosSaleReceiptResponse>.NotFound("POS register was not found");
+
+            return await ContinueCheckoutAsync(replay, replayRegister, request, context.Metadata, ct, replayed: true);
+        }
+
+        var register = await LoadRegisterAsync(tenantId, request.RegisterId, ct);
 
         if (register is null)
             return Result<PosSaleReceiptResponse>.NotFound("POS register was not found");
@@ -66,6 +76,7 @@ public sealed class PosSalesService(
             Status = PosSaleStatus.Draft,
             PaymentMethod = request.Payment.Method,
             IdempotencyKey = idempotencyKey,
+            RequestHash = requestHash,
             DiscountAmount = request.DiscountAmount,
             TaxAmount = request.TaxAmount,
             CreatedAt = now,
@@ -91,66 +102,120 @@ public sealed class PosSalesService(
         db.Set<PosSale>().Add(sale);
         await db.SaveChangesAsync(ct);
 
-        var reservationResult = await ReserveSaleInventoryAsync(sale, request.Metadata, ct);
-        if (!reservationResult.IsSuccess)
+        return await ContinueCheckoutAsync(sale, register, request, context.Metadata, ct, replayed: false);
+    }
+
+    private async Task<Result<PosSaleReceiptResponse>> ContinueCheckoutAsync(
+        PosSale sale,
+        PosRegister register,
+        CheckoutPosSaleRequest request,
+        RequestMetadata metadata,
+        CancellationToken ct,
+        bool replayed)
+    {
+        if (sale.Status == PosSaleStatus.Completed)
+            return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), replayed ? "POS sale replayed" : "POS sale completed");
+
+        if (sale.Status == PosSaleStatus.Cancelled)
+            return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), "POS sale is cancelled");
+
+        if (sale.Status is PosSaleStatus.Draft or PosSaleStatus.ReservingInventory or PosSaleStatus.InventoryReservationFailed)
         {
-            sale.Status = PosSaleStatus.InventoryReservationFailed;
-            sale.FailureReason = reservationResult.Message;
-            sale.RecoveryState = "Inventory reservation failed before payment capture.";
-            await db.SaveChangesAsync(ct);
-            return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), reservationResult.Message);
+            var reservationResult = await ReserveSaleInventoryAsync(sale, metadata, ct);
+            if (!reservationResult.IsSuccess)
+            {
+                sale.Status = PosSaleStatus.InventoryReservationFailed;
+                sale.FailureReason = reservationResult.Message;
+                sale.RecoveryState = "Inventory reservation failed before payment capture.";
+                await db.SaveChangesAsync(ct);
+                return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), reservationResult.Message);
+            }
         }
 
-        sale.Status = PosSaleStatus.PaymentPending;
-        var payment = CreatePayment(sale, register, request);
-        db.Set<PosPayment>().Add(payment);
-        await db.SaveChangesAsync(ct);
-
-        var paymentResult = await CapturePaymentAsync(register, sale, payment, request.Metadata);
-        if (!paymentResult.IsSuccess)
+        if (sale.Status is PosSaleStatus.InventoryReserved or PosSaleStatus.PaymentPending)
         {
-            payment.Status = PosPaymentStatus.Failed;
-            payment.FailureReason = paymentResult.Message;
-            sale.Status = PosSaleStatus.PaymentFailed;
-            sale.FailureReason = paymentResult.Message;
-            sale.RecoveryState = "Payment failed; inventory reservations were released.";
-            await ReleaseReservationsAsync(sale, request.Metadata);
+            sale.Status = PosSaleStatus.PaymentPending;
+            var payment = sale.Payments
+                .OrderBy(item => item.CreatedAt)
+                .FirstOrDefault();
+            if (payment is null)
+            {
+                payment = CreatePayment(sale, register, request);
+                db.Set<PosPayment>().Add(payment);
+                sale.Payments.Add(payment);
+                await db.SaveChangesAsync(ct);
+            }
+
+            if (payment.Status == PosPaymentStatus.Failed)
+            {
+                sale.Status = PosSaleStatus.PaymentFailed;
+                sale.FailureReason = payment.FailureReason;
+                sale.RecoveryState = "Payment failed; inventory reservations were released.";
+                await db.SaveChangesAsync(ct);
+                return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), payment.FailureReason);
+            }
+
+            if (payment.Status != PosPaymentStatus.Captured)
+            {
+                var paymentResult = await CapturePaymentAsync(register, sale, payment, metadata);
+                if (!paymentResult.IsSuccess)
+                {
+                    payment.Status = PosPaymentStatus.Failed;
+                    payment.FailureReason = paymentResult.Message;
+                    sale.Status = PosSaleStatus.PaymentFailed;
+                    sale.FailureReason = paymentResult.Message;
+                    sale.RecoveryState = "Payment failed; inventory reservations were released.";
+                    await ReleaseReservationsAsync(sale, metadata);
+                    await db.SaveChangesAsync(ct);
+                    return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), paymentResult.Message);
+                }
+
+                payment.Status = PosPaymentStatus.Captured;
+                payment.CapturedAt = DateTime.UtcNow;
+            }
+
+            sale.Status = PosSaleStatus.PaymentCaptured;
+            sale.FailureReason = null;
+            sale.RecoveryState = null;
             await db.SaveChangesAsync(ct);
-            return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), paymentResult.Message);
         }
 
-        payment.Status = PosPaymentStatus.Captured;
-        payment.CapturedAt = DateTime.UtcNow;
-        sale.Status = PosSaleStatus.PaymentCaptured;
-        await db.SaveChangesAsync(ct);
-
-        var fulfillmentResult = await FulfillReservationsAsync(sale, request.Metadata);
-        if (!fulfillmentResult.IsSuccess)
+        if (sale.Status is PosSaleStatus.PaymentCaptured or PosSaleStatus.InventoryFulfillmentFailed)
         {
-            sale.Status = PosSaleStatus.InventoryFulfillmentFailed;
-            sale.FailureReason = fulfillmentResult.Message;
-            sale.RecoveryState = "Payment captured; retry fulfillment for unfulfilled reservation IDs.";
+            var fulfillmentResult = await FulfillReservationsAsync(sale, metadata);
+            if (!fulfillmentResult.IsSuccess)
+            {
+                sale.Status = PosSaleStatus.InventoryFulfillmentFailed;
+                sale.FailureReason = fulfillmentResult.Message;
+                sale.RecoveryState = "Payment captured; retry fulfillment for unfulfilled reservation IDs.";
+                await db.SaveChangesAsync(ct);
+                return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), fulfillmentResult.Message);
+            }
+
+            sale.Status = PosSaleStatus.Completed;
+            sale.CompletedAt = DateTime.UtcNow;
+            sale.FailureReason = null;
+            sale.RecoveryState = null;
             await db.SaveChangesAsync(ct);
-            return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), fulfillmentResult.Message);
+
+            var receipt = PosServiceHelpers.ToSaleReceiptResponse(sale);
+            return replayed
+                ? Result<PosSaleReceiptResponse>.Success(receipt, "POS sale replay completed")
+                : Result<PosSaleReceiptResponse>.Success(receipt, 201, "POS sale completed");
         }
 
-        sale.Status = PosSaleStatus.Completed;
-        sale.CompletedAt = DateTime.UtcNow;
-        sale.FailureReason = null;
-        sale.RecoveryState = null;
-        await db.SaveChangesAsync(ct);
-
-        return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), 201, "POS sale completed");
+        return Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale), replayed ? "POS sale replayed" : "POS sale accepted");
     }
 
     public async Task<Result<PosSaleReceiptResponse>> GetAsync(
         GetPosSaleRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosSaleReceiptResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosSaleReceiptResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
 
-        var sale = await LoadSaleAsync(tenantId, request.Id, false, ct);
+        var sale = await LoadSaleAsync(contextResult.Data!.TenantId, request.Id, false, ct);
         return sale is null
             ? Result<PosSaleReceiptResponse>.NotFound("POS sale was not found")
             : Result<PosSaleReceiptResponse>.Success(PosServiceHelpers.ToSaleReceiptResponse(sale));
@@ -160,9 +225,11 @@ public sealed class PosSalesService(
         SearchPosSalesRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<List<PosSaleSummaryResponse>>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<List<PosSaleSummaryResponse>>.Failure(contextResult.Message!, contextResult.StatusCode);
 
+        var tenantId = contextResult.Data!.TenantId;
         var (page, pageSize) = PosServiceHelpers.NormalizePage(request.Page, request.PageSize);
         IQueryable<PosSale> query = db.Set<PosSale>()
             .AsNoTracking()
@@ -202,17 +269,18 @@ public sealed class PosSalesService(
         CancelPosSaleRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosSaleReceiptResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosSaleReceiptResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
 
-        var sale = await LoadSaleAsync(tenantId, request.SaleId, true, ct);
+        var sale = await LoadSaleAsync(contextResult.Data!.TenantId, request.SaleId, true, ct);
         if (sale is null)
             return Result<PosSaleReceiptResponse>.NotFound("POS sale was not found");
 
         if (sale.Status is PosSaleStatus.Completed or PosSaleStatus.PaymentCaptured)
             return Result<PosSaleReceiptResponse>.Conflict("Completed or paid sales cannot be cancelled; create a return instead");
 
-        await ReleaseReservationsAsync(sale, request.Metadata);
+        await ReleaseReservationsAsync(sale, contextResult.Data.Metadata);
         sale.Status = PosSaleStatus.Cancelled;
         sale.CancelledAt = DateTime.UtcNow;
         sale.FailureReason = PosServiceHelpers.NormalizeOptional(request.Reason);
@@ -226,17 +294,18 @@ public sealed class PosSalesService(
         RetryPosSaleFulfillmentRequest request,
         CancellationToken ct)
     {
-        if (!PosServiceHelpers.TryResolveTenantId(request.Metadata, out var tenantId))
-            return Result<PosSaleReceiptResponse>.Failure("Tenant ID is required", 400);
+        var contextResult = contextResolver.Resolve(request);
+        if (!contextResult.IsSuccess)
+            return Result<PosSaleReceiptResponse>.Failure(contextResult.Message!, contextResult.StatusCode);
 
-        var sale = await LoadSaleAsync(tenantId, request.SaleId, true, ct);
+        var sale = await LoadSaleAsync(contextResult.Data!.TenantId, request.SaleId, true, ct);
         if (sale is null)
             return Result<PosSaleReceiptResponse>.NotFound("POS sale was not found");
 
         if (sale.Status != PosSaleStatus.InventoryFulfillmentFailed)
             return Result<PosSaleReceiptResponse>.Conflict("Only sales with failed inventory fulfillment can be retried");
 
-        var fulfillmentResult = await FulfillReservationsAsync(sale, request.Metadata);
+        var fulfillmentResult = await FulfillReservationsAsync(sale, contextResult.Data.Metadata);
         if (!fulfillmentResult.IsSuccess)
         {
             sale.FailureReason = fulfillmentResult.Message;
@@ -332,6 +401,10 @@ public sealed class PosSalesService(
 
         foreach (var line in sale.Lines.OrderBy(item => item.LineNumber))
         {
+            if (line.ReservationId.HasValue)
+                continue;
+
+            var reservationKey = PosServiceHelpers.SaleLineReservationReference(line);
             var reservationResponse = await inventario.ReserveInventory(new ReserveInventoryRequest
             {
                 ProductId = line.ProductId,
@@ -342,6 +415,7 @@ public sealed class PosSalesService(
                 Quantity = line.Quantity,
                 ReferenceType = PosServiceHelpers.SaleLineReferenceType,
                 ReferenceId = line.Id,
+                IdempotencyKey = reservationKey,
                 Reason = $"POS sale {sale.SaleNumber}",
                 Metadata = metadata
             });
@@ -371,6 +445,9 @@ public sealed class PosSalesService(
                 await ReleaseReservationsAsync(sale, metadata);
                 return Result.Failure("Inventory reservation succeeded but no reservation ID was returned", 502);
             }
+
+            line.FailureReason = null;
+            await db.SaveChangesAsync(ct);
         }
 
         sale.Status = PosSaleStatus.InventoryReserved;
@@ -517,6 +594,19 @@ public sealed class PosSalesService(
         }
     }
 
+    private async Task<PosRegister?> LoadRegisterAsync(
+        Guid tenantId,
+        Guid registerId,
+        CancellationToken ct) =>
+        await db.Set<PosRegister>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(item =>
+                item.TenantId == tenantId &&
+                item.Id == registerId &&
+                item.IsEnabled &&
+                !item.IsDeleted,
+                ct);
+
     private async Task<PosSale?> LoadSaleAsync(
         Guid tenantId,
         Guid saleId,
@@ -537,14 +627,16 @@ public sealed class PosSalesService(
     private async Task<PosSale?> LoadSaleByIdempotencyAsync(
         Guid tenantId,
         string idempotencyKey,
+        bool tracking,
         CancellationToken ct) =>
-        await db.Set<PosSale>()
-            .AsNoTracking()
+        await (tracking
+                ? db.Set<PosSale>().AsTracking()
+                : db.Set<PosSale>().AsNoTracking())
             .Include(item => item.Lines)
             .Include(item => item.Payments)
             .FirstOrDefaultAsync(item =>
-                item.TenantId == tenantId &&
-                item.IdempotencyKey == idempotencyKey &&
-                !item.IsDeleted,
+                    item.TenantId == tenantId &&
+                    item.IdempotencyKey == idempotencyKey &&
+                    !item.IsDeleted,
                 ct);
 }

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosServiceHelpers.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosServiceHelpers.cs
@@ -1,7 +1,9 @@
 using POS.Domain.Shared.Contracts;
 using POS.Domain.Shared.Contracts.Responses;
 using POS.Domain.Shared.Enums;
-using XFramework.Domain.Shared.BusinessObjects;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 
 namespace POS.Api.Services;
 
@@ -9,12 +11,6 @@ internal static class PosServiceHelpers
 {
     public const string SaleLineReferenceType = "POS.SaleLine";
     public const string ReturnLineReferenceType = "POS.ReturnLine";
-
-    public static bool TryResolveTenantId(RequestMetadata metadata, out Guid tenantId)
-    {
-        tenantId = metadata.TenantId ?? Guid.Empty;
-        return tenantId != Guid.Empty;
-    }
 
     public static (int Page, int PageSize) NormalizePage(int page, int pageSize, int defaultPageSize = 50)
     {
@@ -43,6 +39,62 @@ internal static class PosServiceHelpers
 
     public static string ReturnRefundReference(PosReturn posReturn) =>
         $"POS-RETURN-{posReturn.Id:N}"[..80];
+
+    public static string BuildSaleRequestHash(CheckoutPosSaleRequest request) =>
+        Hash(new
+        {
+            request.RegisterId,
+            request.CashierCredentialId,
+            request.CustomerCredentialId,
+            request.WarehouseId,
+            request.LocationId,
+            request.CurrencyId,
+            request.WalletTypeId,
+            request.DiscountAmount,
+            request.TaxAmount,
+            Payment = new
+            {
+                request.Payment.Method,
+                request.Payment.Amount,
+                request.Payment.CustomerCredentialId
+            },
+            Lines = request.Lines.Select((line, index) => new
+            {
+                index,
+                line.ProductId,
+                line.ProductVariationId,
+                line.Quantity,
+                line.ExpectedUnitPrice,
+                line.DiscountAmount,
+                line.TaxAmount,
+                line.WarehouseId,
+                line.LocationId,
+                line.LotId,
+                line.UnitOfMeasure
+            }).ToArray()
+        });
+
+    public static string BuildReturnRequestHash(CreatePosReturnRequest request) =>
+        Hash(new
+        {
+            request.SaleId,
+            request.CashierCredentialId,
+            request.RefundMethod,
+            request.Reason,
+            Lines = request.Lines.Select((line, index) => new
+            {
+                index,
+                line.SaleLineId,
+                line.Quantity,
+                line.TaxAmount
+            }).ToArray()
+        });
+
+    private static string Hash<T>(T value)
+    {
+        var json = JsonSerializer.Serialize(value);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(json)));
+    }
 
     public static PosRegisterResponse ToRegisterResponse(PosRegister register) => new()
     {

--- a/src/Modules/XFramework.POS/POS.Domain.Shared/Configurations/PosEntityConfigurations.cs
+++ b/src/Modules/XFramework.POS/POS.Domain.Shared/Configurations/PosEntityConfigurations.cs
@@ -39,6 +39,7 @@ public sealed class PosSaleConfiguration : IEntityTypeConfiguration<PosSale>
         entity.Property(e => e.IdempotencyKey).HasMaxLength(160);
         entity.Property(e => e.FailureReason).HasMaxLength(1000);
         entity.Property(e => e.RecoveryState).HasMaxLength(1000);
+        entity.Property(e => e.RequestHash).HasMaxLength(64);
 
         entity.HasIndex(e => new { e.TenantId, e.SaleNumber })
             .IsUnique()
@@ -218,6 +219,7 @@ public sealed class PosReturnConfiguration : IEntityTypeConfiguration<PosReturn>
         entity.Property(e => e.IdempotencyKey).HasMaxLength(160);
         entity.Property(e => e.RefundReferenceNumber).HasMaxLength(120);
         entity.Property(e => e.FailureReason).HasMaxLength(1000);
+        entity.Property(e => e.RequestHash).HasMaxLength(64);
 
         entity.HasIndex(e => new { e.TenantId, e.ReturnNumber })
             .IsUnique()

--- a/src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/PosEntities.cs
+++ b/src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/PosEntities.cs
@@ -255,6 +255,9 @@ public partial class PosSale : BaseModel
     [MemoryPackOrder(18)]
     public string? RecoveryState { get; set; }
 
+    [MemoryPackOrder(19)]
+    public string? RequestHash { get; set; }
+
     [MemoryPackIgnore]
     public virtual PosRegister Register { get; set; } = null!;
 
@@ -445,6 +448,9 @@ public partial class PosReturn : BaseModel
 
     [MemoryPackOrder(16)]
     public string? FailureReason { get; set; }
+
+    [MemoryPackOrder(17)]
+    public string? RequestHash { get; set; }
 
     [MemoryPackIgnore]
     public virtual PosSale Sale { get; set; } = null!;

--- a/src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/Requests/PosRequests.cs
+++ b/src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/Requests/PosRequests.cs
@@ -7,6 +7,9 @@ public partial record SearchPosCatalogRequest : RequestBase,
 {
     public string? Search { get; set; }
     public Guid? CategoryId { get; set; }
+    public Guid? RegisterId { get; set; }
+    public Guid? WarehouseId { get; set; }
+    public Guid? LocationId { get; set; }
     public bool? IsAvailable { get; set; } = true;
     public bool IncludeBaseProducts { get; set; } = true;
     public bool IncludeVariants { get; set; } = true;
@@ -297,4 +300,12 @@ public partial record SearchPosReturnsRequest : RequestBase,
     public DateTime? To { get; set; }
     public int Page { get; set; } = 1;
     public int PageSize { get; set; } = 50;
+}
+
+[MemoryPackable]
+public partial record RetryPosReturnRequest : RequestBase,
+    ICommand<CmdResponse<PosReturnResponse>>,
+    IBoltRequest<RetryPosReturnRequest, CmdResponse<PosReturnResponse>>
+{
+    public Guid ReturnId { get; set; }
 }

--- a/src/Modules/XFramework.POS/POS.Domain.Shared/Enums/PosEnums.cs
+++ b/src/Modules/XFramework.POS/POS.Domain.Shared/Enums/PosEnums.cs
@@ -43,5 +43,7 @@ public enum PosReturnStatus
     InventoryPosted = 1,
     Refunded = 2,
     Completed = 3,
-    Failed = 4
+    Failed = 4,
+    InventoryPostFailed = 5,
+    RefundFailed = 6
 }

--- a/src/Presentation/XFramework.Portal/Components/Pages/POS/Cashier.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/POS/Cashier.razor
@@ -407,6 +407,8 @@ else
     private Guid? _activeCartId;
     private Guid? _activeCartConcurrencyStamp;
     private string? _activeCartNumber;
+    private string _activeSaleIdempotencyKey = NewSaleIdempotencyKey();
+    private string _activeCartCreateIdempotencyKey = NewCartIdempotencyKey();
     private decimal _discountAmount;
     private decimal _taxAmount;
     private decimal _cashTenderedAmount;
@@ -419,7 +421,12 @@ else
     private decimal CartItemCount => _cart.Sum(line => line.Quantity);
     private bool IsCashPayment => _paymentMethod == PosPaymentMethod.CashDrawer;
     private bool IsWalletPayment => _paymentMethod == PosPaymentMethod.WalletTransfer;
-    private bool CanCheckout => !_checkingOut && _cart.Any() && Total >= 0;
+    private bool CanCheckout =>
+        !_checkingOut &&
+        _cart.Any() &&
+        Total >= 0 &&
+        (!IsCashPayment || _cashTenderedAmount >= Total) &&
+        (!IsWalletPayment || Guid.TryParse(_selectedCustomerCredentialId, out _));
 
     protected override void OnInitialized()
     {
@@ -525,6 +532,7 @@ else
                 Metadata = BuildMetadata(),
                 Search = searchText,
                 CategoryId = _selectedCategoryId,
+                RegisterId = TryResolveSelectedRegisterId(),
                 Page = 1,
                 PageSize = 50
             });
@@ -667,7 +675,7 @@ else
                     DiscountAmount = _discountAmount,
                     TaxAmount = _taxAmount,
                     Suspend = true,
-                    IdempotencyKey = $"Portal.POS.Cart.{Guid.NewGuid():N}",
+                    IdempotencyKey = _activeCartCreateIdempotencyKey,
                     Lines = BuildCartLineRequests()
                 });
 
@@ -819,6 +827,12 @@ else
             return;
         }
 
+        if (IsCashPayment && _cashTenderedAmount < Total)
+        {
+            ToastService.Show("Cash tendered must cover the sale total.");
+            return;
+        }
+
         Guid? customerCredentialId = null;
         if (IsWalletPayment)
         {
@@ -877,7 +891,7 @@ else
                 CustomerCredentialId = customerCredentialId,
                 DiscountAmount = _discountAmount,
                 TaxAmount = _taxAmount,
-                IdempotencyKey = $"Portal.POS.{Guid.NewGuid():N}",
+                IdempotencyKey = _activeSaleIdempotencyKey,
                 Lines = _cart.Select(line => new CheckoutPosSaleLineRequest
                 {
                     ProductId = line.ProductId,
@@ -960,6 +974,8 @@ else
         _discountAmount = 0;
         _taxAmount = 0;
         _cashTenderedAmount = 0;
+        _activeSaleIdempotencyKey = NewSaleIdempotencyKey();
+        _activeCartCreateIdempotencyKey = NewCartIdempotencyKey();
     }
 
     private async Task ConfirmClearCurrentCart()
@@ -1019,6 +1035,11 @@ else
             ? customerCredentialId
             : null;
 
+    private Guid? TryResolveSelectedRegisterId() =>
+        Guid.TryParse(_selectedRegisterId, out var registerId)
+            ? registerId
+            : null;
+
     private async Task FocusCatalogSearchAsync()
     {
         try
@@ -1054,6 +1075,9 @@ else
         string.IsNullOrWhiteSpace(credential.UserName) ? credential.Id.ToString()[..8] : credential.UserName;
     private static string GetCredentialSearchText(IdentityCredential credential) =>
         $"{credential.UserName} {credential.UserAlias}";
+
+    private static string NewSaleIdempotencyKey() => $"Portal.POS.Sale.{Guid.NewGuid():N}";
+    private static string NewCartIdempotencyKey() => $"Portal.POS.Cart.{Guid.NewGuid():N}";
 
     private static string FormatProductMeta(PosCatalogItemResponse item)
     {

--- a/src/Presentation/XFramework.Portal/Components/Pages/POS/Returns.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/POS/Returns.razor
@@ -154,6 +154,7 @@ else
     private bool _dialogOpen;
     private string? _selectedSaleId;
     private string _reason = "";
+    private string _returnIdempotencyKey = NewReturnIdempotencyKey();
     private PosPaymentMethod _refundMethod = PosPaymentMethod.CashDrawer;
 
     private string RefundMethodValue
@@ -240,6 +241,7 @@ else
     {
         _selectedSaleId = _completedSales.FirstOrDefault()?.Id.ToString();
         _reason = "";
+        _returnIdempotencyKey = NewReturnIdempotencyKey();
         _refundMethod = PosPaymentMethod.CashDrawer;
         _returnLines = [];
         if (Guid.TryParse(_selectedSaleId, out var saleId))
@@ -250,6 +252,7 @@ else
     private async Task OnSaleChanged(string? value)
     {
         _selectedSaleId = value;
+        _returnIdempotencyKey = NewReturnIdempotencyKey();
         _returnLines = [];
         if (Guid.TryParse(value, out var saleId))
             await LoadSaleLines(saleId);
@@ -311,7 +314,7 @@ else
                 CashierCredentialId = cashierCredentialId,
                 RefundMethod = _refundMethod,
                 Reason = string.IsNullOrWhiteSpace(_reason) ? null : _reason.Trim(),
-                IdempotencyKey = $"Portal.POS.Return.{Guid.NewGuid():N}",
+                IdempotencyKey = _returnIdempotencyKey,
                 Lines = _returnLines
                     .Where(line => line.ReturnQuantity > 0)
                     .Select(line => new CreatePosReturnLineRequest
@@ -326,6 +329,7 @@ else
             {
                 ToastService.Show(response.Response?.Status == PosReturnStatus.Completed ? "Return completed." : "Return recorded with recovery status.");
                 _dialogOpen = false;
+                _returnIdempotencyKey = NewReturnIdempotencyKey();
                 await Reload();
             }
             else
@@ -353,6 +357,7 @@ else
     private static string GetSaleValue(PosSaleSummaryResponse item) => item.Id.ToString();
     private static string GetSaleLabel(PosSaleSummaryResponse item) => $"{item.SaleNumber} - {item.TotalAmount:N2}";
     private string GetSaleSearchText(PosSaleSummaryResponse item) => $"{item.SaleNumber} {GetRegisterName(item.RegisterId)} {item.TotalAmount:N2} {item.CreatedAt:yyyy-MM-dd}";
+    private static string NewReturnIdempotencyKey() => $"Portal.POS.Return.{Guid.NewGuid():N}";
     private static string GetReturnStatusBadge(PosReturnStatus status) =>
         status switch
         {

--- a/src/Tests/Inventario.Api.Tests/ReservationServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ReservationServiceTests.cs
@@ -55,6 +55,68 @@ public sealed class ReservationServiceTests
     }
 
     [Test]
+    public async Task ReserveAsync_SameIdempotencyKey_ReplaysExistingReservationWithoutDoubleReserving()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedReservationData(tenantId, ids, onHand: 10, reserved: 0);
+        var service = CreateService(dataContext, tenantId);
+        var request = new ReserveInventoryRequest
+        {
+            ProductId = ids.ProductId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            Quantity = 4,
+            ReferenceType = "POS.SaleLine",
+            ReferenceId = Guid.NewGuid(),
+            IdempotencyKey = "pos-line-reservation"
+        };
+
+        var first = await service.ReserveAsync(request);
+        var second = await service.ReserveAsync(request);
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        second.IsSuccess.Should().BeTrue(second.Message);
+        second.StatusCode.Should().Be(200);
+        second.Data!.Id.Should().Be(first.Data!.Id);
+        second.Data.IdempotencyKey.Should().Be("pos-line-reservation");
+        dataContext.Set<StockBalance>().Single().ReservedQuantity.Should().Be(4);
+        dataContext.Added.OfType<Reservation>().Should().ContainSingle();
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task ReserveAsync_SameIdempotencyKeyDifferentPayload_ReturnsConflict()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var dataContext = SeedReservationData(tenantId, ids, onHand: 10, reserved: 0);
+        var service = CreateService(dataContext, tenantId);
+
+        await service.ReserveAsync(new ReserveInventoryRequest
+        {
+            ProductId = ids.ProductId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            Quantity = 4,
+            IdempotencyKey = "pos-line-reservation"
+        });
+        var conflict = await service.ReserveAsync(new ReserveInventoryRequest
+        {
+            ProductId = ids.ProductId,
+            WarehouseId = ids.WarehouseId,
+            LocationId = ids.LocationId,
+            Quantity = 5,
+            IdempotencyKey = "pos-line-reservation"
+        });
+
+        conflict.IsSuccess.Should().BeFalse();
+        conflict.StatusCode.Should().Be(409);
+        dataContext.Set<StockBalance>().Single().ReservedQuantity.Should().Be(4);
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    [Test]
     public async Task ReserveAsync_MultipleLots_AllocatesEarliestExpiryFirst()
     {
         var tenantId = Guid.NewGuid();

--- a/src/Tests/POS.Api.Tests/PosOrchestrationContractTests.cs
+++ b/src/Tests/POS.Api.Tests/PosOrchestrationContractTests.cs
@@ -23,6 +23,9 @@ public sealed class PosOrchestrationContractTests
         source.Should().Contain("InventoryFulfillmentFailed", "paid-but-unfulfilled sales need a recoverable status");
         source.Should().Contain("RetryFulfillmentAsync", "fulfillment retry must be an explicit POS command");
         source.Should().Contain("IdempotencyKey", "cross-module calls must use stable idempotency keys");
+        source.Should().Contain("IPosRequestContextResolver", "checkout must use trusted tenant/cashier context");
+        source.Should().Contain("BuildSaleRequestHash", "checkout replays must compare the original request payload");
+        source.Should().Contain("ContinueCheckoutAsync", "checkout replays must resume the persisted sale state");
     }
 
     [Test]
@@ -36,6 +39,10 @@ public sealed class PosOrchestrationContractTests
         source.Should().Contain("DecrementWallet", "cash refunds must debit the cash drawer wallet");
         source.Should().Contain("TransferWallet", "wallet refunds must reverse transfer through Wallets");
         source.Should().Contain("TransactionPurpose.Refund");
+        source.Should().Contain("RetryAsync", "recoverable return failures need an explicit retry command");
+        source.Should().Contain("InventoryPostFailed", "inventory-post failures need a retryable state");
+        source.Should().Contain("RefundFailed", "refund failures need a retryable state");
+        source.Should().Contain("BuildReturnRequestHash", "return replays must compare the original request payload");
         source.Should().NotContain("db.Set<Wallet", "POS must not directly mutate Wallets tables");
         source.Should().NotContain("db.Set<InventoryMovement", "POS must not directly mutate Inventario tables");
     }
@@ -63,6 +70,9 @@ public sealed class PosOrchestrationContractTests
         var source = ReadSource("src", "Modules", "XFramework.POS", "POS.Api", "Program.cs");
 
         source.Should().Contain("TenantModuleFeatureKeys.PosCarts");
+        source.Should().Contain("TenantModuleFeatureKeys.PosRegisters");
+        source.Should().Contain("TenantModuleFeatureKeys.PosSales");
+        source.Should().Contain("TenantModuleFeatureKeys.PosReturns");
         source.Should().Contain("RequireFeature(TenantModuleFeatureKeys.Pos, \"/api/pos\")");
         source.Should().Contain("MapGeneratedEndpoints");
     }

--- a/src/Tests/POS.Api.Tests/PosRequestContextResolverTests.cs
+++ b/src/Tests/POS.Api.Tests/PosRequestContextResolverTests.cs
@@ -1,0 +1,144 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using POS.Api.Services;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Requests;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Security;
+using XFramework.TestInfrastructure;
+
+namespace POS.Api.Tests;
+
+[TestFixture]
+[Category(TestCategories.POS)]
+public sealed class PosRequestContextResolverTests
+{
+    [Test]
+    public void Resolve_HttpClaimTenantMismatch_ReturnsForbidden()
+    {
+        var trustedTenantId = Guid.NewGuid();
+        var request = new RequestBase
+        {
+            Metadata = new RequestMetadata
+            {
+                TenantId = Guid.NewGuid()
+            }
+        };
+        var resolver = new PosRequestContextResolver(
+            new HttpContextAccessor
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = Principal(("tenant_id", trustedTenantId.ToString()))
+                }
+            },
+            Configuration());
+
+        var result = resolver.Resolve(request);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+    }
+
+    [Test]
+    public void Resolve_TargetCashierMismatchForNonPrivilegedUser_ReturnsForbidden()
+    {
+        var tenantId = Guid.NewGuid();
+        var actorCredentialId = Guid.NewGuid();
+        var request = new RequestBase
+        {
+            Metadata = new RequestMetadata
+            {
+                TenantId = tenantId,
+                CredentialId = actorCredentialId
+            }
+        };
+        var resolver = new PosRequestContextResolver(
+            new HttpContextAccessor
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = Principal(
+                        ("tenant_id", tenantId.ToString()),
+                        ("credential_id", actorCredentialId.ToString()))
+                }
+            },
+            Configuration());
+
+        var result = resolver.Resolve(request, requestCredentialId: Guid.NewGuid());
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+    }
+
+    [Test]
+    public void Resolve_TrustedInternalMetadata_SanitizesTenantAndCredential()
+    {
+        var tenantId = Guid.NewGuid();
+        var actorCredentialId = Guid.NewGuid();
+        var request = new RequestBase
+        {
+            Metadata = new RequestMetadata
+            {
+                TenantId = tenantId,
+                CredentialId = actorCredentialId
+            }
+        };
+        var resolver = new PosRequestContextResolver(
+            new HttpContextAccessor(),
+            Configuration(),
+            new FakeTrustedServiceInvocationResolver(tenantId, actorCredentialId));
+
+        var result = resolver.Resolve(request);
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        result.Data!.TenantId.Should().Be(tenantId);
+        result.Data.ActorCredentialId.Should().Be(actorCredentialId);
+        result.Data.IsTrustedInternal.Should().BeTrue();
+        request.Metadata.TenantId.Should().Be(tenantId);
+        request.Metadata.CredentialId.Should().Be(actorCredentialId);
+        request.Metadata.RequestId.Should().NotBeNull();
+    }
+
+    private static IConfiguration Configuration() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BoltConfiguration:ClientName"] = XFrameworkServiceNames.Pos
+            })
+            .Build();
+
+    private static ClaimsPrincipal Principal(params (string Type, string Value)[] claims) =>
+        new(new ClaimsIdentity(
+            claims.Select(claim => new Claim(claim.Type, claim.Value)),
+            authenticationType: "Test"));
+
+    private sealed class FakeTrustedServiceInvocationResolver(Guid tenantId, Guid actorCredentialId)
+        : ITrustedServiceInvocationResolver
+    {
+        public Task<TrustedServiceInvocationResult> ResolveAsync(
+            RequestMetadata? metadata,
+            string expectedAudience,
+            IReadOnlyCollection<string>? requiredScopes = null,
+            IReadOnlyCollection<string>? allowedCallers = null,
+            bool requireTenant = true,
+            CancellationToken ct = default)
+        {
+            var trustedMetadata = new RequestMetadata
+            {
+                TenantId = tenantId,
+                CredentialId = actorCredentialId,
+                RequestId = Guid.NewGuid()
+            };
+
+            return Task.FromResult(TrustedServiceInvocationResult.Success(new TrustedServiceInvocation(
+                XFrameworkServiceNames.Portal,
+                expectedAudience,
+                tenantId,
+                actorCredentialId,
+                trustedMetadata,
+                requiredScopes?.ToHashSet(StringComparer.OrdinalIgnoreCase) ?? [])));
+        }
+    }
+}

--- a/src/Tests/POS.Api.Tests/PosValidatorTests.cs
+++ b/src/Tests/POS.Api.Tests/PosValidatorTests.cs
@@ -69,6 +69,7 @@ public sealed class PosValidatorTests
             SaleId = Guid.NewGuid(),
             CashierCredentialId = Guid.NewGuid(),
             RefundMethod = PosPaymentMethod.CashDrawer,
+            IdempotencyKey = "return-key",
             Lines =
             [
                 new CreatePosReturnLineRequest
@@ -132,6 +133,7 @@ public sealed class PosValidatorTests
         var request = new CheckoutPosCartRequest
         {
             CartId = Guid.NewGuid(),
+            IdempotencyKey = "cart-checkout-key",
             Payment = new CheckoutPosPaymentRequest
             {
                 Method = PosPaymentMethod.WalletTransfer,
@@ -159,10 +161,57 @@ public sealed class PosValidatorTests
         returns.IsValid.Should().BeFalse();
     }
 
+    [Test]
+    public void CheckoutAndReturnValidators_MissingIdempotencyKeys_ReturnValidationErrors()
+    {
+        var sale = ValidCheckout();
+        sale.IdempotencyKey = "";
+        var cart = new CheckoutPosCartRequest
+        {
+            CartId = Guid.NewGuid(),
+            Payment = new CheckoutPosPaymentRequest
+            {
+                Method = PosPaymentMethod.CashDrawer,
+                Amount = 10
+            }
+        };
+        var posReturn = new CreatePosReturnRequest
+        {
+            SaleId = Guid.NewGuid(),
+            CashierCredentialId = Guid.NewGuid(),
+            RefundMethod = PosPaymentMethod.CashDrawer,
+            Lines =
+            [
+                new CreatePosReturnLineRequest
+                {
+                    SaleLineId = Guid.NewGuid(),
+                    Quantity = 1
+                }
+            ]
+        };
+
+        new CheckoutPosSaleValidator().Validate(sale).Errors
+            .Should().Contain(error => error.PropertyName == nameof(CheckoutPosSaleRequest.IdempotencyKey));
+        new CheckoutPosCartValidator().Validate(cart).Errors
+            .Should().Contain(error => error.PropertyName == nameof(CheckoutPosCartRequest.IdempotencyKey));
+        new CreatePosReturnValidator().Validate(posReturn).Errors
+            .Should().Contain(error => error.PropertyName == nameof(CreatePosReturnRequest.IdempotencyKey));
+    }
+
+    [Test]
+    public void RetryPosReturnValidator_MissingReturnId_ReturnsValidationError()
+    {
+        var result = new RetryPosReturnValidator().Validate(new RetryPosReturnRequest());
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error => error.PropertyName == nameof(RetryPosReturnRequest.ReturnId));
+    }
+
     private static CheckoutPosSaleRequest ValidCheckout() => new()
     {
         RegisterId = Guid.NewGuid(),
         CashierCredentialId = Guid.NewGuid(),
+        IdempotencyKey = "sale-checkout-key",
         Lines =
         [
             new CheckoutPosSaleLineRequest

--- a/src/Tests/POS.IntegrationTests/PortalContractTests.cs
+++ b/src/Tests/POS.IntegrationTests/PortalContractTests.cs
@@ -66,6 +66,7 @@ public sealed class PortalContractTests
         cashier.Should().Contain("pos-cart-panel");
         cashier.Should().Contain("pos-total-bar");
         cashier.Should().Contain("CategoryId = _selectedCategoryId");
+        cashier.Should().Contain("RegisterId = TryResolveSelectedRegisterId()");
         cashier.Should().Contain("DataContext.Query<ProductCategory>()");
         cashier.Should().NotContain("grid-cols-[");
     }
@@ -119,10 +120,14 @@ public sealed class PortalContractTests
         cashier.Should().Contain("POS.CancelPosCart(");
         cashier.Should().Contain("POS.CheckoutPosCart(");
         cashier.Should().Contain("POS.SearchPosCatalog(");
+        cashier.Should().Contain("NewSaleIdempotencyKey()");
+        cashier.Should().Contain("_cashTenderedAmount < Total");
         registers.Should().Contain("POS.CreatePosRegister(");
         sales.Should().Contain("POS.CancelPosSale(");
         sales.Should().Contain("POS.RetryPosSaleFulfillment(");
         returns.Should().Contain("POS.CreatePosReturn(");
+        returns.Should().Contain("NewReturnIdempotencyKey()");
+        returns.Should().Contain("IdempotencyKey = _returnIdempotencyKey");
 
         var offenders = PosPages
             .Select(page => new

--- a/src/Tests/POS.IntegrationTests/WrapperContractTests.cs
+++ b/src/Tests/POS.IntegrationTests/WrapperContractTests.cs
@@ -56,7 +56,8 @@ public sealed class WrapperContractTests
                 typeof(CheckoutPosSaleRequest),
                 typeof(CancelPosSaleRequest),
                 typeof(RetryPosSaleFulfillmentRequest),
-                typeof(CreatePosReturnRequest)
+                typeof(CreatePosReturnRequest),
+                typeof(RetryPosReturnRequest)
             ]);
 
         foreach (var item in typedCommandRequests)

--- a/src/Tools/XFramework.MigrationRunner/Program.cs
+++ b/src/Tools/XFramework.MigrationRunner/Program.cs
@@ -11,6 +11,8 @@ string[] domainAssemblyNames =
     "IdentityServer.Domain.Shared",
     "Inventario.Domain.Shared",
     "Communications.Domain.Shared",
+    "Notifications.Domain.Shared",
+    "SmsGateway.Domain.Shared",
     "Storage.Domain.Shared",
     "POS.Domain.Shared",
     "Wallets.Domain.Shared"


### PR DESCRIPTION
## Summary
- Harden POS request context resolution, tenant validation, exact feature gates, checkout idempotency, recovery states, and return retry states.
- Add Inventario reservation idempotency and a generated EF migration for POS sale/return request hashes plus reservation idempotency indexing.
- Tighten POS register validation, catalog stock filters, Portal cash validation, and IdentityServer service-identity admin protections.
- Fix the migration tooling path by keeping MigrationRunner loaded module assemblies aligned with design-time migration generation.

## Root Cause / Context
The POS MVP path still had production gaps around trusted tenant context, replay safety, recovery, return failure handling, and generated migration coverage. The EF migration failure was resolved by using the actual dotnet ef generation path through XFramework.MigrationRunner instead of manual migrations.

## Validation
- dotnet build src\Tools\XFramework.MigrationRunner\XFramework.MigrationRunner.csproj -m:1 /nr:false
- dotnet test src\Tests\POS.Api.Tests\POS.Api.Tests.csproj -m:1 /nr:false
- dotnet test src\Tests\Inventario.Api.Tests\Inventario.Api.Tests.csproj -m:1 /nr:false
- dotnet test src\Tests\POS.IntegrationTests\POS.IntegrationTests.csproj -m:1 /nr:false
- dotnet build src\Presentation\XFramework.Portal\XFramework.Portal.csproj -m:1 /nr:false
- dotnet test src\Tests\XFramework.Core.Tests\XFramework.Core.Tests.csproj -m:1 /nr:false
- dotnet build src\Modules\XFramework.IdentityServer\IdentityServer.Api\IdentityServer.Api.csproj -m:1 /nr:false

Post-rebase sanity:
- dotnet build src\Tools\XFramework.MigrationRunner\XFramework.MigrationRunner.csproj -m:1 /nr:false
- dotnet test src\Tests\POS.Api.Tests\POS.Api.Tests.csproj -m:1 /nr:false