### PR TITLE
Fix dynamic BlazorBlueprint container portal refreshes

### DIFF
--- a/docs/solutions/tooling-decisions/blazor-blueprint-portal-agent-guide.md
+++ b/docs/solutions/tooling-decisions/blazor-blueprint-portal-agent-guide.md
@@ -45,9 +45,9 @@ The current Portal uses BlazorBlueprint `3.12.0`:
 - `Components/_Imports.razor` imports `BlazorBlueprint.Components`, `BlazorBlueprint.Primitives`, `BlazorBlueprint.Primitives.Services`, `BlazorBlueprint.Icons.Lucide.Components`, and `BlazorBlueprint.Icons.Lucide.Data`.
 - `Components/App.razor` loads `_content/BlazorBlueprint.Components/css/themes.css` and `_content/BlazorBlueprint.Components/blazorblueprint.css`.
 - `Components/App.razor` renders routes with `@rendermode="InteractiveServer"`.
-- `Components/Layout/MainLayout.razor` includes `BbToastProvider`, `BbDialogProvider`, and `BbPortalHost`.
+- `Components/Layout/MainLayout.razor` includes `BbToastProvider`, `BbDialogProvider`, `XfContainerPortalHost`, and `BbOverlayPortalHost`. `XfPortalService` preserves BlazorBlueprint's public portal contract while giving the custom container host the changed portal ID, allowing it to queue only dialog/sheet refreshes whose content already rendered in the active cycle.
 
-Do not remove `BbPortalHost`. The official installation docs state it is required for portal-based controls such as Popover, Dialog, Sheet, Dropdown Menu, Combobox, and Select.
+Do not remove the portal-host composition. Portal-based controls such as Popover, Dialog, Sheet, Dropdown Menu, Combobox, and Select require it. In `MainLayout`, do not replace `XfPortalService`, `XfContainerPortalHost`, and `BbOverlayPortalHost` with the stock service/combined host until a BlazorBlueprint version newer than `3.12.0` has a verified fix for dropped container refreshes and repeated dialog browser tests pass.
 
 ## Component Layering
 
@@ -151,6 +151,7 @@ For overlays inside dialogs, verify the nested overlay in both light and dark th
 ## Known Local Pitfalls
 
 - The profile switcher once used `CloseOnClickOutside` and `CloseOnEscape` on `BbPopover`; that caused runtime failures because those options belong on content components, not the `BbPopover` root.
+- BlazorBlueprint `3.12.0`'s category portal host ignores refresh notifications received while it is rendering. `XfPortalService` and `XfContainerPortalHost` queue a follow-up render only when the changed dialog/sheet portal already rendered in the current cycle; `MainLayout` retains the stock overlay host for popovers and selects. The Portal contract intentionally fails when the package version changes so this compatibility layer is reviewed instead of becoming permanent infrastructure.
 - A profile trigger using `AsChild=true` with plain HTML markup did not open because the raw child did not consume `TriggerContext`. Prefer documented trigger examples and verify the rendered DOM.
 - `LoginLayout` is intentionally plain. If a login page starts using Blueprint overlays, toasts, dialogs, or services, add the required providers or an interactive island.
 - Native OS dropdowns look out of place in Portal. Use BlazorBlueprint Combobox/Select components for tenant and entity selection.

--- a/rules/UiGuidelines.md
+++ b/rules/UiGuidelines.md
@@ -18,7 +18,7 @@ Select-String -Path $xml -Pattern 'BbDataGrid|BbDynamicForm|BbFormWizard|BbFilte
 ## Portal Baseline
 
 - Preserve BlazorBlueprint setup: `AddInteractiveServerComponents`, `AddBlazorBlueprintComponents`, `_content/BlazorBlueprint.Components` CSS, `InteractiveServer` render mode, and shared imports.
