### PR TITLE
Bind Phase 0 deployment to active runner identity

### DIFF
--- a/.github/workflows/deploy-xeon-dev-service.yml
+++ b/.github/workflows/deploy-xeon-dev-service.yml
@@ -41,7 +41,7 @@ jobs:
       IMAGE_TAG: ${{ github.sha }}
       CHANNEL_TAG: develop
       DEPLOY_HOST: github-runner@xeon-dev
-      DEPLOY_SSH_KEY: /home/github-runner/.ssh/xframework_xeon_dev_ed25519
+      DEPLOY_SSH_KEY: /home/xeon/.ssh/xframework_xeon_dev_ed25519
       REMOTE_DEPLOY_DIR: /home/github-runner/xframework-deploy
       REMOTE_COMPOSE_FILE: /home/github-runner/xframework-deploy/docker-compose.yml
       XFRAMEWORK_ENV_FILE: /opt/xframework/xeon-dev.env

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -39,7 +39,7 @@ jobs:
       IMAGE_TAG: ${{ github.sha }}
       CHANNEL_TAG: develop
       DEPLOY_HOST: github-runner@xeon-dev
-      DEPLOY_SSH_KEY: /home/github-runner/.ssh/xframework_xeon_dev_ed25519
+      DEPLOY_SSH_KEY: /home/xeon/.ssh/xframework_xeon_dev_ed25519
       DEPLOY_SSH_OPERATION_TIMEOUT_SECONDS: 1800
       REMOTE_DEPLOY_DIR: /home/github-runner/xframework-deploy
       REMOTE_RUN_DIR: /home/github-runner/xframework-deploy/runs/${{ github.run_id }}-${{ github.run_attempt }}
@@ -151,7 +151,7 @@ jobs:
           known_hosts="$ssh_dir/known_hosts"
           wrapper_dir="$ssh_dir/bin"
           source_known_hosts=".github/known_hosts/xeon-dev"
-          runner_home="/home/github-runner"
+          runner_home="/home/xeon"
           runner_ssh_dir="$runner_home/.ssh"
           expected_deploy_ssh_key="$runner_ssh_dir/xframework_xeon_dev_ed25519"
           runner_uid="$(id -u)"

