### PR TITLE
[codex] Remove service identity fallback secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,22 @@ DB_PASSWORD=change-me-local-db-password
 # Token signing
 JWT_SECRET=change-me-local-jwt-secret-with-at-least-64-characters
 BOLT_SIGNATURE=change-me-local-bolt-signature-with-at-least-64-characters
-SERVICE_IDENTITY_DEVELOPMENT_SECRET=change-me-local-service-identity-secret-with-at-least-64-characters
+
+# Service identity client secrets.
+# These are explicit client credentials registered with IdentityServer in docker-compose.yml.
+# Use distinct high-entropy values per service; do not reuse one shared development fallback secret.
+IDENTITYSERVER_SERVICE_IDENTITY_SECRET=change-me-local-identityserver-service-identity-secret-with-at-least-64-characters
+BOLT_HUB_SERVICE_IDENTITY_SECRET=change-me-local-bolthub-service-identity-secret-with-at-least-64-characters
+COMMUNICATIONS_SERVICE_IDENTITY_SECRET=change-me-local-communications-service-identity-secret-with-at-least-64-characters
+NOTIFICATIONS_SERVICE_IDENTITY_SECRET=change-me-local-notifications-service-identity-secret-with-at-least-64-characters
+STORAGE_SERVICE_IDENTITY_SECRET=change-me-local-storage-service-identity-secret-with-at-least-64-characters
+ATTENDANCE_SERVICE_IDENTITY_SECRET=change-me-local-attendance-service-identity-secret-with-at-least-64-characters
+SMSGATEWAY_SERVICE_IDENTITY_SECRET=change-me-local-smsgateway-service-identity-secret-with-at-least-64-characters
+WALLETS_SERVICE_IDENTITY_SECRET=change-me-local-wallets-service-identity-secret-with-at-least-64-characters
+INVENTARIO_SERVICE_IDENTITY_SECRET=change-me-local-inventario-service-identity-secret-with-at-least-64-characters
+POS_SERVICE_IDENTITY_SECRET=change-me-local-pos-service-identity-secret-with-at-least-64-characters
+PORTAL_SERVICE_IDENTITY_SECRET=change-me-local-portal-service-identity-secret-with-at-least-64-characters
+OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET=change-me-local-operations-dashboard-service-identity-secret-with-at-least-64-characters
 
 # Optional app-level secrets used by gateway/coins when those services are enabled.
 ENCRYPTION_SECRET=change-me-local-encryption-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@
 # Portal uses appsettings.dev.json for the xeon-dev admin surface.
 # Only secrets and infra overrides go in env vars / .env files.
 
+x-service-identity-audiences: &service-identity-audiences XFramework.Attendance,XFramework.Bolt.Hub,XFramework.Communications,XFramework.Portal,XFramework.IdentityServer,XFramework.Inventario,XFramework.Notifications,XFramework.Operations.Dashboard,XFramework.POS,XFramework.SmsGateway,XFramework.Storage,XFramework.Wallets
+x-service-identity-scopes: &service-identity-scopes bolt.service,datacontext.query,datacontext.mutate,attendance.admin,communications.admin,communications.chat,community.admin,identity.admin,inventario.admin,notifications.send,smsgateway.send,storage.read,storage.write,wallets.admin
+
 x-common-env: &common-env
   ASPNETCORE_URLS: http://+:8080
   ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Docker}
@@ -16,8 +19,6 @@ x-common-env: &common-env
   JwtOptions__ValidIssuer: ${JWT_ISSUER:-xframework}
   BoltConfiguration__Signature: ${BOLT_SIGNATURE:?Set BOLT_SIGNATURE in .env}
   ServiceIdentity__Issuer: XFramework.IdentityServer