-- Preserve `BbToastProvider`, `BbDialogProvider`, and `BbPortalHost` in layouts that use portal-based controls.
+- Preserve `BbToastProvider`, `BbDialogProvider`, `XfPortalService`, and the Portal host composition in layouts that use portal-based controls. `MainLayout` uses `XfContainerPortalHost` for dialogs/sheets plus `BbOverlayPortalHost` for popovers/selects because BlazorBlueprint `3.12.0` can discard dynamic container refreshes received during rendering. Re-evaluate and remove this compatibility layer when upgrading BlazorBlueprint.
 - Prefer styled `BlazorBlueprint.Components` controls. Use `BlazorBlueprint.Primitives` only when the styled component cannot support the workflow.
 - Use Lucide icon components from `BlazorBlueprint.Icons.Lucide.Components`; do not hand-draw common UI icons.
 

--- a/src/Presentation/XFramework.Portal/Components/Layout/MainLayout.razor
+++ b/src/Presentation/XFramework.Portal/Components/Layout/MainLayout.razor
@@ -170,7 +170,8 @@
 
 <BbToastProvider Position="ToastPosition.BottomRight" />
 <BbDialogProvider />
-<BbPortalHost />
+<XfContainerPortalHost />
+<BbOverlayPortalHost />
 
 @code {
     [Inject] private IDataContext DataContext { get; set; } = default!;

--- a/src/Presentation/XFramework.Portal/Components/Shared/XfContainerPortalHost.razor
+++ b/src/Presentation/XFramework.Portal/Components/Shared/XfContainerPortalHost.razor
@@ -1,0 +1,133 @@
+@namespace XFramework.Portal.Components.Shared
+@using Microsoft.JSInterop
+@implements IAsyncDisposable
+@inject XfPortalService PortalService
+@inject IJSRuntime JSRuntime
+
+@* Compatibility host adapted from BlazorBlueprint 3.12.0 (Apache-2.0).
+   BlazorBlueprint drops container refreshes received during a host render.
+   Queue one follow-up render so dialogs and sheets receive their latest child content. *@
+@{
+    _isRendering = true;
+    _renderedThisCycle.Clear();
+}
+@foreach (var portal in PortalService.GetPortals(PortalCategory.Container))
+{
+    _renderedThisCycle.Add(portal.Key);
+    <div @key="portal.Key"
+         data-portal-id="@portal.Key"
+         data-portal-category="@PortalCategory.Container"
+         class="blazorblueprint-portal"
+         style="display: contents;">
+        @portal.Value
+    </div>
+}
+
+@code {
+    private readonly HashSet<string> _renderedThisCycle = [];
+    private IJSObjectReference? _portalModule;
+    private bool _isRendering;
+    private bool _isFirstCategoryHost;
+    private bool _refreshRequestedDuringRender;
+
+    protected override void OnInitialized()
+    {
+        if (!PortalService.HasHost)
+        {
+            PortalService.RegisterHost();
+            _isFirstCategoryHost = true;
+        }
+
+        PortalService.OnPortalChanged += HandlePortalChanged;
+    }
+
+    private void HandlePortalChanged(XfPortalChange change)
+    {
+        if (change.Category != PortalCategory.Container)
+        {
+            return;
+        }
+
+        if (_isRendering)
+        {
+            if (_renderedThisCycle.Contains(change.PortalId))
+            {
+                _refreshRequestedDuringRender = true;
+            }
+
+            return;
+        }
+
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        _isRendering = false;
+
+        if (firstRender)
+        {
+            try
+            {
+                _portalModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import",
+                    "./_content/BlazorBlueprint.Primitives/js/primitives/portal.js");
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Expected while an interactive server circuit is disconnecting.
+            }
+            catch (InvalidOperationException)
+            {
+                // JS interop is unavailable during prerendering.
+            }
+        }
+
+        foreach (var portalId in _renderedThisCycle)
+        {
+            PortalService.NotifyPortalRendered(portalId);
+        }
+
+        var currentPortalKeys = PortalService.GetPortals(PortalCategory.Container)
+            .Select(portal => portal.Key)
+            .ToHashSet(StringComparer.Ordinal);
+        var portalsChanged = !_renderedThisCycle.SetEquals(currentPortalKeys);
+        var refreshQueued = _refreshRequestedDuringRender;
+        _refreshRequestedDuringRender = false;
+
+        if (portalsChanged)
+        {
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        if (refreshQueued)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_isFirstCategoryHost)
+        {
+            PortalService.UnregisterHost();
+        }
+
+        PortalService.OnPortalChanged -= HandlePortalChanged;
+
+        if (_portalModule is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _portalModule.DisposeAsync();
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Expected while an interactive server circuit is disconnecting.
+        }
+    }
+}

