### PR TITLE
[codex] Fix Portal tenant deletion workflow

### DIFF
--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Tenants/Delete/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Tenants/Delete/Endpoint.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Tenants.Delete;
+
+public static class DeleteTenantEndpoint
+{
+    [BoltHandler]
+    [MapPost("/api/tenants/delete", Tags = ["Tenants"],
+        Summary = "Delete a tenant",
+        Description = "Soft-deletes a tenant through the IdentityServer admin workflow.",
+        ExcludeFromOpenApi = true)]
+    public static async Task<Result> Handle(
+        DeleteTenantRequest request,
+        IAuthService authService,
+        CancellationToken ct)
+    {
+        return await authService.DeleteTenantAsync(request, ct);
+    }
+}
+
+public class DeleteTenantRequestValidator : AbstractValidator<DeleteTenantRequest>
+{
+    public DeleteTenantRequestValidator()
+    {
+        RuleFor(x => x.TenantId)
+            .NotEmpty().WithMessage("Tenant ID is required");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/AuthService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/AuthService.cs
@@ -136,6 +136,54 @@ public sealed class AuthService : IAuthService
         }
     }
 
+    /// <inheritdoc />
+    public async Task<Result> DeleteTenantAsync(
+        DeleteTenantRequest request,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            if (request.TenantId == Guid.Empty)
+            {
+                return Result.Failure("Tenant identifier is required", 400);
+            }
+
+            if (request.Metadata?.TenantId == request.TenantId)
+            {
+                return Result.Forbidden("The active tenant cannot be deleted");
+            }
+
+            var tenant = await _dataContext.Query<Tenant>()
+                .IgnoreQueryFilters()
+                .Where(x => x.Id == request.TenantId)
+                .FirstOrDefaultAsync(ct);
+
+            if (tenant is null || tenant.IsDeleted)
+            {
+                return Result.NotFound("Tenant not found");
+            }
+
+            tenant.IsEnabled = false;
+
+            _dataContext.Remove(tenant);
+            var saveResult = await _dataContext.SaveChangesAsync(ct);
+            if (!saveResult.IsSuccess)
+            {
+                _logger.OperationFailed("DeleteTenant", "Tenant", tenant.Id, saveResult.Message ?? string.Empty, null);
+                return Result.Failure("Tenant could not be deleted", saveResult.StatusCode);
+            }
+
+            _logger.EntityUpdated("Tenant", tenant.Id);
+
+            return Result.Success("Tenant deleted");
+        }
+        catch (Exception ex)
+        {
+            _logger.OperationFailed("DeleteTenant", "Tenant", request.TenantId, ex.Message, ex);
+            return Result.Failure("Tenant could not be deleted", 500);
+        }
+    }
+
     #endregion
 
     #region Credential Management

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/IAuthService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/IAuthService.cs
@@ -19,6 +19,16 @@ public interface IAuthService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Soft-deletes a tenant through the IdentityServer admin workflow.
+    /// </summary>
+    /// <param name="request">Tenant deletion request</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result indicating whether the tenant was deleted</returns>
+    Task<Result> DeleteTenantAsync(
+        DeleteTenantRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Creates a new identity credential with BCrypt password hashing (workFactor 11).
     /// </summary>
     /// <param name="request">The credential creation request containing username, password, and identity info</param>

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Requests/DeleteTenantRequest.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Requests/DeleteTenantRequest.cs
@@ -1,0 +1,11 @@
+namespace IdentityServer.Domain.Shared.Contracts.Requests;
+
+using TResponse = CmdResponse;
+
+[MemoryPackable]
+public partial record DeleteTenantRequest : RequestBase,
+    ICommand<TResponse>,
+    IBoltRequest<DeleteTenantRequest, TResponse>
+{
+    public Guid TenantId { get; set; }
+}

--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/Tenants.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/Tenants.razor
@@ -349,25 +349,10 @@ else
 
         try
         {
-            var fresh = await DataContext.Query<Tenant>()
-                .IgnoreQueryFilters()
-                .Where(x => x.Id == _deletingTenant.Id)
-                .FirstOrDefaultAsync();
-
-            if (fresh is null)
+            var result = await IdentityServer.DeleteTenant(new DeleteTenantRequest
             {
-                ToastService.Warning("Tenant was not found.", "Tenant unavailable");
-                _deleteDialogOpen = false;
-                return;
-            }
-
-            fresh.IsDeleted = true;
-            fresh.IsEnabled = false;
-            fresh.DeletedAt = DateTime.UtcNow;
-            fresh.ModifiedAt = DateTime.UtcNow;
-
-            DataContext.Update(fresh);
-            var result = await DataContext.SaveChangesAsync();
+                TenantId = _deletingTenant.Id
+            });
 
             if (result.IsSuccess)
             {

--- a/src/Presentation/XFramework.Portal/Components/Shared/ConfirmDeleteDialog.razor
+++ b/src/Presentation/XFramework.Portal/Components/Shared/ConfirmDeleteDialog.razor
@@ -1,5 +1,3 @@
-@inject DialogService DialogService
-
 <BbAlertDialog Open="@Open" OpenChanged="@OpenChanged">
     <BbAlertDialogContent>
         <BbAlertDialogHeader>
@@ -16,8 +14,12 @@
             </BbAlertDialogDescription>
         </BbAlertDialogHeader>
         <BbAlertDialogFooter>
-            <BbAlertDialogCancel>Cancel</BbAlertDialogCancel>
-            <BbAlertDialogAction OnClick="@OnConfirm">Delete</BbAlertDialogAction>
+            <BbAlertDialogCancel>
+                <BbButton Variant="ButtonVariant.Outline">Cancel</BbButton>
+            </BbAlertDialogCancel>
+            <BbAlertDialogAction>
+                <BbButton Variant="ButtonVariant.Destructive" OnClick="@Confirm">Delete</BbButton>
+            </BbAlertDialogAction>
         </BbAlertDialogFooter>
     </BbAlertDialogContent>
 </BbAlertDialog>
@@ -27,4 +29,9 @@
     [Parameter] public EventCallback<bool> OpenChanged { get; set; }
     [Parameter] public string? Message { get; set; }
     [Parameter] public EventCallback OnConfirm { get; set; }
+
+    private async Task Confirm()
+    {
+        await OnConfirm.InvokeAsync();
+    }
 }

--- a/src/Tests/IdentityServer.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
@@ -23,8 +23,10 @@ using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.Contracts;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Domain.Shared.Extensions;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Extensions;
 using XFramework.Integration.Extensions;
+using XFramework.Integration.Security;
 using Contracts = IdentityServer.Domain.Shared.Contracts;
 
 namespace IdentityServer.IntegrationTests;
@@ -46,6 +48,8 @@ public class IntegrationTestFixture
     public static string TestClientUrl => XFramework.TestInfrastructure.TestConstants.Ports.IdentityTestClient;
 
     public static IServiceProvider Services => _identityServerApp.Services;
+    private const string TestServiceClientId = "TestClient";
+    private const string TestServiceClientSecret = "IdentityServerIntegrationTestSecret-2026";
 
     /// <summary>
     /// Service wrapper that calls IdentityServer through the actual Bolt transport.
@@ -146,7 +150,7 @@ public class IntegrationTestFixture
         builder.WebHost.UseUrls(IdentityServerUrl);
 
         // Override configuration first — installers read config at registration time
-        OverrideConfiguration(builder, "IdentityServer", Guid.NewGuid().ToString(), IdentityServerUrl);
+        OverrideConfiguration(builder, XFrameworkServiceNames.IdentityServer, Guid.NewGuid().ToString(), IdentityServerUrl);
         builder.Configuration["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/bolt/ws";
 
         // Register services that the installers normally provide, except WrapperInstaller
@@ -171,6 +175,8 @@ public class IntegrationTestFixture
         builder.Services.AddCommunicationsWrapperServices();
         builder.Services.AddScoped<IStorageServiceWrapper, TestStorageServiceWrapper>();
         builder.Services.AddScoped<IAuthService, AuthService>();
+        builder.Services.AddScoped<IServiceIdentityService, ServiceIdentityService>();
+        builder.Services.AddSingleton<IIdentitySigningKeyProvider, IdentityServerLocalSigningKeyProvider>();
         builder.Services.AddValidatorsFromAssemblyContaining<AuthService>();
         builder.Services.AddXFrameworkBoltClient(builder.Configuration, autoConnect: false);
 
@@ -213,6 +219,8 @@ public class IntegrationTestFixture
             ["BoltConfiguration:ClientName"] = "TestClient",
             ["BoltConfiguration:ClientGuid"] = Guid.NewGuid().ToString(),
             ["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/bolt/ws",
+            ["ServiceIdentity:ClientId"] = TestServiceClientId,
+            ["ServiceIdentity:ClientSecret"] = TestServiceClientSecret,
             ["Tenant:DefaultId"] = TestTenantId.ToString(),
             ["Kestrel:Endpoints:Http:Url"] = TestClientUrl,
             ["urls"] = TestClientUrl,
@@ -312,6 +320,8 @@ public class IntegrationTestFixture
             ["DefaultDatabaseConnection"] = ConnectionString,
             ["BoltConfiguration:ClientGuid"] = clientGuid,
             ["BoltConfiguration:ClientName"] = clientName,
+            ["ServiceIdentity:Clients:0:ClientId"] = TestServiceClientId,
+            ["ServiceIdentity:Clients:0:ClientSecret"] = TestServiceClientSecret,
             ["Tenant:DefaultId"] = TestTenantId.ToString(),
             ["Kestrel:Endpoints:Http:Url"] = serverUrl,
             ["urls"] = serverUrl,

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
@@ -53,6 +53,62 @@ public sealed class WrapperCoverageTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task DeleteTenant_WithExistingTenant_SoftDeletesAndDisablesTenant()
+    {
+        var tenantName = $"Wrapper Delete Tenant {Guid.NewGuid():N}";
+        var create = await IntegrationTestFixture.ServiceWrapper.CreateTenant(new CreateTenantRequest
+        {
+            Name = tenantName,
+            Description = "Created for direct delete wrapper coverage",
+            Version = 1.0m,
+            Status = 1,
+            ParentTenantId = IntegrationTestFixture.TestTenantId,
+            Metadata = CreateMetadata()
+        });
+
+        create.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var lookupDb = CreateDbContext();
+        var tenantId = await lookupDb.Set<Tenant>()
+            .IgnoreQueryFilters()
+            .Where(t => t.Name == tenantName)
+            .Select(t => t.Id)
+            .FirstAsync();
+
+        var result = await IntegrationTestFixture.ServiceWrapper.DeleteTenant(new DeleteTenantRequest
+        {
+            TenantId = tenantId,
+            Metadata = CreateMetadata()
+        });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        result.IsSuccess.Should().BeTrue();
+
+        await using var db = CreateDbContext();
+        var tenant = await db.Set<Tenant>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == tenantId);
+
+        tenant.Should().NotBeNull();
+        tenant!.IsDeleted.Should().BeTrue();
+        tenant.IsEnabled.Should().BeFalse();
+        tenant.DeletedAt.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task DeleteTenant_WithUnknownTenant_ReturnsNotFound()
+    {
+        var result = await IntegrationTestFixture.ServiceWrapper.DeleteTenant(new DeleteTenantRequest
+        {
+            TenantId = Guid.NewGuid(),
+            Metadata = CreateMetadata()
+        });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.NotFound);
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Test]
     public async Task CreateCredential_WithValidData_HashesPasswordAndCreatesCredential()
     {
         var info = await SeedIdentityInfo();

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -174,7 +174,11 @@ public sealed class IdentityServerPortalContractTests
         tenants.Should().Contain("[Inject] private IIdentityServerServiceWrapper IdentityServer");
         tenants.Should().Contain("new CreateTenantRequest");
         tenants.Should().Contain("IdentityServer.CreateTenant(request)");
+        tenants.Should().Contain("new DeleteTenantRequest");
+        tenants.Should().Contain("IdentityServer.DeleteTenant(new DeleteTenantRequest");
         tenants.Should().NotContain("DataContext.Add(tenant)");
+        tenants.Should().NotContain("DataContext.Update(");
+        tenants.Should().NotContain("SaveChangesAsync(");
         tenants.Should().NotContain("TenantId = tenantId");
         userDetail.Should().NotContain("BCrypt.Net.BCrypt.HashPassword");
         userDetail.Should().NotContain("DataContext.Add(credential)");
@@ -249,6 +253,24 @@ public sealed class IdentityServerPortalContractTests
         source.Should().Contain("ToastService.Success(");
         source.Should().Contain("ToastService.Error(");
         source.Should().Contain("ToastService.Warning(");
+    }
+
+    [Test]
+    public void SharedConfirmDeleteDialog_UsesSupportedBlueprintAlertDialogComposition()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "XFramework.Portal",
+            "Components",
+            "Shared",
+            "ConfirmDeleteDialog.razor"));
+
+        source.Should().Contain("<BbAlertDialogAction>");
+        source.Should().Contain("Variant=\"ButtonVariant.Destructive\"");
+        source.Should().NotContain("<BbAlertDialogAction OnClick=");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add an IdentityServer `DeleteTenantRequest` wrapper endpoint for tenant deletion
- route Portal tenant deletion through `IIdentityServerServiceWrapper` instead of direct `IDataContext` mutation
- fix the shared delete confirmation dialog to use supported `BbAlertDialog` composition
- add focused Portal contract and IdentityServer wrapper coverage for the delete workflow

## Root cause
Tenant deletion failed first because `ConfirmDeleteDialog` passed an unsupported `OnClick` parameter to `BbAlertDialogAction`, which crashed the Blazor circuit when the delete confirmation rendered. Behind that, the Portal page was directly mutating `Tenant` state with `IDataContext`, bypassing the IdentityServer admin workflow.

## Validation
- `dotnet build src/Presentation/XFramework.Portal/XFramework.Portal.csproj -m:1 /nr:false`
- `dotnet build src/Modules/XFramework.IdentityServer/IdentityServer.Api/IdentityServer.Api.csproj -m:1 /nr:false`
- `dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --filter "TestCategory=Area:PortalContract" -m:1 /nr:false --logger "console;verbosity=minimal"`
- `dotnet test src/Tests/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj --filter "TestCategory=Area:Wrappers" -m:1 /nr:false --logger "console;verbosity=minimal"`
