### PR TITLE
[codex] Fix xeon-dev service identity deploy config

### DIFF
--- a/.github/workflows/deploy-xeon-dev-service.yml
+++ b/.github/workflows/deploy-xeon-dev-service.yml
@@ -45,7 +45,18 @@ jobs:
       DB_PASSWORD: compose-validation-placeholder
       JWT_SECRET: compose-validation-placeholder
       BOLT_SIGNATURE: compose-validation-placeholder
-      SERVICE_IDENTITY_DEVELOPMENT_SECRET: compose-validation-placeholder
+      IDENTITYSERVER_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      BOLT_HUB_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      COMMUNICATIONS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      NOTIFICATIONS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      STORAGE_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      ATTENDANCE_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      SMSGATEWAY_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      WALLETS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      INVENTARIO_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      POS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      PORTAL_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
       COMMUNICATIONS_TRUSTED_METADATA_SECRET: compose-validation-placeholder
       SERVICE_NAME: ${{ inputs.service }}
       HEALTH_URL: ${{ inputs.health_url }}
@@ -88,6 +99,54 @@ jobs:
         run: |
           set -euo pipefail
           docker compose -f "$COMPOSE_FILE_PATH" config >/tmp/xframework-compose.yml
+
+      - name: Ensure xeon-dev service identity secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_vars=(
+            IDENTITYSERVER_SERVICE_IDENTITY_SECRET
+            BOLT_HUB_SERVICE_IDENTITY_SECRET
+            COMMUNICATIONS_SERVICE_IDENTITY_SECRET
+            NOTIFICATIONS_SERVICE_IDENTITY_SECRET
+            STORAGE_SERVICE_IDENTITY_SECRET
+            ATTENDANCE_SERVICE_IDENTITY_SECRET
+            SMSGATEWAY_SERVICE_IDENTITY_SECRET
+            WALLETS_SERVICE_IDENTITY_SECRET
+            INVENTARIO_SERVICE_IDENTITY_SECRET
+            POS_SERVICE_IDENTITY_SECRET
+            PORTAL_SERVICE_IDENTITY_SECRET
+            OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET
+          )
+
+          quoted_vars="$(printf '%q ' "${required_vars[@]}")"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "XFRAMEWORK_ENV_FILE='$XFRAMEWORK_ENV_FILE' bash -s -- $quoted_vars" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+
+          env_file="$XFRAMEWORK_ENV_FILE"
+          test -f "$env_file"
+
+          tmp_file="$(mktemp)"
+          trap 'rm -f "$tmp_file"' EXIT
+
+          grep -v '^SERVICE_IDENTITY_DEVELOPMENT_SECRET=' "$env_file" > "$tmp_file" || true
+
+          changed=0
+          for variable_name in "$@"; do
+            if ! grep -q "^${variable_name}=" "$tmp_file"; then
+              secret_value="$(head -c 48 /dev/urandom | base64 | tr -d '\n')"
+              printf '%s=%s\n' "$variable_name" "$secret_value" >> "$tmp_file"
+              changed=1
+            fi
+          done
+
+          if [ "$changed" -eq 1 ] || grep -q '^SERVICE_IDENTITY_DEVELOPMENT_SECRET=' "$env_file"; then
+            install -m 600 "$tmp_file" "$env_file"
+          fi
+          REMOTE_SCRIPT
 
       - name: Login to dev registry
         shell: bash

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -50,7 +50,18 @@ jobs:
       DB_PASSWORD: compose-validation-placeholder
       JWT_SECRET: compose-validation-placeholder
       BOLT_SIGNATURE: compose-validation-placeholder
-      SERVICE_IDENTITY_DEVELOPMENT_SECRET: compose-validation-placeholder
+      IDENTITYSERVER_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      BOLT_HUB_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      COMMUNICATIONS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      NOTIFICATIONS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      STORAGE_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      ATTENDANCE_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      SMSGATEWAY_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      WALLETS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      INVENTARIO_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      POS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      PORTAL_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
+      OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
       COMMUNICATIONS_TRUSTED_METADATA_SECRET: compose-validation-placeholder
 
     steps:
@@ -90,6 +101,54 @@ jobs:
         run: |
           set -euo pipefail
           docker compose -f "$COMPOSE_FILE_PATH" config >/tmp/xframework-compose.yml
