### PR TITLE
Fix Phase 0 systemd address-family verification

### DIFF
--- a/scripts/manage-bolt-phase0-root-test.py
+++ b/scripts/manage-bolt-phase0-root-test.py
@@ -595,6 +595,27 @@ class RootBoundaryTests(unittest.TestCase):
                     self.boundary._validate_systemd()
                 self.runner.overrides.clear()
 
+    def test_restrict_address_families_accepts_systemd_canonical_order(self) -> None:
+        service = "xframework-bolt-phase0-watchdog.service"
+        self.runner.overrides[(service, "RestrictAddressFamilies")] = (
+            "AF_INET AF_INET6 AF_UNIX"
+        )
+
+        self.boundary._validate_systemd()
+
+    def test_restrict_address_families_rejects_membership_drift(self) -> None:
+        service = "xframework-bolt-phase0-watchdog.service"
+        for value in (
+            "AF_UNIX AF_INET",
+            "AF_UNIX AF_INET AF_INET6 AF_NETLINK",
+            "AF_UNIX AF_INET AF_INET",
+        ):
+            with self.subTest(value=value):
+                self.runner.overrides[(service, "RestrictAddressFamilies")] = value
+                with self.assertRaisesRegex(MODULE.RootBoundaryError, "systemd-contract"):
+                    self.boundary._validate_systemd()
+                self.runner.overrides.clear()
+
     def test_quarantine_replacement_attempt_never_becomes_lkg(self) -> None:
         candidate = directory(self.paths.run_root / "123-1", 0o700)
         file(candidate / "docker-compose.yml", 0o600, b"services: {}\n")

--- a/scripts/manage-bolt-phase0-root.py
+++ b/scripts/manage-bolt-phase0-root.py
@@ -525,7 +525,6 @@ class RootBoundary:
             (service, "RestrictSUIDSGID"): "yes",
             (service, "UMask"): "0077",
             (service, "ReadWritePaths"): f"{self.paths.deploy_root} {self.paths.protected_env.parent}",
-            (service, "RestrictAddressFamilies"): "AF_UNIX AF_INET AF_INET6",
             (service, "TimeoutStartUSec"): WATCHDOG_TIMEOUT_SYSTEMD,
             (timer, "AccuracyUSec"): "1s",
             (timer, "Persistent"): "yes",
@@ -535,6 +534,13 @@ class RootBoundary:
         for (unit, prop), value in expected.items():
             if self._show(unit, prop) != value:
                 raise RootBoundaryError("systemd-contract")
+        address_families = self._show(service, "RestrictAddressFamilies").split()
+        if len(address_families) != 3 or set(address_families) != {
+            "AF_UNIX",
+            "AF_INET",
+            "AF_INET6",
+        }:
+            raise RootBoundaryError("systemd-contract")
         exec_start = self._show(service, "ExecStart")
         launcher = re.escape(str(self.paths.watchdog))
         if len(re.findall(r"\{\s*path=", exec_start)) != 1 or not re.search(


### PR DESCRIPTION
## What changed
- compare the effective `RestrictAddressFamilies` value as an exact unordered set
- keep fail-closed rejection for missing, extra, or duplicate families
- add regression coverage for the ordering emitted by systemd on xeon-dev

## Root cause
The Phase 0 root helper required one presentation order (`AF_UNIX AF_INET AF_INET6`), while systemd canonicalized the same allow-list as `AF_INET AF_INET6 AF_UNIX`. The semantic contract was valid, but bootstrap failed closed on string ordering.

## Validation
- 19 Phase 0 Python suites: 413 tests passed locally (Windows-only skips retained)
- focused root-helper suite: 33 tests passed
- all 35 Phase 0 Python files compile
- `git diff --check` passed
- independent sub-agent review: PASS, no findings

## Operational state
The xeon-dev Bolt Hub remains stopped and the watchdog remains active. Deployment will resume only after this PR's privileged Ubuntu checks pass and the reviewed fix is merged and re-staged.