### PR TITLE
Fix Bolt RPC completion and Identity permission loading

### DIFF
--- a/src/Infrastructure/XFramework.Integration/Security/IdentityServerServiceTokenProvider.cs
+++ b/src/Infrastructure/XFramework.Integration/Security/IdentityServerServiceTokenProvider.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Threading;
 using Bolt.Client;
 using MemoryPack;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.Configurations;
@@ -13,7 +14,8 @@ public sealed class IdentityServerServiceTokenProvider(
     BoltClient boltClient,
     IOptions<ServiceIdentityOptions> serviceIdentityOptions,
     IOptions<BoltConfiguration> boltConfigurationOptions,
-    TimeProvider timeProvider)
+    TimeProvider timeProvider,
+    ILogger<IdentityServerServiceTokenProvider> logger)
     : IServiceTokenProvider
 {
     private readonly ConcurrentDictionary<string, CachedToken> _cache = new(StringComparer.Ordinal);
@@ -59,7 +61,28 @@ public sealed class IdentityServerServiceTokenProvider(
             {
                 try
                 {
-                    return await AcquireTokenAsync(audience, requestedScopes, cacheKey, CancellationToken.None);
+                    var timeout = ResolveTokenAcquisitionTimeout();
+                    using var timeoutCts = new CancellationTokenSource(timeout);
+                    try
+                    {
+                        return await AcquireTokenAsync(audience, requestedScopes, cacheKey, timeoutCts.Token);
+                    }
+                    catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested)
+                    {
+                        throw new TimeoutException(
+                            $"Service token acquisition for audience '{audience}' timed out after {timeout.TotalSeconds:0} seconds.",
+                            ex);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Service token acquisition failed. ClientId={ClientId} Audience={Audience} Scopes={Scopes}",
+                        ResolveClientIdOrDefault(),
+                        audience,
+                        string.Join(' ', requestedScopes));
+                    throw;
                 }
                 finally
                 {
@@ -177,6 +200,28 @@ public sealed class IdentityServerServiceTokenProvider(
                 RequestId = Guid.NewGuid()
             }
         };
+    }
+
+    private TimeSpan ResolveTokenAcquisitionTimeout()
+    {
+        var options = serviceIdentityOptions.Value;
+        var timeoutSeconds = options.TokenAcquisitionTimeoutSeconds > 0
+            ? options.TokenAcquisitionTimeoutSeconds
+            : Math.Max(1, boltConfigurationOptions.Value.RpcTimeoutSeconds + 5);
+
+        return TimeSpan.FromSeconds(Math.Clamp(timeoutSeconds, 1, 300));
+    }
+
+    private string ResolveClientIdOrDefault()
+    {
+        try
+        {
+            return ResolveClientId();
+        }
+        catch
+        {
+            return "<unresolved>";
+        }
     }
 
     private sealed record CachedToken(string AccessToken, DateTime ExpiresAtUtc);

--- a/src/Infrastructure/XFramework.Integration/Security/ServiceIdentityOptions.cs
+++ b/src/Infrastructure/XFramework.Integration/Security/ServiceIdentityOptions.cs
@@ -12,6 +12,7 @@ public sealed class ServiceIdentityOptions
     public ServiceIdentityValidationFallbackOptions? ValidationFallback { get; set; }
     public string Issuer { get; set; } = "XFramework.IdentityServer";
     public int TokenRefreshSkewSeconds { get; set; } = 60;
+    public int TokenAcquisitionTimeoutSeconds { get; set; } = 30;
     public int SigningKeyCacheMinutes { get; set; } = 15;
     public List<string> DefaultScopes { get; set; } = [];
 

--- a/src/Libraries/Bolt/Bolt.Client/BoltClient.cs
+++ b/src/Libraries/Bolt/Bolt.Client/BoltClient.cs
@@ -536,19 +536,15 @@ public sealed class BoltClient : IAsyncDisposable
         var commandHash = GetCommandHash(commandName);
         var conn = GetConnection();
         var rpcCall = PooledRpcCall.Rent();
+        var responseTask = rpcCall.GetTask().AsTask();
         _pendingCalls[requestId] = rpcCall;
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        ValueTask<BoltRpcResponse> responseTask = default;
-        var responseTaskCreated = false;
 
         try
         {
             using var timeoutCts = new CancellationTokenSource(_rpcTimeout);
             using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
-            rpcCall.RegisterTimeout(timeoutCts.Token);
-            responseTask = rpcCall.GetTask();
-            responseTaskCreated = true;
 
             var writer = RentedBufferWriter.GetThreadLocal();
             BoltCodec.WriteRequest(writer, requestId, recipientHash, _senderHash, commandHash, payload.Span);
@@ -561,8 +557,7 @@ public sealed class BoltClient : IAsyncDisposable
 
             await conn.SendAsync(writer.WrittenMemory, sendCts.Token);
 
-            responseTaskCreated = false;
-            var response = await responseTask;
+            var response = await responseTask.WaitAsync(sendCts.Token);
             sw.Stop();
 
             var level = (int)response.StatusCode >= 400 ? LogLevel.Warning : LogLevel.Debug;
@@ -574,29 +569,29 @@ public sealed class BoltClient : IAsyncDisposable
         catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
         {
             sw.Stop();
-            var timeout = new TimeoutException($"Bolt RPC {commandName} -> {recipientId} timed out before the request was enqueued", ex);
+            var timeout = new TimeoutException($"Bolt RPC {commandName} -> {recipientId} timed out before the request completed", ex);
             _logger.LogError(timeout, "Bolt RPC {Command} -> {Recipient} | FAILED in {Elapsed}ms | RequestSize={RequestSize}B",
                 commandName, recipientId, sw.ElapsedMilliseconds, payload.Length);
-            rpcCall.SetException(timeout);
-            if (responseTaskCreated)
-            {
-                try { await responseTask; } catch { }
-            }
+            await CompleteFailedRpcAsync(requestId, rpcCall, responseTask, timeout);
             throw timeout;
+        }
+        catch (OperationCanceledException ex)
+        {
+            sw.Stop();
+            _logger.LogWarning(ex, "Bolt RPC {Command} -> {Recipient} | CANCELED in {Elapsed}ms | RequestSize={RequestSize}B",
+                commandName, recipientId, sw.ElapsedMilliseconds, payload.Length);
+            await CompleteFailedRpcAsync(requestId, rpcCall, responseTask, ex);
+            throw;
         }
         catch (Exception ex)
         {
             sw.Stop();
             _logger.LogError(ex, "Bolt RPC {Command} -> {Recipient} | FAILED in {Elapsed}ms | RequestSize={RequestSize}B",
                 commandName, recipientId, sw.ElapsedMilliseconds, payload.Length);
-            if (responseTaskCreated)
-            {
-                rpcCall.SetException(ex);
-                try { await responseTask; } catch { }
-            }
+            await CompleteFailedRpcAsync(requestId, rpcCall, responseTask, ex);
             throw;
         }
-        finally { _pendingCalls.TryRemove(requestId, out _); }
+        finally { _pendingCalls.TryRemove(new KeyValuePair<Guid, PooledRpcCall>(requestId, rpcCall)); }
     }
 
     /// <summary>
@@ -613,17 +608,13 @@ public sealed class BoltClient : IAsyncDisposable
 
         // Register pending RPC — response comes back as normal Response frame
         var rpcCall = PooledRpcCall.Rent();
+        var responseTask = rpcCall.GetTask().AsTask();
         _pendingCalls[requestId] = rpcCall;
-        ValueTask<BoltRpcResponse> responseTask = default;
-        var responseTaskCreated = false;
 
         try
         {
             using var timeoutCts = new CancellationTokenSource(_rpcTimeout);
             using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
-            rpcCall.RegisterTimeout(timeoutCts.Token);
-            responseTask = rpcCall.GetTask();
-            responseTaskCreated = true;
 
             // Open stream with special large-RPC command hash
             var stream = await OpenStreamAsync(recipientId, "__bolt_large_rpc__", sendCts.Token);
@@ -649,30 +640,38 @@ public sealed class BoltClient : IAsyncDisposable
 
             // Response arrives as a Request with __bolt_large_rpc_response__ command
             // (handled by RegisterLargeRpcResponseHandler, which resolves our pending call)
-            responseTaskCreated = false;
-            var response = await responseTask;
+            var response = await responseTask.WaitAsync(sendCts.Token);
             return (response.StatusCode, response.Data);
         }
         catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
         {
             var timeout = new TimeoutException($"Large Bolt RPC {commandName} -> {recipientId} timed out before the request completed", ex);
-            rpcCall.SetException(timeout);
-            if (responseTaskCreated)
-            {
-                try { await responseTask; } catch { }
-            }
+            await CompleteFailedRpcAsync(requestId, rpcCall, responseTask, timeout);
             throw timeout;
+        }
+        catch (OperationCanceledException ex)
+        {
+            await CompleteFailedRpcAsync(requestId, rpcCall, responseTask, ex);
+            throw;
         }
         catch (Exception ex)
         {
-            if (responseTaskCreated)
-            {
-                rpcCall.SetException(ex);
-                try { await responseTask; } catch { }
-            }
+            await CompleteFailedRpcAsync(requestId, rpcCall, responseTask, ex);
             throw;
         }
-        finally { _pendingCalls.TryRemove(requestId, out _); }
+        finally { _pendingCalls.TryRemove(new KeyValuePair<Guid, PooledRpcCall>(requestId, rpcCall)); }
+    }
+
+    private async Task CompleteFailedRpcAsync(
+        Guid requestId,
+        PooledRpcCall rpcCall,
+        Task<BoltRpcResponse> responseTask,
+        Exception ex)
+    {
+        if (_pendingCalls.TryRemove(new KeyValuePair<Guid, PooledRpcCall>(requestId, rpcCall)))
+            rpcCall.SetException(ex);
+
+        try { await responseTask; } catch { }
     }
 
     public async Task<TResponse?> SendAsync<TRequest, TResponse>(string recipientId, string commandName, TRequest request, CancellationToken ct = default)