--- a/src/Presentation/XFramework.Portal/Program.cs
+++ b/src/Presentation/XFramework.Portal/Program.cs
@@ -12,6 +12,8 @@ using IdentityServer.Integration.Drivers;
 using Inventario.Integration.Drivers;
 using Communications.Integration.Drivers;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using BlazorBlueprint.Primitives.Services;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using POS.Integration.Drivers;
 using Storage.Integration.Drivers;
@@ -54,6 +56,10 @@ builder.Services.AddBlazorBlueprintComponents(configureTheme: options =>
     options.DefaultRadius = 0.5;
     options.PersistToLocalStorage = true;
 });
+// Remove this compatibility layer after a BlazorBlueprint upgrade passes repeated dynamic-dialog tests.
+builder.Services.AddScoped<XfPortalService>();
+builder.Services.Replace(ServiceDescriptor.Scoped<IPortalService>(
+    services => services.GetRequiredService<XfPortalService>()));
 
 // Bolt - thin binary RPC transport to microservices
 builder.Services.AddXFrameworkBoltClient(builder.Configuration);

--- a/src/Presentation/XFramework.Portal/Properties/AssemblyInfo.cs
+++ b/src/Presentation/XFramework.Portal/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Portal.E2ETests")]

--- a/src/Presentation/XFramework.Portal/Services/XfPortalService.cs
+++ b/src/Presentation/XFramework.Portal/Services/XfPortalService.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using BlazorBlueprint.Primitives;
+using BlazorBlueprint.Primitives.Services;
+using Microsoft.AspNetCore.Components;
+
+namespace XFramework.Portal.Services;
+
+// Compatibility implementation adapted from BlazorBlueprint 3.12.0 PortalService (Apache-2.0).
+public sealed class XfPortalService(ILogger<XfPortalService> logger) : IPortalService
+{
+    private readonly ConcurrentDictionary<string, PortalRegistration> _portals = new();
+    private long _nextOrder;
+    private bool _hasWarnedMissingHost;
+
+    public bool HasHost { get; private set; }
+
+    public event Action<PortalCategory>? OnPortalsCategoryChanged;
+    public event Action<string>? OnPortalRendered;
+    internal event Action<XfPortalChange>? OnPortalChanged;
+
+    public void RegisterHost() => HasHost = true;
+
+    public void UnregisterHost() => HasHost = false;
+
+    public void NotifyPortalRendered(string portalId) =>
+        OnPortalRendered?.Invoke(portalId);
+
+    public void RegisterPortal(string id, RenderFragment content, PortalCategory category)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentNullException.ThrowIfNull(content);
+
+        WarnIfHostIsMissing();
+
+        _portals[id] = new PortalRegistration(
+            content,
+            category,
+            Interlocked.Increment(ref _nextOrder));
+        NotifyPortalChanged(id, category);
+    }
+
+    public void UnregisterPortal(string id)
+    {
+        if (_portals.TryRemove(id, out var registration))
+        {
+            NotifyPortalChanged(id, registration.Category);
+        }
+    }
+
+    public void UpdatePortalContent(string id, RenderFragment content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        if (!_portals.TryGetValue(id, out var registration))
+        {
+            throw new InvalidOperationException($"Portal with ID '{id}' is not registered.");
+        }
+
+        registration.Content = content;
+        NotifyPortalChanged(id, registration.Category);
+    }
+
+    public void RefreshPortal(string id)
+    {
+        if (_portals.TryGetValue(id, out var registration))
+        {
+            NotifyPortalChanged(id, registration.Category);
+        }
+    }
+
+    public IReadOnlyList<KeyValuePair<string, RenderFragment>> GetPortals(PortalCategory category) =>
+        _portals
+            .Where(portal => portal.Value.Category == category)
+            .OrderBy(portal => portal.Value.Order)
+            .Select(portal => new KeyValuePair<string, RenderFragment>(portal.Key, portal.Value.Content))
+            .ToList();
+
+    private void NotifyPortalChanged(string id, PortalCategory category)
+    {
+        OnPortalChanged?.Invoke(new XfPortalChange(id, category));
+        OnPortalsCategoryChanged?.Invoke(category);
+    }
+
+    private void WarnIfHostIsMissing()
+    {
+        if (HasHost || _hasWarnedMissingHost)
+        {
+            return;
+        }
+
+        _hasWarnedMissingHost = true;
+        logger.LogWarning(
+            "No Portal host is registered. Dialog, sheet, popover, and select content cannot render until a host is available.");
+    }
+
+    private sealed class PortalRegistration(
+        RenderFragment content,
+        PortalCategory category,
+        long order)
+    {
+        public RenderFragment Content { get; set; } = content;
+        public PortalCategory Category { get; } = category;
+        public long Order { get; } = order;
+    }
+}
+
+internal readonly record struct XfPortalChange(string PortalId, PortalCategory Category);

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -313,6 +313,53 @@ public sealed class IdentityServerPortalContractTests
     }
 
     [Test]
