### PR TITLE
[codex] Add IdentityServer role capability authorization

### DIFF
--- a/src/Kernel/XFramework.Core/Extensions/TenantModuleFeatureExtensions.cs
+++ b/src/Kernel/XFramework.Core/Extensions/TenantModuleFeatureExtensions.cs
@@ -15,6 +15,7 @@ public static class TenantModuleFeatureExtensions
         services.AddTenantModuleFeatureDefinitions();
         services.AddMemoryCache();
         services.TryAddScoped<ITenantModuleFeatureService, TenantModuleFeatureService>();
+        services.TryAddScoped<ITenantCredentialCapabilityService, TenantCredentialCapabilityService>();
 
         return services;
     }
@@ -27,6 +28,7 @@ public static class TenantModuleFeatureExtensions
         services.AddTenantModuleFeatureDefinitions(configuration);
         services.AddMemoryCache();
         services.TryAddScoped<ITenantModuleFeatureService, TenantModuleFeatureService>();
+        services.TryAddScoped<ITenantCredentialCapabilityService, TenantCredentialCapabilityService>();
 
         return services;
     }

--- a/src/Kernel/XFramework.Core/Middlewares/TenantModuleFeatureGateMiddleware.cs
+++ b/src/Kernel/XFramework.Core/Middlewares/TenantModuleFeatureGateMiddleware.cs
@@ -2,6 +2,7 @@ using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.Security.Claims;
 using XFramework.Core.Patterns;
 using XFramework.Core.Services.FeatureGates;
 