+
+      - name: Ensure xeon-dev service identity secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_vars=(
+            IDENTITYSERVER_SERVICE_IDENTITY_SECRET
+            BOLT_HUB_SERVICE_IDENTITY_SECRET
+            COMMUNICATIONS_SERVICE_IDENTITY_SECRET
+            NOTIFICATIONS_SERVICE_IDENTITY_SECRET
+            STORAGE_SERVICE_IDENTITY_SECRET
+            ATTENDANCE_SERVICE_IDENTITY_SECRET
+            SMSGATEWAY_SERVICE_IDENTITY_SECRET
+            WALLETS_SERVICE_IDENTITY_SECRET
+            INVENTARIO_SERVICE_IDENTITY_SECRET
+            POS_SERVICE_IDENTITY_SECRET
+            PORTAL_SERVICE_IDENTITY_SECRET
+            OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET
+          )
+
+          quoted_vars="$(printf '%q ' "${required_vars[@]}")"
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "XFRAMEWORK_ENV_FILE='$XFRAMEWORK_ENV_FILE' bash -s -- $quoted_vars" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+
+          env_file="$XFRAMEWORK_ENV_FILE"
+          test -f "$env_file"
+
+          tmp_file="$(mktemp)"
+          trap 'rm -f "$tmp_file"' EXIT
+
+          grep -v '^SERVICE_IDENTITY_DEVELOPMENT_SECRET=' "$env_file" > "$tmp_file" || true
+
+          changed=0
+          for variable_name in "$@"; do
+            if ! grep -q "^${variable_name}=" "$tmp_file"; then
+              secret_value="$(head -c 48 /dev/urandom | base64 | tr -d '\n')"
+              printf '%s=%s\n' "$variable_name" "$secret_value" >> "$tmp_file"
+              changed=1
+            fi
+          done
+
+          if [ "$changed" -eq 1 ] || grep -q '^SERVICE_IDENTITY_DEVELOPMENT_SECRET=' "$env_file"; then
+            install -m 600 "$tmp_file" "$env_file"
+          fi
+          REMOTE_SCRIPT
 
       - name: Login to dev registry
         shell: bash

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -45,6 +45,16 @@ public sealed class ServiceIdentityComposeContractTests
         var repositoryRoot = FindRepositoryRoot();
         var compose = File.ReadAllText(Path.Combine(repositoryRoot.FullName, "docker-compose.yml"));
         var envExample = File.ReadAllText(Path.Combine(repositoryRoot.FullName, ".env.example"));
+        var deployWorkflow = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            ".github",
+            "workflows",
+            "deploy-xeon-dev.yml"));
+        var serviceDeployWorkflow = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            ".github",
+            "workflows",
+            "deploy-xeon-dev-service.yml"));
         var serviceIdentityService = File.ReadAllText(Path.Combine(
             repositoryRoot.FullName,
             "src",
@@ -58,6 +68,8 @@ public sealed class ServiceIdentityComposeContractTests
         compose.Should().NotContain("ServiceIdentity__AllowDevelopmentClientSecretFallback");
         compose.Should().NotContain("SERVICE_IDENTITY_DEVELOPMENT_SECRET");
         envExample.Should().NotContain("SERVICE_IDENTITY_DEVELOPMENT_SECRET");
+        deployWorkflow.Should().NotContain("SERVICE_IDENTITY_DEVELOPMENT_SECRET: compose-validation-placeholder");
+        serviceDeployWorkflow.Should().NotContain("SERVICE_IDENTITY_DEVELOPMENT_SECRET: compose-validation-placeholder");
         serviceIdentityService.Should().NotContain("DevelopmentClientSecret");
         serviceIdentityService.Should().NotContain("AllowDevelopmentClientSecretFallback");
         serviceIdentityService.Should().NotContain("AllowsDevelopmentClientFallback");
@@ -66,6 +78,10 @@ public sealed class ServiceIdentityComposeContractTests
         {
             compose.Should().Contain($"${{{variable}:?Set {variable} in .env}}");
             envExample.Should().Contain($"{variable}=");
+            deployWorkflow.Should().Contain($"{variable}: compose-validation-placeholder");
+            serviceDeployWorkflow.Should().Contain($"{variable}: compose-validation-placeholder");
+            deployWorkflow.Should().Contain(variable);
+            serviceDeployWorkflow.Should().Contain(variable);
         }
 
         foreach (var clientId in RegisteredServiceClients)


### PR DESCRIPTION
## Summary
- replaces the old compose-validation service identity fallback placeholder with explicit per-service placeholders
- adds CI-owned xeon-dev env initialization for missing per-service service identity secrets without logging values
- extends the service identity contract test to cover deploy workflows

## Root cause
The develop deploy failed during compose validation because docker-compose.yml now requires per-service *_SERVICE_IDENTITY_SECRET variables, while the deploy workflows still only provided SERVICE_IDENTITY_DEVELOPMENT_SECRET.

## Validation
- git diff --check
- GitHub Actions will run the build/deploy path; no manual xeon-dev deploy was performed