-  ServiceIdentity__DevelopmentClientSecret: ${SERVICE_IDENTITY_DEVELOPMENT_SECRET:?Set SERVICE_IDENTITY_DEVELOPMENT_SECRET in .env}
-  ServiceIdentity__ClientSecret: ${SERVICE_IDENTITY_DEVELOPMENT_SECRET:?Set SERVICE_IDENTITY_DEVELOPMENT_SECRET in .env}
   Seq__ApiKey: ${SEQ_API_KEY:-}
   OpenTelemetry__Sampling__Probability: ${OTEL_SAMPLING_PROBABILITY:-1.0}
   OpenTelemetry__Exporters__OTLP__Enabled: ${OTEL_OTLP_ENABLED:-true}
@@ -103,6 +104,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.Bolt/Bolt.Hub/Bolt.Hub.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${BOLT_HUB_SERVICE_IDENTITY_SECRET:?Set BOLT_HUB_SERVICE_IDENTITY_SECRET in .env}
       BoltConfiguration__Durable__RedisConnectionString: ${BOLT_REDIS_CONNECTION:-redis:6379}
     ports:
       - "${BOLT_HUB_EXPOSE_PORT:-7000}:8080"
@@ -132,6 +134,55 @@ services:
         PROJECT_PATH: src/Modules/XFramework.IdentityServer/IdentityServer.Api/IdentityServer.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${IDENTITYSERVER_SERVICE_IDENTITY_SECRET:?Set IDENTITYSERVER_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__0__ClientId: XFramework.IdentityServer
+      ServiceIdentity__Clients__0__ClientSecret: ${IDENTITYSERVER_SERVICE_IDENTITY_SECRET:?Set IDENTITYSERVER_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__0__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__0__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__1__ClientId: XFramework.Portal
+      ServiceIdentity__Clients__1__ClientSecret: ${PORTAL_SERVICE_IDENTITY_SECRET:?Set PORTAL_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__1__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__1__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__2__ClientId: XFramework.Bolt.Hub
+      ServiceIdentity__Clients__2__ClientSecret: ${BOLT_HUB_SERVICE_IDENTITY_SECRET:?Set BOLT_HUB_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__2__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__2__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__3__ClientId: XFramework.Communications
+      ServiceIdentity__Clients__3__ClientSecret: ${COMMUNICATIONS_SERVICE_IDENTITY_SECRET:?Set COMMUNICATIONS_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__3__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__3__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__4__ClientId: XFramework.Notifications
+      ServiceIdentity__Clients__4__ClientSecret: ${NOTIFICATIONS_SERVICE_IDENTITY_SECRET:?Set NOTIFICATIONS_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__4__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__4__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__5__ClientId: XFramework.Storage
+      ServiceIdentity__Clients__5__ClientSecret: ${STORAGE_SERVICE_IDENTITY_SECRET:?Set STORAGE_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__5__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__5__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__6__ClientId: XFramework.Attendance
+      ServiceIdentity__Clients__6__ClientSecret: ${ATTENDANCE_SERVICE_IDENTITY_SECRET:?Set ATTENDANCE_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__6__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__6__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__7__ClientId: XFramework.SmsGateway
+      ServiceIdentity__Clients__7__ClientSecret: ${SMSGATEWAY_SERVICE_IDENTITY_SECRET:?Set SMSGATEWAY_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__7__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__7__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__8__ClientId: XFramework.Wallets
+      ServiceIdentity__Clients__8__ClientSecret: ${WALLETS_SERVICE_IDENTITY_SECRET:?Set WALLETS_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__8__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__8__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__9__ClientId: XFramework.Inventario
+      ServiceIdentity__Clients__9__ClientSecret: ${INVENTARIO_SERVICE_IDENTITY_SECRET:?Set INVENTARIO_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__9__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__9__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__10__ClientId: XFramework.POS
+      ServiceIdentity__Clients__10__ClientSecret: ${POS_SERVICE_IDENTITY_SECRET:?Set POS_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__10__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__10__AllowedScopes: *service-identity-scopes
+      ServiceIdentity__Clients__11__ClientId: XFramework.Operations.Dashboard
+      ServiceIdentity__Clients__11__ClientSecret: ${OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET:?Set OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET in .env}
+      ServiceIdentity__Clients__11__AllowedAudiences: *service-identity-audiences
+      ServiceIdentity__Clients__11__AllowedScopes: *service-identity-scopes
     ports:
       - "${IDENTITY_EXPOSE_PORT:-8261}:8080"
     depends_on:
@@ -155,6 +206,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.Communications/Communications.Api/Communications.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${COMMUNICATIONS_SERVICE_IDENTITY_SECRET:?Set COMMUNICATIONS_SERVICE_IDENTITY_SECRET in .env}
     ports:
       - "${COMMUNICATIONS_EXPOSE_PORT:-5148}:8080"
     depends_on:
@@ -178,6 +230,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.Notifications/Notifications.Api/Notifications.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${NOTIFICATIONS_SERVICE_IDENTITY_SECRET:?Set NOTIFICATIONS_SERVICE_IDENTITY_SECRET in .env}
     ports:
       - "${NOTIFICATIONS_EXPOSE_PORT:-5166}:8080"
     depends_on:
@@ -200,6 +253,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.Storage/Storage.Api/Storage.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${STORAGE_SERVICE_IDENTITY_SECRET:?Set STORAGE_SERVICE_IDENTITY_SECRET in .env}
       BoltConfiguration__ClientName: XFramework.Storage
       Storage__DefaultProvider: ${STORAGE_DEFAULT_PROVIDER:-S3Compatible}
       Storage__ProviderProfileName: ${STORAGE_PROVIDER_PROFILE_NAME:-default}
@@ -238,6 +292,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.Attendance/Attendance.Api/Attendance.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${ATTENDANCE_SERVICE_IDENTITY_SECRET:?Set ATTENDANCE_SERVICE_IDENTITY_SECRET in .env}
     ports:
       - "${ATTENDANCE_EXPOSE_PORT:-5182}:8080"
     depends_on:
@@ -261,6 +316,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.SmsGateway/SmsGateway.Api/SmsGateway.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${SMSGATEWAY_SERVICE_IDENTITY_SECRET:?Set SMSGATEWAY_SERVICE_IDENTITY_SECRET in .env}
     ports:
       - "${SMSGATEWAY_EXPOSE_PORT:-5274}:8080"
     depends_on:
@@ -284,6 +340,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.Wallets/Wallets.Api/Wallets.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${WALLETS_SERVICE_IDENTITY_SECRET:?Set WALLETS_SERVICE_IDENTITY_SECRET in .env}
     ports:
       - "${WALLETS_EXPOSE_PORT:-9696}:8080"
     depends_on:
@@ -307,6 +364,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${INVENTARIO_SERVICE_IDENTITY_SECRET:?Set INVENTARIO_SERVICE_IDENTITY_SECRET in .env}
     ports:
       - "${INVENTARIO_EXPOSE_PORT:-8105}:8080"
     depends_on:
@@ -330,6 +388,7 @@ services:
         PROJECT_PATH: src/Modules/XFramework.POS/POS.Api/POS.Api.csproj
     environment:
       <<: *common-env
+      ServiceIdentity__ClientSecret: ${POS_SERVICE_IDENTITY_SECRET:?Set POS_SERVICE_IDENTITY_SECRET in .env}
     ports:
       - "${POS_EXPOSE_PORT:-8115}:8080"
     depends_on:
@@ -358,6 +417,7 @@ services:
     environment:
       <<: *common-env
       ASPNETCORE_ENVIRONMENT: ${PORTAL_ASPNETCORE_ENVIRONMENT:-dev}
+      ServiceIdentity__ClientSecret: ${PORTAL_SERVICE_IDENTITY_SECRET:?Set PORTAL_SERVICE_IDENTITY_SECRET in .env}
     ports:
       - "${PORTAL_EXPOSE_PORT:-5000}:8080"
     depends_on:
@@ -404,8 +464,7 @@ services:
       JwtOptions__ValidAudience: ${JWT_AUDIENCE:-xframework}
       JwtOptions__ValidIssuer: ${JWT_ISSUER:-xframework}
       ServiceIdentity__Issuer: XFramework.IdentityServer
-      ServiceIdentity__DevelopmentClientSecret: ${SERVICE_IDENTITY_DEVELOPMENT_SECRET:?Set SERVICE_IDENTITY_DEVELOPMENT_SECRET in .env}
-      ServiceIdentity__ClientSecret: ${SERVICE_IDENTITY_DEVELOPMENT_SECRET:?Set SERVICE_IDENTITY_DEVELOPMENT_SECRET in .env}
+      ServiceIdentity__ClientSecret: ${OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET:?Set OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET in .env}
       Seq__Url: http://seq:80
       Seq__ApiKey: ${SEQ_API_KEY:-}
       Jaeger__QueryUrl: http://jaeger:16686

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityService.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using XFramework.Core.Patterns;
 using XFramework.Domain.Shared.BusinessObjects;
@@ -18,8 +17,7 @@ public sealed class ServiceIdentityService(
     IConfiguration configuration,
     ILogger<ServiceIdentityService> logger,
     IHttpContextAccessor? httpContextAccessor = null,
-    ITrustedServiceInvocationResolver? serviceInvocationResolver = null,
-    IHostEnvironment? hostEnvironment = null)
+    ITrustedServiceInvocationResolver? serviceInvocationResolver = null)
     : IServiceIdentityService
 {
     private const string Algorithm = "RS256";
@@ -224,24 +222,6 @@ public sealed class ServiceIdentityService(
         if (client is not null)
             return client;
 
-        var devSecret = configuration["ServiceIdentity:DevelopmentClientSecret"];
-        if (!string.IsNullOrWhiteSpace(devSecret) && XFrameworkServiceNames.All.Contains(clientId))
-        {
-            if (!AllowsDevelopmentClientFallback())
-            {
-                logger.LogWarning(
-                    "Service identity development client-secret fallback rejected outside a development-style environment. ClientId={ClientId}",
-                    clientId);
-                return null;
-            }
-
-            return new ServiceClientDefinition(
-                clientId,
-                devSecret,
-                XFrameworkServiceNames.All.ToHashSet(StringComparer.Ordinal),
-                XFrameworkServiceScopes.AdminDefaults.ToHashSet(StringComparer.OrdinalIgnoreCase));
-        }
-
         return null;
     }
 
@@ -274,14 +254,6 @@ public sealed class ServiceIdentityService(
         }
 
         return Result.Forbidden("Service signing key administration requires SuperAdmin or trusted identity.admin service metadata");
-    }
-
-    private bool AllowsDevelopmentClientFallback()
-    {
-        if (hostEnvironment?.IsDevelopment() == true)
-            return true;
-
-        return configuration.GetValue<bool>("ServiceIdentity:AllowDevelopmentClientSecretFallback");
     }
 
     private static ServiceSigningKeyResponse ToResponse(ServiceSigningKey key) => new()

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+
+namespace Portal.E2ETests;
+
+[TestFixture]
+[Category("Kind:Integration")]
+[Category("Area:ServiceIdentityContract")]
+public sealed class ServiceIdentityComposeContractTests
+{
+    private static readonly string[] ServiceSecretVariables =
+    [
+        "IDENTITYSERVER_SERVICE_IDENTITY_SECRET",
+        "BOLT_HUB_SERVICE_IDENTITY_SECRET",
+        "COMMUNICATIONS_SERVICE_IDENTITY_SECRET",
+        "NOTIFICATIONS_SERVICE_IDENTITY_SECRET",
+        "STORAGE_SERVICE_IDENTITY_SECRET",
+        "ATTENDANCE_SERVICE_IDENTITY_SECRET",
+        "SMSGATEWAY_SERVICE_IDENTITY_SECRET",
+        "WALLETS_SERVICE_IDENTITY_SECRET",
+        "INVENTARIO_SERVICE_IDENTITY_SECRET",
+        "POS_SERVICE_IDENTITY_SECRET",
+        "PORTAL_SERVICE_IDENTITY_SECRET",
+        "OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET"
+    ];
+
+    private static readonly string[] RegisteredServiceClients =
+    [
+        "XFramework.IdentityServer",
+        "XFramework.Portal",
+        "XFramework.Bolt.Hub",
+        "XFramework.Communications",
+        "XFramework.Notifications",
+        "XFramework.Storage",
+        "XFramework.Attendance",
+        "XFramework.SmsGateway",
+        "XFramework.Wallets",
+        "XFramework.Inventario",
+        "XFramework.POS",
+        "XFramework.Operations.Dashboard"
+    ];
+
+    [Test]
+    public void DockerCompose_UsesExplicitServiceIdentityClientsInsteadOfDevelopmentFallback()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var compose = File.ReadAllText(Path.Combine(repositoryRoot.FullName, "docker-compose.yml"));
+        var envExample = File.ReadAllText(Path.Combine(repositoryRoot.FullName, ".env.example"));
+        var serviceIdentityService = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.IdentityServer",
+            "IdentityServer.Api",
+            "Services",
+            "ServiceIdentityService.cs"));
+
+        compose.Should().NotContain("ServiceIdentity__DevelopmentClientSecret");
+        compose.Should().NotContain("ServiceIdentity__AllowDevelopmentClientSecretFallback");
+        compose.Should().NotContain("SERVICE_IDENTITY_DEVELOPMENT_SECRET");
+        envExample.Should().NotContain("SERVICE_IDENTITY_DEVELOPMENT_SECRET");
+        serviceIdentityService.Should().NotContain("DevelopmentClientSecret");
+        serviceIdentityService.Should().NotContain("AllowDevelopmentClientSecretFallback");
+        serviceIdentityService.Should().NotContain("AllowsDevelopmentClientFallback");
+
+        foreach (var variable in ServiceSecretVariables)
+        {
+            compose.Should().Contain($"${{{variable}:?Set {variable} in .env}}");
+            envExample.Should().Contain($"{variable}=");
+        }
+
+        foreach (var clientId in RegisteredServiceClients)
+        {
+            compose.Should().Contain($"ClientId: {clientId}");
+        }
+
+        compose.Should().Contain("x-service-identity-audiences:");
+        compose.Should().Contain("x-service-identity-scopes:");
+        compose.Should().Contain("ServiceIdentity__Clients__");
+        compose.Should().Contain("AllowedAudiences: *service-identity-audiences");
+        compose.Should().Contain("AllowedScopes: *service-identity-scopes");
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "XFramework.slnx")))
+                return current;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate XFramework repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- remove the IdentityServer development client-secret fallback path
- configure Docker Compose to use explicit service identity clients and distinct per-service secrets
- update `.env.example` with the required per-service service identity secret variables
- add a Portal contract test to prevent reintroducing fallback service identity auth

## Why
The centralized service authentication hardening expects explicit `ServiceIdentity:Clients` registrations. The old shared development fallback caused Portal login to fail in xeon-dev because IdentityServer correctly rejected fallback credentials outside a development-style environment.

## Validation
- `dotnet build src/Modules/XFramework.IdentityServer/IdentityServer.Api/IdentityServer.Api.csproj -m:1 /nr:false`
- `dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --filter "TestCategory=Area:ServiceIdentityContract" -m:1 /nr:false --logger "console;verbosity=minimal"`
- remote `docker compose --env-file <temp env> -f <temp compose> config --quiet`