--- a/docs/solutions/workflow-issues/bolt-phase0-deployment-gate-2026-07-13.md
+++ b/docs/solutions/workflow-issues/bolt-phase0-deployment-gate-2026-07-13.md
@@ -199,12 +199,20 @@ Phase 0 promotion accepts only `BOLT_SYNTHETIC_PROXY_MODE=direct-kestrel`; `BOLT
 - The root-sealed recovery, forced failure recovery, systemd override rejection, indexed-scope bypass, bounded exact Redis ACK, send-loop retirement, large-RPC quota cleanup, and public health redaction regressions are covered.
 - Recovery regressions also cover strict future-heartbeat rejection, transient Docker inspection failure with a present container, exact proven container absence, daemon and empty-version failure, malformed inspection output, bounded stop/kill hangs, privileged bootstrap short reads and source races, root-owned lock replacement across the complete critical section, quarantine artifact replacement between validation and open, the exact systemd env-file write allowance, uninterrupted timer activation, explicit timer re-enablement in the pinned failure path, supervised synthetic heartbeats, and fsync-before-pointer ordering. Targeted pre-final reviews informed these regressions; a formal independent review bound to the exact final tested tree remains open because PR #352 merged without a GitHub review.
 
+## Live Rollout Retry - 2026-07-13 UTC
+
+- The corrected root bootstrap from PR #355 passed on xeon-dev with state `bootstrap-no-lkg-hub-stopped`; the watchdog is enabled and active, and Bolt Hub remains stopped with no deployment lease or LKG pointer.
+- First-attempt workflow run `29242059314` was bound to merge `aa36cff54182ac472652564dea41f5a5af07d97d` and failed before SSH wrapper creation or remote mutation. The active `xeon-dev-deploy` runner is on `xeon-buildserver01` and runs as local user `xeon`, while the workflow incorrectly required local user `github-runner` and `/home/github-runner/.ssh/xframework_xeon_dev_ed25519`.
+- The dedicated key already exists on the active runner as `xeon:xeon` mode `0600` at `/home/xeon/.ssh/xframework_xeon_dev_ed25519`; its parent `.ssh` directory is mode `0700`, it has one link, and the runner has Docker access. The correction binds the workflow to that actual local runner identity while preserving remote SSH user `github-runner`, the checked-in host key, descriptor identity checks, and bounded `ssh`/`scp` wrappers.
+
 ## Rollout Readiness Findings
 
 - **High - Synthetic token refresh expected the wrong HTTP response shape.** Generated IdentityServer HTTP adapters return exact bare DTOs, while the refresh hook expected a `Result` envelope. The mismatch would fail live synthetics before Bolt requests executed. The local worktree now validates exact bare user-token and service-token schemas and field semantics, rejects legacy envelopes and extra or missing fields, populates the generated authentication response contract, and covers the generated HTTP adapters. This fix is not yet merged, CI-validated on the target branch, or deployed.
 - **High - Direct Kestrel publication lacked an explicit proxy-proof N/A contract.** The retained proxy-log gate required paths even though xeon-dev publishes Kestrel directly, creating pressure to provide a non-evidentiary empty source. The local worktree now makes only `direct-kestrel` promotion-eligible, requires proxy log paths to be absent, rejects workflow reruns, and binds a fresh no-intermediary operator attestation to the stable actor ID, matching triggering actor, first attempt, run, commit, public hostname, active host-interface/DNS match, Compose publication, TLS port, qualification, root activation, recovery, and watchdog. This uses the existing trusted self-hosted runner threat model; distrusting that runner would require GitHub OIDC-signed authorization. The utility `logs` mode cannot qualify because its current synthetic target bypasses a proxy. The correction is not merged, CI-validated on the target branch, or deployed.
 
-## xeon-dev Readiness Audit - 2026-07-13
+## Historical xeon-dev Readiness Audit - 2026-07-13
+
+This pre-bootstrap snapshot is retained for audit history and is superseded by the live rollout retry section above.
 
 The post-merge readiness remains `NO-GO`. The prerequisite repairs below changed protected host state, but no container was stopped, restarted, or replaced.
 

--- a/scripts/run-bolt-phase0-watchdog-test.py
+++ b/scripts/run-bolt-phase0-watchdog-test.py
@@ -912,10 +912,11 @@ class WatchdogContractTests(unittest.TestCase):
     def test_workflows_use_runner_home_ssh_key_and_legacy_path_stays_disabled(self) -> None:
         active = WORKFLOW.read_text(encoding="utf-8")
         legacy = LEGACY_WORKFLOW.read_text(encoding="utf-8")
-        expected = "DEPLOY_SSH_KEY: /home/github-runner/.ssh/xframework_xeon_dev_ed25519"
+        expected = "DEPLOY_SSH_KEY: /home/xeon/.ssh/xframework_xeon_dev_ed25519"
         self.assertEqual(1, active.count(expected))
         self.assertEqual(1, legacy.count(expected))
-        self.assertNotIn("/home/xeon/.ssh", active)
+        self.assertNotIn("/home/github-runner/.ssh", active)
+        self.assertNotIn("/home/github-runner/.ssh", legacy)
         self.assertNotIn("ssh-keyscan", active)
         self.assertIn("if: ${{ false }}", legacy)
 
@@ -926,7 +927,7 @@ class WatchdogContractTests(unittest.TestCase):
             content.index("- name: Verify build runner, Docker, registry, and deploy host")
         ]
         for required in (
-            'runner_home="/home/github-runner"',
+            'runner_home="/home/xeon"',
             'runner_ssh_dir="$runner_home/.ssh"',
             'expected_deploy_ssh_key="$runner_ssh_dir/xframework_xeon_dev_ed25519"',
             'test "$DEPLOY_SSH_KEY" = "$expected_deploy_ssh_key"',


### PR DESCRIPTION
## What changed
- bind the active Phase 0 workflow to the actual local deploy-runner identity on `xeon-buildserver01`
- use the existing runner-owned key at `/home/xeon/.ssh/xframework_xeon_dev_ed25519`
- preserve remote SSH as `github-runner@xeon-dev`, pinned host verification, descriptor checks, and bounded wrappers
- keep the disabled legacy workflow consistent and record the failed pre-mutation rollout attempt

## Root cause
The active repository runner executes as local user `xeon`, but the workflow required `/home/github-runner` and a key under that nonexistent local account. Fresh run `29242059314` therefore failed in SSH setup before wrapper creation, lease arming, or remote mutation.

## Validation
- real pinned SSH wrapper round trip from `xeon-buildserver01` to xeon-dev succeeded as remote `github-runner`
- remote root helper returned `bootstrap-no-lkg-hub-stopped`
- all 19 Phase 0 Python suites: 413 tests passed locally
- focused watchdog/workflow contract: 40 tests passed
- all 35 Phase 0 Python files compile
- independent sub-agent review after fixes: PASS, no findings
- `git diff --check` passed

## Live state
Bolt Hub remains stopped, the watchdog remains active, no deployment lease exists, and no LKG pointer exists. A fresh first-attempt promotion will be dispatched only after this PR is merged with all required checks green.