@@ -15,6 +16,7 @@ public sealed class TenantModuleFeatureGateMiddleware(
     public async Task InvokeAsync(
         HttpContext context,
         ITenantModuleFeatureService featureService,
+        ITenantCredentialCapabilityService capabilityService,
         IConfiguration configuration)
     {
         var rule = options.Rules
@@ -54,6 +56,43 @@ public sealed class TenantModuleFeatureGateMiddleware(
 
             await WriteResult(context, result);
             return;
+        }
+
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var credentialId = ResolveCredentialIdFromClaims(context);
+            if (credentialId is null || credentialId == Guid.Empty)
+            {
+                await WriteResult(
+                    context,
+                    Result.Forbidden("Capability gate requires a credential context."));
+                return;
+            }
+
+            var capability = ResolveCapabilityKey(context.Request);
+            var capabilityResult = await capabilityService.EnsureAllowedAsync(
+                tenantId.Value,
+                credentialId.Value,
+                rule.ModuleKey,
+                rule.SubFeatureKey,
+                capability,
+                context.RequestAborted);
+
+            if (!capabilityResult.IsSuccess)
+            {
+                logger.LogWarning(
+                    "Tenant credential capability gate denied request {Method} {Path} for tenant {TenantId}, credential {CredentialId}, feature {FeatureKey}, capability {CapabilityKey}: {Message}",
+                    context.Request.Method,
+                    context.Request.Path,
+                    tenantId,
+                    credentialId,
+                    TenantModuleFeatureKeys.Combine(rule.ModuleKey, rule.SubFeatureKey),
+                    capability,
+                    capabilityResult.Message);
+
+                await WriteResult(context, capabilityResult);
+                return;
+            }
         }
 
         await next(context);
@@ -101,6 +140,65 @@ public sealed class TenantModuleFeatureGateMiddleware(
         }
 
         return null;
+    }
+
+    private static Guid? ResolveCredentialIdFromClaims(HttpContext context)
+    {
+        foreach (var claimName in new[] { "credentialId", "credential_id", ClaimTypes.NameIdentifier, "sub" })
+        {
+            var claimValue = context.User.FindFirst(claimName)?.Value;
+            if (Guid.TryParse(claimValue, out var credentialId))
+                return credentialId;
+        }
+
+        return null;
+    }
+
+    private static string ResolveCapabilityKey(HttpRequest request)
+    {
+        var method = request.Method;
+        if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method))
+            return IdentityAuthorizationConstants.View;
+
+        if (HttpMethods.IsDelete(method))
+            return IdentityAuthorizationConstants.Delete;
+
+        if (HttpMethods.IsPut(method) || HttpMethods.IsPatch(method))
+            return IdentityAuthorizationConstants.Update;
+
+        if (HttpMethods.IsPost(method))
+        {
+            var path = request.Path.Value ?? string.Empty;
+            if (path.Contains("/query", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/search", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/get", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/reports", StringComparison.OrdinalIgnoreCase))
+            {
+                return IdentityAuthorizationConstants.View;
+            }
+
+            if (path.Contains("/delete", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/remove", StringComparison.OrdinalIgnoreCase))
+            {
+                return IdentityAuthorizationConstants.Delete;
+            }
+
+            if (path.Contains("/update", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/patch", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/replace", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/set", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/approve", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/reject", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/settle", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("/cancel", StringComparison.OrdinalIgnoreCase))
+            {
+                return IdentityAuthorizationConstants.Update;
+            }
+
+            return IdentityAuthorizationConstants.Create;
+        }
+
+        return IdentityAuthorizationConstants.Manage;
     }
 
     private static async Task WriteResult(HttpContext context, Result result)

--- a/src/Kernel/XFramework.Core/Services/FeatureGates/ITenantCredentialCapabilityService.cs
+++ b/src/Kernel/XFramework.Core/Services/FeatureGates/ITenantCredentialCapabilityService.cs
@@ -1,0 +1,22 @@
+using XFramework.Core.Patterns;
+
+namespace XFramework.Core.Services.FeatureGates;
+
+public interface ITenantCredentialCapabilityService
+{
+    Task<Result<bool>> IsAllowedAsync(
+        Guid tenantId,
+        Guid credentialId,
+        string moduleKey,
+        string? subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct = default);
+
+    Task<Result> EnsureAllowedAsync(
+        Guid tenantId,
+        Guid credentialId,
+        string moduleKey,
+        string? subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct = default);
+}

--- a/src/Kernel/XFramework.Core/Services/FeatureGates/TenantCredentialCapabilityService.cs
+++ b/src/Kernel/XFramework.Core/Services/FeatureGates/TenantCredentialCapabilityService.cs
@@ -1,0 +1,235 @@
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using XFramework.Core.Patterns;
+
+namespace XFramework.Core.Services.FeatureGates;
+
+public sealed class TenantCredentialCapabilityService(
+    DbContext dbContext,
+    ILogger<TenantCredentialCapabilityService> logger) : ITenantCredentialCapabilityService
+{
+    public async Task<Result<bool>> IsAllowedAsync(
+        Guid tenantId,
+        Guid credentialId,
+        string moduleKey,
+        string? subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct = default)
+    {
+        var result = await ResolveCapabilityAsync(
+            tenantId,
+            credentialId,
+            moduleKey,
+            subFeatureKey,
+            capabilityKey,
+            ct);
+
+        if (!result.IsSuccess || result.Data is null)
+            return Result<bool>.Failure(result.Message ?? "Capability check failed.", result.StatusCode);
+
+        return Result<bool>.Success(result.Data.IsAllowed);
+    }
+
+    public async Task<Result> EnsureAllowedAsync(
+        Guid tenantId,
+        Guid credentialId,
+        string moduleKey,
+        string? subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct = default)
+    {
+        var result = await ResolveCapabilityAsync(
+            tenantId,
+            credentialId,
+            moduleKey,
+            subFeatureKey,
+            capabilityKey,
+            ct);
+
+        if (!result.IsSuccess)
+            return Result.Failure(result.Message ?? "Capability check failed.", result.StatusCode);
+
+        var decision = result.Data;
+        if (decision is null)
+            return Result.Failure("Capability check failed.", 500);
+
+        if (decision.IsAllowed)
+            return Result.Success();
+
+        var featureKey = TenantModuleFeatureKeys.Combine(moduleKey, subFeatureKey);
+        logger.LogWarning(
+            "Credential capability denied for tenant {TenantId}, credential {CredentialId}, feature {FeatureKey}, capability {CapabilityKey}, source {Source}.",
+            tenantId,
+            credentialId,
+            featureKey,
+            capabilityKey,
+            decision.Source);
+
+        return Result.Forbidden($"Capability denied: '{capabilityKey}' is not allowed for feature '{featureKey}'.");
+    }
+
+    private async Task<Result<CapabilityDecision>> ResolveCapabilityAsync(
+        Guid tenantId,
+        Guid credentialId,
+        string moduleKey,
+        string? subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct)
+    {
+        if (tenantId == Guid.Empty)
+            return Result<CapabilityDecision>.Failure("TenantId is required.", 400);
+
+        if (credentialId == Guid.Empty)
+            return Result<CapabilityDecision>.Failure("CredentialId is required.", 400);
+
+        var (normalizedModuleKey, normalizedSubFeatureKey) =
+            TenantModuleFeatureKeys.Normalize(moduleKey, subFeatureKey);
+        var normalizedCapabilityKey = NormalizeCapability(capabilityKey);
+
+        if (string.IsNullOrWhiteSpace(normalizedModuleKey))
+            return Result<CapabilityDecision>.Failure("Module key is required.", 400);
+
+        if (!IdentityAuthorizationConstants.CapabilityKeys.Contains(normalizedCapabilityKey))
+            return Result<CapabilityDecision>.Failure("Capability key is invalid.", 400);
+
+        var credentialExists = await dbContext.Set<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .AnyAsync(x =>
+                x.Id == credentialId &&
+                x.TenantId == tenantId &&
+                !x.IsDeleted &&
+                x.IsEnabled,
+                ct);
+
+        if (!credentialExists)
+            return Result<CapabilityDecision>.NotFound("Credential not found");
+
+        var now = DateTime.UtcNow;
+        var roles = await dbContext.Set<IdentityRole>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                x.CredentialId == credentialId &&
+                x.TypeId != null &&
+                !x.IsDeleted &&
+                x.IsEnabled &&
+                x.RoleExpiration >= now)
+            .Select(x => new ActiveRole(x.Id, x.TypeId!.Value))
+            .ToListAsync(ct);
+
+        if (roles.Count == 0)
+            return Result<CapabilityDecision>.Success(new CapabilityDecision(false, "NoActiveRole"));
+
+        var roleIds = roles.Select(x => x.RoleId).ToList();
+        var roleTypeIds = roles.Select(x => x.RoleTypeId).Distinct().ToList();
+        var capabilityKeys = BuildCapabilityKeySet(normalizedCapabilityKey);
+
+        var overrides = await dbContext.Set<IdentityRoleFeaturePermissionOverride>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                roleIds.Contains(x.IdentityRoleId) &&
+                x.ModuleKey == normalizedModuleKey &&
+                x.SubFeatureKey == normalizedSubFeatureKey &&
+                capabilityKeys.Contains(x.CapabilityKey) &&
+                !x.IsDeleted &&
+                x.IsEnabled)
+            .ToListAsync(ct);
+
+        var roleTypePermissions = await dbContext.Set<IdentityRoleTypeFeaturePermission>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                roleTypeIds.Contains(x.RoleTypeId) &&
+                x.ModuleKey == normalizedModuleKey &&
+                x.SubFeatureKey == normalizedSubFeatureKey &&
+                capabilityKeys.Contains(x.CapabilityKey) &&
+                !x.IsDeleted &&
+                x.IsEnabled)
+            .ToListAsync(ct);
+
+        var decisions = new List<CapabilityDecision>();
+        foreach (var role in roles)
+        {
+            var roleOverrides = overrides
+                .Where(x => x.IdentityRoleId == role.RoleId)
+                .OrderBy(x => x.CapabilityKey == IdentityAuthorizationConstants.Manage ? 1 : 0)
+                .ToList();
+
+            if (roleOverrides.Count > 0)
+            {
+                decisions.AddRange(roleOverrides.Select(permission =>
+                    ToDecision(permission.Effect, permission.CapabilityKey, "CredentialRoleOverride")));
+                continue;
+            }
+
+            var permissions = roleTypePermissions
+                .Where(x => x.RoleTypeId == role.RoleTypeId)
+                .OrderBy(x => x.CapabilityKey == IdentityAuthorizationConstants.Manage ? 1 : 0)
+                .ToList();
+
+            if (permissions.Count > 0)
+            {
+                decisions.AddRange(permissions.Select(permission =>
+                    ToDecision(permission.Effect, permission.CapabilityKey, "RoleTypePermission")));
+            }
+        }
+
+        if (decisions.Any(x => !x.IsAllowed))
+            return Result<CapabilityDecision>.Success(decisions.First(x => !x.IsAllowed));
+
+        if (decisions.Any(x => x.IsAllowed))
+            return Result<CapabilityDecision>.Success(decisions.First(x => x.IsAllowed));
+
+        var policy = await dbContext.Set<TenantAuthorizationPolicy>()
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .Where(x =>
+                x.TenantId == tenantId &&
+                !x.IsDeleted &&
+                x.IsEnabled)
+            .Select(x => (MissingPermissionBehavior?)x.MissingPermissionBehavior)
+            .FirstOrDefaultAsync(ct) ?? MissingPermissionBehavior.Deny;
+
+        return Result<CapabilityDecision>.Success(policy == MissingPermissionBehavior.Allow
+            ? new CapabilityDecision(true, "TenantDefaultAllow")
+            : new CapabilityDecision(false, "TenantDefaultDeny"));
+    }
+
+    private static CapabilityDecision ToDecision(
+        RoleCapabilityPermissionEffect effect,
+        string matchedCapability,
+        string source) =>
+        effect == RoleCapabilityPermissionEffect.Allow
+            ? new CapabilityDecision(true, $"{source}:Allow:{matchedCapability}")
+            : new CapabilityDecision(false, $"{source}:Deny:{matchedCapability}");
+
+    private static HashSet<string> BuildCapabilityKeySet(string capabilityKey)
+    {
+        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            capabilityKey
+        };
+
+        if (!string.Equals(capabilityKey, IdentityAuthorizationConstants.Manage, StringComparison.OrdinalIgnoreCase))
+        {
+            keys.Add(IdentityAuthorizationConstants.Manage);
+        }
+
+        return keys;
+    }
+
+    private static string NormalizeCapability(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : value.Trim().ToLowerInvariant();
+
+    private sealed record ActiveRole(Guid RoleId, Guid RoleTypeId);
+
+    private sealed record CapabilityDecision(bool IsAllowed, string Source);
+}

--- a/src/Kernel/XFramework.Domain/Migrations/20260705084341_AddIdentityRoleCapabilities.Designer.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260705084341_AddIdentityRoleCapabilities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XFramework.Domain.Contexts;
@@ -11,9 +12,11 @@ using XFramework.Domain.Contexts;
 namespace XFramework.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260705084341_AddIdentityRoleCapabilities")]
+    partial class AddIdentityRoleCapabilities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kernel/XFramework.Domain/Migrations/20260705084341_AddIdentityRoleCapabilities.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260705084341_AddIdentityRoleCapabilities.cs
@@ -1,0 +1,368 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIdentityRoleCapabilities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "IdentityRoleFeaturePermissionOverride",
+                schema: "Identity",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    IdentityRoleId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModuleKey = table.Column<string>(type: "character varying", maxLength: 128, nullable: false),
+                    SubFeatureKey = table.Column<string>(type: "character varying", maxLength: 128, nullable: false, defaultValue: ""),
+                    CapabilityKey = table.Column<string>(type: "character varying", maxLength: 64, nullable: false),
+                    Effect = table.Column<int>(type: "integer", nullable: false, defaultValue: 1),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("identityrolefeaturepermissionoverride_pk", x => x.ID);
+                    table.ForeignKey(
+                        name: "identityrolefeaturepermissionoverride_identityrole_fk",
+                        column: x => x.IdentityRoleId,
+                        principalSchema: "Identity",
+                        principalTable: "IdentityRole",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IdentityRoleTypeFeaturePermission",
+                schema: "Identity",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    RoleTypeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModuleKey = table.Column<string>(type: "character varying", maxLength: 128, nullable: false),
+                    SubFeatureKey = table.Column<string>(type: "character varying", maxLength: 128, nullable: false, defaultValue: ""),
+                    CapabilityKey = table.Column<string>(type: "character varying", maxLength: 64, nullable: false),
+                    Effect = table.Column<int>(type: "integer", nullable: false, defaultValue: 1),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("identityroletypefeaturepermission_pk", x => x.ID);
+                    table.ForeignKey(
+                        name: "identityroletypefeaturepermission_roletype_fk",
+                        column: x => x.RoleTypeId,
+                        principalSchema: "Identity",
+                        principalTable: "IdentityRoleType",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TenantAuthorizationPolicy",
+                schema: "Identity",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "(uuid_generate_v4())"),
+                    MissingPermissionBehavior = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "true"),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValueSql: "false"),
+                    ConcurrencyStamp = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true, defaultValueSql: "now()"),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("tenantauthorizationpolicy_pk", x => x.ID);
+                    table.ForeignKey(
+                        name: "tenantauthorizationpolicy_tenant_tenantid_fk",
+                        column: x => x.TenantId,
+                        principalSchema: "Application",
+                        principalTable: "Application",
+                        principalColumn: "ID");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IdentityRoleFeaturePermissionOverride_IdentityRoleId",
+                schema: "Identity",
+                table: "IdentityRoleFeaturePermissionOverride",
+                column: "IdentityRoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IdentityRoleFeaturePermissionOverride_Role_Feature_Capability",
+                schema: "Identity",
+                table: "IdentityRoleFeaturePermissionOverride",
+                columns: new[] { "TenantId", "IdentityRoleId", "ModuleKey", "SubFeatureKey", "CapabilityKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IdentityRoleTypeFeaturePermission_Role_Feature_Capability",
+                schema: "Identity",
+                table: "IdentityRoleTypeFeaturePermission",
+                columns: new[] { "TenantId", "RoleTypeId", "ModuleKey", "SubFeatureKey", "CapabilityKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IdentityRoleTypeFeaturePermission_RoleTypeId",
+                schema: "Identity",
+                table: "IdentityRoleTypeFeaturePermission",
+                column: "RoleTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantAuthorizationPolicy_Tenant",
+                schema: "Identity",
+                table: "TenantAuthorizationPolicy",
+                column: "TenantId",
+                unique: true);
+
+            migrationBuilder.Sql("""
+                INSERT INTO "Identity"."TenantAuthorizationPolicy"
+                    ("ID", "TenantId", "MissingPermissionBehavior", "IsEnabled", "IsDeleted", "ConcurrencyStamp", "CreatedAt", "ModifiedAt")
+                SELECT
+                    uuid_generate_v4(),
+                    tenant."ID",
+                    0,
+                    true,
+                    false,
+                    uuid_generate_v4(),
+                    now(),
+                    now()
+                FROM "Application"."Application" tenant
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM "Identity"."TenantAuthorizationPolicy" policy
+                    WHERE policy."TenantId" = tenant."ID"
+                );
+                """);
+
+            migrationBuilder.Sql("""
+                INSERT INTO "Identity"."TenantModuleFeature"
+                    ("ID", "ModuleKey", "SubFeatureKey", "DisplayName", "Description", "IsEnabled", "IsDeleted", "ConcurrencyStamp", "CreatedAt", "ModifiedAt", "TenantId")
+                SELECT
+                    uuid_generate_v4(),
+                    definitions."ModuleKey",
+                    definitions."SubFeatureKey",
+                    definitions."DisplayName",
+                    definitions."Description",
+                    true,
+                    false,
+                    uuid_generate_v4(),
+                    now(),
+                    now(),
+                    tenant."ID"
+                FROM "Application"."Application" tenant
+                CROSS JOIN (VALUES
+                    ('identity', '', 'Identity', 'Identity, credential, role, tenant, session, and verification administration.'),
+                    ('identity', 'users', 'Identity Users', 'Identity information and user administration.'),
+                    ('identity', 'credentials', 'Identity Credentials', 'Credential creation, status, avatars, and credential metadata.'),
+                    ('identity', 'roles', 'Identity Roles', 'Role assignment, role types, and role capability permissions.'),
+                    ('identity', 'tenants', 'Identity Tenants', 'Tenant records, hierarchy, module access, and authorization policy.'),
+                    ('identity', 'sessions', 'Identity Sessions', 'Session monitoring, refresh, and termination.'),
+                    ('identity', 'verifications', 'Identity Verifications', 'Verification tokens, password reset, and approval workflows.'),
+                    ('identity', 'contacts', 'Identity Contacts', 'Credential contact records and contact grouping.'),
+                    ('identity', 'addresses', 'Identity Addresses', 'Identity address records and geographic lookups.'),
+                    ('identity', 'auth_logs', 'Identity Auth Logs', 'Authentication audit log review.')
+                ) AS definitions("ModuleKey", "SubFeatureKey", "DisplayName", "Description")
+                WHERE tenant."IsDeleted" = false
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM "Identity"."TenantModuleFeature" existing
+                      WHERE existing."TenantId" = tenant."ID"
+                        AND existing."ModuleKey" = definitions."ModuleKey"
+                        AND existing."SubFeatureKey" = definitions."SubFeatureKey"
+                  );
+                """);
+
+            migrationBuilder.Sql("""
+                WITH features("ModuleKey", "SubFeatureKey") AS (
+                    VALUES
+                        ('wallets', ''),
+                        ('wallets', 'transfers'),
+                        ('wallets', 'deposits'),
+                        ('wallets', 'withdrawals'),
+                        ('wallets', 'batch'),
+                        ('wallets', 'reconciliation'),
+                        ('wallets', 'policy'),
+                        ('wallets', 'webhooks'),
+                        ('wallets', 'reporting'),
+                        ('inventario', ''),
+                        ('inventario', 'catalog'),
+                        ('inventario', 'variations'),
+                        ('inventario', 'transactions'),
+                        ('inventario', 'low_stock_alerts'),
+                        ('inventario', 'warehousing'),
+                        ('inventario', 'stock_balances'),
+                        ('inventario', 'movements'),
+                        ('inventario', 'reservations'),
+                        ('inventario', 'fulfillment'),
+                        ('inventario', 'purchasing'),
+                        ('inventario', 'traceability'),
+                        ('inventario', 'planning'),
+                        ('inventario', 'reporting'),
+                        ('inventario', 'negative_stock'),
+                        ('pos', ''),
+                        ('pos', 'registers'),
+                        ('pos', 'sales'),
+                        ('pos', 'carts'),
+                        ('pos', 'returns'),
+                        ('pos', 'reporting'),
+                        ('communications', ''),
+                        ('communications', 'chat'),
+                        ('communications', 'audio_video'),
+                        ('community', ''),
+                        ('payments', ''),
+                        ('notifications', ''),
+                        ('attendance', ''),
+                        ('storage', ''),
+                        ('identity', ''),
+                        ('identity', 'users'),
+                        ('identity', 'credentials'),
+                        ('identity', 'roles'),
+                        ('identity', 'tenants'),
+                        ('identity', 'sessions'),
+                        ('identity', 'verifications'),
+                        ('identity', 'contacts'),
+                        ('identity', 'addresses'),
+                        ('identity', 'auth_logs')
+                ),
+                capabilities("CapabilityKey") AS (
+                    VALUES ('view'), ('create'), ('update'), ('delete'), ('manage')
+                )
+                UPDATE "Identity"."IdentityRoleTypeFeaturePermission" permission
+                SET
+                    "Effect" = 1,
+                    "IsEnabled" = true,
+                    "IsDeleted" = false,
+                    "DeletedAt" = NULL,
+                    "ModifiedAt" = now()
+                FROM "Identity"."IdentityRoleType" role_type
+                CROSS JOIN features
+                CROSS JOIN capabilities
+                WHERE role_type."ID" = permission."RoleTypeId"
+                  AND role_type."SystemReferenceId" = '6e7b6bf5-6ad6-49fb-80b0-38e967fc35f3'
+                  AND permission."TenantId" = role_type."TenantId"
+                  AND permission."ModuleKey" = features."ModuleKey"
+                  AND permission."SubFeatureKey" = features."SubFeatureKey"
+                  AND permission."CapabilityKey" = capabilities."CapabilityKey";
+                """);
+
+            migrationBuilder.Sql("""
+                WITH features("ModuleKey", "SubFeatureKey") AS (
+                    VALUES
+                        ('wallets', ''),
+                        ('wallets', 'transfers'),
+                        ('wallets', 'deposits'),
+                        ('wallets', 'withdrawals'),
+                        ('wallets', 'batch'),
+                        ('wallets', 'reconciliation'),
+                        ('wallets', 'policy'),
+                        ('wallets', 'webhooks'),
+                        ('wallets', 'reporting'),
+                        ('inventario', ''),
+                        ('inventario', 'catalog'),
+                        ('inventario', 'variations'),
+                        ('inventario', 'transactions'),
+                        ('inventario', 'low_stock_alerts'),
+                        ('inventario', 'warehousing'),
+                        ('inventario', 'stock_balances'),
+                        ('inventario', 'movements'),
+                        ('inventario', 'reservations'),
+                        ('inventario', 'fulfillment'),
+                        ('inventario', 'purchasing'),
+                        ('inventario', 'traceability'),
+                        ('inventario', 'planning'),
+                        ('inventario', 'reporting'),
+                        ('inventario', 'negative_stock'),
+                        ('pos', ''),
+                        ('pos', 'registers'),
+                        ('pos', 'sales'),
+                        ('pos', 'carts'),
+                        ('pos', 'returns'),
+                        ('pos', 'reporting'),
+                        ('communications', ''),
+                        ('communications', 'chat'),
+                        ('communications', 'audio_video'),
+                        ('community', ''),
+                        ('payments', ''),
+                        ('notifications', ''),
+                        ('attendance', ''),
+                        ('storage', ''),
+                        ('identity', ''),
+                        ('identity', 'users'),
+                        ('identity', 'credentials'),
+                        ('identity', 'roles'),
+                        ('identity', 'tenants'),
+                        ('identity', 'sessions'),
+                        ('identity', 'verifications'),
+                        ('identity', 'contacts'),
+                        ('identity', 'addresses'),
+                        ('identity', 'auth_logs')
+                ),
+                capabilities("CapabilityKey") AS (
+                    VALUES ('view'), ('create'), ('update'), ('delete'), ('manage')
+                )
+                INSERT INTO "Identity"."IdentityRoleTypeFeaturePermission"
+                    ("ID", "TenantId", "RoleTypeId", "ModuleKey", "SubFeatureKey", "CapabilityKey", "Effect", "IsEnabled", "IsDeleted", "ConcurrencyStamp", "CreatedAt", "ModifiedAt")
+                SELECT
+                    uuid_generate_v4(),
+                    role_type."TenantId",
+                    role_type."ID",
+                    features."ModuleKey",
+                    features."SubFeatureKey",
+                    capabilities."CapabilityKey",
+                    1,
+                    true,
+                    false,
+                    uuid_generate_v4(),
+                    now(),
+                    now()
+                FROM "Identity"."IdentityRoleType" role_type
+                CROSS JOIN features
+                CROSS JOIN capabilities
+                WHERE role_type."SystemReferenceId" = '6e7b6bf5-6ad6-49fb-80b0-38e967fc35f3'
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM "Identity"."IdentityRoleTypeFeaturePermission" permission
+                      WHERE permission."TenantId" = role_type."TenantId"
+                        AND permission."RoleTypeId" = role_type."ID"
+                        AND permission."ModuleKey" = features."ModuleKey"
+                        AND permission."SubFeatureKey" = features."SubFeatureKey"
+                        AND permission."CapabilityKey" = capabilities."CapabilityKey"
+                  );
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IdentityRoleFeaturePermissionOverride",
+                schema: "Identity");
+
+            migrationBuilder.DropTable(
+                name: "IdentityRoleTypeFeaturePermission",
+                schema: "Identity");
+
+            migrationBuilder.DropTable(
+                name: "TenantAuthorizationPolicy",
+                schema: "Identity");
+        }
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/AssignCredentialRole/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/AssignCredentialRole/Endpoint.cs
@@ -1,0 +1,41 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.AssignCredentialRole;
+
+public static class AssignCredentialRoleEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<IdentityRole>> Handle(
+        AssignCredentialRoleRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.AssignCredentialRoleAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/roles/assign", Tags = ["Identity Authorization"],
+        Summary = "Assign a credential role",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<IdentityRole>> HandleHttp(
+        AssignCredentialRoleRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.AssignCredentialRoleAsync(request, ct);
+    }
+}
+
+public sealed class AssignCredentialRoleRequestValidator : AbstractValidator<AssignCredentialRoleRequest>
+{
+    public AssignCredentialRoleRequestValidator()
+    {
+        RuleFor(x => x.CredentialId)
+            .NotEmpty().WithMessage("Credential is required");
+
+        RuleFor(x => x.RoleTypeId)
+            .NotEmpty().WithMessage("Role type is required");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/CheckCredentialCapability/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/CheckCredentialCapability/Endpoint.cs
@@ -1,0 +1,48 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.CheckCredentialCapability;
+
+public static class CheckCredentialCapabilityEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<CredentialCapabilityCheckResponse>> Handle(
+        CheckCredentialCapabilityRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.CheckCredentialCapabilityAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/check-capability", Tags = ["Identity Authorization"],
+        Summary = "Check a credential capability",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<CredentialCapabilityCheckResponse>> HandleHttp(
+        CheckCredentialCapabilityRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.CheckCredentialCapabilityAsync(request, ct);
+    }
+}
+
+public sealed class CheckCredentialCapabilityRequestValidator : AbstractValidator<CheckCredentialCapabilityRequest>
+{
+    public CheckCredentialCapabilityRequestValidator()
+    {
+        RuleFor(x => x.CredentialId)
+            .NotEmpty().WithMessage("Credential is required");
+
+        RuleFor(x => x.ModuleKey)
+            .NotEmpty().WithMessage("Module key is required");
+
+        RuleFor(x => x.CapabilityKey)
+            .NotEmpty().WithMessage("Capability key is required")
+            .Must(BeKnownCapability).WithMessage("Capability key is invalid");
+    }
+
+    private static bool BeKnownCapability(string? value) =>
+        IdentityAuthorizationConstants.CapabilityKeys.Contains(value?.Trim().ToLowerInvariant());
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/GetCredentialRolePermissionOverrides/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/GetCredentialRolePermissionOverrides/Endpoint.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.GetCredentialRolePermissionOverrides;
+
+public static class GetCredentialRolePermissionOverridesEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<CredentialRolePermissionOverridesResponse>> Handle(
+        GetCredentialRolePermissionOverridesRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.GetCredentialRolePermissionOverridesAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/credential-role-overrides/get", Tags = ["Identity Authorization"],
+        Summary = "Get credential role permission overrides",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<CredentialRolePermissionOverridesResponse>> HandleHttp(
+        GetCredentialRolePermissionOverridesRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.GetCredentialRolePermissionOverridesAsync(request, ct);
+    }
+}
+
+public sealed class GetCredentialRolePermissionOverridesRequestValidator :
+    AbstractValidator<GetCredentialRolePermissionOverridesRequest>
+{
+    public GetCredentialRolePermissionOverridesRequestValidator()
+    {
+        RuleFor(x => x.IdentityRoleId)
+            .NotEmpty().WithMessage("Identity role is required");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/GetEffectiveCredentialCapabilities/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/GetEffectiveCredentialCapabilities/Endpoint.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.GetEffectiveCredentialCapabilities;
+
+public static class GetEffectiveCredentialCapabilitiesEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<EffectiveCredentialCapabilitiesResponse>> Handle(
+        GetEffectiveCredentialCapabilitiesRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.GetEffectiveCredentialCapabilitiesAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/effective-capabilities", Tags = ["Identity Authorization"],
+        Summary = "Get effective credential capabilities",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<EffectiveCredentialCapabilitiesResponse>> HandleHttp(
+        GetEffectiveCredentialCapabilitiesRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.GetEffectiveCredentialCapabilitiesAsync(request, ct);
+    }
+}
+
+public sealed class GetEffectiveCredentialCapabilitiesRequestValidator :
+    AbstractValidator<GetEffectiveCredentialCapabilitiesRequest>
+{
+    public GetEffectiveCredentialCapabilitiesRequestValidator()
+    {
+        RuleFor(x => x.CredentialId)
+            .NotEmpty().WithMessage("Credential is required");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/GetRoleTypePermissions/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/GetRoleTypePermissions/Endpoint.cs
@@ -1,0 +1,38 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.GetRoleTypePermissions;
+
+public static class GetRoleTypePermissionsEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<RoleTypePermissionsResponse>> Handle(
+        GetRoleTypePermissionsRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.GetRoleTypePermissionsAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/role-type-permissions/get", Tags = ["Identity Authorization"],
+        Summary = "Get role type permissions",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<RoleTypePermissionsResponse>> HandleHttp(
+        GetRoleTypePermissionsRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.GetRoleTypePermissionsAsync(request, ct);
+    }
+}
+
+public sealed class GetRoleTypePermissionsRequestValidator : AbstractValidator<GetRoleTypePermissionsRequest>
+{
+    public GetRoleTypePermissionsRequestValidator()
+    {
+        RuleFor(x => x.RoleTypeId)
+            .NotEmpty().WithMessage("Role type is required");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/GetTenantAuthorizationPolicy/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/GetTenantAuthorizationPolicy/Endpoint.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.GetTenantAuthorizationPolicy;
+
+public static class GetTenantAuthorizationPolicyEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<TenantAuthorizationPolicyResponse>> Handle(
+        GetTenantAuthorizationPolicyRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.GetTenantAuthorizationPolicyAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/tenant-policy/get", Tags = ["Identity Authorization"],
+        Summary = "Get tenant authorization policy",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<TenantAuthorizationPolicyResponse>> HandleHttp(
+        GetTenantAuthorizationPolicyRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.GetTenantAuthorizationPolicyAsync(request, ct);
+    }
+}
+
+public sealed class GetTenantAuthorizationPolicyRequestValidator :
+    AbstractValidator<GetTenantAuthorizationPolicyRequest>
+{
+    public GetTenantAuthorizationPolicyRequestValidator()
+    {
+        RuleFor(x => x.TenantId)
+            .NotEmpty().WithMessage("Tenant is required");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/RemoveCredentialRole/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/RemoveCredentialRole/Endpoint.cs
@@ -1,0 +1,38 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.RemoveCredentialRole;
+
+public static class RemoveCredentialRoleEndpoint
+{
+    [BoltHandler]
+    public static Task<Result> Handle(
+        RemoveCredentialRoleRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.RemoveCredentialRoleAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/roles/remove", Tags = ["Identity Authorization"],
+        Summary = "Remove a credential role",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result> HandleHttp(
+        RemoveCredentialRoleRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.RemoveCredentialRoleAsync(request, ct);
+    }
+}
+
+public sealed class RemoveCredentialRoleRequestValidator : AbstractValidator<RemoveCredentialRoleRequest>
+{
+    public RemoveCredentialRoleRequestValidator()
+    {
+        RuleFor(x => x.IdentityRoleId)
+            .NotEmpty().WithMessage("Identity role is required");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/SetCredentialRolePermissionOverrides/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/SetCredentialRolePermissionOverrides/Endpoint.cs
@@ -1,0 +1,42 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.SetCredentialRolePermissionOverrides;
+
+public static class SetCredentialRolePermissionOverridesEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<CredentialRolePermissionOverridesResponse>> Handle(
+        SetCredentialRolePermissionOverridesRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.SetCredentialRolePermissionOverridesAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/credential-role-overrides/set", Tags = ["Identity Authorization"],
+        Summary = "Set credential role permission overrides",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<CredentialRolePermissionOverridesResponse>> HandleHttp(
+        SetCredentialRolePermissionOverridesRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.SetCredentialRolePermissionOverridesAsync(request, ct);
+    }
+}
+
+public sealed class SetCredentialRolePermissionOverridesRequestValidator :
+    AbstractValidator<SetCredentialRolePermissionOverridesRequest>
+{
+    public SetCredentialRolePermissionOverridesRequestValidator()
+    {
+        RuleFor(x => x.IdentityRoleId)
+            .NotEmpty().WithMessage("Identity role is required");
+
+        RuleForEach(x => x.Overrides)
+            .SetValidator(new CapabilityPermissionDtoValidator());
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/SetRoleTypePermissions/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/SetRoleTypePermissions/Endpoint.cs
@@ -1,0 +1,41 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.SetRoleTypePermissions;
+
+public static class SetRoleTypePermissionsEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<RoleTypePermissionsResponse>> Handle(
+        SetRoleTypePermissionsRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.SetRoleTypePermissionsAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/role-type-permissions/set", Tags = ["Identity Authorization"],
+        Summary = "Set role type permissions",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<RoleTypePermissionsResponse>> HandleHttp(
+        SetRoleTypePermissionsRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.SetRoleTypePermissionsAsync(request, ct);
+    }
+}
+
+public sealed class SetRoleTypePermissionsRequestValidator : AbstractValidator<SetRoleTypePermissionsRequest>
+{
+    public SetRoleTypePermissionsRequestValidator()
+    {
+        RuleFor(x => x.RoleTypeId)
+            .NotEmpty().WithMessage("Role type is required");
+
+        RuleForEach(x => x.Permissions)
+            .SetValidator(new CapabilityPermissionDtoValidator());
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/Shared/CapabilityPermissionDtoValidator.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/Shared/CapabilityPermissionDtoValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace IdentityServer.Api.Features.Authorization;
+
+public sealed class CapabilityPermissionDtoValidator : AbstractValidator<CapabilityPermissionDto>
+{
+    public CapabilityPermissionDtoValidator()
+    {
+        RuleFor(x => x.ModuleKey)
+            .NotEmpty().WithMessage("Module key is required");
+
+        RuleFor(x => x.CapabilityKey)
+            .NotEmpty().WithMessage("Capability key is required")
+            .Must(BeKnownCapability).WithMessage("Capability key is invalid");
+
+        RuleFor(x => x.Effect)
+            .IsInEnum().WithMessage("Permission effect is invalid");
+    }
+
+    private static bool BeKnownCapability(string? value) =>
+        IdentityAuthorizationConstants.CapabilityKeys.Contains(value?.Trim().ToLowerInvariant());
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/Shared/IdentityAuthorizationEndpointMetadata.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/Shared/IdentityAuthorizationEndpointMetadata.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+
+namespace IdentityServer.Api.Features.Authorization.Shared;
+
+internal static class IdentityAuthorizationEndpointMetadata
+{
+    public static void ApplyHttpContextActor(RequestMetadata metadata, HttpContext httpContext)
+    {
+        metadata.TenantId = ResolveGuidClaim(httpContext.User, "tenant_id", "tenantId", "TenantId", "tid", "tenant");
+        metadata.CredentialId = ResolveGuidClaim(
+            httpContext.User,
+            "credentialId",
+            "credential_id",
+            ClaimTypes.NameIdentifier,
+            "sub");
+        metadata.ServiceAccessToken = null;
+    }
+
+    private static Guid? ResolveGuidClaim(ClaimsPrincipal user, params string[] claimNames)
+    {
+        foreach (var claimName in claimNames)
+        {
+            var claimValue = user.FindFirst(claimName)?.Value;
+            if (Guid.TryParse(claimValue, out var value))
+                return value;
+        }
+
+        return null;
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/UpdateTenantAuthorizationPolicy/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/Authorization/UpdateTenantAuthorizationPolicy/Endpoint.cs
@@ -1,0 +1,42 @@
+using FluentValidation;
+using IdentityServer.Api.Features.Authorization.Shared;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.Authorization.UpdateTenantAuthorizationPolicy;
+
+public static class UpdateTenantAuthorizationPolicyEndpoint
+{
+    [BoltHandler]
+    public static Task<Result<TenantAuthorizationPolicyResponse>> Handle(
+        UpdateTenantAuthorizationPolicyRequest request,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct) =>
+        authorizationService.UpdateTenantAuthorizationPolicyAsync(request, ct);
+
+    [MapPost("/api/identity/authorization/tenant-policy/update", Tags = ["Identity Authorization"],
+        Summary = "Update tenant authorization policy",
+        RequireAuthorization = true,
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<TenantAuthorizationPolicyResponse>> HandleHttp(
+        UpdateTenantAuthorizationPolicyRequest request,
+        HttpContext httpContext,
+        IIdentityAuthorizationService authorizationService,
+        CancellationToken ct)
+    {
+        IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);
+        return authorizationService.UpdateTenantAuthorizationPolicyAsync(request, ct);
+    }
+}
+
+public sealed class UpdateTenantAuthorizationPolicyRequestValidator :
+    AbstractValidator<UpdateTenantAuthorizationPolicyRequest>
+{
+    public UpdateTenantAuthorizationPolicyRequestValidator()
+    {
+        RuleFor(x => x.TenantId)
+            .NotEmpty().WithMessage("Tenant is required");
+
+        RuleFor(x => x.MissingPermissionBehavior)
+            .IsInEnum().WithMessage("Missing permission behavior is invalid");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Infrastructure/IdentityServerFeatureGateRoutes.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Infrastructure/IdentityServerFeatureGateRoutes.cs
@@ -1,0 +1,37 @@
+using IdentityServer.Domain.Shared.Contracts;
+using XFramework.Core.Services.FeatureGates;
+
+namespace IdentityServer.Api.Infrastructure;
+
+public static class IdentityServerFeatureGateRoutes
+{
+    public static void Configure(TenantModuleFeatureGateOptions options)
+    {
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityUsers, "/api/identity-informations");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityCredentials, "/api/identity-credentials");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityCredentials, "/api/credentials");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityRoles, "/api/identity-roles");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityRoles, "/api/identity-role-types");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityRoles, "/api/identity-role-type-groups");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityRoles, "/api/identity-role-type-feature-permissions");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityTenants, "/api/tenants");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityTenants, "/api/tenant-module-features");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityTenants, "/api/identity/authorization/tenant-policy");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityRoles, "/api/identity-role-feature-permission-overrides");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityRoles, "/api/identity/authorization");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentitySessions, "/api/sessions");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentitySessions, "/api/session-types");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityVerifications, "/api/verifications");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityVerifications, "/api/identity-verifications");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityVerifications, "/api/identity-verification-types");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityContacts, "/api/identity-contacts");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityContacts, "/api/identity-contact-types");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityContacts, "/api/identity-contact-groups");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityAddresses, "/api/identity-addresses");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityAddresses, "/api/identity-address-types");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityAddresses, "/api/address");
+        options.RequireFeature(TenantModuleFeatureKeys.IdentityAuthLogs, "/api/authorization-logs");
+        options.RequireFeature(TenantModuleFeatureKeys.Identity, "/api/registry-configurations");
+        options.RequireFeature(TenantModuleFeatureKeys.Identity, "/api/registry-configuration-groups");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Installers/ServicesInstaller.cs
@@ -15,5 +15,6 @@ public class ServicesInstaller : IInstaller
 
         // Register AuthService for VSA pattern
         services.AddScoped<IAuthService, AuthService>();
+        services.AddScoped<IIdentityAuthorizationService, IdentityAuthorizationService>();
     }
 }

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Program.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Program.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using IdentityServer.Api.Features.Verification.Confirm;
 using IdentityServer.Api.Generated;
+using IdentityServer.Api.Infrastructure;
 using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
 using XFramework.Core.Health;
@@ -14,6 +15,7 @@ builder.Logging.AddXFrameworkLogging(builder.Configuration);
 
 // Register AuthService
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IIdentityAuthorizationService, IdentityAuthorizationService>();
 builder.Services.AddScoped<IServiceIdentityService, ServiceIdentityService>();
 builder.Services.AddSingleton<IIdentitySigningKeyProvider, IdentityServerLocalSigningKeyProvider>();
 
@@ -43,6 +45,7 @@ var app = (WebApplication)builder.Build();
 
 app.UseCorrelationId();
 app.UseXFrameworkRateLimiting();
+app.UseTenantModuleFeatureGate(IdentityServerFeatureGateRoutes.Configure);
 app.EnsureDatabase<DbContext>();
 // Bolt handlers are now source-generated from [BoltHandler] on endpoint methods.
 // Generated IBoltHandler implementations are auto-registered by

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/AuthService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/AuthService.cs
@@ -101,6 +101,7 @@ public sealed class AuthService : IAuthService
             }
 
             var tenantId = Guid.NewGuid();
+            var now = DateTime.UtcNow;
             var tenant = new Tenant
             {
                 Id = tenantId,
@@ -112,12 +113,39 @@ public sealed class AuthService : IAuthService
                 Expiration = request.Expiration,
                 AvailabilityDate = request.AvailabilityDate,
                 ParentTenantId = request.ParentTenantId,
-                CreatedAt = DateTime.UtcNow,
+                CreatedAt = now,
                 IsEnabled = true,
                 ConcurrencyStamp = Guid.NewGuid()
             };
 
             _dataContext.Add(tenant);
+            _dataContext.Add(new TenantAuthorizationPolicy
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                MissingPermissionBehavior = MissingPermissionBehavior.Deny,
+                CreatedAt = now,
+                IsEnabled = true,
+                ConcurrencyStamp = Guid.NewGuid()
+            });
+
+            foreach (var feature in TenantModuleFeatureKeys.All
+                         .Where(x => string.Equals(x.ModuleKey, TenantModuleFeatureKeys.Identity, StringComparison.OrdinalIgnoreCase)))
+            {
+                _dataContext.Add(new TenantModuleFeature
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = tenantId,
+                    ModuleKey = feature.ModuleKey,
+                    SubFeatureKey = feature.SubFeatureKey,
+                    DisplayName = feature.DisplayName,
+                    Description = feature.Description,
+                    CreatedAt = now,
+                    IsEnabled = true,
+                    ConcurrencyStamp = Guid.NewGuid()
+                });
+            }
+
             var saveResult = await _dataContext.SaveChangesAsync(ct);
             if (!saveResult.IsSuccess)
             {
@@ -1503,10 +1531,14 @@ public sealed class AuthService : IAuthService
         IdentityCredential credential,
         CancellationToken ct)
     {
+        var now = DateTime.UtcNow;
         var roleList = await _dataContext.Query<IdentityRole>()
             .IgnoreQueryFilters()
             .Include(i => i.Type)
+            .Where(i => i.TenantId == credential.TenantId)
             .Where(i => i.CredentialId == credential.Id)
+            .Where(i => !i.IsDeleted && i.IsEnabled)
+            .Where(i => i.RoleExpiration >= now)
             .ToListAsync(ct);
 
         return roleList.Any() ? roleList : null;

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/IIdentityAuthorizationService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/IIdentityAuthorizationService.cs
@@ -1,0 +1,49 @@
+namespace IdentityServer.Api.Services;
+
+public interface IIdentityAuthorizationService
+{
+    Task<Result<CredentialCapabilityCheckResponse>> CheckCredentialCapabilityAsync(
+        CheckCredentialCapabilityRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<EffectiveCredentialCapabilitiesResponse>> GetEffectiveCredentialCapabilitiesAsync(
+        GetEffectiveCredentialCapabilitiesRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<TenantAuthorizationPolicyResponse>> GetTenantAuthorizationPolicyAsync(
+        GetTenantAuthorizationPolicyRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<TenantAuthorizationPolicyResponse>> UpdateTenantAuthorizationPolicyAsync(
+        UpdateTenantAuthorizationPolicyRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<RoleTypePermissionsResponse>> GetRoleTypePermissionsAsync(
+        GetRoleTypePermissionsRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<RoleTypePermissionsResponse>> SetRoleTypePermissionsAsync(
+        SetRoleTypePermissionsRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<CredentialRolePermissionOverridesResponse>> GetCredentialRolePermissionOverridesAsync(
+        GetCredentialRolePermissionOverridesRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<CredentialRolePermissionOverridesResponse>> SetCredentialRolePermissionOverridesAsync(
+        SetCredentialRolePermissionOverridesRequest request,
+        CancellationToken ct = default);
+
+    Task<Result<IdentityRole>> AssignCredentialRoleAsync(
+        AssignCredentialRoleRequest request,
+        CancellationToken ct = default);
+
+    Task<Result> RemoveCredentialRoleAsync(
+        RemoveCredentialRoleRequest request,
+        CancellationToken ct = default);
+
+    Task<Result> SeedRoleTypePermissionsAsync(
+        Guid tenantId,
+        Guid roleTypeId,
+        CancellationToken ct = default);
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/IdentityAuthorizationService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/IdentityAuthorizationService.cs
@@ -1,0 +1,1099 @@
+using XFramework.Domain.Shared.DataContext;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Security;
+using System.Security.Claims;
+
+namespace IdentityServer.Api.Services;
+
+public sealed class IdentityAuthorizationService(
+    IDataContext dataContext,
+    ITrustedServiceInvocationResolver trustedServiceInvocationResolver,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<IdentityAuthorizationService> logger) : IIdentityAuthorizationService
+{
+    private const string SourceCredentialOverrideAllow = "CredentialRoleOverrideAllow";
+    private const string SourceCredentialOverrideDeny = "CredentialRoleOverrideDeny";
+    private const string SourceRoleTypeAllow = "RoleTypePermissionAllow";
+    private const string SourceRoleTypeDeny = "RoleTypePermissionDeny";
+    private const string SourceTenantDefaultAllow = "TenantDefaultAllow";
+    private const string SourceTenantDefaultDeny = "TenantDefaultDeny";
+    private const string SourceTenantFeatureDisabled = "TenantFeatureDisabled";
+
+    public async Task<Result<CredentialCapabilityCheckResponse>> CheckCredentialCapabilityAsync(
+        CheckCredentialCapabilityRequest request,
+        CancellationToken ct = default)
+    {
+        var normalized = NormalizePermissionTarget(request.ModuleKey, request.SubFeatureKey, request.CapabilityKey);
+        if (!normalized.IsSuccess)
+            return Result<CredentialCapabilityCheckResponse>.Failure(normalized.Message!, normalized.StatusCode);
+
+        var credential = await dataContext.Query<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.Id == request.CredentialId)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .FirstOrDefaultAsync(ct);
+
+        if (credential is null)
+            return Result<CredentialCapabilityCheckResponse>.NotFound("Credential not found");
+
+        if (request.Metadata.TenantId is { } metadataTenantId && metadataTenantId != credential.TenantId)
+            return Result<CredentialCapabilityCheckResponse>.Failure("Credential does not belong to the active tenant", 403);
+
+        var inspectAuthorization = await EnsureCanInspectCredentialCapabilitiesAsync(
+            request.Metadata,
+            credential.TenantId,
+            credential.Id,
+            ct);
+        if (!inspectAuthorization.IsSuccess)
+            return Result<CredentialCapabilityCheckResponse>.Failure(
+                inspectAuthorization.Message!,
+                inspectAuthorization.StatusCode);
+
+        var decision = await ResolveCapabilityAsync(
+            credential.TenantId,
+            credential.Id,
+            normalized.Data!.ModuleKey,
+            normalized.Data.SubFeatureKey,
+            normalized.Data.CapabilityKey,
+            ct,
+            credentialAlreadyValidated: true);
+
+        return Result<CredentialCapabilityCheckResponse>.Success(new CredentialCapabilityCheckResponse
+        {
+            TenantId = credential.TenantId,
+            CredentialId = credential.Id,
+            ModuleKey = normalized.Data.ModuleKey,
+            SubFeatureKey = normalized.Data.SubFeatureKey,
+            CapabilityKey = normalized.Data.CapabilityKey,
+            IsAllowed = decision.IsAllowed,
+            DecisionSource = decision.Source
+        });
+    }
+
+    public async Task<Result<EffectiveCredentialCapabilitiesResponse>> GetEffectiveCredentialCapabilitiesAsync(
+        GetEffectiveCredentialCapabilitiesRequest request,
+        CancellationToken ct = default)
+    {
+        var credential = await dataContext.Query<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.Id == request.CredentialId)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .FirstOrDefaultAsync(ct);
+
+        if (credential is null)
+            return Result<EffectiveCredentialCapabilitiesResponse>.NotFound("Credential not found");
+
+        if (request.Metadata.TenantId is { } metadataTenantId && metadataTenantId != credential.TenantId)
+            return Result<EffectiveCredentialCapabilitiesResponse>.Failure(
+                "Credential does not belong to the active tenant",
+                403);
+
+        var inspectAuthorization = await EnsureCanInspectCredentialCapabilitiesAsync(
+            request.Metadata,
+            credential.TenantId,
+            credential.Id,
+            ct);
+        if (!inspectAuthorization.IsSuccess)
+            return Result<EffectiveCredentialCapabilitiesResponse>.Failure(
+                inspectAuthorization.Message!,
+                inspectAuthorization.StatusCode);
+
+        var response = new EffectiveCredentialCapabilitiesResponse
+        {
+            TenantId = credential.TenantId,
+            CredentialId = credential.Id
+        };
+
+        foreach (var feature in TenantModuleFeatureKeys.All.OrderBy(x => x.ModuleKey).ThenBy(x => x.SubFeatureKey))
+        {
+            foreach (var capability in IdentityAuthorizationConstants.CapabilityKeys)
+            {
+                var decision = await ResolveCapabilityAsync(
+                    credential.TenantId,
+                    credential.Id,
+                    feature.ModuleKey,
+                    feature.SubFeatureKey,
+                    capability,
+                    ct,
+                    credentialAlreadyValidated: true);
+
+                response.Capabilities.Add(new CredentialCapabilityCheckResponse
+                {
+                    TenantId = credential.TenantId,
+                    CredentialId = credential.Id,
+                    ModuleKey = feature.ModuleKey,
+                    SubFeatureKey = feature.SubFeatureKey,
+                    CapabilityKey = capability,
+                    IsAllowed = decision.IsAllowed,
+                    DecisionSource = decision.Source
+                });
+            }
+        }
+
+        return Result<EffectiveCredentialCapabilitiesResponse>.Success(response);
+    }
+
+    public async Task<Result<TenantAuthorizationPolicyResponse>> GetTenantAuthorizationPolicyAsync(
+        GetTenantAuthorizationPolicyRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantId = ResolveRequestedTenantId(request.TenantId, request.Metadata.TenantId);
+        if (!tenantId.IsSuccess)
+            return Result<TenantAuthorizationPolicyResponse>.Failure(tenantId.Message!, tenantId.StatusCode);
+        var resolvedTenantId = tenantId.Data;
+
+        var tenantExists = await TenantExistsAsync(resolvedTenantId, ct);
+        if (!tenantExists)
+            return Result<TenantAuthorizationPolicyResponse>.NotFound("Tenant not found");
+
+        var authorization = await EnsureCallerCapabilityAsync(
+            request.Metadata,
+            resolvedTenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.TenantsSubFeature,
+            IdentityAuthorizationConstants.View,
+            ct);
+        if (!authorization.IsSuccess)
+            return Result<TenantAuthorizationPolicyResponse>.Failure(authorization.Message!, authorization.StatusCode);
+
+        var policy = await dataContext.Query<TenantAuthorizationPolicy>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == resolvedTenantId)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .FirstOrDefaultAsync(ct);
+
+        return Result<TenantAuthorizationPolicyResponse>.Success(new TenantAuthorizationPolicyResponse
+        {
+            TenantId = resolvedTenantId,
+            MissingPermissionBehavior = policy?.MissingPermissionBehavior ?? MissingPermissionBehavior.Deny
+        });
+    }
+
+    public async Task<Result<TenantAuthorizationPolicyResponse>> UpdateTenantAuthorizationPolicyAsync(
+        UpdateTenantAuthorizationPolicyRequest request,
+        CancellationToken ct = default)
+    {
+        var tenantId = ResolveRequestedTenantId(request.TenantId, request.Metadata.TenantId);
+        if (!tenantId.IsSuccess)
+            return Result<TenantAuthorizationPolicyResponse>.Failure(tenantId.Message!, tenantId.StatusCode);
+        var resolvedTenantId = tenantId.Data;
+
+        var tenantExists = await TenantExistsAsync(resolvedTenantId, ct);
+        if (!tenantExists)
+            return Result<TenantAuthorizationPolicyResponse>.NotFound("Tenant not found");
+
+        var authorization = await EnsureCallerCapabilityAsync(
+            request.Metadata,
+            resolvedTenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.TenantsSubFeature,
+            IdentityAuthorizationConstants.Manage,
+            ct);
+        if (!authorization.IsSuccess)
+            return Result<TenantAuthorizationPolicyResponse>.Failure(authorization.Message!, authorization.StatusCode);
+
+        var policy = await dataContext.Query<TenantAuthorizationPolicy>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == resolvedTenantId)
+            .FirstOrDefaultAsync(ct);
+
+        if (policy is null)
+        {
+            policy = new TenantAuthorizationPolicy
+            {
+                Id = Guid.NewGuid(),
+                TenantId = resolvedTenantId,
+                MissingPermissionBehavior = request.MissingPermissionBehavior,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow,
+                ConcurrencyStamp = Guid.NewGuid()
+            };
+            dataContext.Add(policy);
+        }
+        else
+        {
+            policy.MissingPermissionBehavior = request.MissingPermissionBehavior;
+            policy.IsEnabled = true;
+            policy.IsDeleted = false;
+            policy.ModifiedAt = DateTime.UtcNow;
+            dataContext.Update(policy);
+        }
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<TenantAuthorizationPolicyResponse>.Failure("Tenant authorization policy could not be saved", saveResult.StatusCode);
+
+        return Result<TenantAuthorizationPolicyResponse>.Success(new TenantAuthorizationPolicyResponse
+        {
+            TenantId = resolvedTenantId,
+            MissingPermissionBehavior = policy.MissingPermissionBehavior
+        });
+    }
+
+    public async Task<Result<RoleTypePermissionsResponse>> GetRoleTypePermissionsAsync(
+        GetRoleTypePermissionsRequest request,
+        CancellationToken ct = default)
+    {
+        var roleType = await GetRoleTypeAsync(request.RoleTypeId, request.Metadata.TenantId, ct);
+        if (!roleType.IsSuccess)
+            return Result<RoleTypePermissionsResponse>.Failure(roleType.Message!, roleType.StatusCode);
+
+        var authorization = await EnsureCallerCapabilityAsync(
+            request.Metadata,
+            roleType.Data!.TenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.RolesSubFeature,
+            IdentityAuthorizationConstants.View,
+            ct);
+        if (!authorization.IsSuccess)
+            return Result<RoleTypePermissionsResponse>.Failure(authorization.Message!, authorization.StatusCode);
+
+        var permissions = await dataContext.Query<IdentityRoleTypeFeaturePermission>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == roleType.Data!.TenantId)
+            .Where(x => x.RoleTypeId == roleType.Data.Id)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .OrderBy(x => x.ModuleKey)
+            .ThenBy(x => x.SubFeatureKey)
+            .ThenBy(x => x.CapabilityKey)
+            .ToListAsync(ct);
+
+        return Result<RoleTypePermissionsResponse>.Success(new RoleTypePermissionsResponse
+        {
+            TenantId = roleType.Data.TenantId,
+            RoleTypeId = roleType.Data.Id,
+            Permissions = permissions.Select(ToPermissionDto).ToList()
+        });
+    }
+
+    public async Task<Result<RoleTypePermissionsResponse>> SetRoleTypePermissionsAsync(
+        SetRoleTypePermissionsRequest request,
+        CancellationToken ct = default)
+    {
+        var roleType = await GetRoleTypeAsync(request.RoleTypeId, request.Metadata.TenantId, ct);
+        if (!roleType.IsSuccess)
+            return Result<RoleTypePermissionsResponse>.Failure(roleType.Message!, roleType.StatusCode);
+
+        var authorization = await EnsureCallerCapabilityAsync(
+            request.Metadata,
+            roleType.Data!.TenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.RolesSubFeature,
+            IdentityAuthorizationConstants.Update,
+            ct);
+        if (!authorization.IsSuccess)
+            return Result<RoleTypePermissionsResponse>.Failure(authorization.Message!, authorization.StatusCode);
+
+        var normalized = NormalizePermissionDtos(request.Permissions);
+        if (!normalized.IsSuccess)
+            return Result<RoleTypePermissionsResponse>.Failure(normalized.Message!, normalized.StatusCode);
+
+        var existing = await dataContext.Query<IdentityRoleTypeFeaturePermission>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == roleType.Data!.TenantId)
+            .Where(x => x.RoleTypeId == roleType.Data.Id)
+            .ToListAsync(ct);
+
+        var existingByKey = existing.ToDictionary(BuildPermissionKey, StringComparer.OrdinalIgnoreCase);
+        var desiredKeys = normalized.Data!
+            .Select(BuildPermissionKey)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var permission in normalized.Data!)
+        {
+            if (existingByKey.TryGetValue(BuildPermissionKey(permission), out var row))
+            {
+                row.Effect = permission.Effect;
+                row.IsEnabled = true;
+                row.IsDeleted = false;
+                row.ModifiedAt = DateTime.UtcNow;
+                dataContext.Update(row);
+                continue;
+            }
+
+            dataContext.Add(new IdentityRoleTypeFeaturePermission
+            {
+                Id = Guid.NewGuid(),
+                TenantId = roleType.Data.TenantId,
+                RoleTypeId = roleType.Data.Id,
+                ModuleKey = permission.ModuleKey,
+                SubFeatureKey = permission.SubFeatureKey,
+                CapabilityKey = permission.CapabilityKey,
+                Effect = permission.Effect,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow,
+                ConcurrencyStamp = Guid.NewGuid()
+            });
+        }
+
+        foreach (var row in existing.Where(row => !desiredKeys.Contains(BuildPermissionKey(row))))
+        {
+            row.IsEnabled = false;
+            row.IsDeleted = true;
+            row.DeletedAt = DateTime.UtcNow;
+            dataContext.Update(row);
+        }
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<RoleTypePermissionsResponse>.Failure("Role type permissions could not be saved", saveResult.StatusCode);
+
+        return await GetRoleTypePermissionsAsync(new GetRoleTypePermissionsRequest
+        {
+            RoleTypeId = request.RoleTypeId,
+            Metadata = request.Metadata
+        }, ct);
+    }
+
+    public async Task<Result<CredentialRolePermissionOverridesResponse>> GetCredentialRolePermissionOverridesAsync(
+        GetCredentialRolePermissionOverridesRequest request,
+        CancellationToken ct = default)
+    {
+        var role = await GetIdentityRoleAsync(request.IdentityRoleId, request.Metadata.TenantId, ct);
+        if (!role.IsSuccess)
+            return Result<CredentialRolePermissionOverridesResponse>.Failure(role.Message!, role.StatusCode);
+
+        var authorization = await EnsureCallerCapabilityAsync(
+            request.Metadata,
+            role.Data!.TenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.RolesSubFeature,
+            IdentityAuthorizationConstants.View,
+            ct);
+        if (!authorization.IsSuccess)
+            return Result<CredentialRolePermissionOverridesResponse>.Failure(
+                authorization.Message!,
+                authorization.StatusCode);
+
+        var overrides = await dataContext.Query<IdentityRoleFeaturePermissionOverride>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == role.Data!.TenantId)
+            .Where(x => x.IdentityRoleId == role.Data.Id)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .OrderBy(x => x.ModuleKey)
+            .ThenBy(x => x.SubFeatureKey)
+            .ThenBy(x => x.CapabilityKey)
+            .ToListAsync(ct);
+
+        return Result<CredentialRolePermissionOverridesResponse>.Success(new CredentialRolePermissionOverridesResponse
+        {
+            TenantId = role.Data.TenantId,
+            IdentityRoleId = role.Data.Id,
+            Overrides = overrides.Select(ToPermissionDto).ToList()
+        });
+    }
+
+    public async Task<Result<CredentialRolePermissionOverridesResponse>> SetCredentialRolePermissionOverridesAsync(
+        SetCredentialRolePermissionOverridesRequest request,
+        CancellationToken ct = default)
+    {
+        var role = await GetIdentityRoleAsync(request.IdentityRoleId, request.Metadata.TenantId, ct);
+        if (!role.IsSuccess)
+            return Result<CredentialRolePermissionOverridesResponse>.Failure(role.Message!, role.StatusCode);
+
+        var authorization = await EnsureCallerCapabilityAsync(
+            request.Metadata,
+            role.Data!.TenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.RolesSubFeature,
+            IdentityAuthorizationConstants.Update,
+            ct);
+        if (!authorization.IsSuccess)
+            return Result<CredentialRolePermissionOverridesResponse>.Failure(
+                authorization.Message!,
+                authorization.StatusCode);
+
+        var normalized = NormalizePermissionDtos(request.Overrides);
+        if (!normalized.IsSuccess)
+            return Result<CredentialRolePermissionOverridesResponse>.Failure(normalized.Message!, normalized.StatusCode);
+
+        var existing = await dataContext.Query<IdentityRoleFeaturePermissionOverride>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == role.Data!.TenantId)
+            .Where(x => x.IdentityRoleId == role.Data.Id)
+            .ToListAsync(ct);
+
+        var existingByKey = existing.ToDictionary(BuildPermissionKey, StringComparer.OrdinalIgnoreCase);
+        var desiredKeys = normalized.Data!
+            .Select(BuildPermissionKey)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var permission in normalized.Data!)
+        {
+            if (existingByKey.TryGetValue(BuildPermissionKey(permission), out var row))
+            {
+                row.Effect = permission.Effect;
+                row.IsEnabled = true;
+                row.IsDeleted = false;
+                row.ModifiedAt = DateTime.UtcNow;
+                dataContext.Update(row);
+                continue;
+            }
+
+            dataContext.Add(new IdentityRoleFeaturePermissionOverride
+            {
+                Id = Guid.NewGuid(),
+                TenantId = role.Data.TenantId,
+                IdentityRoleId = role.Data.Id,
+                ModuleKey = permission.ModuleKey,
+                SubFeatureKey = permission.SubFeatureKey,
+                CapabilityKey = permission.CapabilityKey,
+                Effect = permission.Effect,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow,
+                ConcurrencyStamp = Guid.NewGuid()
+            });
+        }
+
+        foreach (var row in existing.Where(row => !desiredKeys.Contains(BuildPermissionKey(row))))
+        {
+            row.IsEnabled = false;
+            row.IsDeleted = true;
+            row.DeletedAt = DateTime.UtcNow;
+            dataContext.Update(row);
+        }
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<CredentialRolePermissionOverridesResponse>.Failure("Credential role overrides could not be saved", saveResult.StatusCode);
+
+        return await GetCredentialRolePermissionOverridesAsync(new GetCredentialRolePermissionOverridesRequest
+        {
+            IdentityRoleId = request.IdentityRoleId,
+            Metadata = request.Metadata
+        }, ct);
+    }
+
+    public async Task<Result<IdentityRole>> AssignCredentialRoleAsync(
+        AssignCredentialRoleRequest request,
+        CancellationToken ct = default)
+    {
+        var credential = await dataContext.Query<IdentityCredential>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.Id == request.CredentialId)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .FirstOrDefaultAsync(ct);
+
+        if (credential is null)
+            return Result<IdentityRole>.NotFound("Credential not found");
+
+        if (request.Metadata.TenantId is { } metadataTenantId && metadataTenantId != credential.TenantId)
+            return Result<IdentityRole>.Failure("Credential does not belong to the active tenant", 403);
+
+        var authorization = await EnsureCallerCapabilityAsync(
+            request.Metadata,
+            credential.TenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.RolesSubFeature,
+            IdentityAuthorizationConstants.Create,
+            ct);
+        if (!authorization.IsSuccess)
+            return Result<IdentityRole>.Failure(authorization.Message!, authorization.StatusCode);
+
+        var roleType = await GetRoleTypeAsync(request.RoleTypeId, credential.TenantId, ct);
+        if (!roleType.IsSuccess)
+            return Result<IdentityRole>.Failure(roleType.Message!, roleType.StatusCode);
+        var roleTypeData = roleType.Data!;
+
+        var existing = await dataContext.Query<IdentityRole>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == credential.TenantId)
+            .Where(x => x.CredentialId == credential.Id)
+            .Where(x => x.TypeId == roleTypeData.Id)
+            .FirstOrDefaultAsync(ct);
+
+        var expiration = request.RoleExpiration == default
+            ? DateTime.UtcNow.AddYears(1)
+            : request.RoleExpiration.ToUniversalTime();
+
+        if (existing is null)
+        {
+            existing = new IdentityRole
+            {
+                Id = Guid.NewGuid(),
+                TenantId = credential.TenantId,
+                CredentialId = credential.Id,
+                TypeId = roleTypeData.Id,
+                RoleExpiration = expiration,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow,
+                ConcurrencyStamp = Guid.NewGuid()
+            };
+            dataContext.Add(existing);
+        }
+        else
+        {
+            existing.RoleExpiration = expiration;
+            existing.IsEnabled = true;
+            existing.IsDeleted = false;
+            existing.ModifiedAt = DateTime.UtcNow;
+            dataContext.Update(existing);
+        }
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        if (!saveResult.IsSuccess)
+            return Result<IdentityRole>.Failure("Role could not be assigned", saveResult.StatusCode);
+
+        existing.Type = roleTypeData;
+        existing.Credential = credential;
+        return Result<IdentityRole>.Success(existing);
+    }
+
+    public async Task<Result> RemoveCredentialRoleAsync(
+        RemoveCredentialRoleRequest request,
+        CancellationToken ct = default)
+    {
+        var role = await GetIdentityRoleAsync(request.IdentityRoleId, request.Metadata.TenantId, ct);
+        if (!role.IsSuccess)
+            return Result.Failure(role.Message!, role.StatusCode);
+
+        var authorization = await EnsureCallerCapabilityAsync(
+            request.Metadata,
+            role.Data!.TenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.RolesSubFeature,
+            IdentityAuthorizationConstants.Delete,
+            ct);
+        if (!authorization.IsSuccess)
+            return Result.Failure(authorization.Message!, authorization.StatusCode);
+
+        role.Data!.IsEnabled = false;
+        role.Data.IsDeleted = true;
+        role.Data.DeletedAt = DateTime.UtcNow;
+        dataContext.Update(role.Data);
+
+        var overrides = await dataContext.Query<IdentityRoleFeaturePermissionOverride>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == role.Data.TenantId)
+            .Where(x => x.IdentityRoleId == role.Data.Id)
+            .Where(x => !x.IsDeleted)
+            .ToListAsync(ct);
+
+        foreach (var permissionOverride in overrides)
+        {
+            permissionOverride.IsEnabled = false;
+            permissionOverride.IsDeleted = true;
+            permissionOverride.DeletedAt = DateTime.UtcNow;
+            dataContext.Update(permissionOverride);
+        }
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        return saveResult.IsSuccess
+            ? Result.Success("Role removed")
+            : Result.Failure("Role could not be removed", saveResult.StatusCode);
+    }
+
+    public async Task<Result> SeedRoleTypePermissionsAsync(
+        Guid tenantId,
+        Guid roleTypeId,
+        CancellationToken ct = default)
+    {
+        var roleType = await GetRoleTypeAsync(roleTypeId, tenantId, ct);
+        if (!roleType.IsSuccess)
+            return Result.Failure(roleType.Message!, roleType.StatusCode);
+
+        var allPermissions = TenantModuleFeatureKeys.All
+            .SelectMany(feature => IdentityAuthorizationConstants.CapabilityKeys.Select(capability =>
+                new CapabilityPermissionDto
+                {
+                    ModuleKey = feature.ModuleKey,
+                    SubFeatureKey = feature.SubFeatureKey,
+                    CapabilityKey = capability,
+                    Effect = RoleCapabilityPermissionEffect.Allow,
+                    IsEnabled = true
+                }))
+            .ToList();
+
+        var existing = await dataContext.Query<IdentityRoleTypeFeaturePermission>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Where(x => x.RoleTypeId == roleTypeId)
+            .ToListAsync(ct);
+
+        var existingByKey = existing.ToDictionary(BuildPermissionKey, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var permission in allPermissions)
+        {
+            if (existingByKey.TryGetValue(BuildPermissionKey(permission), out var row))
+            {
+                row.Effect = RoleCapabilityPermissionEffect.Allow;
+                row.IsEnabled = true;
+                row.IsDeleted = false;
+                row.ModifiedAt = DateTime.UtcNow;
+                dataContext.Update(row);
+                continue;
+            }
+
+            dataContext.Add(new IdentityRoleTypeFeaturePermission
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                RoleTypeId = roleTypeId,
+                ModuleKey = permission.ModuleKey,
+                SubFeatureKey = permission.SubFeatureKey,
+                CapabilityKey = permission.CapabilityKey,
+                Effect = RoleCapabilityPermissionEffect.Allow,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow,
+                ConcurrencyStamp = Guid.NewGuid()
+            });
+        }
+
+        var saveResult = await dataContext.SaveChangesAsync(ct);
+        return saveResult.IsSuccess
+            ? Result.Success("Role type permissions seeded")
+            : Result.Failure("Role type permissions could not be seeded", saveResult.StatusCode);
+    }
+
+    private async Task<CapabilityDecision> ResolveCapabilityAsync(
+        Guid tenantId,
+        Guid credentialId,
+        string moduleKey,
+        string subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct,
+        bool credentialAlreadyValidated = false)
+    {
+        if (!credentialAlreadyValidated)
+        {
+            var credentialExists = await dataContext.Query<IdentityCredential>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.Id == credentialId)
+                .Where(x => !x.IsDeleted && x.IsEnabled)
+                .AnyAsync(ct);
+
+            if (!credentialExists)
+                return new CapabilityDecision(false, "CredentialNotFound");
+        }
+
+        if (RequiresTenantFeature(moduleKey, subFeatureKey))
+        {
+            var tenantFeature = await dataContext.Query<TenantModuleFeature>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Where(x => x.TenantId == tenantId)
+                .Where(x => x.ModuleKey == moduleKey)
+                .Where(x => x.SubFeatureKey == subFeatureKey)
+                .Where(x => !x.IsDeleted && x.IsEnabled)
+                .FirstOrDefaultAsync(ct);
+
+            if (tenantFeature is null)
+                return new CapabilityDecision(false, SourceTenantFeatureDisabled);
+        }
+
+        var now = DateTime.UtcNow;
+        var activeRoles = await dataContext.Query<IdentityRole>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Where(x => x.CredentialId == credentialId)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .Where(x => x.TypeId != null)
+            .Where(x => x.RoleExpiration >= now)
+            .ToListAsync(ct);
+
+        if (activeRoles.Count == 0)
+            return new CapabilityDecision(false, "NoActiveRole");
+
+        var roleIds = activeRoles.Select(x => x.Id).ToArray();
+        var roleTypeIds = activeRoles
+            .Select(x => x.TypeId!.Value)
+            .Distinct()
+            .ToArray();
+        var capabilityKeys = BuildCapabilityKeySet(capabilityKey);
+
+        var overrides = await dataContext.Query<IdentityRoleFeaturePermissionOverride>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Where(x => roleIds.Contains(x.IdentityRoleId))
+            .Where(x => x.ModuleKey == moduleKey)
+            .Where(x => x.SubFeatureKey == subFeatureKey)
+            .Where(x => capabilityKeys.Contains(x.CapabilityKey))
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .ToListAsync(ct);
+
+        var roleTypePermissions = await dataContext.Query<IdentityRoleTypeFeaturePermission>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Where(x => roleTypeIds.Contains(x.RoleTypeId))
+            .Where(x => x.ModuleKey == moduleKey)
+            .Where(x => x.SubFeatureKey == subFeatureKey)
+            .Where(x => capabilityKeys.Contains(x.CapabilityKey))
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .ToListAsync(ct);
+
+        var decisions = new List<CapabilityDecision>();
+        foreach (var role in activeRoles)
+        {
+            var roleOverrides = overrides
+                .Where(x => x.IdentityRoleId == role.Id)
+                .OrderBy(x => string.Equals(x.CapabilityKey, capabilityKey, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .ToList();
+            if (roleOverrides.Count > 0)
+            {
+                decisions.AddRange(roleOverrides.Select(x => ToDecision(x.Effect, isOverride: true)));
+                continue;
+            }
+
+            var roleTypePermissionMatches = roleTypePermissions
+                .Where(x => x.RoleTypeId == role.TypeId)
+                .OrderBy(x => string.Equals(x.CapabilityKey, capabilityKey, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .ToList();
+            if (roleTypePermissionMatches.Count > 0)
+            {
+                decisions.AddRange(roleTypePermissionMatches.Select(x => ToDecision(x.Effect, isOverride: false)));
+            }
+        }
+
+        if (decisions.Any(x => !x.IsAllowed))
+            return decisions.First(x => !x.IsAllowed);
+
+        if (decisions.Any(x => x.IsAllowed))
+            return decisions.First(x => x.IsAllowed);
+
+        return await ResolveMissingPermissionAsync(tenantId, ct);
+    }
+
+    private async Task<CapabilityDecision> ResolveMissingPermissionAsync(Guid tenantId, CancellationToken ct)
+    {
+        var policy = await dataContext.Query<TenantAuthorizationPolicy>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.TenantId == tenantId)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .FirstOrDefaultAsync(ct);
+
+        var behavior = policy?.MissingPermissionBehavior ?? MissingPermissionBehavior.Deny;
+
+        return behavior == MissingPermissionBehavior.Allow
+            ? new CapabilityDecision(true, SourceTenantDefaultAllow)
+            : new CapabilityDecision(false, SourceTenantDefaultDeny);
+    }
+
+    private async Task<Result<IdentityRoleType>> GetRoleTypeAsync(
+        Guid roleTypeId,
+        Guid? tenantId,
+        CancellationToken ct)
+    {
+        if (roleTypeId == Guid.Empty)
+            return Result<IdentityRoleType>.Failure("Role type is required", 400);
+
+        if (tenantId is null || tenantId == Guid.Empty)
+            return Result<IdentityRoleType>.Forbidden("Tenant metadata is required");
+
+        var roleType = await dataContext.Query<IdentityRoleType>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.Id == roleTypeId)
+            .Where(x => x.TenantId == tenantId.Value)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .FirstOrDefaultAsync(ct);
+
+        if (roleType is null)
+            return Result<IdentityRoleType>.NotFound("Role type not found");
+
+        return Result<IdentityRoleType>.Success(roleType);
+    }
+
+    private async Task<Result<IdentityRole>> GetIdentityRoleAsync(
+        Guid roleId,
+        Guid? tenantId,
+        CancellationToken ct)
+    {
+        if (roleId == Guid.Empty)
+            return Result<IdentityRole>.Failure("Identity role is required", 400);
+
+        if (tenantId is null || tenantId == Guid.Empty)
+            return Result<IdentityRole>.Forbidden("Tenant metadata is required");
+
+        var role = await dataContext.Query<IdentityRole>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.Id == roleId)
+            .Where(x => x.TenantId == tenantId.Value)
+            .Where(x => !x.IsDeleted && x.IsEnabled)
+            .FirstOrDefaultAsync(ct);
+
+        if (role is null)
+            return Result<IdentityRole>.NotFound("Identity role not found");
+
+        return Result<IdentityRole>.Success(role);
+    }
+
+    private async Task<bool> TenantExistsAsync(Guid tenantId, CancellationToken ct) =>
+        await dataContext.Query<Tenant>()
+            .IgnoreQueryFilters()
+            .NoCache()
+            .Where(x => x.Id == tenantId)
+            .Where(x => !x.IsDeleted)
+            .AnyAsync(ct);
+
+    private static Result<Guid> ResolveRequestedTenantId(Guid requestedTenantId, Guid? metadataTenantId)
+    {
+        if (metadataTenantId is null || metadataTenantId == Guid.Empty)
+            return Result<Guid>.Forbidden("Tenant metadata is required");
+
+        if (requestedTenantId != Guid.Empty && requestedTenantId != metadataTenantId.Value)
+            return Result<Guid>.Failure("Requested tenant does not match the active tenant", 403);
+
+        return Result<Guid>.Success(metadataTenantId.Value);
+    }
+
+    private async Task<Result> EnsureCanInspectCredentialCapabilitiesAsync(
+        RequestMetadata metadata,
+        Guid targetTenantId,
+        Guid targetCredentialId,
+        CancellationToken ct)
+    {
+        var tenantCheck = EnsureMetadataTenantMatchesTarget(metadata, targetTenantId);
+        if (!tenantCheck.IsSuccess)
+            return tenantCheck;
+
+        if (TryResolveAuthenticatedHttpCredential(metadata, targetTenantId, out var credentialId) &&
+            credentialId == targetCredentialId)
+        {
+            return Result.Success();
+        }
+
+        return await EnsureCallerCapabilityAsync(
+            metadata,
+            targetTenantId,
+            TenantModuleFeatureKeys.Identity,
+            TenantModuleFeatureKeys.RolesSubFeature,
+            IdentityAuthorizationConstants.View,
+            ct);
+    }
+
+    private async Task<Result> EnsureCallerCapabilityAsync(
+        RequestMetadata metadata,
+        Guid targetTenantId,
+        string moduleKey,
+        string subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct)
+    {
+        var tenantCheck = EnsureMetadataTenantMatchesTarget(metadata, targetTenantId);
+        if (!tenantCheck.IsSuccess)
+            return tenantCheck;
+
+        if (TryResolveAuthenticatedHttpCredential(metadata, targetTenantId, out var credentialId))
+        {
+            var decision = await ResolveCapabilityAsync(
+                targetTenantId,
+                credentialId,
+                moduleKey,
+                subFeatureKey,
+                capabilityKey,
+                ct);
+
+            if (decision.IsAllowed)
+                return Result.Success();
+        }
+
+        var trustedInvocation = await trustedServiceInvocationResolver.ResolveAsync(
+            metadata,
+            XFrameworkServiceNames.IdentityServer,
+            [XFrameworkServiceScopes.IdentityAdmin],
+            requireTenant: true,
+            ct: ct);
+
+        if (trustedInvocation.IsSuccess)
+        {
+            return trustedInvocation.Invocation?.TenantId == targetTenantId
+                ? Result.Success()
+                : Result.Forbidden("Trusted service tenant does not match the active tenant");
+        }
+
+        logger.LogWarning(
+            "Identity authorization denied for tenant {TenantId}, module {ModuleKey}, subfeature {SubFeatureKey}, capability {CapabilityKey}: {Reason}",
+            targetTenantId,
+            moduleKey,
+            subFeatureKey,
+            capabilityKey,
+            trustedInvocation.Error ?? "Caller capability was not allowed");
+
+        return Result.Forbidden("Caller is not allowed to manage IdentityServer authorization");
+    }
+
+    private static Result EnsureMetadataTenantMatchesTarget(RequestMetadata metadata, Guid targetTenantId)
+    {
+        if (metadata.TenantId is null || metadata.TenantId == Guid.Empty)
+            return Result.Forbidden("Tenant metadata is required");
+
+        return metadata.TenantId.Value == targetTenantId
+            ? Result.Success()
+            : Result.Forbidden("Requested tenant does not match the active tenant");
+    }
+
+    private bool TryResolveAuthenticatedHttpCredential(
+        RequestMetadata metadata,
+        Guid targetTenantId,
+        out Guid credentialId)
+    {
+        credentialId = default;
+
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return false;
+
+        var claimTenantId = ResolveGuidClaim(user, "tenant_id", "tenantId", "TenantId", "tid", "tenant");
+        var claimCredentialId = ResolveGuidClaim(
+            user,
+            "credentialId",
+            "credential_id",
+            ClaimTypes.NameIdentifier,
+            "sub");
+
+        if (claimTenantId != targetTenantId ||
+            claimCredentialId is null ||
+            claimCredentialId == Guid.Empty ||
+            metadata.TenantId != claimTenantId ||
+            metadata.CredentialId != claimCredentialId)
+        {
+            return false;
+        }
+
+        credentialId = claimCredentialId.Value;
+        return true;
+    }
+
+    private static Guid? ResolveGuidClaim(ClaimsPrincipal user, params string[] claimNames)
+    {
+        foreach (var claimName in claimNames)
+        {
+            var claimValue = user.FindFirst(claimName)?.Value;
+            if (Guid.TryParse(claimValue, out var value))
+                return value;
+        }
+
+        return null;
+    }
+
+    private static Result<PermissionTarget> NormalizePermissionTarget(
+        string? moduleKey,
+        string? subFeatureKey,
+        string? capabilityKey)
+    {
+        var (normalizedModuleKey, normalizedSubFeatureKey) =
+            TenantModuleFeatureKeys.Normalize(moduleKey ?? string.Empty, subFeatureKey);
+
+        if (string.IsNullOrWhiteSpace(normalizedModuleKey))
+            return Result<PermissionTarget>.Failure("Module key is required", 400);
+
+        var normalizedCapability = NormalizeCapabilityKey(capabilityKey);
+        if (normalizedCapability is null)
+            return Result<PermissionTarget>.Failure("Capability key is required", 400);
+
+        return Result<PermissionTarget>.Success(
+            new PermissionTarget(normalizedModuleKey, normalizedSubFeatureKey, normalizedCapability));
+    }
+
+    private static Result<List<CapabilityPermissionDto>> NormalizePermissionDtos(
+        IEnumerable<CapabilityPermissionDto> permissions)
+    {
+        var rows = new Dictionary<string, CapabilityPermissionDto>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var permission in permissions)
+        {
+            var normalized = NormalizePermissionTarget(permission.ModuleKey, permission.SubFeatureKey, permission.CapabilityKey);
+            if (!normalized.IsSuccess)
+                return Result<List<CapabilityPermissionDto>>.Failure(normalized.Message!, normalized.StatusCode);
+
+            if (!Enum.IsDefined(permission.Effect))
+                return Result<List<CapabilityPermissionDto>>.Failure("Permission effect is invalid", 400);
+
+            var dto = permission with
+            {
+                ModuleKey = normalized.Data!.ModuleKey,
+                SubFeatureKey = normalized.Data.SubFeatureKey,
+                CapabilityKey = normalized.Data.CapabilityKey,
+                IsEnabled = true
+            };
+
+            rows[BuildPermissionKey(dto)] = dto;
+        }
+
+        return Result<List<CapabilityPermissionDto>>.Success(rows.Values.ToList());
+    }
+
+    private static string? NormalizeCapabilityKey(string? capabilityKey)
+    {
+        var normalized = capabilityKey?.Trim().ToLowerInvariant();
+        return IdentityAuthorizationConstants.CapabilityKeys.Contains(normalized)
+            ? normalized
+            : null;
+    }
+
+    private static bool RequiresTenantFeature(string moduleKey, string subFeatureKey) =>
+        !string.Equals(moduleKey, TenantModuleFeatureKeys.Identity, StringComparison.OrdinalIgnoreCase) ||
+        !string.IsNullOrWhiteSpace(subFeatureKey);
+
+    private static string[] BuildCapabilityKeySet(string capabilityKey)
+    {
+        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            capabilityKey
+        };
+
+        if (!string.Equals(capabilityKey, IdentityAuthorizationConstants.Manage, StringComparison.OrdinalIgnoreCase))
+        {
+            keys.Add(IdentityAuthorizationConstants.Manage);
+        }
+
+        return keys.ToArray();
+    }
+
+    private static CapabilityDecision ToDecision(RoleCapabilityPermissionEffect effect, bool isOverride) =>
+        effect == RoleCapabilityPermissionEffect.Allow
+            ? new CapabilityDecision(true, isOverride ? SourceCredentialOverrideAllow : SourceRoleTypeAllow)
+            : new CapabilityDecision(false, isOverride ? SourceCredentialOverrideDeny : SourceRoleTypeDeny);
+
+    private static CapabilityPermissionDto ToPermissionDto(IdentityRoleTypeFeaturePermission permission) => new()
+    {
+        Id = permission.Id,
+        ModuleKey = permission.ModuleKey,
+        SubFeatureKey = permission.SubFeatureKey,
+        CapabilityKey = permission.CapabilityKey,
+        Effect = permission.Effect,
+        IsEnabled = permission.IsEnabled
+    };
+
+    private static CapabilityPermissionDto ToPermissionDto(IdentityRoleFeaturePermissionOverride permission) => new()
+    {
+        Id = permission.Id,
+        ModuleKey = permission.ModuleKey,
+        SubFeatureKey = permission.SubFeatureKey,
+        CapabilityKey = permission.CapabilityKey,
+        Effect = permission.Effect,
+        IsEnabled = permission.IsEnabled
+    };
+
+    private static string BuildPermissionKey(CapabilityPermissionDto permission) =>
+        $"{permission.ModuleKey}:{permission.SubFeatureKey}:{permission.CapabilityKey}";
+
+    private static string BuildPermissionKey(IdentityRoleTypeFeaturePermission permission) =>
+        $"{permission.ModuleKey}:{permission.SubFeatureKey}:{permission.CapabilityKey}";
+
+    private static string BuildPermissionKey(IdentityRoleFeaturePermissionOverride permission) =>
+        $"{permission.ModuleKey}:{permission.SubFeatureKey}:{permission.CapabilityKey}";
+
+    private sealed record PermissionTarget(string ModuleKey, string SubFeatureKey, string CapabilityKey);
+
+    private sealed record CapabilityDecision(bool IsAllowed, string Source);
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/IdentityRoleFeaturePermissionOverrideConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/IdentityRoleFeaturePermissionOverrideConfiguration.cs
@@ -1,0 +1,57 @@
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace IdentityServer.Domain.Shared.Configurations;
+
+public sealed class IdentityRoleFeaturePermissionOverrideConfiguration :
+    IEntityTypeConfiguration<IdentityRoleFeaturePermissionOverride>
+{
+    public void Configure(EntityTypeBuilder<IdentityRoleFeaturePermissionOverride> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("identityrolefeaturepermissionoverride_pk");
+
+        entity.ToTable("IdentityRoleFeaturePermissionOverride", "Identity");
+
+        entity.HasIndex(e => new { e.TenantId, e.IdentityRoleId, e.ModuleKey, e.SubFeatureKey, e.CapabilityKey })
+            .IsUnique()
+            .HasDatabaseName("IX_IdentityRoleFeaturePermissionOverride_Role_Feature_Capability");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+
+        entity.Property(e => e.ModuleKey)
+            .IsRequired()
+            .HasMaxLength(128)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.SubFeatureKey)
+            .IsRequired()
+            .HasMaxLength(128)
+            .HasDefaultValue(string.Empty)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.CapabilityKey)
+            .IsRequired()
+            .HasMaxLength(64)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.Effect)
+            .IsRequired()
+            .HasDefaultValue(RoleCapabilityPermissionEffect.Allow);
+
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.IsDeleted).HasDefaultValueSql("false");
+        entity.Property(e => e.IsEnabled)
+            .IsRequired()
+            .HasDefaultValueSql("true")
+            .HasSentinel(true);
+
+        entity.HasOne(d => d.IdentityRole).WithMany(p => p.PermissionOverrides)
+            .HasForeignKey(d => d.IdentityRoleId)
+            .OnDelete(DeleteBehavior.Cascade)
+            .HasConstraintName("identityrolefeaturepermissionoverride_identityrole_fk");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/IdentityRoleTypeFeaturePermissionConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/IdentityRoleTypeFeaturePermissionConfiguration.cs
@@ -1,0 +1,57 @@
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace IdentityServer.Domain.Shared.Configurations;
+
+public sealed class IdentityRoleTypeFeaturePermissionConfiguration :
+    IEntityTypeConfiguration<IdentityRoleTypeFeaturePermission>
+{
+    public void Configure(EntityTypeBuilder<IdentityRoleTypeFeaturePermission> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("identityroletypefeaturepermission_pk");
+
+        entity.ToTable("IdentityRoleTypeFeaturePermission", "Identity");
+
+        entity.HasIndex(e => new { e.TenantId, e.RoleTypeId, e.ModuleKey, e.SubFeatureKey, e.CapabilityKey })
+            .IsUnique()
+            .HasDatabaseName("IX_IdentityRoleTypeFeaturePermission_Role_Feature_Capability");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+
+        entity.Property(e => e.ModuleKey)
+            .IsRequired()
+            .HasMaxLength(128)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.SubFeatureKey)
+            .IsRequired()
+            .HasMaxLength(128)
+            .HasDefaultValue(string.Empty)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.CapabilityKey)
+            .IsRequired()
+            .HasMaxLength(64)
+            .HasColumnType("character varying");
+
+        entity.Property(e => e.Effect)
+            .IsRequired()
+            .HasDefaultValue(RoleCapabilityPermissionEffect.Allow);
+
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.IsDeleted).HasDefaultValueSql("false");
+        entity.Property(e => e.IsEnabled)
+            .IsRequired()
+            .HasDefaultValueSql("true")
+            .HasSentinel(true);
+
+        entity.HasOne(d => d.RoleType).WithMany(p => p.FeaturePermissions)
+            .HasForeignKey(d => d.RoleTypeId)
+            .OnDelete(DeleteBehavior.Cascade)
+            .HasConstraintName("identityroletypefeaturepermission_roletype_fk");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/TenantAuthorizationPolicyConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/TenantAuthorizationPolicyConfiguration.cs
@@ -1,0 +1,40 @@
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace IdentityServer.Domain.Shared.Configurations;
+
+public sealed class TenantAuthorizationPolicyConfiguration : IEntityTypeConfiguration<TenantAuthorizationPolicy>
+{
+    public void Configure(EntityTypeBuilder<TenantAuthorizationPolicy> entity)
+    {
+        entity.HasKey(e => e.Id).HasName("tenantauthorizationpolicy_pk");
+
+        entity.ToTable("TenantAuthorizationPolicy", "Identity");
+
+        entity.HasIndex(e => e.TenantId)
+            .IsUnique()
+            .HasDatabaseName("IX_TenantAuthorizationPolicy_Tenant");
+
+        entity.Property(e => e.Id)
+            .HasColumnName("ID")
+            .HasDefaultValueSql("(uuid_generate_v4())");
+
+        entity.Property(e => e.MissingPermissionBehavior)
+            .IsRequired()
+            .HasDefaultValue(MissingPermissionBehavior.Deny);
+
+        entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");
+        entity.Property(e => e.IsDeleted).HasDefaultValueSql("false");
+        entity.Property(e => e.IsEnabled)
+            .IsRequired()
+            .HasDefaultValueSql("true")
+            .HasSentinel(true);
+
+        entity.HasOne(d => d.Tenant).WithOne(p => p.AuthorizationPolicy)
+            .HasForeignKey<TenantAuthorizationPolicy>(d => d.TenantId)
+            .OnDelete(DeleteBehavior.ClientSetNull)
+            .HasConstraintName("tenantauthorizationpolicy_tenant_tenantid_fk");
+    }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityAuthorizationConstants.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityAuthorizationConstants.cs
@@ -1,0 +1,24 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public static class IdentityAuthorizationConstants
+{
+    public const string View = "view";
+    public const string Create = "create";
+    public const string Update = "update";
+    public const string Delete = "delete";
+    public const string Manage = "manage";
+
+    public const string Identity = "identity";
+    public const string IdentityUsers = "identity.users";
+    public const string IdentityCredentials = "identity.credentials";
+    public const string IdentityRoles = "identity.roles";
+    public const string IdentityTenants = "identity.tenants";
+    public const string IdentitySessions = "identity.sessions";
+    public const string IdentityVerifications = "identity.verifications";
+    public const string IdentityContacts = "identity.contacts";
+    public const string IdentityAddresses = "identity.addresses";
+    public const string IdentityAuthLogs = "identity.auth_logs";
+
+    public static IReadOnlyList<string> CapabilityKeys { get; } =
+        [View, Create, Update, Delete, Manage];
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityRole.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityRole.cs
@@ -6,7 +6,7 @@ namespace IdentityServer.Domain.Shared.Contracts;
 [MemoryPackable(GenerateType.CircularReference)]
 [GenerateEndpoints(
     Type = EndpointType.Both,
-    Actions = EndpointActions.Create | EndpointActions.Get | EndpointActions.GetList | EndpointActions.Delete,
+    Actions = EndpointActions.Get | EndpointActions.GetList,
     RoutePrefix = "api/identity-roles",
     RequireAuthorization = true,
     CacheDurationSeconds = 300,
@@ -29,6 +29,10 @@ public partial class IdentityRole : BaseModel
 
     [MemoryPackOrder(5)]
     public virtual IdentityCredential Credential { get; set; } = null!;
+
+    [MemoryPackOrder(6)]
+    public virtual ICollection<IdentityRoleFeaturePermissionOverride> PermissionOverrides { get; set; } =
+        new List<IdentityRoleFeaturePermissionOverride>();
 }
 
 public class CreateIdentityRoleRequest

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityRoleFeaturePermissionOverride.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityRoleFeaturePermissionOverride.cs
@@ -1,0 +1,26 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+public partial class IdentityRoleFeaturePermissionOverride : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid IdentityRoleId { get; set; }
+
+    [MemoryPackOrder(1)]
+    public string ModuleKey { get; set; } = null!;
+
+    [MemoryPackOrder(2)]
+    public string SubFeatureKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string CapabilityKey { get; set; } = null!;
+
+    [MemoryPackOrder(4)]
+    public RoleCapabilityPermissionEffect Effect { get; set; } = RoleCapabilityPermissionEffect.Allow;
+
+    [MemoryPackOrder(5)]
+    public virtual IdentityRole IdentityRole { get; set; } = null!;
+
+    [MemoryPackIgnore]
+    public string FeatureKey => TenantModuleFeatureKeys.Combine(ModuleKey, SubFeatureKey);
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityRoleType.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityRoleType.cs
@@ -33,6 +33,10 @@ public partial class IdentityRoleType : BaseModel, IHasSystemReferenceId
     [MemoryPackOrder(5)]
     public virtual ICollection<IdentityRole> IdentityRoles { get; set; } = new List<IdentityRole>();
 
+    [MemoryPackOrder(6)]
+    public virtual ICollection<IdentityRoleTypeFeaturePermission> FeaturePermissions { get; set; } =
+        new List<IdentityRoleTypeFeaturePermission>();
+
     [MemoryPackOrder(200)]
     public Guid SystemReferenceId { get; set; }
 }

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityRoleTypeFeaturePermission.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/IdentityRoleTypeFeaturePermission.cs
@@ -1,0 +1,26 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+public partial class IdentityRoleTypeFeaturePermission : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public Guid RoleTypeId { get; set; }
+
+    [MemoryPackOrder(1)]
+    public string ModuleKey { get; set; } = null!;
+
+    [MemoryPackOrder(2)]
+    public string SubFeatureKey { get; set; } = string.Empty;
+
+    [MemoryPackOrder(3)]
+    public string CapabilityKey { get; set; } = null!;
+
+    [MemoryPackOrder(4)]
+    public RoleCapabilityPermissionEffect Effect { get; set; } = RoleCapabilityPermissionEffect.Allow;
+
+    [MemoryPackOrder(5)]
+    public virtual IdentityRoleType RoleType { get; set; } = null!;
+
+    [MemoryPackIgnore]
+    public string FeatureKey => TenantModuleFeatureKeys.Combine(ModuleKey, SubFeatureKey);
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/MissingPermissionBehavior.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/MissingPermissionBehavior.cs
@@ -1,0 +1,7 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public enum MissingPermissionBehavior
+{
+    Deny = 0,
+    Allow = 1
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Requests/AuthorizationPermissionRequests.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Requests/AuthorizationPermissionRequests.cs
@@ -1,0 +1,89 @@
+namespace IdentityServer.Domain.Shared.Contracts.Requests;
+
+[MemoryPackable]
+public partial record CheckCredentialCapabilityRequest : RequestBase,
+    IQuery<QueryResponse<CredentialCapabilityCheckResponse>>,
+    IBoltRequest<CheckCredentialCapabilityRequest, QueryResponse<CredentialCapabilityCheckResponse>>
+{
+    public Guid CredentialId { get; set; }
+    public string? ModuleKey { get; set; }
+    public string? SubFeatureKey { get; set; }
+    public string? CapabilityKey { get; set; }
+}
+
+[MemoryPackable]
+public partial record GetEffectiveCredentialCapabilitiesRequest : RequestBase,
+    IQuery<QueryResponse<EffectiveCredentialCapabilitiesResponse>>,
+    IBoltRequest<GetEffectiveCredentialCapabilitiesRequest, QueryResponse<EffectiveCredentialCapabilitiesResponse>>
+{
+    public Guid CredentialId { get; set; }
+}
+
+[MemoryPackable]
+public partial record GetTenantAuthorizationPolicyRequest : RequestBase,
+    IQuery<QueryResponse<TenantAuthorizationPolicyResponse>>,
+    IBoltRequest<GetTenantAuthorizationPolicyRequest, QueryResponse<TenantAuthorizationPolicyResponse>>
+{
+    public Guid TenantId { get; set; }
+}
+
+[MemoryPackable]
+public partial record UpdateTenantAuthorizationPolicyRequest : RequestBase,
+    IQuery<QueryResponse<TenantAuthorizationPolicyResponse>>,
+    IBoltRequest<UpdateTenantAuthorizationPolicyRequest, QueryResponse<TenantAuthorizationPolicyResponse>>
+{
+    public Guid TenantId { get; set; }
+    public MissingPermissionBehavior MissingPermissionBehavior { get; set; } = MissingPermissionBehavior.Deny;
+}
+
+[MemoryPackable]
+public partial record GetRoleTypePermissionsRequest : RequestBase,
+    IQuery<QueryResponse<RoleTypePermissionsResponse>>,
+    IBoltRequest<GetRoleTypePermissionsRequest, QueryResponse<RoleTypePermissionsResponse>>
+{
+    public Guid RoleTypeId { get; set; }
+}
+
+[MemoryPackable]
+public partial record SetRoleTypePermissionsRequest : RequestBase,
+    IQuery<QueryResponse<RoleTypePermissionsResponse>>,
+    IBoltRequest<SetRoleTypePermissionsRequest, QueryResponse<RoleTypePermissionsResponse>>
+{
+    public Guid RoleTypeId { get; set; }
+    public List<CapabilityPermissionDto> Permissions { get; set; } = [];
+}
+
+[MemoryPackable]
+public partial record GetCredentialRolePermissionOverridesRequest : RequestBase,
+    IQuery<QueryResponse<CredentialRolePermissionOverridesResponse>>,
+    IBoltRequest<GetCredentialRolePermissionOverridesRequest, QueryResponse<CredentialRolePermissionOverridesResponse>>
+{
+    public Guid IdentityRoleId { get; set; }
+}
+
+[MemoryPackable]
+public partial record SetCredentialRolePermissionOverridesRequest : RequestBase,
+    IQuery<QueryResponse<CredentialRolePermissionOverridesResponse>>,
+    IBoltRequest<SetCredentialRolePermissionOverridesRequest, QueryResponse<CredentialRolePermissionOverridesResponse>>
+{
+    public Guid IdentityRoleId { get; set; }
+    public List<CapabilityPermissionDto> Overrides { get; set; } = [];
+}
+
+[MemoryPackable]
+public partial record AssignCredentialRoleRequest : RequestBase,
+    IQuery<QueryResponse<IdentityRole>>,
+    IBoltRequest<AssignCredentialRoleRequest, QueryResponse<IdentityRole>>
+{
+    public Guid CredentialId { get; set; }
+    public Guid RoleTypeId { get; set; }
+    public DateTime RoleExpiration { get; set; }
+}
+
+[MemoryPackable]
+public partial record RemoveCredentialRoleRequest : RequestBase,
+    ICommand<CmdResponse>,
+    IBoltRequest<RemoveCredentialRoleRequest, CmdResponse>
+{
+    public Guid IdentityRoleId { get; set; }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Responses/AuthorizationPermissionResponses.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Responses/AuthorizationPermissionResponses.cs
@@ -1,0 +1,55 @@
+namespace IdentityServer.Domain.Shared.Contracts.Responses;
+
+[MemoryPackable]
+public partial record TenantAuthorizationPolicyResponse
+{
+    public Guid TenantId { get; set; }
+    public MissingPermissionBehavior MissingPermissionBehavior { get; set; }
+}
+
+[MemoryPackable]
+public partial record CapabilityPermissionDto
+{
+    public Guid? Id { get; set; }
+    public string ModuleKey { get; set; } = string.Empty;
+    public string SubFeatureKey { get; set; } = string.Empty;
+    public string CapabilityKey { get; set; } = string.Empty;
+    public RoleCapabilityPermissionEffect Effect { get; set; }
+    public bool IsEnabled { get; set; } = true;
+}
+
+[MemoryPackable]
+public partial record RoleTypePermissionsResponse
+{
+    public Guid TenantId { get; set; }
+    public Guid RoleTypeId { get; set; }
+    public List<CapabilityPermissionDto> Permissions { get; set; } = [];
+}
+
+[MemoryPackable]
+public partial record CredentialRolePermissionOverridesResponse
+{
+    public Guid TenantId { get; set; }
+    public Guid IdentityRoleId { get; set; }
+    public List<CapabilityPermissionDto> Overrides { get; set; } = [];
+}
+
+[MemoryPackable]
+public partial record CredentialCapabilityCheckResponse
+{
+    public Guid TenantId { get; set; }
+    public Guid CredentialId { get; set; }
+    public string ModuleKey { get; set; } = string.Empty;
+    public string SubFeatureKey { get; set; } = string.Empty;
+    public string CapabilityKey { get; set; } = string.Empty;
+    public bool IsAllowed { get; set; }
+    public string DecisionSource { get; set; } = string.Empty;
+}
+
+[MemoryPackable]
+public partial record EffectiveCredentialCapabilitiesResponse
+{
+    public Guid TenantId { get; set; }
+    public Guid CredentialId { get; set; }
+    public List<CredentialCapabilityCheckResponse> Capabilities { get; set; } = [];
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/RoleCapabilityPermissionEffect.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/RoleCapabilityPermissionEffect.cs
@@ -1,0 +1,7 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+public enum RoleCapabilityPermissionEffect
+{
+    Deny = 0,
+    Allow = 1
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Tenant.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/Tenant.cs
@@ -54,6 +54,9 @@ public partial class Tenant : BaseModel
     public virtual ICollection<TenantModuleFeature> TenantModuleFeatures { get; set; } =
         new List<TenantModuleFeature>();
 
+    [MemoryPackOrder(12)]
+    public virtual TenantAuthorizationPolicy? AuthorizationPolicy { get; set; }
+
 }
 
 public class GetTenantListRequest

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantAuthorizationPolicy.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantAuthorizationPolicy.cs
@@ -1,0 +1,11 @@
+namespace IdentityServer.Domain.Shared.Contracts;
+
+[MemoryPackable(GenerateType.CircularReference)]
+public partial class TenantAuthorizationPolicy : BaseModel
+{
+    [MemoryPackOrder(0)]
+    public MissingPermissionBehavior MissingPermissionBehavior { get; set; } = MissingPermissionBehavior.Deny;
+
+    [MemoryPackOrder(1)]
+    public virtual Tenant Tenant { get; set; } = null!;
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureKeys.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Contracts/TenantModuleFeatureKeys.cs
@@ -40,6 +40,16 @@ public static class TenantModuleFeatureKeys
     public const string Notifications = "notifications";
     public const string Attendance = "attendance";
     public const string Storage = "storage";
+    public const string Identity = "identity";
+    public const string IdentityUsers = "identity.users";
+    public const string IdentityCredentials = "identity.credentials";
+    public const string IdentityRoles = "identity.roles";
+    public const string IdentityTenants = "identity.tenants";
+    public const string IdentitySessions = "identity.sessions";
+    public const string IdentityVerifications = "identity.verifications";
+    public const string IdentityContacts = "identity.contacts";
+    public const string IdentityAddresses = "identity.addresses";
+    public const string IdentityAuthLogs = "identity.auth_logs";
 
     public const string CatalogSubFeature = "catalog";
     public const string TransfersSubFeature = "transfers";
@@ -70,6 +80,15 @@ public static class TenantModuleFeatureKeys
     public const string PosReportingSubFeature = "reporting";
     public const string ChatSubFeature = "chat";
     public const string AudioVideoSubFeature = "audio_video";
+    public const string UsersSubFeature = "users";
+    public const string CredentialsSubFeature = "credentials";
+    public const string RolesSubFeature = "roles";
+    public const string TenantsSubFeature = "tenants";
+    public const string SessionsSubFeature = "sessions";
+    public const string VerificationsSubFeature = "verifications";
+    public const string ContactsSubFeature = "contacts";
+    public const string AddressesSubFeature = "addresses";
+    public const string AuthLogsSubFeature = "auth_logs";
 
     public static IReadOnlyList<TenantModuleFeatureDefinition> All { get; } =
     [
@@ -110,7 +129,17 @@ public static class TenantModuleFeatureKeys
         new(Payments, string.Empty, "Payments", "Payment gateway and cash-in/cash-out capabilities.", "credit-card"),
         new(Notifications, string.Empty, "Notifications", "Tenant notifications and read-state workflows.", "bell"),
         new(Attendance, string.Empty, "Attendance", "Attendance contexts, sessions, participants, time events, and reports.", "calendar-check"),
-        new(Storage, string.Empty, "Storage", "Tenant file metadata, resumable uploads, signed URLs, and retention cleanup.", "hard-drive")
+        new(Storage, string.Empty, "Storage", "Tenant file metadata, resumable uploads, signed URLs, and retention cleanup.", "hard-drive"),
+        new(Identity, string.Empty, "Identity", "Identity, credential, role, tenant, session, and verification administration.", "users"),
+        new(Identity, UsersSubFeature, "Identity Users", "Identity information and user administration.", "users"),
+        new(Identity, CredentialsSubFeature, "Identity Credentials", "Credential creation, status, avatars, and credential metadata.", "key-round"),
+        new(Identity, RolesSubFeature, "Identity Roles", "Role assignment, role types, and role capability permissions.", "shield-check"),
+        new(Identity, TenantsSubFeature, "Identity Tenants", "Tenant records, hierarchy, module access, and authorization policy.", "building-2"),
+        new(Identity, SessionsSubFeature, "Identity Sessions", "Session monitoring, refresh, and termination.", "monitor"),
+        new(Identity, VerificationsSubFeature, "Identity Verifications", "Verification tokens, password reset, and approval workflows.", "badge-check"),
+        new(Identity, ContactsSubFeature, "Identity Contacts", "Credential contact records and contact grouping.", "contact"),
+        new(Identity, AddressesSubFeature, "Identity Addresses", "Identity address records and geographic lookups.", "map-pin"),
+        new(Identity, AuthLogsSubFeature, "Identity Auth Logs", "Authentication audit log review.", "scroll-text")
     ];
 
     public static (string ModuleKey, string SubFeatureKey) Normalize(string moduleKey, string? subFeatureKey = null)

--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/RoleTypeDetail.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/RoleTypeDetail.razor
@@ -1,0 +1,515 @@
+@page "/identity/tenants/{TenantId:guid}/role-types/{RoleTypeId:guid}"
+
+<PageTitle>Role Type Permissions - Portal</PageTitle>
+
+@if (!_accessChecked)
+{
+    <CenteredSpinner />
+}
+else if (!_canManageTenants)
+{
+    <BbAlert Variant="AlertVariant.Danger">
+        <BbAlertTitle>Tenant Management Restricted</BbAlertTitle>
+        <BbAlertDescription>Only super users can manage tenant role permissions.</BbAlertDescription>
+    </BbAlert>
+}
+else if (_loading)
+{
+    <CenteredSpinner />
+}
+else if (_roleType is null)
+{
+    <div class="space-y-4">
+        <BbButton Variant="ButtonVariant.Ghost" OnClick="@BackToTenantRoles">
+            <LucideIcon Name="arrow-left" class="mr-2 h-4 w-4" />
+            Back to Role Types
+        </BbButton>
+        <BbAlert Variant="AlertVariant.Danger">
+            <BbAlertTitle>Role Type Not Found</BbAlertTitle>
+            <BbAlertDescription>No role type found for this tenant.</BbAlertDescription>
+        </BbAlert>
+    </div>
+}
+else
+{
+    <FadeInContent>
+        <div class="space-y-6">
+            <div class="xf-page-header">
+                <div class="flex items-center gap-4">
+                    <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon" title="Back to role types" OnClick="@BackToTenantRoles">
+                        <LucideIcon Name="arrow-left" class="h-4 w-4" />
+                    </BbButton>
+                    <div>
+                        <div class="flex items-center gap-2">
+                            <BbTypographyH3>@(_roleType.Name ?? "Unnamed Role Type")</BbTypographyH3>
+                            <StatusBadge Text="@(_roleType.IsEnabled ? "Enabled" : "Disabled")"
+                                         Status="@(_roleType.IsEnabled ? "active" : "inactive")" />
+                        </div>
+                        <BbTypographyMuted>
+                            @(_roleType.Group?.Name ?? "No group") - Level @(_roleType.RoleLevel?.ToString() ?? "N/A")
+                        </BbTypographyMuted>
+                    </div>
+                </div>
+                <div class="xf-page-actions">
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="@ReloadPermissions" Disabled="@_saving">
+                        <LucideIcon Name="refresh-cw" class="mr-2 h-4 w-4" />
+                        Reload
+                    </BbButton>
+                    <BbButton OnClick="@SaveRoleTypePermissions" Disabled="@(_saving || !_permissionsLoaded)">
+                        <LucideIcon Name="save" class="mr-2 h-4 w-4" />
+                        @(_saving ? "Saving..." : "Save")
+                    </BbButton>
+                </div>
+            </div>
+
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Tenant Permission Default</BbCardTitle>
+                    <BbCardDescription>Choose how this tenant handles capabilities with no explicit role permission.</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="xf-detail-field-grid">
+                        <BbFormFieldSelect TValue="string"
+                                           Value="@_missingPermissionBehaviorValue"
+                                           ValueChanged="@((string value) => _missingPermissionBehaviorValue = value)"
+                                           Label="Missing Permission Behavior">
+                            <BbSelectItem Value="@MissingPermissionDeny">Deny</BbSelectItem>
+                            <BbSelectItem Value="@MissingPermissionAllow">Allow</BbSelectItem>
+                        </BbFormFieldSelect>
+                    </div>
+                </BbCardContent>
+            </BbCard>
+
+            @if (!_permissionsLoaded)
+            {
+                <BbAlert Variant="AlertVariant.Danger">
+                    <BbAlertTitle>Permissions Not Loaded</BbAlertTitle>
+                    <BbAlertDescription>Reload permissions before making changes.</BbAlertDescription>
+                </BbAlert>
+            }
+
+            <div class="tenant-modules-grid">
+                <BbCard class="tenant-modules-tree-card">
+                    <BbCardHeader>
+                        <BbCardTitle>Feature Tree</BbCardTitle>
+                        <BbCardDescription>Select a module feature to configure CRUD capabilities.</BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbTreeView TItem="PermissionFeatureTreeNode"
+                                    ShowIcons="true"
+                                    ShowLines="true"
+                                    ShowSearch="true"
+                                    SearchPlaceholder="Search features..."
+                                    ExpandOnClick="true"
+                                    SelectionMode="TreeSelectionMode.Single"
+                                    SelectedValue="@_selectedFeatureKey"
+                                    SelectedValueChanged="@OnFeatureSelected"
+                                    ExpandedValues="@_expandedFeatureKeys"
+                                    ExpandedValuesChanged="@OnFeatureTreeExpandedValuesChanged"
+                                    AriaLabel="Role type permission feature tree"
+                                    Class="tenant-module-tree">
+                            @foreach (var node in _permissionTreeNodes)
+                            {
+                                <BbTreeItem Value="@node.Feature.Key"
+                                            Label="@node.Feature.DisplayName"
+                                            Icon="@node.Feature.IconName"
+                                            Badge="@GetPermissionBadge(node.Feature)"
+                                            Class="@GetPermissionTreeItemClass(node.Feature)">
+                                    <LabelTemplate>
+                                        <div class="tenant-module-tree-label">
+                                            <span class="tenant-module-tree-label-main">@node.Feature.DisplayName</span>
+                                            <span class="tenant-module-tree-label-sub">@node.Feature.Description</span>
+                                        </div>
+                                    </LabelTemplate>
+                                    <ChildContent>
+                                        @foreach (var childNode in node.Children)
+                                        {
+                                            <BbTreeItem Value="@childNode.Feature.Key"
+                                                        Label="@childNode.Feature.DisplayName"
+                                                        Icon="@childNode.Feature.IconName"
+                                                        Badge="@GetPermissionBadge(childNode.Feature)"
+                                                        IsLeaf="true"
+                                                        Class="@GetPermissionTreeItemClass(childNode.Feature)">
+                                                <LabelTemplate>
+                                                    <div class="tenant-module-tree-label tenant-module-tree-label-child">
+                                                        <span class="tenant-module-tree-label-main">@childNode.Feature.DisplayName</span>
+                                                        <span class="tenant-module-tree-label-sub">@childNode.Feature.Description</span>
+                                                    </div>
+                                                </LabelTemplate>
+                                            </BbTreeItem>
+                                        }
+                                    </ChildContent>
+                                </BbTreeItem>
+                            }
+                        </BbTreeView>
+                    </BbCardContent>
+                </BbCard>
+
+                <BbCard class="tenant-module-preview-card">
+                    <BbCardHeader>
+                        <BbCardTitle>@(SelectedFeature?.DisplayName ?? "Select a Feature")</BbCardTitle>
+                        <BbCardDescription>
+                            @(SelectedFeature?.Description ?? "Use the feature tree to inspect role permissions.")
+                        </BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        @if (SelectedFeature is null)
+                        {
+                            <BbEmpty Title="No feature selected" Description="Select a module or sub-feature to configure permissions." />
+                        }
+                        else
+                        {
+                            <div class="grid gap-3 md:grid-cols-5">
+                                @foreach (var capability in PermissionCapabilities)
+                                {
+                                    <BbFormFieldSelect TValue="string"
+                                                       Label="@FormatCapabilityLabel(capability)"
+                                                       Value="@GetPermissionValue(SelectedFeature, capability)"
+                                                       ValueChanged="@((string value) => SetPermissionValue(SelectedFeature, capability, value))">
+                                        <BbSelectItem Value="@PermissionDefault">Tenant default</BbSelectItem>
+                                        <BbSelectItem Value="@PermissionAllow">Allow</BbSelectItem>
+                                        <BbSelectItem Value="@PermissionDeny">Deny</BbSelectItem>
+                                    </BbFormFieldSelect>
+                                }
+                            </div>
+                        }
+                    </BbCardContent>
+                </BbCard>
+            </div>
+        </div>
+    </FadeInContent>
+}
+
+@code {
+    [Parameter] public Guid TenantId { get; set; }
+    [Parameter] public Guid RoleTypeId { get; set; }
+
+    [Inject] private global::XFramework.Domain.Shared.DataContext.IDataContext DataContext { get; set; } = default!;
+    [Inject] private IIdentityServerServiceWrapper IdentityServer { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ToastService ToastService { get; set; } = default!;
+    [CascadingParameter] private Task<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>? AuthenticationStateTask { get; set; }
+
+    private IdentityRoleType? _roleType;
+    private bool _accessChecked;
+    private bool _canManageTenants;
+    private bool _loading = true;
+    private bool _saving;
+    private bool _permissionsLoaded;
+    private string _selectedFeatureKey = TenantModuleFeatureKeys.Identity;
+    private HashSet<string> _expandedFeatureKeys = new(StringComparer.OrdinalIgnoreCase);
+    private List<PermissionFeatureTreeNode> _permissionTreeNodes = [];
+    private Dictionary<string, string> _permissionValues = new(StringComparer.OrdinalIgnoreCase);
+    private string _missingPermissionBehaviorValue = MissingPermissionDeny;
+
+    private const string PermissionDefault = "default";
+    private const string PermissionAllow = "allow";
+    private const string PermissionDeny = "deny";
+    private const string MissingPermissionAllow = "allow";
+    private const string MissingPermissionDeny = "deny";
+    private static readonly IReadOnlyList<string> PermissionCapabilities = IdentityAuthorizationConstants.CapabilityKeys;
+
+    private TenantModuleFeatureDefinition? SelectedFeature =>
+        TenantModuleFeatureKeys.Find(_selectedFeatureKey);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await ResolveAccess();
+        if (!_canManageTenants)
+        {
+            return;
+        }
+
+        await LoadRoleType();
+    }
+
+    private async Task ResolveAccess()
+    {
+        if (AuthenticationStateTask is null)
+        {
+            _accessChecked = true;
+            return;
+        }
+
+        var authState = await AuthenticationStateTask;
+        _canManageTenants = PortalAccess.CanManageTenants(authState.User);
+        _accessChecked = true;
+    }
+
+    private async Task LoadRoleType()
+    {
+        _loading = true;
+        try
+        {
+            _permissionsLoaded = false;
+            _permissionTreeNodes = BuildPermissionTree();
+            _expandedFeatureKeys = _permissionTreeNodes
+                .Select(x => x.Feature.Key)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            _selectedFeatureKey = TenantModuleFeatureKeys.Identity;
+
+            _roleType = await DataContext.Query<IdentityRoleType>()
+                .IgnoreQueryFilters()
+                .NoCache()
+                .Include(x => x.Group)
+                .Where(x => x.Id == RoleTypeId && x.TenantId == TenantId)
+                .Where(x => !x.IsDeleted && x.IsEnabled)
+                .FirstOrDefaultAsync();
+
+            if (_roleType is null)
+            {
+                _permissionValues = [];
+                return;
+            }
+
+            await LoadPermissions();
+        }
+        catch
+        {
+            ToastService.Error("Role type permissions could not be loaded.", "Permissions failed");
+            _roleType = null;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task LoadPermissions()
+    {
+        _permissionsLoaded = false;
+        _permissionValues = BuildEmptyPermissionValueMap();
+
+        var policyResult = await IdentityServer.GetTenantAuthorizationPolicy(new GetTenantAuthorizationPolicyRequest
+        {
+            TenantId = TenantId,
+            Metadata = CreateMetadata(TenantId)
+        });
+
+        if (policyResult.IsSuccess && policyResult.Response is not null)
+        {
+            _missingPermissionBehaviorValue = policyResult.Response.MissingPermissionBehavior == MissingPermissionBehavior.Allow
+                ? MissingPermissionAllow
+                : MissingPermissionDeny;
+        }
+        else
+        {
+            ToastService.Error("Tenant permission default could not be loaded.", "Permissions failed");
+            return;
+        }
+
+        var permissionsResult = await IdentityServer.GetRoleTypePermissions(new GetRoleTypePermissionsRequest
+        {
+            RoleTypeId = RoleTypeId,
+            Metadata = CreateMetadata(TenantId)
+        });
+
+        if (!permissionsResult.IsSuccess || permissionsResult.Response is null)
+        {
+            ToastService.Error("Role type permissions could not be loaded.", "Permissions failed");
+            return;
+        }
+
+        foreach (var permission in permissionsResult.Response.Permissions)
+        {
+            _permissionValues[BuildPermissionKey(permission.ModuleKey, permission.SubFeatureKey, permission.CapabilityKey)] =
+                permission.Effect == RoleCapabilityPermissionEffect.Allow ? PermissionAllow : PermissionDeny;
+        }
+
+        _permissionsLoaded = true;
+    }
+
+    private async Task ReloadPermissions()
+    {
+        if (_roleType is null)
+        {
+            return;
+        }
+
+        _loading = true;
+        try
+        {
+            await LoadPermissions();
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task SaveRoleTypePermissions()
+    {
+        if (_roleType is null)
+        {
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var policyResult = await IdentityServer.UpdateTenantAuthorizationPolicy(new UpdateTenantAuthorizationPolicyRequest
+            {
+                TenantId = TenantId,
+                MissingPermissionBehavior = _missingPermissionBehaviorValue == MissingPermissionAllow
+                    ? MissingPermissionBehavior.Allow
+                    : MissingPermissionBehavior.Deny,
+                Metadata = CreateMetadata(TenantId)
+            });
+
+            if (!policyResult.IsSuccess)
+            {
+                ToastService.Error("Tenant permission default could not be saved.", "Permissions failed");
+                return;
+            }
+
+            var permissionsResult = await IdentityServer.SetRoleTypePermissions(new SetRoleTypePermissionsRequest
+            {
+                RoleTypeId = RoleTypeId,
+                Permissions = BuildRoleTypePermissions(),
+                Metadata = CreateMetadata(TenantId)
+            });
+
+            if (permissionsResult.IsSuccess)
+            {
+                ToastService.Success("Role type permissions saved.", "Permissions saved");
+            }
+            else
+            {
+                ToastService.Error("Role type permissions could not be saved.", "Permissions failed");
+            }
+        }
+        catch
+        {
+            ToastService.Error("Role type permissions could not be saved.", "Permissions failed");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private List<CapabilityPermissionDto> BuildRoleTypePermissions()
+    {
+        var permissions = new List<CapabilityPermissionDto>();
+        foreach (var feature in TenantModuleFeatureKeys.All)
+        {
+            foreach (var capability in PermissionCapabilities)
+            {
+                var value = GetPermissionValue(feature, capability);
+                if (value == PermissionDefault)
+                {
+                    continue;
+                }
+
+                permissions.Add(new CapabilityPermissionDto
+                {
+                    ModuleKey = feature.ModuleKey,
+                    SubFeatureKey = feature.SubFeatureKey,
+                    CapabilityKey = capability,
+                    Effect = value == PermissionAllow
+                        ? RoleCapabilityPermissionEffect.Allow
+                        : RoleCapabilityPermissionEffect.Deny
+                });
+            }
+        }
+
+        return permissions;
+    }
+
+    private static List<PermissionFeatureTreeNode> BuildPermissionTree()
+    {
+        var roots = TenantModuleFeatureKeys.All
+            .Where(x => string.IsNullOrWhiteSpace(x.SubFeatureKey))
+            .Select(root => new PermissionFeatureTreeNode(
+                root,
+                TenantModuleFeatureKeys.All
+                    .Where(child => string.Equals(child.ModuleKey, root.ModuleKey, StringComparison.OrdinalIgnoreCase)
+                                    && !string.IsNullOrWhiteSpace(child.SubFeatureKey))
+                    .Select(child => new PermissionFeatureTreeNode(child, []))
+                    .ToList()))
+            .ToList();
+
+        return roots;
+    }
+
+    private static Dictionary<string, string> BuildEmptyPermissionValueMap()
+    {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var feature in TenantModuleFeatureKeys.All)
+        {
+            foreach (var capability in PermissionCapabilities)
+            {
+                values[BuildPermissionKey(feature, capability)] = PermissionDefault;
+            }
+        }
+
+        return values;
+    }
+
+    private string GetPermissionValue(TenantModuleFeatureDefinition feature, string capability) =>
+        _permissionValues.TryGetValue(BuildPermissionKey(feature, capability), out var value)
+            ? value
+            : PermissionDefault;
+
+    private void SetPermissionValue(TenantModuleFeatureDefinition feature, string capability, string value)
+    {
+        _permissionValues[BuildPermissionKey(feature, capability)] =
+            value == PermissionAllow || value == PermissionDeny ? value : PermissionDefault;
+    }
+
+    private string GetPermissionBadge(TenantModuleFeatureDefinition feature)
+    {
+        var explicitCount = PermissionCapabilities.Count(capability =>
+            GetPermissionValue(feature, capability) is var value
+            && (value == PermissionAllow || value == PermissionDeny));
+
+        return explicitCount == 0 ? "Tenant default" : $"{explicitCount} explicit";
+    }
+
+    private string GetPermissionTreeItemClass(TenantModuleFeatureDefinition feature) =>
+        string.Equals(feature.Key, _selectedFeatureKey, StringComparison.OrdinalIgnoreCase)
+            ? "tenant-module-tree-item-selected"
+            : string.Empty;
+
+    private Task OnFeatureSelected(string value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            _selectedFeatureKey = value;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnFeatureTreeExpandedValuesChanged(HashSet<string> values)
+    {
+        _expandedFeatureKeys = new HashSet<string>(values, StringComparer.OrdinalIgnoreCase);
+        return Task.CompletedTask;
+    }
+
+    private void BackToTenantRoles() =>
+        Navigation.NavigateTo($"/identity/tenants/{TenantId}/role-types");
+
+    private static string BuildPermissionKey(TenantModuleFeatureDefinition feature, string capability) =>
+        BuildPermissionKey(feature.ModuleKey, feature.SubFeatureKey, capability);
+
+    private static string BuildPermissionKey(string moduleKey, string? subFeatureKey, string capability) =>
+        $"{moduleKey}|{subFeatureKey ?? string.Empty}|{capability}";
+
+    private static string FormatCapabilityLabel(string capability) =>
+        CultureInfo.CurrentCulture.TextInfo.ToTitleCase(capability.Replace('_', ' '));
+
+    private static RequestMetadata CreateMetadata(Guid tenantId) => new()
+    {
+        TenantId = tenantId,
+        RequestId = Guid.NewGuid(),
+        Name = "Portal",
+        DeviceName = "Portal",
+        DeviceAgent = "Portal",
+        IpAddress = "Portal"
+    };
+
+    private sealed record PermissionFeatureTreeNode(
+        TenantModuleFeatureDefinition Feature,
+        IReadOnlyList<PermissionFeatureTreeNode> Children);
+}

--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/TenantDetail.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/TenantDetail.razor
@@ -405,35 +405,40 @@ else
             <BbTabsContent Value="role-types" Class="xf-fade-in">
                 <BbCard>
                     <BbCardContent>
-                        @if (_detailRoleTypes.Count == 0)
-                        {
-                            <BbAlert Variant="AlertVariant.Info">No role types found for this tenant.</BbAlert>
-                        }
-                        else
-                        {
-                            <BbDataGrid Items="@_detailRoleTypes" ShowPagination="true" InitialPageSize="10">
-                                <Columns>
-                                    <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
-                                    <BbDataGridTemplateColumn Title="Role Level">
-                                        <ChildContent Context="rt">
-                                            @(rt.RoleLevel?.ToString() ?? "N/A")
-                                        </ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                    <BbDataGridTemplateColumn Title="Group">
-                                        <ChildContent Context="rt">
-                                            @(rt.Group?.Name ?? rt.GroupId.ToString()[..8])
-                                        </ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                    <BbDataGridTemplateColumn Title="Enabled">
-                                        <ChildContent Context="rt">
-                                            <StatusBadge Text="@(rt.IsEnabled ? "Enabled" : "Disabled")"
-                                                         Status="@(rt.IsEnabled ? "active" : "inactive")" />
-                                        </ChildContent>
-                                    </BbDataGridTemplateColumn>
-                                    <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
-                                </Columns>
-                            </BbDataGrid>
-                        }
+                        <BbDataGrid Items="@_detailRoleTypes" ShowPagination="true" InitialPageSize="10">
+                            <Columns>
+                                <BbDataGridPropertyColumn Property="@(x => x.Name)" Title="Name" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Role Level" Sortable="true" Filterable="true" FilterBy="@(rt => FormatRoleLevel(rt))">
+                                    <ChildContent Context="rt">
+                                        @FormatRoleLevel(rt)
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Group" Filterable="true" FilterBy="@(rt => GetRoleTypeGroupLabel(rt))">
+                                    <ChildContent Context="rt">
+                                        @GetRoleTypeGroupLabel(rt)
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridTemplateColumn Title="Enabled" Filterable="true" FilterBy="@(rt => FormatBoolean(rt.IsEnabled))">
+                                    <ChildContent Context="rt">
+                                        <StatusBadge Text="@(rt.IsEnabled ? "Enabled" : "Disabled")"
+                                                     Status="@(rt.IsEnabled ? "active" : "inactive")" />
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                                <BbDataGridPropertyColumn Property="@(x => x.CreatedAt)" Title="Created" Sortable="true" Filterable="true" />
+                                <BbDataGridTemplateColumn Title="Actions">
+                                    <ChildContent Context="rt">
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  title="Edit role type permissions"
+                                                  OnClick="@(() => Navigation.NavigateTo($"/identity/tenants/{Id}/role-types/{rt.Id}"))">
+                                            <LucideIcon Name="shield-check" class="h-4 w-4" />
+                                        </BbButton>
+                                    </ChildContent>
+                                </BbDataGridTemplateColumn>
+                            </Columns>
+                            <EmptyTemplate>
+                                <BbEmpty Title="No role types" Description="No role types are configured for this tenant." />
+                            </EmptyTemplate>
+                        </BbDataGrid>
                     </BbCardContent>
                 </BbCard>
             </BbTabsContent>
@@ -1483,6 +1488,9 @@ else
 
     private static string FormatBoolean(bool value) => value ? "Yes" : "No";
     private static string FormatDateTime(DateTime value) => value == default ? "N/A" : value.ToString("g");
+    private static string FormatRoleLevel(IdentityRoleType roleType) => roleType.RoleLevel?.ToString() ?? "N/A";
+    private static string GetRoleTypeGroupLabel(IdentityRoleType roleType) =>
+        roleType.Group?.Name ?? roleType.GroupId.ToString()[..8];
 
     private sealed class ModuleFeatureTreeNode(ModuleFeatureRow row, IReadOnlyList<ModuleFeatureTreeNode> children)
     {

--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
@@ -202,12 +202,12 @@ else
                                         <span class="text-sm">@(roleCred is null ? "Unknown credential" : GetCredentialLabel(roleCred))</span>
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Level">
+                                <BbDataGridTemplateColumn Title="Level" Sortable="true" Filterable="true" FilterBy="@(role => GetRoleLevelFilter(role))">
                                     <ChildContent Context="role">
-                                        @(role.Type?.RoleLevel?.ToString() ?? "N/A")
+                                        @GetRoleLevelFilter(role)
                                     </ChildContent>
                                 </BbDataGridTemplateColumn>
-                                <BbDataGridTemplateColumn Title="Expiration" Sortable="true">
+                                <BbDataGridTemplateColumn Title="Expiration" Sortable="true" Filterable="true" FilterBy="@(role => GetRoleExpirationFilter(role))">
                                     <ChildContent Context="role">
                                         @{
                                             var hasNoExpiration = IsRoleExpirationUnlimited(role.RoleExpiration);
@@ -226,6 +226,12 @@ else
                                 <BbDataGridTemplateColumn Title="Actions">
                                     <ChildContent Context="role">
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  title="Edit role permission overrides"
+                                                  OnClick="@(() => OpenRolePermissionsDialog(role))">
+                                            <LucideIcon Name="shield-check" class="h-4 w-4" />
+                                        </BbButton>
+                                        <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
+                                                  title="Remove assigned role"
                                                   OnClick="@(() => OpenRemoveRoleDialog(role))">
                                             <LucideIcon Name="trash-2" class="h-4 w-4 text-destructive" />
                                         </BbButton>
@@ -768,18 +774,73 @@ else
                             ShowCreate="false"
                             AdvancedSearchTitle="Find Role Type"
                             AdvancedSearchDescription="Search available role types for the active tenant." />
-            <div class="xf-form-field">
-                <BbLabel>Expiration Date</BbLabel>
-                <input type="datetime-local"
-                       class="xf-datetime-input"
-                       value="@_roleForm.ExpirationString"
-                       @oninput="@((ChangeEventArgs e) => _roleForm.ExpirationString = e.Value?.ToString() ?? string.Empty)" />
-            </div>
+            <BbFormFieldDatePicker @bind-Value="_roleForm.ExpirationDate" Label="Expiration Date" />
         </div>
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _assignRoleDialogOpen = false)">Cancel</BbButton>
             <BbButton OnClick="@AssignRole" Disabled="@_saving">
                 @(_saving ? "Assigning..." : "Assign")
+            </BbButton>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>
+
+<!-- Credential Role Permission Overrides Dialog -->
+<BbDialog Open="@_rolePermissionDialogOpen" OpenChanged="@CloseRolePermissionsDialog">
+    <BbDialogContent TrapFocus="false">
+        <BbDialogHeader>
+            <BbDialogTitle>Role Permission Overrides</BbDialogTitle>
+            <BbDialogDescription>
+                Set credential-specific allow or deny overrides for @(_permissionRole?.Type?.Name ?? "this role").
+            </BbDialogDescription>
+        </BbDialogHeader>
+
+        @if (_loadingRolePermissions)
+        {
+            <CenteredSpinner />
+        }
+        else
+        {
+            <div class="grid max-h-[65vh] gap-4 overflow-y-auto py-4 pr-2">
+                @foreach (var moduleGroup in PermissionFeatureGroups)
+                {
+                    <section class="grid gap-3">
+                        <div>
+                            <h4 class="text-sm font-semibold">@GetModulePermissionHeading(moduleGroup)</h4>
+                            <p class="text-xs text-muted-foreground">Capability overrides inherit from the role type unless an explicit allow or deny is selected.</p>
+                        </div>
+
+                        @foreach (var feature in moduleGroup)
+                        {
+                            <div class="grid gap-3 rounded-md border border-border p-3">
+                                <div>
+                                    <div class="text-sm font-medium">@feature.DisplayName</div>
+                                    <div class="text-xs text-muted-foreground">@feature.Description</div>
+                                </div>
+                                <div class="grid gap-3 md:grid-cols-5">
+                                    @foreach (var capability in PermissionCapabilities)
+                                    {
+                                        <BbFormFieldSelect TValue="string"
+                                                           Label="@FormatCapabilityLabel(capability)"
+                                                           Value="@GetPermissionOverrideValue(feature, capability)"
+                                                           ValueChanged="@((string value) => SetPermissionOverrideValue(feature, capability, value))">
+                                            <BbSelectItem Value="@PermissionInherit">Inherit</BbSelectItem>
+                                            <BbSelectItem Value="@PermissionAllow">Allow</BbSelectItem>
+                                            <BbSelectItem Value="@PermissionDeny">Deny</BbSelectItem>
+                                        </BbFormFieldSelect>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </section>
+                }
+            </div>
+        }
+
+        <BbDialogFooter>
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => CloseRolePermissionsDialog(false))">Cancel</BbButton>
+            <BbButton OnClick="@SaveRolePermissionOverrides" Disabled="@(_saving || _loadingRolePermissions || !_rolePermissionOverridesLoaded)">
+                @(_saving ? "Saving..." : "Save Overrides")
             </BbButton>
         </BbDialogFooter>
     </BbDialogContent>
@@ -983,6 +1044,17 @@ else
     // Assign Role dialog
     private bool _assignRoleDialogOpen;
     private RoleForm _roleForm = new();
+    private bool _rolePermissionDialogOpen;
+    private bool _loadingRolePermissions;
+    private bool _rolePermissionOverridesLoaded;
+    private IdentityRole? _permissionRole;
+    private Dictionary<string, string> _rolePermissionValues = new(StringComparer.OrdinalIgnoreCase);
+    private const string PermissionInherit = "inherit";
+    private const string PermissionAllow = "allow";
+    private const string PermissionDeny = "deny";
+    private static readonly IReadOnlyList<string> PermissionCapabilities = IdentityAuthorizationConstants.CapabilityKeys;
+    private static IEnumerable<IGrouping<string, TenantModuleFeatureDefinition>> PermissionFeatureGroups =>
+        TenantModuleFeatureKeys.All.GroupBy(x => x.ModuleKey);
 
     // Remove Role dialog
     private bool _removeRoleDialogOpen;
@@ -1593,25 +1665,19 @@ else
         _saving = true;
         try
         {
-            if (!TryResolveRoleExpiration(_roleForm.ExpirationString, out var expiration))
+            if (!TryResolveRoleExpiration(_roleForm.ExpirationDate, out var expiration))
             {
-                ToastService.Warning("Choose a valid expiration date and time.", "Invalid expiration");
+                ToastService.Warning("Choose a valid expiration date.", "Invalid expiration");
                 return;
             }
 
-            var role = new IdentityRole
+            var result = await IdentityServer.AssignCredentialRole(new AssignCredentialRoleRequest
             {
-                Id = Guid.NewGuid(),
-                TenantId = _user!.TenantId,
                 CredentialId = credId,
-                TypeId = typeId,
+                RoleTypeId = typeId,
                 RoleExpiration = expiration,
-                IsEnabled = true,
-                CreatedAt = DateTime.UtcNow
-            };
-
-            DataContext.Add(role);
-            var result = await DataContext.SaveChangesAsync();
+                Metadata = CreateMetadata(_user!.TenantId)
+            });
 
             if (result.IsSuccess)
             {
@@ -1646,10 +1712,11 @@ else
 
         try
         {
-            _removingRole.IsDeleted = true;
-            _removingRole.IsEnabled = false;
-            DataContext.Update(_removingRole);
-            var result = await DataContext.SaveChangesAsync();
+            var result = await IdentityServer.RemoveCredentialRole(new RemoveCredentialRoleRequest
+            {
+                IdentityRoleId = _removingRole.Id,
+                Metadata = CreateMetadata(_removingRole.TenantId)
+            });
 
             if (result.IsSuccess)
             {
@@ -1671,6 +1738,176 @@ else
             await LoadRoles();
         }
     }
+
+    private async Task OpenRolePermissionsDialog(IdentityRole role)
+    {
+        _permissionRole = role;
+        _rolePermissionValues = BuildEmptyPermissionValueMap();
+        _rolePermissionDialogOpen = true;
+        _loadingRolePermissions = true;
+        _rolePermissionOverridesLoaded = false;
+
+        try
+        {
+            var result = await IdentityServer.GetCredentialRolePermissionOverrides(new GetCredentialRolePermissionOverridesRequest
+            {
+                IdentityRoleId = role.Id,
+                Metadata = CreateMetadata(role.TenantId)
+            });
+
+            if (!result.IsSuccess || result.Response is null)
+            {
+                ToastService.Error("Role permission overrides could not be loaded.", "Permissions failed");
+                CloseRolePermissionsDialog(false);
+                return;
+            }
+
+            foreach (var permission in result.Response.Overrides)
+            {
+                var key = BuildPermissionKey(permission.ModuleKey, permission.SubFeatureKey, permission.CapabilityKey);
+                _rolePermissionValues[key] = permission.Effect == RoleCapabilityPermissionEffect.Allow
+                    ? PermissionAllow
+                    : PermissionDeny;
+            }
+
+            _rolePermissionOverridesLoaded = true;
+        }
+        catch
+        {
+            ToastService.Error("Role permission overrides could not be loaded.", "Permissions failed");
+            CloseRolePermissionsDialog(false);
+        }
+        finally
+        {
+            _loadingRolePermissions = false;
+        }
+    }
+
+    private void CloseRolePermissionsDialog(bool open)
+    {
+        _rolePermissionDialogOpen = open;
+        if (open)
+        {
+            return;
+        }
+
+        _permissionRole = null;
+        _rolePermissionValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        _loadingRolePermissions = false;
+        _rolePermissionOverridesLoaded = false;
+    }
+
+    private async Task SaveRolePermissionOverrides()
+    {
+        if (_permissionRole is null || !_rolePermissionOverridesLoaded)
+        {
+            if (_permissionRole is not null)
+            {
+                ToastService.Warning("Reload permission overrides before saving.", "Permissions not loaded");
+            }
+
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var overrides = BuildPermissionOverrides();
+            var result = await IdentityServer.SetCredentialRolePermissionOverrides(new SetCredentialRolePermissionOverridesRequest
+            {
+                IdentityRoleId = _permissionRole.Id,
+                Overrides = overrides,
+                Metadata = CreateMetadata(_permissionRole.TenantId)
+            });
+
+            if (result.IsSuccess)
+            {
+                ToastService.Success("Role permission overrides saved.", "Permissions saved");
+                CloseRolePermissionsDialog(false);
+            }
+            else
+            {
+                ToastService.Error("Role permission overrides could not be saved.", "Permissions failed");
+            }
+        }
+        catch
+        {
+            ToastService.Error("Role permission overrides could not be saved.", "Permissions failed");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private List<CapabilityPermissionDto> BuildPermissionOverrides()
+    {
+        var overrides = new List<CapabilityPermissionDto>();
+        foreach (var feature in TenantModuleFeatureKeys.All)
+        {
+            foreach (var capability in PermissionCapabilities)
+            {
+                var value = GetPermissionOverrideValue(feature, capability);
+                if (value == PermissionInherit)
+                {
+                    continue;
+                }
+
+                overrides.Add(new CapabilityPermissionDto
+                {
+                    ModuleKey = feature.ModuleKey,
+                    SubFeatureKey = feature.SubFeatureKey,
+                    CapabilityKey = capability,
+                    Effect = value == PermissionAllow
+                        ? RoleCapabilityPermissionEffect.Allow
+                        : RoleCapabilityPermissionEffect.Deny
+                });
+            }
+        }
+
+        return overrides;
+    }
+
+    private static Dictionary<string, string> BuildEmptyPermissionValueMap()
+    {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var feature in TenantModuleFeatureKeys.All)
+        {
+            foreach (var capability in PermissionCapabilities)
+            {
+                values[BuildPermissionKey(feature, capability)] = PermissionInherit;
+            }
+        }
+
+        return values;
+    }
+
+    private string GetPermissionOverrideValue(TenantModuleFeatureDefinition feature, string capability) =>
+        _rolePermissionValues.TryGetValue(BuildPermissionKey(feature, capability), out var value)
+            ? value
+            : PermissionInherit;
+
+    private void SetPermissionOverrideValue(
+        TenantModuleFeatureDefinition feature,
+        string capability,
+        string value)
+    {
+        _rolePermissionValues[BuildPermissionKey(feature, capability)] =
+            value == PermissionAllow || value == PermissionDeny ? value : PermissionInherit;
+    }
+
+    private static string BuildPermissionKey(TenantModuleFeatureDefinition feature, string capability) =>
+        BuildPermissionKey(feature.ModuleKey, feature.SubFeatureKey, capability);
+
+    private static string BuildPermissionKey(string moduleKey, string? subFeatureKey, string capability) =>
+        $"{moduleKey}|{subFeatureKey ?? string.Empty}|{capability}";
+
+    private static string GetModulePermissionHeading(IGrouping<string, TenantModuleFeatureDefinition> moduleGroup) =>
+        moduleGroup.FirstOrDefault(x => string.IsNullOrWhiteSpace(x.SubFeatureKey))?.DisplayName
+        ?? moduleGroup.Key;
+
+    private static string FormatCapabilityLabel(string capability) =>
+        CultureInfo.CurrentCulture.TextInfo.ToTitleCase(capability.Replace('_', ' '));
 
     // --- Contacts -----------------------------------------------------
 
@@ -1877,6 +2114,14 @@ else
     private static string GetRoleTypeColumnFilter(IdentityRole role) =>
         role.Type?.Name ?? string.Empty;
 
+    private static string GetRoleLevelFilter(IdentityRole role) =>
+        role.Type?.RoleLevel?.ToString() ?? "N/A";
+
+    private static string GetRoleExpirationFilter(IdentityRole role) =>
+        IsRoleExpirationUnlimited(role.RoleExpiration)
+            ? "No expiration"
+            : role.RoleExpiration.ToLocalTime().ToString("g");
+
     private static string GetContactTypeColumnFilter(IdentityContact contact) =>
         contact.Type?.Name ?? string.Empty;
 
@@ -2045,23 +2290,15 @@ else
     private static string FormatNullableDateFilter(DateTime? value) => value.HasValue ? value.Value.ToString("g") : string.Empty;
     private static string FormatNullableDateDisplay(DateTime? value) => value.HasValue ? value.Value.ToString("g") : "N/A";
 
-    private static bool TryResolveRoleExpiration(string? value, out DateTime expiration)
+    private static bool TryResolveRoleExpiration(DateTime? value, out DateTime expiration)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (value is null)
         {
             expiration = NoRoleExpirationUtc;
             return true;
         }
 
-        if (!DateTime.TryParse(
-                value,
-                System.Globalization.CultureInfo.CurrentCulture,
-                System.Globalization.DateTimeStyles.AssumeLocal,
-                out var parsed))
-        {
-            expiration = default;
-            return false;
-        }
+        var parsed = value.Value.Date.AddDays(1).AddTicks(-1);
 
         expiration = parsed.Kind switch
         {
@@ -2087,7 +2324,7 @@ else
     {
         public string CredentialId { get; set; } = "";
         public string RoleTypeId { get; set; } = "";
-        public string ExpirationString { get; set; } = "";
+        public DateTime? ExpirationDate { get; set; }
     }
 
     private class ContactForm

--- a/src/Presentation/XFramework.Portal/Components/_Imports.razor
+++ b/src/Presentation/XFramework.Portal/Components/_Imports.razor
@@ -33,6 +33,7 @@
 @using IdentityServer.Domain.Shared
 @using IdentityServer.Domain.Shared.Contracts
 @using IdentityServer.Domain.Shared.Contracts.Requests
+@using IdentityServer.Domain.Shared.Contracts.Responses
 @using IdentityServer.Integration.Drivers
 @using XFramework.Inventario.Domain.Shared.Contracts
 @using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products

--- a/src/Presentation/XFramework.Portal/Services/PortalBootstrapSeeder.cs
+++ b/src/Presentation/XFramework.Portal/Services/PortalBootstrapSeeder.cs
@@ -2,6 +2,7 @@ using System.Text;
 using IdentityServer.Domain.Shared;
 using IdentityServer.Domain.Shared.Contracts;
 using IdentityServer.Domain.Shared.Contracts.Requests;
+using IdentityServer.Domain.Shared.Contracts.Responses;
 using IdentityServer.Integration.Drivers;
 using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
@@ -35,6 +36,8 @@ public sealed class PortalBootstrapSeeder(
         {
             throw new InvalidOperationException($"Bootstrap admin seed failed: {result.Message}");
         }
+
+        await EnsureAdminAuthorization(tenant.Id, roleType.Id, ct);
 
         logger.LogInformation(
             "Portal bootstrap admin ensured for tenant {TenantId} and credential {CredentialId}.",
@@ -360,6 +363,51 @@ public sealed class PortalBootstrapSeeder(
             ConcurrencyStamp = Guid.NewGuid()
         });
     }
+
+    private async Task EnsureAdminAuthorization(Guid tenantId, Guid roleTypeId, CancellationToken ct)
+    {
+        var policyResult = await identityServer.UpdateTenantAuthorizationPolicy(new UpdateTenantAuthorizationPolicyRequest
+        {
+            TenantId = tenantId,
+            MissingPermissionBehavior = MissingPermissionBehavior.Deny,
+            Metadata = BuildMetadata(tenantId)
+        });
+
+        if (!policyResult.IsSuccess)
+        {
+            throw new InvalidOperationException($"Bootstrap admin authorization policy could not be saved: {policyResult.Message}");
+        }
+
+        var permissionResult = await identityServer.SetRoleTypePermissions(new SetRoleTypePermissionsRequest
+        {
+            RoleTypeId = roleTypeId,
+            Permissions = BuildAdminPermissions(),
+            Metadata = BuildMetadata(tenantId)
+        });
+
+        if (!permissionResult.IsSuccess)
+        {
+            throw new InvalidOperationException($"Bootstrap admin permissions could not be saved: {permissionResult.Message}");
+        }
+    }
+
+    private static List<CapabilityPermissionDto> BuildAdminPermissions() =>
+        TenantModuleFeatureKeys.All
+            .SelectMany(feature => IdentityAuthorizationConstants.CapabilityKeys.Select(capability => new CapabilityPermissionDto
+            {
+                ModuleKey = feature.ModuleKey,
+                SubFeatureKey = feature.SubFeatureKey,
+                CapabilityKey = capability,
+                Effect = RoleCapabilityPermissionEffect.Allow
+            }))
+            .ToList();
+
+    private static RequestMetadata BuildMetadata(Guid tenantId) => new()
+    {
+        TenantId = tenantId,
+        Name = "Portal",
+        RequestId = Guid.NewGuid()
+    };
 
     private static byte[] HashPassword(string password) =>
         Encoding.ASCII.GetBytes(BCrypt.Net.BCrypt.HashPassword(inputKey: password, workFactor: 11));

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/AuthenticationTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/AuthenticationTests.cs
@@ -394,6 +394,7 @@ public class AuthenticationTests : IntegrationTestBase
             Id = Guid.NewGuid(),
             CredentialId = credential.Id,
             TypeId = TestData.RoleTypeId,
+            RoleExpiration = DateTime.UtcNow.AddYears(1),
             TenantId = IntegrationTestFixture.TestTenantId
         };
         db.Set<IdentityRole>().Add(role);

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageCompletenessTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageCompletenessTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using XFramework.TestInfrastructure;
 
 namespace IdentityServer.IntegrationTests.Tests;
@@ -31,9 +32,12 @@ public sealed class WrapperCoverageCompletenessTests
         var requestContracts = Directory
             .EnumerateFiles(requestsRoot, "*.cs", SearchOption.AllDirectories)
             .Where(path => File.ReadAllText(path).Contains("IBoltRequest", StringComparison.Ordinal))
-            .Select(path => Path.GetFileNameWithoutExtension(path))
-            .Where(name => name.EndsWith("Request", StringComparison.Ordinal))
+            .SelectMany(path => Regex.Matches(
+                    File.ReadAllText(path),
+                    @"\b(?:class|record|struct)\s+(?<name>[A-Za-z0-9_]+Request)\b")
+                .Select(match => match.Groups["name"].Value))
             .Select(name => name[..^"Request".Length])
+            .Distinct(StringComparer.Ordinal)
             .OrderBy(name => name)
             .ToArray();
 

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
@@ -511,6 +511,261 @@ public sealed class WrapperCoverageTests : IntegrationTestBase
         result.IsSuccess.Should().BeFalse();
     }
 
+    [Test]
+    public async Task TenantAuthorizationPolicy_WrapperCanGetAndUpdateMissingPermissionBehavior()
+    {
+        var tenantName = $"Authorization Policy Tenant {Guid.NewGuid():N}";
+        var create = await IntegrationTestFixture.ServiceWrapper.CreateTenant(new CreateTenantRequest
+        {
+            Name = tenantName,
+            Description = "Created for authorization policy wrapper coverage",
+            Version = 1.0m,
+            Status = 1,
+            ParentTenantId = IntegrationTestFixture.TestTenantId,
+            Metadata = CreateMetadata()
+        });
+        create.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDbContext();
+        var tenantId = await db.Set<Tenant>()
+            .IgnoreQueryFilters()
+            .Where(t => t.Name == tenantName)
+            .Select(t => t.Id)
+            .FirstAsync();
+
+        var initial = await IntegrationTestFixture.ServiceWrapper.GetTenantAuthorizationPolicy(new GetTenantAuthorizationPolicyRequest
+        {
+            TenantId = tenantId,
+            Metadata = CreateMetadata(tenantId)
+        });
+
+        initial.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        initial.Response.Should().NotBeNull();
+        initial.Response!.MissingPermissionBehavior.Should().Be(MissingPermissionBehavior.Deny);
+
+        var update = await IntegrationTestFixture.ServiceWrapper.UpdateTenantAuthorizationPolicy(new UpdateTenantAuthorizationPolicyRequest
+        {
+            TenantId = tenantId,
+            MissingPermissionBehavior = MissingPermissionBehavior.Allow,
+            Metadata = CreateMetadata(tenantId)
+        });
+
+        update.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        update.Response.Should().NotBeNull();
+        update.Response!.MissingPermissionBehavior.Should().Be(MissingPermissionBehavior.Allow);
+    }
+
+    [Test]
+    public async Task RoleTypePermissions_WrapperCanSetGetAndCheckCredentialCapability()
+    {
+        var roleType = await SeedRoleType("Capability Role");
+        var credential = await SeedCredentialWithRole(UniqueUsername(), "CapabilityPassword123!", roleType.Id);
+
+        var set = await IntegrationTestFixture.ServiceWrapper.SetRoleTypePermissions(new SetRoleTypePermissionsRequest
+        {
+            RoleTypeId = roleType.Id,
+            Permissions =
+            [
+                new CapabilityPermissionDto
+                {
+                    ModuleKey = TenantModuleFeatureKeys.Identity,
+                    CapabilityKey = IdentityAuthorizationConstants.View,
+                    Effect = RoleCapabilityPermissionEffect.Allow
+                }
+            ],
+            Metadata = CreateMetadata()
+        });
+
+        set.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        set.Response.Should().NotBeNull();
+        set.Response!.Permissions.Should().ContainSingle(x =>
+            x.ModuleKey == TenantModuleFeatureKeys.Identity &&
+            x.CapabilityKey == IdentityAuthorizationConstants.View &&
+            x.Effect == RoleCapabilityPermissionEffect.Allow);
+
+        var get = await IntegrationTestFixture.ServiceWrapper.GetRoleTypePermissions(new GetRoleTypePermissionsRequest
+        {
+            RoleTypeId = roleType.Id,
+            Metadata = CreateMetadata()
+        });
+
+        get.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        get.Response.Should().NotBeNull();
+        get.Response!.Permissions.Should().ContainSingle(x =>
+            x.ModuleKey == TenantModuleFeatureKeys.Identity &&
+            x.CapabilityKey == IdentityAuthorizationConstants.View);
+
+        var allowed = await IntegrationTestFixture.ServiceWrapper.CheckCredentialCapability(new CheckCredentialCapabilityRequest
+        {
+            CredentialId = credential.Id,
+            ModuleKey = TenantModuleFeatureKeys.Identity,
+            CapabilityKey = IdentityAuthorizationConstants.View,
+            Metadata = CreateMetadata()
+        });
+
+        allowed.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        allowed.Response.Should().NotBeNull();
+        allowed.Response!.IsAllowed.Should().BeTrue();
+
+        var denied = await IntegrationTestFixture.ServiceWrapper.CheckCredentialCapability(new CheckCredentialCapabilityRequest
+        {
+            CredentialId = credential.Id,
+            ModuleKey = TenantModuleFeatureKeys.Identity,
+            CapabilityKey = IdentityAuthorizationConstants.Delete,
+            Metadata = CreateMetadata()
+        });
+
+        denied.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        denied.Response.Should().NotBeNull();
+        denied.Response!.IsAllowed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CredentialRolePermissionOverrides_WrapperCanSetGetAndOverrideRoleTypePermissions()
+    {
+        var roleType = await SeedRoleType("Override Role");
+        var credential = await SeedCredentialWithoutRole(UniqueUsername(), "OverridePassword123!");
+
+        var assign = await IntegrationTestFixture.ServiceWrapper.AssignCredentialRole(new AssignCredentialRoleRequest
+        {
+            CredentialId = credential.Id,
+            RoleTypeId = roleType.Id,
+            RoleExpiration = DateTime.UtcNow.AddYears(1),
+            Metadata = CreateMetadata()
+        });
+        assign.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        assign.Response.Should().NotBeNull();
+
+        await IntegrationTestFixture.ServiceWrapper.SetRoleTypePermissions(new SetRoleTypePermissionsRequest
+        {
+            RoleTypeId = roleType.Id,
+            Permissions =
+            [
+                new CapabilityPermissionDto
+                {
+                    ModuleKey = TenantModuleFeatureKeys.Identity,
+                    CapabilityKey = IdentityAuthorizationConstants.View,
+                    Effect = RoleCapabilityPermissionEffect.Allow
+                }
+            ],
+            Metadata = CreateMetadata()
+        });
+
+        var setOverrides = await IntegrationTestFixture.ServiceWrapper.SetCredentialRolePermissionOverrides(
+            new SetCredentialRolePermissionOverridesRequest
+            {
+                IdentityRoleId = assign.Response!.Id,
+                Overrides =
+                [
+                    new CapabilityPermissionDto
+                    {
+                        ModuleKey = TenantModuleFeatureKeys.Identity,
+                        CapabilityKey = IdentityAuthorizationConstants.View,
+                        Effect = RoleCapabilityPermissionEffect.Deny
+                    },
+                    new CapabilityPermissionDto
+                    {
+                        ModuleKey = TenantModuleFeatureKeys.Identity,
+                        CapabilityKey = IdentityAuthorizationConstants.Delete,
+                        Effect = RoleCapabilityPermissionEffect.Allow
+                    }
+                ],
+                Metadata = CreateMetadata()
+            });
+
+        setOverrides.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        setOverrides.Response.Should().NotBeNull();
+        setOverrides.Response!.Overrides.Should().HaveCount(2);
+
+        var getOverrides = await IntegrationTestFixture.ServiceWrapper.GetCredentialRolePermissionOverrides(
+            new GetCredentialRolePermissionOverridesRequest
+            {
+                IdentityRoleId = assign.Response.Id,
+                Metadata = CreateMetadata()
+            });
+
+        getOverrides.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        getOverrides.Response.Should().NotBeNull();
+        getOverrides.Response!.Overrides.Should().Contain(x =>
+            x.CapabilityKey == IdentityAuthorizationConstants.View &&
+            x.Effect == RoleCapabilityPermissionEffect.Deny);
+
+        var deniedView = await IntegrationTestFixture.ServiceWrapper.CheckCredentialCapability(new CheckCredentialCapabilityRequest
+        {
+            CredentialId = credential.Id,
+            ModuleKey = TenantModuleFeatureKeys.Identity,
+            CapabilityKey = IdentityAuthorizationConstants.View,
+            Metadata = CreateMetadata()
+        });
+        deniedView.Response!.IsAllowed.Should().BeFalse();
+
+        var allowedDelete = await IntegrationTestFixture.ServiceWrapper.CheckCredentialCapability(new CheckCredentialCapabilityRequest
+        {
+            CredentialId = credential.Id,
+            ModuleKey = TenantModuleFeatureKeys.Identity,
+            CapabilityKey = IdentityAuthorizationConstants.Delete,
+            Metadata = CreateMetadata()
+        });
+        allowedDelete.Response!.IsAllowed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task AssignAndRemoveCredentialRole_WrapperMutatesRoleThroughAuthorizationApi()
+    {
+        var roleType = await SeedRoleType("Assignable Role");
+        var credential = await SeedCredentialWithoutRole(UniqueUsername(), "AssignPassword123!");
+
+        var assign = await IntegrationTestFixture.ServiceWrapper.AssignCredentialRole(new AssignCredentialRoleRequest
+        {
+            CredentialId = credential.Id,
+            RoleTypeId = roleType.Id,
+            RoleExpiration = DateTime.UtcNow.AddMonths(6),
+            Metadata = CreateMetadata()
+        });
+
+        assign.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        assign.Response.Should().NotBeNull();
+        assign.Response!.CredentialId.Should().Be(credential.Id);
+        assign.Response.TypeId.Should().Be(roleType.Id);
+
+        var remove = await IntegrationTestFixture.ServiceWrapper.RemoveCredentialRole(new RemoveCredentialRoleRequest
+        {
+            IdentityRoleId = assign.Response.Id,
+            Metadata = CreateMetadata()
+        });
+
+        remove.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        remove.IsSuccess.Should().BeTrue();
+
+        await using var db = CreateDbContext();
+        var savedRole = await db.Set<IdentityRole>()
+            .IgnoreQueryFilters()
+            .FirstAsync(x => x.Id == assign.Response.Id);
+
+        savedRole.IsDeleted.Should().BeTrue();
+        savedRole.IsEnabled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetEffectiveCredentialCapabilities_WrapperReturnsResolvedCapabilities()
+    {
+        var credential = await SeedCredentialWithRole(UniqueUsername(), "EffectivePassword123!");
+
+        var result = await IntegrationTestFixture.ServiceWrapper.GetEffectiveCredentialCapabilities(
+            new GetEffectiveCredentialCapabilitiesRequest
+            {
+                CredentialId = credential.Id,
+                Metadata = CreateMetadata()
+            });
+
+        result.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        result.Response.Should().NotBeNull();
+        result.Response!.Capabilities.Should().Contain(x =>
+            x.ModuleKey == TenantModuleFeatureKeys.Identity &&
+            x.CapabilityKey == IdentityAuthorizationConstants.View &&
+            x.IsAllowed);
+    }
+
     private async Task<QueryResponse<AuthenticateIdentityResponse>> AuthenticateThroughWrapper()
     {
         var username = UniqueUsername();
@@ -554,7 +809,26 @@ public sealed class WrapperCoverageTests : IntegrationTestBase
         return info;
     }
 
-    private async Task<IdentityCredential> SeedCredentialWithRole(string username, string password)
+    private async Task<IdentityCredential> SeedCredentialWithRole(string username, string password, Guid? roleTypeId = null)
+    {
+        var credential = await SeedCredentialWithoutRole(username, password);
+
+        await using var db = CreateDbContext();
+        var role = new IdentityRole
+        {
+            Id = Guid.NewGuid(),
+            CredentialId = credential.Id,
+            TypeId = roleTypeId ?? TestData.RoleTypeId,
+            RoleExpiration = DateTime.UtcNow.AddYears(1),
+            TenantId = IntegrationTestFixture.TestTenantId
+        };
+        db.Set<IdentityRole>().Add(role);
+
+        await db.SaveChangesAsync();
+        return credential;
+    }
+
+    private async Task<IdentityCredential> SeedCredentialWithoutRole(string username, string password)
     {
         await using var db = CreateDbContext();
 
@@ -579,17 +853,26 @@ public sealed class WrapperCoverageTests : IntegrationTestBase
         };
         db.Set<IdentityCredential>().Add(credential);
 
-        var role = new IdentityRole
-        {
-            Id = Guid.NewGuid(),
-            CredentialId = credential.Id,
-            TypeId = TestData.RoleTypeId,
-            TenantId = IntegrationTestFixture.TestTenantId
-        };
-        db.Set<IdentityRole>().Add(role);
-
         await db.SaveChangesAsync();
         return credential;
+    }
+
+    private async Task<IdentityRoleType> SeedRoleType(string namePrefix)
+    {
+        await using var db = CreateDbContext();
+        var roleType = new IdentityRoleType
+        {
+            Id = Guid.NewGuid(),
+            TenantId = IntegrationTestFixture.TestTenantId,
+            Name = $"{namePrefix} {Guid.NewGuid():N}",
+            GroupId = XFramework.TestInfrastructure.TestConstants.RoleGroupId,
+            RoleLevel = 10,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        };
+        db.Set<IdentityRoleType>().Add(roleType);
+        await db.SaveChangesAsync();
+        return roleType;
     }
 
     private async Task<string> SeedPendingPasswordResetVerification(Guid credentialId)

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -168,6 +168,11 @@ public sealed class IdentityServerPortalContractTests
         userDetail.Should().Contain("IdentityServer.Logout(new LogoutRequest");
         userDetail.Should().Contain("IdentityServer.UploadCredentialAvatar(new UploadCredentialAvatarRequest");
         userDetail.Should().Contain("IdentityServer.RemoveCredentialAvatar(new RemoveCredentialAvatarRequest");
+        userDetail.Should().Contain("IdentityServer.AssignCredentialRole(new AssignCredentialRoleRequest");
+        userDetail.Should().Contain("IdentityServer.RemoveCredentialRole(new RemoveCredentialRoleRequest");
+        userDetail.Should().Contain("IdentityServer.GetCredentialRolePermissionOverrides(new GetCredentialRolePermissionOverridesRequest");
+        userDetail.Should().Contain("IdentityServer.SetCredentialRolePermissionOverrides(new SetCredentialRolePermissionOverridesRequest");
+        userDetail.Should().Contain("title=\"Edit role permission overrides\"");
         credentials.Should().Contain("[Inject] private IIdentityServerServiceWrapper IdentityServer");
         credentials.Should().Contain("IdentityServer.UploadCredentialAvatar(new UploadCredentialAvatarRequest");
         credentials.Should().Contain("IdentityServer.RemoveCredentialAvatar(new RemoveCredentialAvatarRequest");
@@ -182,8 +187,190 @@ public sealed class IdentityServerPortalContractTests
         tenants.Should().NotContain("TenantId = tenantId");
         userDetail.Should().NotContain("BCrypt.Net.BCrypt.HashPassword");
         userDetail.Should().NotContain("DataContext.Add(credential)");
+        userDetail.Should().NotContain("DataContext.Add(role)");
+        userDetail.Should().NotContain("DataContext.Update(_removingRole)");
+        userDetail.Should().NotContain("DataContext.Remove(_removingRole)");
         userDetail.Should().NotContain("DataContext.Update(session)");
         userDetail.Should().NotContain("fresh.Status = CurrentSessionState.Inactive");
+    }
+
+    [Test]
+    public void IdentityServerRoleCapabilities_UseSharedWrapperBackedPermissionSurfaces()
+    {
+        var pagesRoot = GetIdentityPagesRoot();
+        var tenantDetail = File.ReadAllText(Path.Combine(pagesRoot, "TenantDetail.razor"));
+        var roleTypeDetail = File.ReadAllText(Path.Combine(pagesRoot, "RoleTypeDetail.razor"));
+        var userDetail = File.ReadAllText(Path.Combine(pagesRoot, "UserDetail.razor"));
+
+        tenantDetail.Should().Contain("/identity/tenants/{Id}/role-types/{rt.Id}");
+        tenantDetail.Should().Contain("title=\"Edit role type permissions\"");
+        tenantDetail.Should().Contain("<BbDataGrid Items=\"@_detailRoleTypes\" ShowPagination=\"true\" InitialPageSize=\"10\">");
+        tenantDetail.Should().Contain("<BbDataGridTemplateColumn Title=\"Role Level\" Sortable=\"true\" Filterable=\"true\" FilterBy=\"@(rt => FormatRoleLevel(rt))\">");
+        tenantDetail.Should().Contain("<BbDataGridTemplateColumn Title=\"Group\" Filterable=\"true\" FilterBy=\"@(rt => GetRoleTypeGroupLabel(rt))\">");
+        tenantDetail.Should().Contain("<BbDataGridTemplateColumn Title=\"Enabled\" Filterable=\"true\" FilterBy=\"@(rt => FormatBoolean(rt.IsEnabled))\">");
+        tenantDetail.Should().Contain("<EmptyTemplate>");
+        tenantDetail.Should().Contain("<BbEmpty Title=\"No role types\"");
+
+        roleTypeDetail.Should().Contain("@page \"/identity/tenants/{TenantId:guid}/role-types/{RoleTypeId:guid}\"");
+        roleTypeDetail.Should().Contain("<BbTreeView TItem=\"PermissionFeatureTreeNode\"");
+        roleTypeDetail.Should().Contain("IdentityServer.GetTenantAuthorizationPolicy(new GetTenantAuthorizationPolicyRequest");
+        roleTypeDetail.Should().Contain("IdentityServer.UpdateTenantAuthorizationPolicy(new UpdateTenantAuthorizationPolicyRequest");
+        roleTypeDetail.Should().Contain("IdentityServer.GetRoleTypePermissions(new GetRoleTypePermissionsRequest");
+        roleTypeDetail.Should().Contain("IdentityServer.SetRoleTypePermissions(new SetRoleTypePermissionsRequest");
+        roleTypeDetail.Should().Contain("IdentityAuthorizationConstants.CapabilityKeys");
+        roleTypeDetail.Should().Contain("MissingPermissionBehavior.Allow");
+        roleTypeDetail.Should().Contain("MissingPermissionBehavior.Deny");
+        roleTypeDetail.Should().Contain("_permissionsLoaded");
+        roleTypeDetail.Should().Contain("title=\"Back to role types\"");
+        roleTypeDetail.Should().Contain(".Where(x => !x.IsDeleted && x.IsEnabled)");
+        roleTypeDetail.Should().NotContain("_roleType is null || !_permissionsLoaded");
+        roleTypeDetail.Should().NotContain("DataContext.Add(");
+        roleTypeDetail.Should().NotContain("DataContext.Update(");
+        roleTypeDetail.Should().NotContain("DataContext.Remove(");
+        roleTypeDetail.Should().NotContain("SaveChangesAsync(");
+
+        userDetail.Should().Contain("Role Permission Overrides");
+        userDetail.Should().Contain("IdentityServer.GetCredentialRolePermissionOverrides(new GetCredentialRolePermissionOverridesRequest");
+        userDetail.Should().Contain("IdentityServer.SetCredentialRolePermissionOverrides(new SetCredentialRolePermissionOverridesRequest");
+        userDetail.Should().Contain("IdentityAuthorizationConstants.CapabilityKeys");
+        userDetail.Should().Contain("RoleCapabilityPermissionEffect.Allow");
+        userDetail.Should().Contain("RoleCapabilityPermissionEffect.Deny");
+        userDetail.Should().Contain("_rolePermissionOverridesLoaded");
+        userDetail.Should().Contain("<BbDataGridTemplateColumn Title=\"Level\" Sortable=\"true\" Filterable=\"true\" FilterBy=\"@(role => GetRoleLevelFilter(role))\">");
+        userDetail.Should().Contain("<BbDataGridTemplateColumn Title=\"Expiration\" Sortable=\"true\" Filterable=\"true\" FilterBy=\"@(role => GetRoleExpirationFilter(role))\">");
+        userDetail.Should().Contain("title=\"Remove assigned role\"");
+        userDetail.Should().Contain("<BbFormFieldDatePicker @bind-Value=\"_roleForm.ExpirationDate\" Label=\"Expiration Date\" />");
+        userDetail.Should().NotContain("type=\"datetime-local\"");
+    }
+
+    [Test]
+    public void IdentityServerAuthorizationBackend_RequiresEndpointAndServiceLevelAuthorization()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var authorizationRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.IdentityServer",
+            "IdentityServer.Api",
+            "Features",
+            "Authorization");
+        var endpointFiles = Directory.EnumerateFiles(authorizationRoot, "Endpoint.cs", SearchOption.AllDirectories)
+            .ToArray();
+
+        endpointFiles.Should().NotBeEmpty();
+        foreach (var endpointFile in endpointFiles)
+        {
+            var source = File.ReadAllText(endpointFile);
+            source.Should().Contain(
+                "RequireAuthorization = true",
+                $"{Path.GetFileName(Path.GetDirectoryName(endpointFile))} must require HTTP authorization");
+            source.Should().Contain("[BoltHandler]");
+            source.Should().Contain("HandleHttp(");
+            source.Should().Contain("HttpContext httpContext");
+            source.Should().Contain("IdentityAuthorizationEndpointMetadata.ApplyHttpContextActor(request.Metadata, httpContext);");
+        }
+
+        var endpointMetadata = File.ReadAllText(Path.Combine(
+            authorizationRoot,
+            "Shared",
+            "IdentityAuthorizationEndpointMetadata.cs"));
+        endpointMetadata.Should().Contain("metadata.TenantId = ResolveGuidClaim(httpContext.User");
+        endpointMetadata.Should().Contain("metadata.CredentialId = ResolveGuidClaim(");
+        endpointMetadata.Should().Contain("metadata.ServiceAccessToken = null");
+
+        var serviceSource = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.IdentityServer",
+            "IdentityServer.Api",
+            "Services",
+            "IdentityAuthorizationService.cs"));
+
+        serviceSource.Should().Contain("ITrustedServiceInvocationResolver trustedServiceInvocationResolver");
+        serviceSource.Should().Contain("IHttpContextAccessor httpContextAccessor");
+        serviceSource.Should().Contain("EnsureCallerCapabilityAsync(");
+        serviceSource.Should().Contain("EnsureCanInspectCredentialCapabilitiesAsync(");
+        serviceSource.Should().Contain("TryResolveAuthenticatedHttpCredential(");
+        serviceSource.Should().Contain("httpContextAccessor.HttpContext?.User");
+        serviceSource.Should().Contain("XFrameworkServiceNames.IdentityServer");
+        serviceSource.Should().Contain("XFrameworkServiceScopes.IdentityAdmin");
+        serviceSource.Should().Contain("metadata.TenantId.Value == targetTenantId");
+        serviceSource.Should().Contain("new CapabilityDecision(false, \"NoActiveRole\")");
+        serviceSource.Should().Contain("RequiresTenantFeature(moduleKey, subFeatureKey)");
+        serviceSource.Should().NotContain("IsCoreIdentityFeature(");
+
+        var authServiceSource = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.IdentityServer",
+            "IdentityServer.Api",
+            "Services",
+            "AuthService.cs"));
+        authServiceSource.Should().Contain("TenantModuleFeatureKeys.All");
+        authServiceSource.Should().Contain("TenantModuleFeatureKeys.Identity");
+        authServiceSource.Should().Contain("new TenantModuleFeature");
+    }
+
+    [Test]
+    public void IdentityServerAuthorizationRoutes_UseCorrectFeatureGatesAndDisableGeneratedRoleWrites()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var routes = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.IdentityServer",
+            "IdentityServer.Api",
+            "Infrastructure",
+            "IdentityServerFeatureGateRoutes.cs"));
+        var identityRole = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.IdentityServer",
+            "IdentityServer.Domain.Shared",
+            "Contracts",
+            "IdentityRole.cs"));
+
+        var tenantPolicyRouteIndex = routes.IndexOf(
+            "TenantModuleFeatureKeys.IdentityTenants, \"/api/identity/authorization/tenant-policy\"",
+            StringComparison.Ordinal);
+        var authorizationRouteIndex = routes.IndexOf(
+            "TenantModuleFeatureKeys.IdentityRoles, \"/api/identity/authorization\"",
+            StringComparison.Ordinal);
+
+        tenantPolicyRouteIndex.Should().BeGreaterThanOrEqualTo(0);
+        authorizationRouteIndex.Should().BeGreaterThanOrEqualTo(0);
+        tenantPolicyRouteIndex.Should().BeLessThan(authorizationRouteIndex);
+
+        identityRole.Should().Contain("Actions = EndpointActions.Get | EndpointActions.GetList");
+        identityRole.Should().NotContain("EndpointActions.Create");
+        identityRole.Should().NotContain("EndpointActions.Delete");
+    }
+
+    [Test]
+    public void IdentityServerRoleCapabilityMigration_BackfillsAdminPermissions()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var migration = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Kernel",
+            "XFramework.Domain",
+            "Migrations",
+            "20260705084341_AddIdentityRoleCapabilities.cs"));
+
+        migration.Should().Contain("\"Identity\".\"TenantAuthorizationPolicy\"");
+        migration.Should().Contain("\"Identity\".\"TenantModuleFeature\"");
+        migration.Should().Contain("\"Identity\".\"IdentityRoleTypeFeaturePermission\"");
+        migration.Should().Contain("('identity', 'roles', 'Identity Roles'");
+        migration.Should().Contain("('identity', 'tenants', 'Identity Tenants'");
+        migration.Should().Contain("role_type.\"SystemReferenceId\" = '6e7b6bf5-6ad6-49fb-80b0-38e967fc35f3'");
+        migration.Should().Contain("('identity', 'roles')");
+        migration.Should().Contain("VALUES ('view'), ('create'), ('update'), ('delete'), ('manage')");
     }
 
     [Test]

--- a/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantCredentialCapabilityServiceTests.cs
+++ b/src/Tests/XFramework.Core.Tests/Services/FeatureGates/TenantCredentialCapabilityServiceTests.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using XFramework.Core.Services.FeatureGates;
+using XFramework.Domain.Contexts;
+
+namespace XFramework.Core.Tests.Services.FeatureGates;
+
+[TestFixture]
+public sealed class TenantCredentialCapabilityServiceTests
+{
+    [Test]
+    public async Task EnsureAllowedAsync_RoleTypePermissionAllowsRequestedCapability()
+    {
+        await using var db = CreateDbContext();
+        var subject = SeedSubject(db);
+        SeedRoleTypePermission(
+            db,
+            subject,
+            IdentityAuthorizationConstants.View,
+            RoleCapabilityPermissionEffect.Allow);
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+        var result = await service.EnsureAllowedAsync(
+            subject.TenantId,
+            subject.CredentialId,
+            TenantModuleFeatureKeys.Identity,
+            null,
+            IdentityAuthorizationConstants.View);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task EnsureAllowedAsync_ManagePermissionAllowsSpecificCrudCapability()
+    {
+        await using var db = CreateDbContext();
+        var subject = SeedSubject(db);
+        SeedRoleTypePermission(
+            db,
+            subject,
+            IdentityAuthorizationConstants.Manage,
+            RoleCapabilityPermissionEffect.Allow);
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+        var result = await service.EnsureAllowedAsync(
+            subject.TenantId,
+            subject.CredentialId,
+            TenantModuleFeatureKeys.Identity,
+            null,
+            IdentityAuthorizationConstants.Delete);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task EnsureAllowedAsync_CredentialOverrideDenyBeatsRoleTypeAllow()
+    {
+        await using var db = CreateDbContext();
+        var subject = SeedSubject(db);
+        SeedRoleTypePermission(
+            db,
+            subject,
+            IdentityAuthorizationConstants.View,
+            RoleCapabilityPermissionEffect.Allow);
+        db.Set<IdentityRoleFeaturePermissionOverride>().Add(new IdentityRoleFeaturePermissionOverride
+        {
+            Id = Guid.NewGuid(),
+            TenantId = subject.TenantId,
+            IdentityRoleId = subject.RoleId,
+            ModuleKey = TenantModuleFeatureKeys.Identity,
+            SubFeatureKey = string.Empty,
+            CapabilityKey = IdentityAuthorizationConstants.View,
+            Effect = RoleCapabilityPermissionEffect.Deny,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+        var result = await service.EnsureAllowedAsync(
+            subject.TenantId,
+            subject.CredentialId,
+            TenantModuleFeatureKeys.Identity,
+            null,
+            IdentityAuthorizationConstants.View);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+    }
+
+    [Test]
+    public async Task EnsureAllowedAsync_MissingPermissionUsesTenantDefaultDeny()
+    {
+        await using var db = CreateDbContext();
+        var subject = SeedSubject(db);
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+        var result = await service.EnsureAllowedAsync(
+            subject.TenantId,
+            subject.CredentialId,
+            TenantModuleFeatureKeys.Identity,
+            null,
+            IdentityAuthorizationConstants.Create);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+    }
+
+    [Test]
+    public async Task EnsureAllowedAsync_NoActiveRoleDoesNotUseTenantDefaultAllow()
+    {
+        await using var db = CreateDbContext();
+        var subject = SeedSubject(db);
+        db.Set<IdentityRole>().Remove(db.Set<IdentityRole>().Local.Single(x => x.Id == subject.RoleId));
+        db.Set<TenantAuthorizationPolicy>().Local.Single(x => x.TenantId == subject.TenantId)
+            .MissingPermissionBehavior = MissingPermissionBehavior.Allow;
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+        var result = await service.EnsureAllowedAsync(
+            subject.TenantId,
+            subject.CredentialId,
+            TenantModuleFeatureKeys.Identity,
+            null,
+            IdentityAuthorizationConstants.View);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+    }
+
+    private static AppDbContext CreateDbContext()
+    {
+        _ = typeof(IdentityCredential);
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static TenantCredentialCapabilityService CreateService(AppDbContext db) =>
+        new(db, NullLogger<TenantCredentialCapabilityService>.Instance);
+
+    private static AuthorizationSubject SeedSubject(AppDbContext db)
+    {
+        var tenantId = Guid.NewGuid();
+        var roleTypeId = Guid.NewGuid();
+        var credentialId = Guid.NewGuid();
+        var roleId = Guid.NewGuid();
+        var identityInfoId = Guid.NewGuid();
+
+        db.Set<TenantAuthorizationPolicy>().Add(new TenantAuthorizationPolicy
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            MissingPermissionBehavior = MissingPermissionBehavior.Deny,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        db.Set<IdentityInformation>().Add(new IdentityInformation
+        {
+            Id = identityInfoId,
+            TenantId = tenantId,
+            FirstName = "Capability",
+            LastName = "User",
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        db.Set<IdentityCredential>().Add(new IdentityCredential
+        {
+            Id = credentialId,
+            TenantId = tenantId,
+            IdentityInfoId = identityInfoId,
+            UserName = $"capability-{Guid.NewGuid():N}",
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        db.Set<IdentityRoleType>().Add(new IdentityRoleType
+        {
+            Id = roleTypeId,
+            TenantId = tenantId,
+            Name = "Capability Role",
+            GroupId = Guid.NewGuid(),
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        db.Set<IdentityRole>().Add(new IdentityRole
+        {
+            Id = roleId,
+            TenantId = tenantId,
+            CredentialId = credentialId,
+            TypeId = roleTypeId,
+            RoleExpiration = DateTime.UtcNow.AddYears(1),
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        return new AuthorizationSubject(tenantId, credentialId, roleId, roleTypeId);
+    }
+
+    private static void SeedRoleTypePermission(
+        AppDbContext db,
+        AuthorizationSubject subject,
+        string capability,
+        RoleCapabilityPermissionEffect effect)
+    {
+        db.Set<IdentityRoleTypeFeaturePermission>().Add(new IdentityRoleTypeFeaturePermission
+        {
+            Id = Guid.NewGuid(),
+            TenantId = subject.TenantId,
+            RoleTypeId = subject.RoleTypeId,
+            ModuleKey = TenantModuleFeatureKeys.Identity,
+            SubFeatureKey = string.Empty,
+            CapabilityKey = capability,
+            Effect = effect,
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow
+        });
+    }
+
+    private sealed record AuthorizationSubject(
+        Guid TenantId,
+        Guid CredentialId,
+        Guid RoleId,
+        Guid RoleTypeId);
+}

--- a/src/Tests/XFramework.TestInfrastructure/TestHelpers.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestHelpers.cs
@@ -78,6 +78,7 @@ public static class TestHelpers
             Id = Guid.NewGuid(),
             CredentialId = credential.Id,
             TypeId = TestConstants.RoleTypeId,
+            RoleExpiration = DateTime.UtcNow.AddYears(1),
             TenantId = TestConstants.TenantId
         };
         db.Set<IdentityRole>().Add(role);

--- a/src/Tests/XFramework.TestInfrastructure/TestSeedData.cs
+++ b/src/Tests/XFramework.TestInfrastructure/TestSeedData.cs
@@ -35,6 +35,18 @@ public static class TestSeedData
                 Description = "Shared integration test tenant"
             });
         }
+
+        if (!await db.Set<IdentityContracts.TenantAuthorizationPolicy>().AnyAsync(p => p.TenantId == TestConstants.TenantId))
+        {
+            db.Set<IdentityContracts.TenantAuthorizationPolicy>().Add(new IdentityContracts.TenantAuthorizationPolicy
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TestConstants.TenantId,
+                MissingPermissionBehavior = IdentityContracts.MissingPermissionBehavior.Deny,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
     }
 
     private static async Task SeedIdentityRoles(AppDbContext db)
@@ -59,6 +71,37 @@ public static class TestSeedData
                 GroupId = TestConstants.RoleGroupId,
                 TenantId = TestConstants.TenantId
             });
+        }
+
+        foreach (var feature in IdentityContracts.TenantModuleFeatureKeys.All)
+        {
+            foreach (var capability in IdentityContracts.IdentityAuthorizationConstants.CapabilityKeys)
+            {
+                var exists = await db.Set<IdentityContracts.IdentityRoleTypeFeaturePermission>()
+                    .IgnoreQueryFilters()
+                    .AnyAsync(permission =>
+                        permission.TenantId == TestConstants.TenantId &&
+                        permission.RoleTypeId == TestConstants.RoleTypeId &&
+                        permission.ModuleKey == feature.ModuleKey &&
+                        permission.SubFeatureKey == feature.SubFeatureKey &&
+                        permission.CapabilityKey == capability);
+
+                if (exists)
+                    continue;
+
+                db.Set<IdentityContracts.IdentityRoleTypeFeaturePermission>().Add(new IdentityContracts.IdentityRoleTypeFeaturePermission
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = TestConstants.TenantId,
+                    RoleTypeId = TestConstants.RoleTypeId,
+                    ModuleKey = feature.ModuleKey,
+                    SubFeatureKey = feature.SubFeatureKey,
+                    CapabilityKey = capability,
+                    Effect = IdentityContracts.RoleCapabilityPermissionEffect.Allow,
+                    IsEnabled = true,
+                    CreatedAt = DateTime.UtcNow
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add tenant/role/credential capability authorization contracts, EF entities, migration/backfill, and IdentityServer wrapper endpoints.
- Enforce credential capability checks in Core feature gate middleware after tenant module gating.
- Add Portal UI for tenant role-type permissions, role assignments, and credential role permission overrides.
- Add wrapper/integration coverage guards plus Portal contract tests and focused Core tests.

## Validation
- `dotnet build src/Modules/XFramework.IdentityServer/IdentityServer.Api/IdentityServer.Api.csproj -m:1 /nr:false`
- `dotnet build src/Presentation/XFramework.Portal/XFramework.Portal.csproj -m:1 /nr:false`
- `dotnet build src/Tests/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj -m:1 /nr:false`
- `dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --no-build --filter TestCategory=Area:PortalContract`
- `dotnet test src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj --no-build --filter FullyQualifiedName~TenantCredentialCapabilityServiceTests`

## Notes
- Builds pass with existing warning noise from package pruning, generated code nullability, and obsolete `DialogService.Confirm` usages outside this change.