### PR TITLE
Fix role permission dialog portal race

### DIFF
--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
@@ -1951,14 +1951,22 @@ else
 
     private string GetRolePermissionActionAriaLabel(IdentityRole role) =>
         IsLoadingRolePermissions(role)
-            ? "Loading role permission overrides"
-            : "Edit role permission overrides";
+            ? $"Loading permission overrides for {GetRolePermissionActionContext(role)}"
+            : $"Edit permission overrides for {GetRolePermissionActionContext(role)}";
+
+    private string GetRolePermissionActionContext(IdentityRole role) =>
+        $"{role.Type?.Name ?? "assigned role"}, {GetCredentialLabelById(role.CredentialId)}";
 
     private string GetRolePermissionAriaBusy(IdentityRole role) =>
         IsLoadingRolePermissions(role) ? "true" : "false";
 
     private async Task SaveRolePermissionOverrides()
     {
+        if (_savingRolePermissions)
+        {
+            return;
+        }
+
         if (_permissionRole is null || !_rolePermissionOverridesLoaded)
         {
             if (_permissionRole is not null)

--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
@@ -227,8 +227,16 @@ else
                                     <ChildContent Context="role">
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
                                                   title="Edit role permission overrides"
+                                                  Disabled="@_loadingRolePermissions"
                                                   OnClick="@(() => OpenRolePermissionsDialog(role))">
-                                            <LucideIcon Name="shield-check" class="h-4 w-4" />
+                                            @if (_loadingRolePermissions && _loadingRolePermissionsRoleId == role.Id)
+                                            {
+                                                <LucideIcon Name="loader-2" class="h-4 w-4 animate-spin" />
+                                            }
+                                            else
+                                            {
+                                                <LucideIcon Name="shield-check" class="h-4 w-4" />
+                                            }
                                         </BbButton>
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
                                                   title="Remove assigned role"
@@ -795,51 +803,94 @@ else
             </BbDialogDescription>
         </BbDialogHeader>
 
-        @if (_loadingRolePermissions)
-        {
-            <CenteredSpinner />
-        }
-        else
-        {
-            <div class="identity-role-permissions-dialog-body">
-                @foreach (var moduleGroup in PermissionFeatureGroups)
-                {
-                    <section class="grid gap-3">
-                        <div>
-                            <h4 class="text-sm font-semibold">@GetModulePermissionHeading(moduleGroup)</h4>
-                            <p class="text-xs text-muted-foreground">Capability overrides inherit from the role type unless an explicit allow or deny is selected.</p>
-                        </div>
+        <div class="identity-role-permissions-dialog-body">
+            <section class="identity-role-permissions-tree-panel" aria-label="Permission features">
+                <BbTreeView TItem="PermissionFeatureTreeNode"
+                            ShowIcons="true"
+                            ShowLines="true"
+                            ShowSearch="true"
+                            SearchPlaceholder="Search features..."
+                            ExpandOnClick="true"
+                            SelectionMode="TreeSelectionMode.Single"
+                            SelectedValue="@_selectedRolePermissionFeatureKey"
+                            SelectedValueChanged="@OnRolePermissionFeatureSelected"
+                            ExpandedValues="@_expandedRolePermissionFeatureKeys"
+                            ExpandedValuesChanged="@OnRolePermissionTreeExpandedValuesChanged"
+                            AriaLabel="Credential role permission feature tree"
+                            Class="tenant-module-tree identity-role-permissions-tree">
+                    @foreach (var node in _rolePermissionTreeNodes)
+                    {
+                        <BbTreeItem Value="@node.Feature.Key"
+                                    Label="@node.Feature.DisplayName"
+                                    Icon="@node.Feature.IconName"
+                                    Badge="@GetPermissionOverrideBadge(node.Feature)"
+                                    Class="@GetRolePermissionTreeItemClass(node.Feature)">
+                            <LabelTemplate>
+                                <div class="tenant-module-tree-label">
+                                    <span class="tenant-module-tree-label-main">@node.Feature.DisplayName</span>
+                                    <span class="tenant-module-tree-label-sub">@node.Feature.Description</span>
+                                </div>
+                            </LabelTemplate>
+                            <ChildContent>
+                                @foreach (var childNode in node.Children)
+                                {
+                                    <BbTreeItem Value="@childNode.Feature.Key"
+                                                Label="@childNode.Feature.DisplayName"
+                                                Icon="@childNode.Feature.IconName"
+                                                Badge="@GetPermissionOverrideBadge(childNode.Feature)"
+                                                IsLeaf="true"
+                                                Class="@GetRolePermissionTreeItemClass(childNode.Feature)">
+                                        <LabelTemplate>
+                                            <div class="tenant-module-tree-label tenant-module-tree-label-child">
+                                                <span class="tenant-module-tree-label-main">@childNode.Feature.DisplayName</span>
+                                                <span class="tenant-module-tree-label-sub">@childNode.Feature.Description</span>
+                                            </div>
+                                        </LabelTemplate>
+                                    </BbTreeItem>
+                                }
+                            </ChildContent>
+                        </BbTreeItem>
+                    }
+                </BbTreeView>
+            </section>
 
-                        @foreach (var feature in moduleGroup)
-                        {
-                            <div class="grid gap-3 rounded-md border border-border p-3">
-                                <div>
-                                    <div class="text-sm font-medium">@feature.DisplayName</div>
-                                    <div class="text-xs text-muted-foreground">@feature.Description</div>
-                                </div>
-                                <div class="grid gap-3 md:grid-cols-5">
-                                    @foreach (var capability in PermissionCapabilities)
-                                    {
-                                        <BbFormFieldSelect TValue="string"
-                                                           Label="@FormatCapabilityLabel(capability)"
-                                                           Value="@GetPermissionOverrideValue(feature, capability)"
-                                                           ValueChanged="@((string value) => SetPermissionOverrideValue(feature, capability, value))">
-                                            <BbSelectItem Value="@PermissionInherit">Inherit</BbSelectItem>
-                                            <BbSelectItem Value="@PermissionAllow">Allow</BbSelectItem>
-                                            <BbSelectItem Value="@PermissionDeny">Deny</BbSelectItem>
-                                        </BbFormFieldSelect>
-                                    }
-                                </div>
-                            </div>
-                        }
-                    </section>
+            <section class="identity-role-permissions-feature-panel" aria-label="Selected feature permissions">
+                <div>
+                    <h4 class="text-sm font-semibold">@(SelectedRolePermissionFeature?.DisplayName ?? "Select a Feature")</h4>
+                    <p class="text-xs text-muted-foreground">
+                        @(SelectedRolePermissionFeature?.Description ?? "Select a module or sub-feature to configure credential overrides.")
+                    </p>
+                </div>
+
+                @if (SelectedRolePermissionFeature is null)
+                {
+                    <BbEmpty Title="No feature selected" Description="Select a feature to configure credential permission overrides." />
                 }
-            </div>
-        }
+                else
+                {
+                    <p class="identity-role-permissions-inheritance-note">
+                        Capabilities inherit from the assigned role type unless an explicit allow or deny is selected.
+                    </p>
+                    <div class="identity-role-permissions-capabilities">
+                        @foreach (var capability in PermissionCapabilities)
+                        {
+                            <BbFormFieldSelect TValue="string"
+                                               Label="@FormatCapabilityLabel(capability)"
+                                               Value="@GetPermissionOverrideValue(SelectedRolePermissionFeature, capability)"
+                                               ValueChanged="@((string value) => SetPermissionOverrideValue(SelectedRolePermissionFeature, capability, value))">
+                                <BbSelectItem Value="@PermissionInherit">Inherit</BbSelectItem>
+                                <BbSelectItem Value="@PermissionAllow">Allow</BbSelectItem>
+                                <BbSelectItem Value="@PermissionDeny">Deny</BbSelectItem>
+                            </BbFormFieldSelect>
+                        }
+                    </div>
+                }
+            </section>
+        </div>
 
         <BbDialogFooter>
             <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => CloseRolePermissionsDialog(false))">Cancel</BbButton>
-            <BbButton OnClick="@SaveRolePermissionOverrides" Disabled="@(_saving || _loadingRolePermissions || !_rolePermissionOverridesLoaded)">
+            <BbButton OnClick="@SaveRolePermissionOverrides" Disabled="@(_saving || !_rolePermissionOverridesLoaded)">
                 @(_saving ? "Saving..." : "Save Overrides")
             </BbButton>
         </BbDialogFooter>
@@ -1046,15 +1097,20 @@ else
     private RoleForm _roleForm = new();
     private bool _rolePermissionDialogOpen;
     private bool _loadingRolePermissions;
+    private Guid? _loadingRolePermissionsRoleId;
     private bool _rolePermissionOverridesLoaded;
     private IdentityRole? _permissionRole;
     private Dictionary<string, string> _rolePermissionValues = new(StringComparer.OrdinalIgnoreCase);
+    private string _selectedRolePermissionFeatureKey = TenantModuleFeatureKeys.Identity;
+    private HashSet<string> _expandedRolePermissionFeatureKeys = new(StringComparer.OrdinalIgnoreCase);
+    private List<PermissionFeatureTreeNode> _rolePermissionTreeNodes = [];
     private const string PermissionInherit = "inherit";
     private const string PermissionAllow = "allow";
     private const string PermissionDeny = "deny";
     private static readonly IReadOnlyList<string> PermissionCapabilities = IdentityAuthorizationConstants.CapabilityKeys;
-    private static IEnumerable<IGrouping<string, TenantModuleFeatureDefinition>> PermissionFeatureGroups =>
-        TenantModuleFeatureKeys.All.GroupBy(x => x.ModuleKey);
+
+    private TenantModuleFeatureDefinition? SelectedRolePermissionFeature =>
+        TenantModuleFeatureKeys.Find(_selectedRolePermissionFeatureKey);
 
     // Remove Role dialog
     private bool _removeRoleDialogOpen;
@@ -1741,14 +1797,18 @@ else
 
     private async Task OpenRolePermissionsDialog(IdentityRole role)
     {
-        _permissionRole = role;
-        _rolePermissionValues = BuildEmptyPermissionValueMap();
-        _rolePermissionDialogOpen = true;
+        if (_loadingRolePermissions)
+        {
+            return;
+        }
+
         _loadingRolePermissions = true;
+        _loadingRolePermissionsRoleId = role.Id;
         _rolePermissionOverridesLoaded = false;
 
         try
         {
+            var permissionValues = BuildEmptyPermissionValueMap();
             var result = await IdentityServer.GetCredentialRolePermissionOverrides(new GetCredentialRolePermissionOverridesRequest
             {
                 IdentityRoleId = role.Id,
@@ -1758,28 +1818,37 @@ else
             if (!result.IsSuccess || result.Response is null)
             {
                 ToastService.Error("Role permission overrides could not be loaded.", "Permissions failed");
-                CloseRolePermissionsDialog(false);
                 return;
             }
 
             foreach (var permission in result.Response.Overrides)
             {
                 var key = BuildPermissionKey(permission.ModuleKey, permission.SubFeatureKey, permission.CapabilityKey);
-                _rolePermissionValues[key] = permission.Effect == RoleCapabilityPermissionEffect.Allow
+                permissionValues[key] = permission.Effect == RoleCapabilityPermissionEffect.Allow
                     ? PermissionAllow
                     : PermissionDeny;
             }
 
+            _permissionRole = role;
+            _rolePermissionValues = permissionValues;
+            _rolePermissionTreeNodes = BuildPermissionTree();
+            _expandedRolePermissionFeatureKeys = _rolePermissionTreeNodes
+                .Select(x => x.Feature.Key)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            _selectedRolePermissionFeatureKey = TenantModuleFeatureKeys.Identity;
             _rolePermissionOverridesLoaded = true;
+            // BlazorBlueprint 3.12 can drop a portal refresh during the opening render.
+            // Open only after the dialog's content is complete so no loading fragment must be replaced.
+            _rolePermissionDialogOpen = true;
         }
         catch
         {
             ToastService.Error("Role permission overrides could not be loaded.", "Permissions failed");
-            CloseRolePermissionsDialog(false);
         }
         finally
         {
             _loadingRolePermissions = false;
+            _loadingRolePermissionsRoleId = null;
         }
     }
 
@@ -1793,7 +1862,9 @@ else
 
         _permissionRole = null;
         _rolePermissionValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        _loadingRolePermissions = false;
+        _rolePermissionTreeNodes = [];
+        _expandedRolePermissionFeatureKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        _selectedRolePermissionFeatureKey = TenantModuleFeatureKeys.Identity;
         _rolePermissionOverridesLoaded = false;
     }
 
@@ -1882,6 +1953,18 @@ else
         return values;
     }
 
+    private static List<PermissionFeatureTreeNode> BuildPermissionTree() =>
+        TenantModuleFeatureKeys.All
+            .Where(x => string.IsNullOrWhiteSpace(x.SubFeatureKey))
+            .Select(root => new PermissionFeatureTreeNode(
+                root,
+                TenantModuleFeatureKeys.All
+                    .Where(child => string.Equals(child.ModuleKey, root.ModuleKey, StringComparison.OrdinalIgnoreCase)
+                                    && !string.IsNullOrWhiteSpace(child.SubFeatureKey))
+                    .Select(child => new PermissionFeatureTreeNode(child, []))
+                    .ToList()))
+            .ToList();
+
     private string GetPermissionOverrideValue(TenantModuleFeatureDefinition feature, string capability) =>
         _rolePermissionValues.TryGetValue(BuildPermissionKey(feature, capability), out var value)
             ? value
@@ -1896,15 +1979,41 @@ else
             value == PermissionAllow || value == PermissionDeny ? value : PermissionInherit;
     }
 
+    private string GetPermissionOverrideBadge(TenantModuleFeatureDefinition feature)
+    {
+        var explicitCount = PermissionCapabilities.Count(capability =>
+            GetPermissionOverrideValue(feature, capability) is var value
+            && (value == PermissionAllow || value == PermissionDeny));
+
+        return explicitCount == 0 ? "Inherited" : $"{explicitCount} explicit";
+    }
+
+    private string GetRolePermissionTreeItemClass(TenantModuleFeatureDefinition feature) =>
+        string.Equals(feature.Key, _selectedRolePermissionFeatureKey, StringComparison.OrdinalIgnoreCase)
+            ? "tenant-module-tree-item-selected"
+            : string.Empty;
+
+    private Task OnRolePermissionFeatureSelected(string value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            _selectedRolePermissionFeatureKey = value;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnRolePermissionTreeExpandedValuesChanged(HashSet<string> values)
+    {
+        _expandedRolePermissionFeatureKeys = new HashSet<string>(values, StringComparer.OrdinalIgnoreCase);
+        return Task.CompletedTask;
+    }
+
     private static string BuildPermissionKey(TenantModuleFeatureDefinition feature, string capability) =>
         BuildPermissionKey(feature.ModuleKey, feature.SubFeatureKey, capability);
 
     private static string BuildPermissionKey(string moduleKey, string? subFeatureKey, string capability) =>
         $"{moduleKey}|{subFeatureKey ?? string.Empty}|{capability}";
-
-    private static string GetModulePermissionHeading(IGrouping<string, TenantModuleFeatureDefinition> moduleGroup) =>
-        moduleGroup.FirstOrDefault(x => string.IsNullOrWhiteSpace(x.SubFeatureKey))?.DisplayName
-        ?? moduleGroup.Key;
 
     private static string FormatCapabilityLabel(string capability) =>
         CultureInfo.CurrentCulture.TextInfo.ToTitleCase(capability.Replace('_', ' '));
@@ -2311,6 +2420,10 @@ else
 
     private static bool IsRoleExpirationUnlimited(DateTime expiration) =>
         expiration >= NoRoleExpirationUtc.AddDays(-1);
+
+    private sealed record PermissionFeatureTreeNode(
+        TenantModuleFeatureDefinition Feature,
+        IReadOnlyList<PermissionFeatureTreeNode> Children);
 
     private class CredentialForm
     {

--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
@@ -180,7 +180,9 @@ else
                     <BbCardHeader>
                         <div class="flex items-center justify-between">
                             <BbCardTitle>Assigned Roles</BbCardTitle>
-                            <BbButton Size="ButtonSize.Small" OnClick="@OpenAssignRoleDialog">
+                            <BbButton Size="ButtonSize.Small"
+                                      OnClick="@OpenAssignRoleDialog"
+                                      Disabled="@(_loadingRolePermissions || _savingRolePermissions)">
                                 <LucideIcon Name="plus" class="mr-2 h-4 w-4" />
                                 Assign Role
                             </BbButton>
@@ -227,9 +229,11 @@ else
                                     <ChildContent Context="role">
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
                                                   title="Edit role permission overrides"
-                                                  Disabled="@_loadingRolePermissions"
+                                                  AriaLabel="@GetRolePermissionActionAriaLabel(role)"
+                                                  aria-busy="@GetRolePermissionAriaBusy(role)"
+                                                  Disabled="@(_loadingRolePermissions || _savingRolePermissions)"
                                                   OnClick="@(() => OpenRolePermissionsDialog(role))">
-                                            @if (_loadingRolePermissions && _loadingRolePermissionsRoleId == role.Id)
+                                            @if (IsLoadingRolePermissions(role))
                                             {
                                                 <LucideIcon Name="loader-2" class="h-4 w-4 animate-spin" />
                                             }
@@ -240,6 +244,7 @@ else
                                         </BbButton>
                                         <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Icon"
                                                   title="Remove assigned role"
+                                                  Disabled="@(_loadingRolePermissions || _savingRolePermissions)"
                                                   OnClick="@(() => OpenRemoveRoleDialog(role))">
                                             <LucideIcon Name="trash-2" class="h-4 w-4 text-destructive" />
                                         </BbButton>
@@ -795,7 +800,9 @@ else
 
 <!-- Credential Role Permission Overrides Dialog -->
 <BbDialog Open="@_rolePermissionDialogOpen" OpenChanged="@CloseRolePermissionsDialog">
-    <BbDialogContent TrapFocus="false" Class="identity-role-permissions-dialog">
+    <BbDialogContent TrapFocus="false"
+                     ShowClose="@(!_savingRolePermissions)"
+                     Class="identity-role-permissions-dialog">
         <BbDialogHeader>
             <BbDialogTitle>Role Permission Overrides</BbDialogTitle>
             <BbDialogDescription>
@@ -877,6 +884,7 @@ else
                             <BbFormFieldSelect TValue="string"
                                                Label="@FormatCapabilityLabel(capability)"
                                                Value="@GetPermissionOverrideValue(SelectedRolePermissionFeature, capability)"
+                                               Disabled="@_savingRolePermissions"
                                                ValueChanged="@((string value) => SetPermissionOverrideValue(SelectedRolePermissionFeature, capability, value))">
                                 <BbSelectItem Value="@PermissionInherit">Inherit</BbSelectItem>
                                 <BbSelectItem Value="@PermissionAllow">Allow</BbSelectItem>
@@ -889,9 +897,13 @@ else
         </div>
 
         <BbDialogFooter>
-            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => CloseRolePermissionsDialog(false))">Cancel</BbButton>
-            <BbButton OnClick="@SaveRolePermissionOverrides" Disabled="@(_saving || !_rolePermissionOverridesLoaded)">
-                @(_saving ? "Saving..." : "Save Overrides")
+            <BbButton Variant="ButtonVariant.Outline"
+                      OnClick="@(() => CloseRolePermissionsDialog(false))"
+                      Disabled="@_savingRolePermissions">
+                Cancel
+            </BbButton>
+            <BbButton OnClick="@SaveRolePermissionOverrides" Disabled="@(_savingRolePermissions || !_rolePermissionOverridesLoaded)">
+                @(_savingRolePermissions ? "Saving..." : "Save Overrides")
             </BbButton>
         </BbDialogFooter>
     </BbDialogContent>
@@ -1098,6 +1110,8 @@ else
     private bool _rolePermissionDialogOpen;
     private bool _loadingRolePermissions;
     private Guid? _loadingRolePermissionsRoleId;
+    private bool _savingRolePermissions;
+    private long _rolePermissionOperationVersion;
     private bool _rolePermissionOverridesLoaded;
     private IdentityRole? _permissionRole;
     private Dictionary<string, string> _rolePermissionValues = new(StringComparer.OrdinalIgnoreCase);
@@ -1133,6 +1147,11 @@ else
     protected override async Task OnParametersSetAsync()
     {
         var normalizedSection = NormalizeSection(Section);
+        if (_loadedId != Id || !string.Equals(normalizedSection, "roles", StringComparison.OrdinalIgnoreCase))
+        {
+            InvalidateRolePermissionDialogState();
+        }
+
         if (ShouldCanonicalizeSection(normalizedSection))
         {
             Navigation.NavigateTo(GetSectionHref(normalizedSection), replace: true);
@@ -1178,6 +1197,7 @@ else
 
     private void OnTenantFilterChanged()
     {
+        InvalidateRolePermissionDialogState();
         _ = InvokeAsync(async () =>
         {
             await ReloadAllData();
@@ -1187,6 +1207,7 @@ else
 
     private async Task ReloadAllData()
     {
+        InvalidateRolePermissionDialogState();
         _loading = true;
         try
         {
@@ -1701,6 +1722,11 @@ else
 
     private void OpenAssignRoleDialog()
     {
+        if (_loadingRolePermissions || _savingRolePermissions)
+        {
+            return;
+        }
+
         _roleForm = new RoleForm();
         _assignRoleDialogOpen = true;
     }
@@ -1758,6 +1784,11 @@ else
 
     private void OpenRemoveRoleDialog(IdentityRole role)
     {
+        if (_loadingRolePermissions || _savingRolePermissions)
+        {
+            return;
+        }
+
         _removingRole = role;
         _removeRoleDialogOpen = true;
     }
@@ -1797,11 +1828,14 @@ else
 
     private async Task OpenRolePermissionsDialog(IdentityRole role)
     {
-        if (_loadingRolePermissions)
+        if (_loadingRolePermissions || _savingRolePermissions)
         {
             return;
         }
 
+        var operationVersion = ++_rolePermissionOperationVersion;
+        var userId = Id;
+        var section = CurrentSection;
         _loadingRolePermissions = true;
         _loadingRolePermissionsRoleId = role.Id;
         _rolePermissionOverridesLoaded = false;
@@ -1814,6 +1848,11 @@ else
                 IdentityRoleId = role.Id,
                 Metadata = CreateMetadata(role.TenantId)
             });
+
+            if (!IsRolePermissionLoadCurrent(operationVersion, userId, section, role))
+            {
+                return;
+            }
 
             if (!result.IsSuccess || result.Response is null)
             {
@@ -1843,23 +1882,43 @@ else
         }
         catch
         {
-            ToastService.Error("Role permission overrides could not be loaded.", "Permissions failed");
+            if (IsRolePermissionLoadCurrent(operationVersion, userId, section, role))
+            {
+                ToastService.Error("Role permission overrides could not be loaded.", "Permissions failed");
+            }
         }
         finally
         {
-            _loadingRolePermissions = false;
-            _loadingRolePermissionsRoleId = null;
+            if (_rolePermissionOperationVersion == operationVersion)
+            {
+                _loadingRolePermissions = false;
+                _loadingRolePermissionsRoleId = null;
+            }
         }
     }
 
     private void CloseRolePermissionsDialog(bool open)
     {
-        _rolePermissionDialogOpen = open;
         if (open)
+        {
+            _rolePermissionDialogOpen = true;
+            return;
+        }
+
+        if (_savingRolePermissions)
         {
             return;
         }
 
+        InvalidateRolePermissionDialogState();
+    }
+
+    private void InvalidateRolePermissionDialogState()
+    {
+        _rolePermissionOperationVersion++;
+        _rolePermissionDialogOpen = false;
+        _loadingRolePermissions = false;
+        _loadingRolePermissionsRoleId = null;
         _permissionRole = null;
         _rolePermissionValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         _rolePermissionTreeNodes = [];
@@ -1867,6 +1926,36 @@ else
         _selectedRolePermissionFeatureKey = TenantModuleFeatureKeys.Identity;
         _rolePermissionOverridesLoaded = false;
     }
+
+    private bool IsRolePermissionLoadCurrent(
+        long operationVersion,
+        Guid userId,
+        string section,
+        IdentityRole role) =>
+        _rolePermissionOperationVersion == operationVersion
+        && Id == userId
+        && _loadedId == userId
+        && string.Equals(CurrentSection, section, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(section, "roles", StringComparison.OrdinalIgnoreCase)
+        && _roles.Any(candidate => candidate.Id == role.Id && candidate.TenantId == role.TenantId);
+
+    private bool IsRolePermissionSaveCurrent(long operationVersion, IdentityRole role) =>
+        _rolePermissionOperationVersion == operationVersion
+        && _rolePermissionDialogOpen
+        && _permissionRole is { } currentRole
+        && currentRole.Id == role.Id
+        && currentRole.TenantId == role.TenantId;
+
+    private bool IsLoadingRolePermissions(IdentityRole role) =>
+        _loadingRolePermissions && _loadingRolePermissionsRoleId == role.Id;
+
+    private string GetRolePermissionActionAriaLabel(IdentityRole role) =>
+        IsLoadingRolePermissions(role)
+            ? "Loading role permission overrides"
+            : "Edit role permission overrides";
+
+    private string GetRolePermissionAriaBusy(IdentityRole role) =>
+        IsLoadingRolePermissions(role) ? "true" : "false";
 
     private async Task SaveRolePermissionOverrides()
     {
@@ -1880,21 +1969,28 @@ else
             return;
         }
 
-        _saving = true;
+        var permissionRole = _permissionRole;
+        var operationVersion = _rolePermissionOperationVersion;
+        var overrides = BuildPermissionOverrides();
+        _savingRolePermissions = true;
         try
         {
-            var overrides = BuildPermissionOverrides();
             var result = await IdentityServer.SetCredentialRolePermissionOverrides(new SetCredentialRolePermissionOverridesRequest
             {
-                IdentityRoleId = _permissionRole.Id,
+                IdentityRoleId = permissionRole.Id,
                 Overrides = overrides,
-                Metadata = CreateMetadata(_permissionRole.TenantId)
+                Metadata = CreateMetadata(permissionRole.TenantId)
             });
+
+            if (!IsRolePermissionSaveCurrent(operationVersion, permissionRole))
+            {
+                return;
+            }
 
             if (result.IsSuccess)
             {
                 ToastService.Success("Role permission overrides saved.", "Permissions saved");
-                CloseRolePermissionsDialog(false);
+                InvalidateRolePermissionDialogState();
             }
             else
             {
@@ -1903,11 +1999,14 @@ else
         }
         catch
         {
-            ToastService.Error("Role permission overrides could not be saved.", "Permissions failed");
+            if (IsRolePermissionSaveCurrent(operationVersion, permissionRole))
+            {
+                ToastService.Error("Role permission overrides could not be saved.", "Permissions failed");
+            }
         }
         finally
         {
-            _saving = false;
+            _savingRolePermissions = false;
         }
     }
 
@@ -2460,6 +2559,7 @@ else
 
     public void Dispose()
     {
+        InvalidateRolePermissionDialogState();
         TenantFilter.OnChanged -= OnTenantFilterChanged;
         ModuleNavigation.OnChanged -= OnTenantFilterChanged;
     }

--- a/src/Presentation/XFramework.Portal/wwwroot/css/app.css
+++ b/src/Presentation/XFramework.Portal/wwwroot/css/app.css
@@ -829,16 +829,53 @@
 }
 
 .identity-role-permissions-dialog {
-    width: min(52rem, calc(100vw - 2rem));
-    max-width: min(52rem, calc(100vw - 2rem));
+    width: min(68rem, calc(100vw - 2rem));
+    max-width: min(68rem, calc(100vw - 2rem));
 }
 
 .identity-role-permissions-dialog-body {
     display: grid;
+    grid-template-columns: minmax(18rem, 0.9fr) minmax(24rem, 1.1fr);
+    gap: 1rem;
+    min-height: min(26rem, 62vh);
+    max-height: min(66vh, 38rem);
+    overflow: hidden;
+    padding-block: 0.5rem;
+}
+
+.identity-role-permissions-tree-panel,
+.identity-role-permissions-feature-panel {
+    min-width: 0;
+}
+
+.identity-role-permissions-tree-panel {
+    overflow-y: auto;
+    border-right: 1px solid var(--border);
+    padding-right: 1rem;
+}
+
+.tenant-module-tree.identity-role-permissions-tree {
+    max-height: none;
+}
+
+.identity-role-permissions-feature-panel {
+    display: grid;
+    align-content: start;
     gap: 1rem;
     overflow-y: auto;
-    max-height: min(62vh, 34rem);
-    padding: 1rem 0.5rem 1rem 0;
+    padding-right: 0.25rem;
+}
+
+.identity-role-permissions-inheritance-note {
+    color: var(--muted-foreground);
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
+}
+
+.identity-role-permissions-capabilities {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
 }
 
 .xf-entity-picker-advanced-hint {
@@ -2341,6 +2378,28 @@
     }
 
     .tenant-module-preview-meta {
+        grid-template-columns: 1fr;
+    }
+
+    .identity-role-permissions-dialog-body {
+        grid-template-columns: 1fr;
+        overflow-y: auto;
+    }
+
+    .identity-role-permissions-tree-panel {
+        max-height: 18rem;
+        border-right: 0;
+        border-bottom: 1px solid var(--border);
+        padding-right: 0;
+        padding-bottom: 1rem;
+    }
+
+    .identity-role-permissions-feature-panel {
+        overflow: visible;
+        padding-right: 0;
+    }
+
+    .identity-role-permissions-capabilities {
         grid-template-columns: 1fr;
     }
 }

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -247,6 +247,51 @@ public sealed class IdentityServerPortalContractTests
     }
 
     [Test]
+    public void IdentityServerRolePermissionDialog_LoadsBeforeOpeningAndRendersOnlyTheSelectedFeature()
+    {
+        var userDetail = File.ReadAllText(Path.Combine(GetIdentityPagesRoot(), "UserDetail.razor"));
+
+        var dialogStart = userDetail.IndexOf(
+            "<!-- Credential Role Permission Overrides Dialog -->",
+            StringComparison.Ordinal);
+        var dialogEnd = userDetail.IndexOf(
+            "<!-- Remove Role Confirmation -->",
+            dialogStart,
+            StringComparison.Ordinal);
+        dialogStart.Should().BeGreaterThanOrEqualTo(0);
+        dialogEnd.Should().BeGreaterThan(dialogStart);
+
+        var dialogSource = userDetail[dialogStart..dialogEnd];
+        dialogSource.Should().Contain("<BbTreeView TItem=\"PermissionFeatureTreeNode\"");
+        dialogSource.Should().Contain("SelectedRolePermissionFeature");
+        dialogSource.Should().NotContain("<CenteredSpinner");
+        dialogSource.Split("<BbFormFieldSelect", StringSplitOptions.None)
+            .Should().HaveCount(2, "the selected feature should render one capability editor template");
+
+        var openMethodStart = userDetail.IndexOf(
+            "private async Task OpenRolePermissionsDialog",
+            StringComparison.Ordinal);
+        var openMethodEnd = userDetail.IndexOf(
+            "private void CloseRolePermissionsDialog",
+            openMethodStart,
+            StringComparison.Ordinal);
+        var openMethod = userDetail[openMethodStart..openMethodEnd];
+        var loadIndex = openMethod.IndexOf(
+            "await IdentityServer.GetCredentialRolePermissionOverrides",
+            StringComparison.Ordinal);
+        var loadedIndex = openMethod.IndexOf("_rolePermissionOverridesLoaded = true;", StringComparison.Ordinal);
+        var dialogOpenIndex = openMethod.IndexOf("_rolePermissionDialogOpen = true;", StringComparison.Ordinal);
+
+        loadIndex.Should().BeGreaterThanOrEqualTo(0);
+        loadedIndex.Should().BeGreaterThan(loadIndex);
+        dialogOpenIndex.Should().BeGreaterThan(
+            loadedIndex,
+            "portaled dialog content must be complete before the dialog is registered as open");
+        openMethod.Split("_rolePermissionDialogOpen = true;", StringSplitOptions.None)
+            .Should().HaveCount(2, "the dialog should have one post-load open transition");
+    }
+
+    [Test]
     public void IdentityServerAuthorizationBackend_RequiresEndpointAndServiceLevelAuthorization()
     {
         var repositoryRoot = FindRepositoryRoot();

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -236,7 +236,8 @@ public sealed class IdentityServerPortalContractTests
         userDetail.Should().Contain("RoleCapabilityPermissionEffect.Allow");
         userDetail.Should().Contain("RoleCapabilityPermissionEffect.Deny");
         userDetail.Should().Contain("_rolePermissionOverridesLoaded");
-        userDetail.Should().Contain("<BbDialogContent TrapFocus=\"false\" Class=\"identity-role-permissions-dialog\">");
+        userDetail.Should().Contain("<BbDialogContent TrapFocus=\"false\"");
+        userDetail.Should().Contain("Class=\"identity-role-permissions-dialog\">");
         userDetail.Should().Contain("<div class=\"identity-role-permissions-dialog-body\">");
         userDetail.Should().NotContain("max-h-[65vh]");
         userDetail.Should().Contain("<BbDataGridTemplateColumn Title=\"Level\" Sortable=\"true\" Filterable=\"true\" FilterBy=\"@(role => GetRoleLevelFilter(role))\">");
@@ -264,6 +265,8 @@ public sealed class IdentityServerPortalContractTests
         var dialogSource = userDetail[dialogStart..dialogEnd];
         dialogSource.Should().Contain("<BbTreeView TItem=\"PermissionFeatureTreeNode\"");
         dialogSource.Should().Contain("SelectedRolePermissionFeature");
+        dialogSource.Should().Contain("ShowClose=\"@(!_savingRolePermissions)\"");
+        dialogSource.Should().Contain("Disabled=\"@_savingRolePermissions\"");
         dialogSource.Should().NotContain("<CenteredSpinner");
         dialogSource.Split("<BbFormFieldSelect", StringSplitOptions.None)
             .Should().HaveCount(2, "the selected feature should render one capability editor template");
@@ -284,11 +287,27 @@ public sealed class IdentityServerPortalContractTests
 
         loadIndex.Should().BeGreaterThanOrEqualTo(0);
         loadedIndex.Should().BeGreaterThan(loadIndex);
+        openMethod.Should().Contain("IsRolePermissionLoadCurrent(operationVersion, userId, section, role)");
         dialogOpenIndex.Should().BeGreaterThan(
             loadedIndex,
             "portaled dialog content must be complete before the dialog is registered as open");
         openMethod.Split("_rolePermissionDialogOpen = true;", StringSplitOptions.None)
             .Should().HaveCount(2, "the dialog should have one post-load open transition");
+
+        var saveMethodStart = userDetail.IndexOf(
+            "private async Task SaveRolePermissionOverrides",
+            StringComparison.Ordinal);
+        var saveMethodEnd = userDetail.IndexOf(
+            "private List<CapabilityPermissionDto> BuildPermissionOverrides",
+            saveMethodStart,
+            StringComparison.Ordinal);
+        var saveMethod = userDetail[saveMethodStart..saveMethodEnd];
+        saveMethod.Should().Contain("var operationVersion = _rolePermissionOperationVersion;");
+        saveMethod.Should().Contain("IsRolePermissionSaveCurrent(operationVersion, permissionRole)");
+        saveMethod.Should().Contain("_savingRolePermissions = true;");
+
+        userDetail.Should().Contain("InvalidateRolePermissionDialogState();");
+        userDetail.Should().Contain("AriaLabel=\"@GetRolePermissionActionAriaLabel(role)\"");
     }
 
     [Test]

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -302,12 +302,14 @@ public sealed class IdentityServerPortalContractTests
             saveMethodStart,
             StringComparison.Ordinal);
         var saveMethod = userDetail[saveMethodStart..saveMethodEnd];
+        saveMethod.Should().Contain("if (_savingRolePermissions)");
         saveMethod.Should().Contain("var operationVersion = _rolePermissionOperationVersion;");
         saveMethod.Should().Contain("IsRolePermissionSaveCurrent(operationVersion, permissionRole)");
         saveMethod.Should().Contain("_savingRolePermissions = true;");
 
         userDetail.Should().Contain("InvalidateRolePermissionDialogState();");
         userDetail.Should().Contain("AriaLabel=\"@GetRolePermissionActionAriaLabel(role)\"");
+        userDetail.Should().Contain("GetCredentialLabelById(role.CredentialId)");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- load credential role permission overrides before opening the portaled dialog
- replace the 240-select matrix with a feature tree and selected-feature editor
- add Portal contract coverage for load-before-open ordering and bounded rendering

## Verification
- dotnet build src/Presentation/XFramework.Portal/XFramework.Portal.csproj -m:1 /nr:false
- dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --filter TestCategory=Area:PortalContract -m:1 /nr:false