--- a/src/Libraries/Bolt/Bolt.Server/BoltServer.cs
+++ b/src/Libraries/Bolt/Bolt.Server/BoltServer.cs
@@ -760,10 +760,12 @@ public sealed class BoltServer : IDisposable
             if (pending.ExpectedResponder.StreamId != responder.StreamId)
             {
                 _logger.LogWarning(
-                    "Rejected response from unexpected responder. requestId={RequestId} expected={Expected} actual={Actual}",
+                    "Rejected response from unexpected Bolt responder. requestId={RequestId} expectedClient={ExpectedClient} expectedStream={ExpectedStream} actualClient={ActualClient} actualStream={ActualStream}",
                     requestId,
                     pending.ExpectedResponder.ClientId,
-                    responder.ClientId);
+                    pending.ExpectedResponder.StreamId,
+                    responder.ClientId,
+                    responder.StreamId);
                 return;
             }
 
@@ -3061,6 +3063,52 @@ public sealed class BoltServer : IDisposable
         return firstAlive;
     }
 
+    private async Task SendInvocationTerminalResponseAsync(
+        Guid requestId,
+        BoltHubConnection caller,
+        HttpStatusCode statusCode,
+        string reason,
+        CancellationToken ct)
+    {
+        if (!caller.IsAlive)
+        {
+            _logger.LogDebug(
+                "Skipped terminal Bolt invocation response because caller is disconnected. requestId={RequestId} caller={CallerClientId} callerStream={CallerStreamId} statusCode={StatusCode} reason={Reason}",
+                requestId,
+                caller.ClientId,
+                caller.StreamId,
+                (int)statusCode,
+                reason);
+            return;
+        }
+
+        try
+        {
+            var writer = new ArrayBufferWriter<byte>(BoltCodec.ResponseHeaderSize);
+            BoltCodec.WriteResponse(writer, requestId, statusCode, ReadOnlySpan<byte>.Empty);
+            await caller.SendAsync(writer.WrittenMemory, ct);
+
+            _logger.LogDebug(
+                "Sent terminal Bolt invocation response. requestId={RequestId} caller={CallerClientId} callerStream={CallerStreamId} statusCode={StatusCode} reason={Reason}",
+                requestId,
+                caller.ClientId,
+                caller.StreamId,
+                (int)statusCode,
+                reason);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            _logger.LogDebug(
+                ex,
+                "Failed to send terminal Bolt invocation response. requestId={RequestId} caller={CallerClientId} callerStream={CallerStreamId} statusCode={StatusCode} reason={Reason}",
+                requestId,
+                caller.ClientId,
+                caller.StreamId,
+                (int)statusCode,
+                reason);
+        }
+    }
+
     private async Task RemoveConnectionAsync(BoltHubConnection connection)
     {
         using var notificationCts = new CancellationTokenSource(_transportCloseTimeout);
@@ -3424,8 +3472,26 @@ public sealed class BoltServer : IDisposable
         {
             if (now - pending.Timestamp > _invocationTimeoutMs)
             {
-                if (TryRemovePendingInvocation(requestId, pending, out _))
-                    _logger.LogDebug("Cleaned up stale invocation {RequestId}", requestId);
+                if (TryRemovePendingInvocation(requestId, pending, out var removed))
+                {
+                    var ageMs = now - removed.Timestamp;
+                    _logger.LogWarning(
+                        "Completing stale Bolt invocation at hub timeout. requestId={RequestId} caller={CallerClientId} callerStream={CallerStreamId} responder={ResponderClientId} responderStream={ResponderStreamId} ageMs={AgeMs} timeoutMs={TimeoutMs}",
+                        requestId,
+                        removed.Caller.ClientId,
+                        removed.Caller.StreamId,
+                        removed.ExpectedResponder.ClientId,
+                        removed.ExpectedResponder.StreamId,
+                        ageMs,
+                        _invocationTimeoutMs);
+
+                    _ = SendInvocationTerminalResponseAsync(
+                        requestId,
+                        removed.Caller,
+                        HttpStatusCode.GatewayTimeout,
+                        "hub-invocation-timeout",
+                        CancellationToken.None);
+                }
             }
         }
 

--- a/src/Modules/XFramework.Communications/Communications.Tests/Services/ThreadServiceSecurityTests.cs
+++ b/src/Modules/XFramework.Communications/Communications.Tests/Services/ThreadServiceSecurityTests.cs
@@ -650,43 +650,43 @@ public sealed class ThreadServiceSecurityTests
         public IAsyncEnumerable<byte[]> ExecuteQueryStreamAsync(byte[] queryDescriptorBytes, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage query streams are not used by these tests.");
 
-        public Task<QueryResponse<StorageUploadSessionResponse>> CreateStorageUploadSession(CreateStorageUploadSessionRequest request) =>
+        public Task<QueryResponse<StorageUploadSessionResponse>> CreateStorageUploadSession(CreateStorageUploadSessionRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload sessions are not used by these tests.");
 
-        public Task<QueryResponse<StorageUploadPartResponse>> UploadStorageFilePart(UploadStorageFilePartRequest request) =>
+        public Task<QueryResponse<StorageUploadPartResponse>> UploadStorageFilePart(UploadStorageFilePartRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload parts are not used by these tests.");
 
-        public Task<QueryResponse<StorageUploadPartListResponse>> ListStorageUploadParts(ListStorageUploadPartsRequest request) =>
+        public Task<QueryResponse<StorageUploadPartListResponse>> ListStorageUploadParts(ListStorageUploadPartsRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload parts are not used by these tests.");
 
-        public Task<QueryResponse<StorageFileResponse>> CompleteStorageUploadSession(CompleteStorageUploadSessionRequest request) =>
+        public Task<QueryResponse<StorageFileResponse>> CompleteStorageUploadSession(CompleteStorageUploadSessionRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload completion is not used by these tests.");
 
-        public Task<CmdResponse> AbortStorageUploadSession(AbortStorageUploadSessionRequest request) =>
+        public Task<CmdResponse> AbortStorageUploadSession(AbortStorageUploadSessionRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload abort is not used by these tests.");
 
-        public Task<QueryResponse<StorageFileResponse>> GetStorageFile(GetStorageFileRequest request) =>
+        public Task<QueryResponse<StorageFileResponse>> GetStorageFile(GetStorageFileRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage file reads are not used by these tests.");
 
-        public Task<QueryResponse<StorageFileListResponse>> GetStorageFiles(GetStorageFilesRequest request) =>
+        public Task<QueryResponse<StorageFileListResponse>> GetStorageFiles(GetStorageFilesRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage file listing is not used by these tests.");
 
-        public Task<QueryResponse<StorageDownloadUrlResponse>> GetStorageDownloadUrl(GetStorageDownloadUrlRequest request) =>
+        public Task<QueryResponse<StorageDownloadUrlResponse>> GetStorageDownloadUrl(GetStorageDownloadUrlRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage download URLs are not used by these tests.");
 
-        public Task<QueryResponse<StoragePublicUrlResponse>> GetStoragePublicUrl(GetStoragePublicUrlRequest request) =>
+        public Task<QueryResponse<StoragePublicUrlResponse>> GetStoragePublicUrl(GetStoragePublicUrlRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage public URLs are not used by these tests.");
 
-        public Task<CmdResponse> DeleteStorageFile(DeleteStorageFileRequest request) =>
+        public Task<CmdResponse> DeleteStorageFile(DeleteStorageFileRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage deletes are not used by these tests.");
 
-        public Task<QueryResponse<StorageFileResponse>> RestoreStorageFile(RestoreStorageFileRequest request) =>
+        public Task<QueryResponse<StorageFileResponse>> RestoreStorageFile(RestoreStorageFileRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage restores are not used by these tests.");
 
-        public Task<QueryResponse<StorageRetentionCleanupResponse>> CleanupStorageRetention(CleanupStorageRetentionRequest request) =>
+        public Task<QueryResponse<StorageRetentionCleanupResponse>> CleanupStorageRetention(CleanupStorageRetentionRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage cleanup is not used by these tests.");
 
-        public Task<QueryResponse<StorageFileValidationResponse>> ValidateStorageFileReference(ValidateStorageFileReferenceRequest request) =>
+        public Task<QueryResponse<StorageFileValidationResponse>> ValidateStorageFileReference(ValidateStorageFileReferenceRequest request, CancellationToken ct = default) =>
             Task.FromResult(new QueryResponse<StorageFileValidationResponse>
             {
                 HttpStatusCode = HttpStatusCode.OK,

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/IdentityRoleFeaturePermissionOverrideConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/IdentityRoleFeaturePermissionOverrideConfiguration.cs
@@ -39,7 +39,8 @@ public sealed class IdentityRoleFeaturePermissionOverrideConfiguration :
 
         entity.Property(e => e.Effect)
             .IsRequired()
-            .HasDefaultValue(RoleCapabilityPermissionEffect.Allow);
+            .HasDefaultValue(RoleCapabilityPermissionEffect.Allow)
+            .HasSentinel(RoleCapabilityPermissionEffect.Allow);
 
         entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/IdentityRoleTypeFeaturePermissionConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Domain.Shared/Configurations/IdentityRoleTypeFeaturePermissionConfiguration.cs
@@ -39,7 +39,8 @@ public sealed class IdentityRoleTypeFeaturePermissionConfiguration :
 
         entity.Property(e => e.Effect)
             .IsRequired()
-            .HasDefaultValue(RoleCapabilityPermissionEffect.Allow);
+            .HasDefaultValue(RoleCapabilityPermissionEffect.Allow)
+            .HasSentinel(RoleCapabilityPermissionEffect.Allow);
 
         entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
         entity.Property(e => e.ModifiedAt).HasDefaultValueSql("now()");

--- a/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Identity/UserDetail.razor
@@ -1045,6 +1045,7 @@ else
     [Inject] private TenantModuleNavigationService ModuleNavigation { get; set; } = default!;
     [Inject] private AttendancePortalReadService AttendanceReadService { get; set; } = default!;
     [Inject] private IIdentityServerServiceWrapper IdentityServer { get; set; } = default!;
+    [Inject] private ILogger<UserDetail> Logger { get; set; } = default!;
 
     // Main data
     private IdentityInformation? _user;
@@ -1114,6 +1115,7 @@ else
     private long _rolePermissionOperationVersion;
     private bool _rolePermissionOverridesLoaded;
     private IdentityRole? _permissionRole;
+    private CancellationTokenSource? _rolePermissionLoadCts;
     private Dictionary<string, string> _rolePermissionValues = new(StringComparer.OrdinalIgnoreCase);
     private string _selectedRolePermissionFeatureKey = TenantModuleFeatureKeys.Identity;
     private HashSet<string> _expandedRolePermissionFeatureKeys = new(StringComparer.OrdinalIgnoreCase);
@@ -1121,6 +1123,7 @@ else
     private const string PermissionInherit = "inherit";
     private const string PermissionAllow = "allow";
     private const string PermissionDeny = "deny";
+    private static readonly TimeSpan RolePermissionLoadTimeout = TimeSpan.FromSeconds(35);
     private static readonly IReadOnlyList<string> PermissionCapabilities = IdentityAuthorizationConstants.CapabilityKeys;
 
     private TenantModuleFeatureDefinition? SelectedRolePermissionFeature =>
@@ -1836,6 +1839,11 @@ else
         var operationVersion = ++_rolePermissionOperationVersion;
         var userId = Id;
         var section = CurrentSection;
+        _rolePermissionLoadCts?.Cancel();
+        _rolePermissionLoadCts?.Dispose();
+
+        var loadCts = new CancellationTokenSource(RolePermissionLoadTimeout);
+        _rolePermissionLoadCts = loadCts;
         _loadingRolePermissions = true;
         _loadingRolePermissionsRoleId = role.Id;
         _rolePermissionOverridesLoaded = false;
@@ -1847,7 +1855,12 @@ else
             {
                 IdentityRoleId = role.Id,
                 Metadata = CreateMetadata(role.TenantId)
-            });
+            }, loadCts.Token);
+
+            if (!ReferenceEquals(_rolePermissionLoadCts, loadCts) || loadCts.IsCancellationRequested)
+            {
+                return;
+            }
 
             if (!IsRolePermissionLoadCurrent(operationVersion, userId, section, role))
             {
@@ -1880,20 +1893,40 @@ else
             // Open only after the dialog's content is complete so no loading fragment must be replaced.
             _rolePermissionDialogOpen = true;
         }
-        catch
+        catch (OperationCanceledException) when (loadCts.IsCancellationRequested)
+        {
+            if (ReferenceEquals(_rolePermissionLoadCts, loadCts) &&
+                IsRolePermissionLoadCurrent(operationVersion, userId, section, role))
+            {
+                ToastService.Error("Role permission overrides timed out. Try again shortly.", "Permissions timed out");
+            }
+        }
+        catch (Exception ex)
         {
             if (IsRolePermissionLoadCurrent(operationVersion, userId, section, role))
             {
+                Logger.LogWarning(
+                    ex,
+                    "Role permission overrides failed to load. RoleId={RoleId} OperationVersion={OperationVersion}",
+                    role.Id,
+                    operationVersion);
                 ToastService.Error("Role permission overrides could not be loaded.", "Permissions failed");
             }
         }
         finally
         {
+            if (ReferenceEquals(_rolePermissionLoadCts, loadCts))
+            {
+                _rolePermissionLoadCts = null;
+            }
+
             if (_rolePermissionOperationVersion == operationVersion)
             {
                 _loadingRolePermissions = false;
                 _loadingRolePermissionsRoleId = null;
             }
+
+            loadCts.Dispose();
         }
     }
 
@@ -1919,6 +1952,9 @@ else
         _rolePermissionDialogOpen = false;
         _loadingRolePermissions = false;
         _loadingRolePermissionsRoleId = null;
+        _rolePermissionLoadCts?.Cancel();
+        _rolePermissionLoadCts?.Dispose();
+        _rolePermissionLoadCts = null;
         _permissionRole = null;
         _rolePermissionValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         _rolePermissionTreeNodes = [];

--- a/src/SourceGenerators/XFramework.SourceGenerators/ServiceWrapperGenerator.cs
+++ b/src/SourceGenerators/XFramework.SourceGenerators/ServiceWrapperGenerator.cs
@@ -622,19 +622,19 @@ public class ServiceWrapperGenerator : IIncrementalGenerator
                 if (isQueryResponse)
                 {
                     var innerType = ((INamedTypeSymbol)tResponse).TypeArguments[0].ToDisplayString();
-                    interfaceSig = $"Task<QueryResponse<{innerType}>> {methodName}({requestFullName} request);";
-                    implMethod = $"public Task<QueryResponse<{innerType}>> {methodName}({requestFullName} request) => SendAsync<{requestFullName}, {innerType}>(request);";
+                    interfaceSig = $"Task<QueryResponse<{innerType}>> {methodName}({requestFullName} request, System.Threading.CancellationToken ct = default);";
+                    implMethod = $"public Task<QueryResponse<{innerType}>> {methodName}({requestFullName} request, System.Threading.CancellationToken ct = default) => SendAsync<{requestFullName}, {innerType}>(request, ct);";
                 }
                 else if (isTypedCommandResponse)
                 {
                     var innerType = ((INamedTypeSymbol)tResponse).TypeArguments[0].ToDisplayString();
-                    interfaceSig = $"Task<CmdResponse<{innerType}>> {methodName}({requestFullName} request);";
-                    implMethod = $"public Task<CmdResponse<{innerType}>> {methodName}({requestFullName} request) => SendVoidAsync<{requestFullName}, {innerType}>(request);";
+                    interfaceSig = $"Task<CmdResponse<{innerType}>> {methodName}({requestFullName} request, System.Threading.CancellationToken ct = default);";
+                    implMethod = $"public Task<CmdResponse<{innerType}>> {methodName}({requestFullName} request, System.Threading.CancellationToken ct = default) => SendVoidAsync<{requestFullName}, {innerType}>(request, ct);";
                 }
                 else
                 {
-                    interfaceSig = $"Task<CmdResponse> {methodName}({requestFullName} request);";
-                    implMethod = $"public Task<CmdResponse> {methodName}({requestFullName} request) => SendVoidAsync(request);";
+                    interfaceSig = $"Task<CmdResponse> {methodName}({requestFullName} request, System.Threading.CancellationToken ct = default);";
+                    implMethod = $"public Task<CmdResponse> {methodName}({requestFullName} request, System.Threading.CancellationToken ct = default) => SendVoidAsync(request, ct);";
                 }
 
                 if (!seen.Add(requestFullName))

--- a/src/Tests/Bolt.Tests/BoltRpcReadinessTests.cs
+++ b/src/Tests/Bolt.Tests/BoltRpcReadinessTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Reflection;
+using System.Collections.Concurrent;
 using Bolt.Client;
 using Bolt.Protocol.Transport;
 using Bolt.Server;
@@ -8,7 +9,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using XFramework.Domain.Shared.Configurations;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Security;
 
 namespace Bolt.Tests;
 
@@ -16,6 +21,7 @@ namespace Bolt.Tests;
 [CancelAfter(30000)]
 public class BoltRpcReadinessTests
 {
+    private const string ServiceIdentityTestSecret = "bolt-readiness-service-identity-secret-g0";
     private WebApplication _serverApp = null!;
     private ILoggerFactory _loggerFactory = null!;
     private static int _portCounter = 19700;
@@ -27,7 +33,13 @@ public class BoltRpcReadinessTests
         _port = Interlocked.Increment(ref _portCounter);
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseUrls($"http://localhost:{_port}");
-        builder.Services.AddBoltServer();
+        builder.Services.AddBoltServer(options =>
+        {
+            options.InvocationTimeoutMs = 250;
+            options.CleanupIntervalSeconds = 1;
+            options.MaxPendingRpcCalls = 1;
+            options.MaxPendingRpcCallsPerPrincipal = 1;
+        });
         builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
         _serverApp = builder.Build();
@@ -95,6 +107,77 @@ public class BoltRpcReadinessTests
 
         await caller.DisposeAsync();
         await receiver.DisposeAsync();
+    }
+
+    [Test]
+    public async Task InvokeAsync_WhenResponderNeverReplies_ReturnsHubGatewayTimeout()
+    {
+        var responder = CreateClient("timeout_responder", "TimeoutResponder");
+        var caller = CreateClient("timeout_caller", "TimeoutCaller");
+        var handlerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        responder.RegisterHandler("hang", async (_, _, ct) =>
+        {
+            handlerEntered.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            return (HttpStatusCode.OK, ReadOnlyMemory<byte>.Empty);
+        });
+
+        await responder.ConnectAsync();
+        await caller.ConnectAsync();
+
+        var started = DateTime.UtcNow;
+        var invokeTask = caller.InvokeAsync("timeout_responder", "hang", new byte[] { 1 });
+        await handlerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var (statusCode, responsePayload) = await invokeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        statusCode.Should().Be(HttpStatusCode.GatewayTimeout);
+        responsePayload.Length.Should().Be(0);
+        (DateTime.UtcNow - started).Should().BeLessThan(TimeSpan.FromSeconds(4));
+        GetServerPendingInvocationCount().Should().Be(0);
+
+        var secondInvoke = caller.InvokeAsync("timeout_responder", "hang", new byte[] { 2 });
+        var (secondStatusCode, secondResponsePayload) = await secondInvoke.WaitAsync(TimeSpan.FromSeconds(5));
+
+        secondStatusCode.Should().Be(HttpStatusCode.GatewayTimeout,
+            "the first timeout must release global and per-principal pending-invocation capacity");
+        secondResponsePayload.Length.Should().Be(0);
+        GetServerPendingInvocationCount().Should().Be(0);
+
+        await caller.DisposeAsync();
+        await responder.DisposeAsync();
+    }
+
+    [Test]
+    public async Task InvokeAsync_WhenResponderDisconnectsDuringPendingInvocation_ReturnsServiceUnavailable()
+    {
+        var responder = CreateClient("disconnect_responder", "DisconnectResponder");
+        var caller = CreateClient("disconnect_caller", "DisconnectCaller");
+        var handlerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        responder.RegisterHandler("hang", async (_, _, ct) =>
+        {
+            handlerEntered.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            return (HttpStatusCode.OK, ReadOnlyMemory<byte>.Empty);
+        });
+
+        await responder.ConnectAsync();
+        await caller.ConnectAsync();
+
+        var invokeTask = caller.InvokeAsync("disconnect_responder", "hang", new byte[] { 1 });
+        await handlerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await responder.DisposeAsync();
+
+        var (statusCode, responsePayload) = await invokeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        statusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        responsePayload.Length.Should().Be(0);
+        GetServerPendingInvocationCount().Should().Be(0);
+
+        await caller.DisposeAsync();
     }
 
     [Test]
@@ -271,6 +354,187 @@ public class BoltRpcReadinessTests
     }
 
     [Test]
+    public async Task InvokeAsync_WhenResponseNeverArrives_HonorsCallerCancellation()
+    {
+        await using var client = new BoltClient(
+            new Uri($"ws://localhost:{_port}/bolt"),
+            "cancel_wait_caller",
+            "CancelWaitCaller",
+            new BoltClientOptions { RpcTimeoutSeconds = 30, SendQueueCapacity = 4 },
+            _loggerFactory.CreateLogger<BoltClient>());
+        var connection = new BoltConnection(new NoopBoltConnection(), sendQueueCapacity: 4);
+
+        var connections = (List<BoltConnection>)typeof(BoltClient)
+            .GetField("_connections", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+        connections.Add(connection);
+        typeof(BoltClient)
+            .GetField("_isRegistered", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(client, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(75));
+        var started = DateTime.UtcNow;
+        Func<Task> invoke = async () => await client.InvokeAsync(
+            "missing_receiver",
+            "noop",
+            new byte[] { 1 },
+            cts.Token);
+
+        await invoke.Should().ThrowAsync<OperationCanceledException>();
+        (DateTime.UtcNow - started).Should().BeLessThan(TimeSpan.FromSeconds(2));
+
+        var pendingCalls = (ConcurrentDictionary<Guid, PooledRpcCall>)typeof(BoltClient)
+            .GetField("_pendingCalls", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+        pendingCalls.Should().BeEmpty();
+
+        connection.CompleteSendChannel();
+    }
+
+    [Test]
+    public async Task InvokeAsync_WhenResponseNeverArrives_UsesContextualRpcTimeoutAndClearsPendingCall()
+    {
+        await using var client = new BoltClient(
+            new Uri($"ws://localhost:{_port}/bolt"),
+            "timeout_wait_caller",
+            "TimeoutWaitCaller",
+            new BoltClientOptions { RpcTimeoutSeconds = 1, SendQueueCapacity = 4 },
+            _loggerFactory.CreateLogger<BoltClient>());
+        var connection = new BoltConnection(new NoopBoltConnection(), sendQueueCapacity: 4);
+
+        var connections = (List<BoltConnection>)typeof(BoltClient)
+            .GetField("_connections", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+        connections.Add(connection);
+        typeof(BoltClient)
+            .GetField("_isRegistered", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(client, true);
+
+        Func<Task> invoke = async () => await client.InvokeAsync(
+            "missing_receiver",
+            "noop",
+            new byte[] { 1 });
+
+        await invoke.Should().ThrowAsync<TimeoutException>()
+            .WithMessage("*timed out before the request completed*");
+
+        var pendingCalls = (ConcurrentDictionary<Guid, PooledRpcCall>)typeof(BoltClient)
+            .GetField("_pendingCalls", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+        pendingCalls.Should().BeEmpty();
+
+        connection.CompleteSendChannel();
+    }
+
+    [Test]
+    public async Task IdentityServerServiceTokenProvider_WhenTokenRpcNeverCompletes_TimesOutAndClearsInflight()
+    {
+        await using var client = new BoltClient(
+            new Uri($"ws://localhost:{_port}/bolt"),
+            "token_timeout_caller",
+            "TokenTimeoutCaller",
+            new BoltClientOptions { RpcTimeoutSeconds = 30, SendQueueCapacity = 4 },
+            _loggerFactory.CreateLogger<BoltClient>());
+        var connection = new BoltConnection(new NoopBoltConnection(), sendQueueCapacity: 4);
+
+        var connections = (List<BoltConnection>)typeof(BoltClient)
+            .GetField("_connections", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+        connections.Add(connection);
+        typeof(BoltClient)
+            .GetField("_isRegistered", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(client, true);
+
+        var provider = new IdentityServerServiceTokenProvider(
+            client,
+            Options.Create(new ServiceIdentityOptions
+            {
+                ClientId = XFrameworkServiceNames.Portal,
+                GenerationId = "test-g0",
+                ClientSecret = ServiceIdentityTestSecret,
+                DefaultScopes = [XFrameworkServiceScopes.IdentityAdmin],
+                TokenAcquisitionTimeoutSeconds = 1
+            }),
+            Options.Create(new BoltConfiguration
+            {
+                ClientName = XFrameworkServiceNames.Portal,
+                RpcTimeoutSeconds = 30
+            }),
+            TimeProvider.System,
+            _loggerFactory.CreateLogger<IdentityServerServiceTokenProvider>());
+
+        var started = DateTime.UtcNow;
+        Func<Task> getToken = async () => await provider.GetTokenAsync(XFrameworkServiceNames.IdentityServer);
+
+        await getToken.Should().ThrowAsync<TimeoutException>();
+        (DateTime.UtcNow - started).Should().BeLessThan(TimeSpan.FromSeconds(5));
+
+        var inflight = (ConcurrentDictionary<string, Lazy<Task<string>>>)typeof(IdentityServerServiceTokenProvider)
+            .GetField("_inflight", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(provider)!;
+        inflight.Should().BeEmpty();
+
+        connection.CompleteSendChannel();
+    }
+
+    [Test]
+    public async Task IdentityServerServiceTokenProvider_WhenCallerCancelsTokenRpc_PreservesSharedAcquisition()
+    {
+        await using var client = new BoltClient(
+            new Uri($"ws://localhost:{_port}/bolt"),
+            "token_cancel_caller",
+            "TokenCancelCaller",
+            new BoltClientOptions { RpcTimeoutSeconds = 30, SendQueueCapacity = 4 },
+            _loggerFactory.CreateLogger<BoltClient>());
+        var connection = new BoltConnection(new NoopBoltConnection(), sendQueueCapacity: 4);
+
+        var connections = (List<BoltConnection>)typeof(BoltClient)
+            .GetField("_connections", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+        connections.Add(connection);
+        typeof(BoltClient)
+            .GetField("_isRegistered", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(client, true);
+
+        var provider = new IdentityServerServiceTokenProvider(
+            client,
+            Options.Create(new ServiceIdentityOptions
+            {
+                ClientId = XFrameworkServiceNames.Portal,
+                GenerationId = "test-g0",
+                ClientSecret = ServiceIdentityTestSecret,
+                DefaultScopes = [XFrameworkServiceScopes.IdentityAdmin],
+                TokenAcquisitionTimeoutSeconds = 1
+            }),
+            Options.Create(new BoltConfiguration
+            {
+                ClientName = XFrameworkServiceNames.Portal,
+                RpcTimeoutSeconds = 30
+            }),
+            TimeProvider.System,
+            _loggerFactory.CreateLogger<IdentityServerServiceTokenProvider>());
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(75));
+        Func<Task> getToken = async () => await provider.GetTokenAsync(
+            XFrameworkServiceNames.IdentityServer,
+            ct: cts.Token);
+
+        await getToken.Should().ThrowAsync<OperationCanceledException>();
+
+        var inflight = (ConcurrentDictionary<string, Lazy<Task<string>>>)typeof(IdentityServerServiceTokenProvider)
+            .GetField("_inflight", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(provider)!;
+        inflight.Should().ContainSingle();
+
+        Func<Task> awaitSharedAcquisition = async () =>
+            await provider.GetTokenAsync(XFrameworkServiceNames.IdentityServer);
+        await awaitSharedAcquisition.Should().ThrowAsync<TimeoutException>();
+        inflight.Should().BeEmpty();
+
+        connection.CompleteSendChannel();
+    }
+
+    [Test]
     public async Task GetHealthSnapshot_WhenPendingSendsExceedThreshold_IsUnhealthy()
     {
         await using var client = new BoltClient(
@@ -348,6 +612,17 @@ public class BoltRpcReadinessTests
         }
 
         throw new TimeoutException("Condition was not met before timeout.");
+    }
+
+    private int GetServerPendingInvocationCount()
+    {
+        var server = _serverApp.Services.GetRequiredService<BoltServer>();
+        var field = typeof(BoltServer).GetField("_pendingInvocations", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("BoltServer pending-invocation field not found.");
+        var pendingInvocations = field.GetValue(server)!;
+        var countProperty = pendingInvocations.GetType().GetProperty("Count")
+            ?? throw new InvalidOperationException("BoltServer pending-invocation collection does not expose Count.");
+        return (int)countProperty.GetValue(pendingInvocations)!;
     }
 
     private class NoopBoltConnection : IBoltConnection

--- a/src/Tests/Community.Tests/Services/CommunitySecurityTests.cs
+++ b/src/Tests/Community.Tests/Services/CommunitySecurityTests.cs
@@ -337,43 +337,43 @@ public sealed class CommunitySecurityTests
         public IAsyncEnumerable<byte[]> ExecuteQueryStreamAsync(byte[] queryDescriptorBytes, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage query streams should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageUploadSessionResponse>> CreateStorageUploadSession(CreateStorageUploadSessionRequest request) =>
+        public Task<QueryResponse<StorageUploadSessionResponse>> CreateStorageUploadSession(CreateStorageUploadSessionRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload sessions should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageUploadPartResponse>> UploadStorageFilePart(UploadStorageFilePartRequest request) =>
+        public Task<QueryResponse<StorageUploadPartResponse>> UploadStorageFilePart(UploadStorageFilePartRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload parts should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageUploadPartListResponse>> ListStorageUploadParts(ListStorageUploadPartsRequest request) =>
+        public Task<QueryResponse<StorageUploadPartListResponse>> ListStorageUploadParts(ListStorageUploadPartsRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload part listing should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageFileResponse>> CompleteStorageUploadSession(CompleteStorageUploadSessionRequest request) =>
+        public Task<QueryResponse<StorageFileResponse>> CompleteStorageUploadSession(CompleteStorageUploadSessionRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload completion should not be called by these security tests.");
 
-        public Task<CmdResponse> AbortStorageUploadSession(AbortStorageUploadSessionRequest request) =>
+        public Task<CmdResponse> AbortStorageUploadSession(AbortStorageUploadSessionRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage upload abort should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageFileResponse>> GetStorageFile(GetStorageFileRequest request) =>
+        public Task<QueryResponse<StorageFileResponse>> GetStorageFile(GetStorageFileRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage file reads should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageFileListResponse>> GetStorageFiles(GetStorageFilesRequest request) =>
+        public Task<QueryResponse<StorageFileListResponse>> GetStorageFiles(GetStorageFilesRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage file listing should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageDownloadUrlResponse>> GetStorageDownloadUrl(GetStorageDownloadUrlRequest request) =>
+        public Task<QueryResponse<StorageDownloadUrlResponse>> GetStorageDownloadUrl(GetStorageDownloadUrlRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage download URLs should not be called by these security tests.");
 
-        public Task<QueryResponse<StoragePublicUrlResponse>> GetStoragePublicUrl(GetStoragePublicUrlRequest request) =>
+        public Task<QueryResponse<StoragePublicUrlResponse>> GetStoragePublicUrl(GetStoragePublicUrlRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage public URLs should not be called by these security tests.");
 
-        public Task<CmdResponse> DeleteStorageFile(DeleteStorageFileRequest request) =>
+        public Task<CmdResponse> DeleteStorageFile(DeleteStorageFileRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage deletes should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageFileResponse>> RestoreStorageFile(RestoreStorageFileRequest request) =>
+        public Task<QueryResponse<StorageFileResponse>> RestoreStorageFile(RestoreStorageFileRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage restores should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageRetentionCleanupResponse>> CleanupStorageRetention(CleanupStorageRetentionRequest request) =>
+        public Task<QueryResponse<StorageRetentionCleanupResponse>> CleanupStorageRetention(CleanupStorageRetentionRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage cleanup should not be called by these security tests.");
 
-        public Task<QueryResponse<StorageFileValidationResponse>> ValidateStorageFileReference(ValidateStorageFileReferenceRequest request) =>
+        public Task<QueryResponse<StorageFileValidationResponse>> ValidateStorageFileReference(ValidateStorageFileReferenceRequest request, CancellationToken ct = default) =>
             throw new NotSupportedException("Storage validation should not be called by these security tests.");
     }
 

--- a/src/Tests/IdentityServer.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
@@ -49,7 +49,10 @@ public class IntegrationTestFixture
 
     public static IServiceProvider Services => _identityServerApp.Services;
     private const string TestServiceClientId = "TestClient";
+    private const string TestServiceGenerationId = "test-client-g1";
     private const string TestServiceClientSecret = "IdentityServerIntegrationTestSecret-2026";
+    private const string TestHostServiceGenerationId = "test-host-service-g1";
+    private const string TestHostServiceClientSecret = "IdentityServerHostIntegrationSecret-2026";
 
     /// <summary>
     /// Service wrapper that calls IdentityServer through the actual Bolt transport.
@@ -175,6 +178,7 @@ public class IntegrationTestFixture
         builder.Services.AddCommunicationsWrapperServices();
         builder.Services.AddScoped<IStorageServiceWrapper, TestStorageServiceWrapper>();
         builder.Services.AddScoped<IAuthService, AuthService>();
+        builder.Services.AddScoped<IIdentityAuthorizationService, IdentityAuthorizationService>();
         builder.Services.AddScoped<IServiceIdentityService, ServiceIdentityService>();
         builder.Services.AddSingleton(serviceProvider => ServiceIdentityConfiguration.FromConfiguration(
             serviceProvider.GetRequiredService<IConfiguration>(),
@@ -224,7 +228,7 @@ public class IntegrationTestFixture
             ["BoltConfiguration:ClientGuid"] = Guid.NewGuid().ToString(),
             ["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/bolt/ws",
             ["ServiceIdentity:ClientId"] = TestServiceClientId,
-            ["ServiceIdentity:GenerationId"] = "test-client-g1",
+            ["ServiceIdentity:GenerationId"] = TestServiceGenerationId,
             ["ServiceIdentity:ClientSecret"] = TestServiceClientSecret,
             ["Tenant:DefaultId"] = TestTenantId.ToString(),
             ["Kestrel:Endpoints:Http:Url"] = TestClientUrl,
@@ -326,9 +330,15 @@ public class IntegrationTestFixture
             ["DefaultDatabaseConnection"] = ConnectionString,
             ["BoltConfiguration:ClientGuid"] = clientGuid,
             ["BoltConfiguration:ClientName"] = clientName,
+            ["ServiceIdentity:ClientId"] = clientName,
+            ["ServiceIdentity:GenerationId"] = TestHostServiceGenerationId,
+            ["ServiceIdentity:ClientSecret"] = TestHostServiceClientSecret,
             ["ServiceIdentity:Clients:0:ClientId"] = TestServiceClientId,
-            ["ServiceIdentity:Clients:0:GenerationId"] = "test-client-g1",
+            ["ServiceIdentity:Clients:0:GenerationId"] = TestServiceGenerationId,
             ["ServiceIdentity:Clients:0:ClientSecret"] = TestServiceClientSecret,
+            ["ServiceIdentity:Clients:1:ClientId"] = clientName,
+            ["ServiceIdentity:Clients:1:GenerationId"] = TestHostServiceGenerationId,
+            ["ServiceIdentity:Clients:1:ClientSecret"] = TestHostServiceClientSecret,
             ["Tenant:DefaultId"] = TestTenantId.ToString(),
             ["Kestrel:Endpoints:Http:Url"] = serverUrl,
             ["urls"] = serverUrl,
@@ -422,7 +432,8 @@ internal sealed class TestStorageServiceWrapper(DbContext db) : IStorageServiceW
         throw new NotSupportedException("Storage query streams are not used by these tests.");
 
     public async Task<QueryResponse<StorageUploadSessionResponse>> CreateStorageUploadSession(
-        CreateStorageUploadSessionRequest request)
+        CreateStorageUploadSessionRequest request,
+        CancellationToken ct = default)
     {
         var tenantId = request.Metadata.TenantId ?? IntegrationTestFixture.TestTenantId;
         var storageFileId = Guid.NewGuid();
@@ -457,7 +468,7 @@ internal sealed class TestStorageServiceWrapper(DbContext db) : IStorageServiceW
         };
 
         db.Set<StorageFile>().Add(file);
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(ct);
         var fileResponse = ToFileResponse(file);
         db.Entry(file).State = EntityState.Detached;
 
@@ -487,7 +498,8 @@ internal sealed class TestStorageServiceWrapper(DbContext db) : IStorageServiceW
     }
 
     public Task<QueryResponse<StorageUploadPartResponse>> UploadStorageFilePart(
-        UploadStorageFilePartRequest request)
+        UploadStorageFilePartRequest request,
+        CancellationToken ct = default)
     {
         return Task.FromResult(new QueryResponse<StorageUploadPartResponse>
         {
@@ -506,11 +518,14 @@ internal sealed class TestStorageServiceWrapper(DbContext db) : IStorageServiceW
         });
     }
 
-    public Task<QueryResponse<StorageUploadPartListResponse>> ListStorageUploadParts(ListStorageUploadPartsRequest request) =>
+    public Task<QueryResponse<StorageUploadPartListResponse>> ListStorageUploadParts(
+        ListStorageUploadPartsRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage upload part listing is not used by these tests.");
 
     public async Task<QueryResponse<StorageFileResponse>> CompleteStorageUploadSession(
-        CompleteStorageUploadSessionRequest request)
+        CompleteStorageUploadSessionRequest request,
+        CancellationToken ct = default)
     {
         if (!_sessions.TryGetValue(request.UploadSessionId, out var session))
         {
@@ -523,14 +538,14 @@ internal sealed class TestStorageServiceWrapper(DbContext db) : IStorageServiceW
 
         var file = await db.Set<StorageFile>()
             .IgnoreQueryFilters()
-            .FirstAsync(item => item.Id == session.StorageFileId);
+            .FirstAsync(item => item.Id == session.StorageFileId, ct);
         file.Status = StorageFileStatus.Available;
         file.UploadedAt = DateTime.UtcNow;
         file.CompletedAt = file.UploadedAt;
         file.Sha256Hash = request.ExpectedSha256Hash ?? file.Sha256Hash;
         file.Hash = file.Sha256Hash;
         db.Update(file);
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(ct);
         var response = ToFileResponse(file);
         db.Entry(file).State = EntityState.Detached;
 
@@ -541,32 +556,49 @@ internal sealed class TestStorageServiceWrapper(DbContext db) : IStorageServiceW
         };
     }
 
-    public Task<CmdResponse> AbortStorageUploadSession(AbortStorageUploadSessionRequest request) =>
+    public Task<CmdResponse> AbortStorageUploadSession(
+        AbortStorageUploadSessionRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage upload abort is not used by these tests.");
 
-    public Task<QueryResponse<StorageFileResponse>> GetStorageFile(GetStorageFileRequest request) =>
+    public Task<QueryResponse<StorageFileResponse>> GetStorageFile(
+        GetStorageFileRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage file reads are not used by these tests.");
 
-    public Task<QueryResponse<StorageFileListResponse>> GetStorageFiles(GetStorageFilesRequest request) =>
+    public Task<QueryResponse<StorageFileListResponse>> GetStorageFiles(
+        GetStorageFilesRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage file listing is not used by these tests.");
 
-    public Task<QueryResponse<StorageDownloadUrlResponse>> GetStorageDownloadUrl(GetStorageDownloadUrlRequest request) =>
+    public Task<QueryResponse<StorageDownloadUrlResponse>> GetStorageDownloadUrl(
+        GetStorageDownloadUrlRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage download URLs are not used by these tests.");
 
-    public Task<QueryResponse<StoragePublicUrlResponse>> GetStoragePublicUrl(GetStoragePublicUrlRequest request) =>
+    public Task<QueryResponse<StoragePublicUrlResponse>> GetStoragePublicUrl(
+        GetStoragePublicUrlRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage public URLs are not used by these tests.");
 
-    public Task<CmdResponse> DeleteStorageFile(DeleteStorageFileRequest request) =>
+    public Task<CmdResponse> DeleteStorageFile(
+        DeleteStorageFileRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage deletes are not used by these tests.");
 
-    public Task<QueryResponse<StorageFileResponse>> RestoreStorageFile(RestoreStorageFileRequest request) =>
+    public Task<QueryResponse<StorageFileResponse>> RestoreStorageFile(
+        RestoreStorageFileRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage restores are not used by these tests.");
 
-    public Task<QueryResponse<StorageRetentionCleanupResponse>> CleanupStorageRetention(CleanupStorageRetentionRequest request) =>
+    public Task<QueryResponse<StorageRetentionCleanupResponse>> CleanupStorageRetention(
+        CleanupStorageRetentionRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage cleanup is not used by these tests.");
 
     public Task<QueryResponse<StorageFileValidationResponse>> ValidateStorageFileReference(
-        ValidateStorageFileReferenceRequest request) =>
+        ValidateStorageFileReferenceRequest request,
+        CancellationToken ct = default) =>
         throw new NotSupportedException("Storage validation is not used by these tests.");
 
     private static StorageFileResponse ToFileResponse(StorageFile file) => new()

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/AuthenticationTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/AuthenticationTests.cs
@@ -395,6 +395,7 @@ public class AuthenticationTests : IntegrationTestBase
             CredentialId = credential.Id,
             TypeId = TestData.RoleTypeId,
             RoleExpiration = DateTime.UtcNow.AddYears(1),
+            IsEnabled = true,
             TenantId = IntegrationTestFixture.TestTenantId
         };
         db.Set<IdentityRole>().Add(role);

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/WrapperCoverageTests.cs
@@ -820,6 +820,7 @@ public sealed class WrapperCoverageTests : IntegrationTestBase
             CredentialId = credential.Id,
             TypeId = roleTypeId ?? TestData.RoleTypeId,
             RoleExpiration = DateTime.UtcNow.AddYears(1),
+            IsEnabled = true,
             TenantId = IntegrationTestFixture.TestTenantId
         };
         db.Set<IdentityRole>().Add(role);

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -288,6 +288,9 @@ public sealed class IdentityServerPortalContractTests
         loadIndex.Should().BeGreaterThanOrEqualTo(0);
         loadedIndex.Should().BeGreaterThan(loadIndex);
         openMethod.Should().Contain("IsRolePermissionLoadCurrent(operationVersion, userId, section, role)");
+        openMethod.Should().Contain("new CancellationTokenSource(RolePermissionLoadTimeout)");
+        openMethod.Should().Contain("}, loadCts.Token);");
+        openMethod.Should().Contain("catch (OperationCanceledException) when (loadCts.IsCancellationRequested)");
         dialogOpenIndex.Should().BeGreaterThan(
             loadedIndex,
             "portaled dialog content must be complete before the dialog is registered as open");

--- a/src/Tests/XFramework.SourceGenerators.Tests/ServiceWrapperGeneratorTests.cs
+++ b/src/Tests/XFramework.SourceGenerators.Tests/ServiceWrapperGeneratorTests.cs
@@ -58,7 +58,8 @@ public sealed class ServiceWrapperGeneratorTests
         generatedSource.Should().Contain($"TargetClient = \"{"XFramework.JuanBarangay".ToSha256()}\"");
         generatedSource.Should().Contain("IServiceTokenProvider serviceTokenProvider");
         generatedSource.Should().Contain("public IResidentCrudService Resident { get; init; }");
-        generatedSource.Should().Contain("ValidateBarangayId(");
+        generatedSource.Should().Contain("Task<QueryResponse<Juan.Barangay.Domain.Shared.Contracts.Residents.ResidentResponse>> ValidateBarangayId(Juan.Barangay.Domain.Shared.Contracts.Residents.ValidateBarangayIdRequest request, System.Threading.CancellationToken ct = default);");
+        generatedSource.Should().Contain("SendAsync<Juan.Barangay.Domain.Shared.Contracts.Residents.ValidateBarangayIdRequest, Juan.Barangay.Domain.Shared.Contracts.Residents.ResidentResponse>(request, ct);");
         generatedSource.Should().NotContain("namespace Juan.Integration.Drivers");
     }
 
@@ -99,7 +100,8 @@ public sealed class ServiceWrapperGeneratorTests
         generatedSource.Should().Contain($"TargetClient = \"{"XFramework.Inventario".ToSha256()}\"");
         generatedSource.Should().Contain("IServiceTokenProvider serviceTokenProvider");
         generatedSource.Should().Contain("public IProductCrudService Product { get; init; }");
-        generatedSource.Should().Contain("ReserveInventory(");
+        generatedSource.Should().Contain("Task<CmdResponse> ReserveInventory(XFramework.Inventario.Domain.Shared.Contracts.Requests.Reservations.ReserveInventoryRequest request, System.Threading.CancellationToken ct = default);");
+        generatedSource.Should().Contain("SendVoidAsync(request, ct);");
     }
 
     [Test]
@@ -132,8 +134,8 @@ public sealed class ServiceWrapperGeneratorTests
             new Dictionary<string, string>());
 
         generatedSource.Should().Contain("public partial interface IPOSServiceWrapper");
-        generatedSource.Should().Contain("Task<CmdResponse<POS.Domain.Shared.Contracts.Responses.PosSaleReceiptResponse>> CheckoutPosSale(POS.Domain.Shared.Contracts.Requests.CheckoutPosSaleRequest request);");
-        generatedSource.Should().Contain("SendVoidAsync<POS.Domain.Shared.Contracts.Requests.CheckoutPosSaleRequest, POS.Domain.Shared.Contracts.Responses.PosSaleReceiptResponse>(request);");
+        generatedSource.Should().Contain("Task<CmdResponse<POS.Domain.Shared.Contracts.Responses.PosSaleReceiptResponse>> CheckoutPosSale(POS.Domain.Shared.Contracts.Requests.CheckoutPosSaleRequest request, System.Threading.CancellationToken ct = default);");
+        generatedSource.Should().Contain("SendVoidAsync<POS.Domain.Shared.Contracts.Requests.CheckoutPosSaleRequest, POS.Domain.Shared.Contracts.Responses.PosSaleReceiptResponse>(request, ct);");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- bound Bolt caller and service-token waits with deterministic cancellation/timeout behavior
- return terminal 503/504 responses when routed responders disconnect or exceed the hub deadline, with quota-safe cleanup
- propagate cancellation through generated service wrappers and the Portal role-permission dialog
- preserve explicit IdentityServer permission denies and align the integration fixture with generation-bound service identities

## Verification
- Bolt.Tests: 304 passed, 5 skipped
- IdentityServer.IntegrationTests (xeon-dev Docker): 80 passed
- IdentityServer.UnitTests: 21 passed
- Portal IdentityServer contract tests: 18 passed
- XFramework.SourceGenerators.Tests: 12 passed
- Communications.Tests: 68 passed
- Community.Tests: 8 passed
- XFramework.Portal build: passed

A solution-wide no-restore compile was also attempted; restored projects compiled, while 27 untouched projects lacked local project.assets.json files. GitHub Actions will perform the authoritative restore/build.