+    public void PortalContainerHost_QueuesAlreadyRenderedDialogRefreshes()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var portalRoot = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "XFramework.Portal",
+            "Components");
+        var mainLayout = File.ReadAllText(Path.Combine(portalRoot, "Layout", "MainLayout.razor"));
+        var containerHost = File.ReadAllText(Path.Combine(portalRoot, "Shared", "XfContainerPortalHost.razor"));
+        var portalService = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "XFramework.Portal",
+            "Services",
+            "XfPortalService.cs"));
+        var program = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "XFramework.Portal",
+            "Program.cs"));
+        var packageVersions = File.ReadAllText(Path.Combine(repositoryRoot.FullName, "Directory.Packages.props"));
+
+        mainLayout.Should().Contain("<XfContainerPortalHost />");
+        mainLayout.Should().Contain("<BbOverlayPortalHost />");
+        mainLayout.Should().NotContain("<BbPortalHost />");
+
+        program.Should().Contain("builder.Services.AddScoped<XfPortalService>();");
+        program.Should().Contain("ServiceDescriptor.Scoped<IPortalService>");
+        portalService.Should().Contain("internal event Action<XfPortalChange>? OnPortalChanged;");
+        portalService.Should().Contain("OnPortalChanged?.Invoke(new XfPortalChange(id, category));");
+
+        containerHost.Should().Contain("change.Category != PortalCategory.Container");
+        containerHost.Should().Contain("_renderedThisCycle.Contains(change.PortalId)");
+        containerHost.Should().Contain("_refreshRequestedDuringRender = true;");
+        containerHost.Should().Contain("if (refreshQueued)");
+        containerHost.Should().NotContain("_isDeferredRefreshRender");
+        containerHost.Should().Contain("await InvokeAsync(StateHasChanged);");
+
+        packageVersions.Should().Contain("<PackageVersion Include=\"BlazorBlueprint.Components\" Version=\"3.12.0\" />");
+        packageVersions.Should().Contain("<PackageVersion Include=\"BlazorBlueprint.Primitives\" Version=\"3.12.0\" />");
+    }
+
+    [Test]
     public void IdentityServerAuthorizationBackend_RequiresEndpointAndServiceLevelAuthorization()
     {
         var repositoryRoot = FindRepositoryRoot();

--- a/src/Tests/Portal.E2ETests/Portal.E2ETests.csproj
+++ b/src/Tests/Portal.E2ETests/Portal.E2ETests.csproj
@@ -20,4 +20,8 @@
     <Using Include="NUnit.Framework" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Presentation\XFramework.Portal\XFramework.Portal.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/Portal.E2ETests/XfPortalServiceTests.cs
+++ b/src/Tests/Portal.E2ETests/XfPortalServiceTests.cs
@@ -1,0 +1,65 @@
+using BlazorBlueprint.Primitives;
+using BlazorBlueprint.Primitives.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using XFramework.Portal.Services;
+
+namespace Portal.E2ETests;
+
+[TestFixture]
+[Category("Kind:Integration")]
+[Category("Area:PortalContract")]
+public sealed class XfPortalServiceTests
+{
+    [Test]
+    public void ScopedAlias_UsesSameServiceAndReportsChangedPortalId()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddScoped<IPortalService, PortalService>();
+        services.AddScoped<XfPortalService>();
+        services.Replace(ServiceDescriptor.Scoped<IPortalService>(
+            provider => provider.GetRequiredService<XfPortalService>()));
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var portalService = scope.ServiceProvider.GetRequiredService<XfPortalService>();
+        var portalServiceAlias = scope.ServiceProvider.GetRequiredService<IPortalService>();
+        portalServiceAlias.Should().BeSameAs(portalService);
+
+        var changes = new List<XfPortalChange>();
+        portalService.OnPortalChanged += changes.Add;
+        portalService.RegisterHost();
+
+        RenderFragment content = builder => builder.AddContent(0, "Dialog content");
+        portalServiceAlias.RegisterPortal("dialog-1", content, PortalCategory.Container);
+        portalServiceAlias.RefreshPortal("dialog-1");
+        portalServiceAlias.UnregisterPortal("dialog-1");
+
+        changes.Should().Equal(
+            new XfPortalChange("dialog-1", PortalCategory.Container),
+            new XfPortalChange("dialog-1", PortalCategory.Container),
+            new XfPortalChange("dialog-1", PortalCategory.Container));
+    }
+
+    [Test]
+    public void GetPortals_PreservesRegistrationOrderAndUpdatedContent()
+    {
+        var portalService = new XfPortalService(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<XfPortalService>.Instance);
+        portalService.RegisterHost();
+
+        RenderFragment firstContent = builder => builder.AddContent(0, "First");
+        RenderFragment updatedFirstContent = builder => builder.AddContent(0, "Updated first");
+        RenderFragment secondContent = builder => builder.AddContent(0, "Second");
+        portalService.RegisterPortal("first", firstContent, PortalCategory.Container);
+        portalService.RegisterPortal("second", secondContent, PortalCategory.Container);
+        portalService.UpdatePortalContent("first", updatedFirstContent);
+
+        var portals = portalService.GetPortals(PortalCategory.Container);
+        portals.Select(portal => portal.Key).Should().Equal("first", "second");
+        portals[0].Value.Should().BeSameAs(updatedFirstContent);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the affected BlazorBlueprint 3.12.0 container portal host with a source-aware compatibility host
- preserve the stock overlay host for popovers and selects
- queue dialog and sheet refreshes only when the changed portal already rendered in the active cycle
- add scoped DI, portal event/order tests, package-version guard, and removal guidance

## Context
Browser verification of PR #350 passed 10 repeated opens but exposed stale selected-feature content inside the open dialog. This follow-up fixes the underlying container-host refresh loss.

## Verification
- dotnet build src/Presentation/XFramework.Portal/XFramework.Portal.csproj -m:1 /nr:false
- dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --filter TestCategory=Area:PortalContract -m:1 /nr:false (26 passed)