### PR TITLE
[codex] Fix role permission override dialog scrolling

### DIFF
--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
@@ -787,7 +787,7 @@ else
 
 <!-- Credential Role Permission Overrides Dialog -->
 <BbDialog Open="@_rolePermissionDialogOpen" OpenChanged="@CloseRolePermissionsDialog">
-    <BbDialogContent TrapFocus="false">
+    <BbDialogContent TrapFocus="false" Class="identity-role-permissions-dialog">
         <BbDialogHeader>
             <BbDialogTitle>Role Permission Overrides</BbDialogTitle>
             <BbDialogDescription>
@@ -801,7 +801,7 @@ else
         }
         else
         {
-            <div class="grid max-h-[65vh] gap-4 overflow-y-auto py-4 pr-2">
+            <div class="identity-role-permissions-dialog-body">
                 @foreach (var moduleGroup in PermissionFeatureGroups)
                 {
                     <section class="grid gap-3">

--- a/src/Presentation/XFramework.Portal/wwwroot/css/app.css
+++ b/src/Presentation/XFramework.Portal/wwwroot/css/app.css
@@ -828,6 +828,19 @@
     max-width: min(74rem, calc(100vw - 2rem));
 }
 
+.identity-role-permissions-dialog {
+    width: min(52rem, calc(100vw - 2rem));
+    max-width: min(52rem, calc(100vw - 2rem));
+}
+
+.identity-role-permissions-dialog-body {
+    display: grid;
+    gap: 1rem;
+    overflow-y: auto;
+    max-height: min(62vh, 34rem);
+    padding: 1rem 0.5rem 1rem 0;
+}
+
 .xf-entity-picker-advanced-hint {
     color: var(--muted-foreground);
     font-size: 0.8125rem;

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -236,6 +236,9 @@ public sealed class IdentityServerPortalContractTests
         userDetail.Should().Contain("RoleCapabilityPermissionEffect.Allow");
         userDetail.Should().Contain("RoleCapabilityPermissionEffect.Deny");
         userDetail.Should().Contain("_rolePermissionOverridesLoaded");
+        userDetail.Should().Contain("<BbDialogContent TrapFocus=\"false\" Class=\"identity-role-permissions-dialog\">");
+        userDetail.Should().Contain("<div class=\"identity-role-permissions-dialog-body\">");
+        userDetail.Should().NotContain("max-h-[65vh]");
         userDetail.Should().Contain("<BbDataGridTemplateColumn Title=\"Level\" Sortable=\"true\" Filterable=\"true\" FilterBy=\"@(role => GetRoleLevelFilter(role))\">");
         userDetail.Should().Contain("<BbDataGridTemplateColumn Title=\"Expiration\" Sortable=\"true\" Filterable=\"true\" FilterBy=\"@(role => GetRoleExpirationFilter(role))\">");
         userDetail.Should().Contain("title=\"Remove assigned role\"");


### PR DESCRIPTION
## Summary
- gives the IdentityServer role permission override dialog an explicit Portal CSS class
- moves the capability matrix into a bounded scroll body so the footer remains reachable
- adds a Portal contract guard to prevent the missing arbitrary Tailwind max-height class from returning

## Validation
- git diff --check
- Browser investigation on xeon-dev showed the existing footer was pushed outside the viewport before this fix
- GitHub Actions will run PR checks; no manual deploy was performed