### PR TITLE
Fix Bolt Hub authorization model loading

### DIFF
--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/DbInstaller.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/DbInstaller.cs
@@ -1,3 +1,6 @@
+using System.Runtime.CompilerServices;
+using Communications.Domain.Shared.Contracts;
+using IdentityServer.Domain.Shared.Contracts;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using XFramework.Core.DataContext;
 using XFramework.Domain.Shared.Interfaces;
@@ -9,6 +12,11 @@ public sealed class DbInstaller : IInstaller
 {
     public void InstallServices<TApp>(IServiceCollection services, IConfiguration configuration, IHostEnvironment hostEnvironment)
     {
+        // AppDbContext discovers mappings from loaded Domain.Shared assemblies. Load the
+        // two authorization read-model assemblies before EF builds and caches the Hub model.
+        RuntimeHelpers.RunClassConstructor(typeof(IdentityCredential).TypeHandle);
+        RuntimeHelpers.RunClassConstructor(typeof(MessageThreadMember).TypeHandle);
+
         // Register HttpContextAccessor for audit tracking
         services.AddHttpContextAccessor();
         

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Services/CommunicationsBoltTopicAuthorizer.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Services/CommunicationsBoltTopicAuthorizer.cs
@@ -62,12 +62,16 @@ public sealed class CommunicationsBoltTopicAuthorizer(
         await using var scope = scopeFactory.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<DbContext>();
 
-        var credential = await db.Set<IdentityCredential>()
+        // This system read may run under a tenantless service HttpContext. Replace the
+        // ambient filters with the complete topic-tenant and credential-state boundary.
+        var credentialExists = await db.Set<IdentityCredential>()
+            .IgnoreQueryFilters()
             .Where(c => c.Id == credentialId.Value)
+            .Where(c => c.TenantId == topicTenantId)
             .Where(c => !c.IsDeleted && c.IsEnabled)
-            .FirstOrDefaultAsync(ct);
+            .AnyAsync(ct);
 
-        if (credential is null || credential.TenantId != topicTenantId)
+        if (!credentialExists)
             return false;
 
         var allowed = context.Operation switch
@@ -174,7 +178,9 @@ public sealed class CommunicationsBoltTopicAuthorizer(
             !TryParseCanonicalGuid(segments[4], out var threadId))
             return false;
 
+        // Thread authorization uses the same explicit system-read boundary.
         return await db.Set<MessageThreadMember>()
+            .IgnoreQueryFilters()
             .Where(m => m.TenantId == tenantId)
             .Where(m => m.MessageThreadId == threadId)
             .Where(m => m.CredentialId == credentialId)

--- a/src/Tests/Bolt.Tests/Bolt.Tests.csproj
+++ b/src/Tests/Bolt.Tests/Bolt.Tests.csproj
@@ -19,6 +19,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Tests/Bolt.Tests/BoltHubConfigurationTests.cs
+++ b/src/Tests/Bolt.Tests/BoltHubConfigurationTests.cs
@@ -1,6 +1,7 @@
 using Bolt.Hub.Installers;
 using Bolt.Server;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
@@ -47,6 +48,37 @@ public class BoltHubConfigurationTests
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*DefaultDatabaseConnection*ConnectionStrings:DatabaseConnection*");
+    }
+
+    [Test]
+    public void InstallServices_RegistersHubAuthorizationEntitiesInTheEfModel()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["DefaultDatabaseConnection"] = "Host=localhost;Database=XFramework;Username=test;Password=test"
+        });
+        var services = new ServiceCollection();
+
+        new DbInstaller().InstallServices<BoltHubConfigurationTests>(
+            services,
+            configuration,
+            new TestHostEnvironment());
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var model = scope.ServiceProvider.GetRequiredService<DbContext>().Model;
+
+        var credential = model.FindEntityType("IdentityServer.Domain.Shared.Contracts.IdentityCredential");
+        credential.Should().NotBeNull();
+        var mappedCredential = credential!;
+        mappedCredential.GetSchema().Should().Be("Identity");
+        mappedCredential.GetTableName().Should().Be("IdentityCredential");
+
+        var threadMember = model.FindEntityType("Communications.Domain.Shared.Contracts.MessageThreadMember");
+        threadMember.Should().NotBeNull();
+        var mappedThreadMember = threadMember!;
+        mappedThreadMember.GetSchema().Should().Be("Communications");
+        mappedThreadMember.GetTableName().Should().Be("MessageThreadMember");
     }
 
     [Test]

--- a/src/Tests/Bolt.Tests/BoltPhase0ContainmentTests.cs
+++ b/src/Tests/Bolt.Tests/BoltPhase0ContainmentTests.cs
@@ -719,12 +719,13 @@ public sealed class BoltPhase0ContainmentTests
     public async Task DurableDisconnectCleanup_GateTimeoutDoesNotMutateWithoutOwnership()
     {
         var authorizer = new CountingAllowAuthorizer();
+        var cleanupLogger = new DurableCleanupTimeoutLogger();
         var durableOptions = Options.Create(new DurableQueueOptions());
         var durableStore = new InMemoryDurableQueueStore(
             durableOptions,
             NullLogger<InMemoryDurableQueueStore>.Instance);
         using var server = new BoltServer(
-            NullLogger<BoltServer>.Instance,
+            cleanupLogger,
             new BoltServerOptions
             {
                 MaxSubscriptionsPerPrincipal = 1,
@@ -752,6 +753,7 @@ public sealed class BoltPhase0ContainmentTests
         try
         {
             connection.Complete();
+            await cleanupLogger.WaitForTimeoutAsync(TimeSpan.FromSeconds(10));
             await connectionTask.WaitAsync(TimeSpan.FromSeconds(3));
 
             GetDurableBinding(server, topicHash, subscriberId).ClientId.Should().Be("cleanup-owner");
@@ -1012,6 +1014,35 @@ public sealed class BoltPhase0ContainmentTests
 
             Volatile.Read(ref _callCount).Should().BeGreaterThanOrEqualTo(expected);
         }
+    }
+
+    private sealed class DurableCleanupTimeoutLogger : ILogger<BoltServer>
+    {
+        private const string CleanupTimeoutMessage =
+            "Durable subscription cleanup gate timed out; cleanup will retry.";
+
+        private readonly TaskCompletionSource _timeoutLogged =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning &&
+                formatter(state, exception).StartsWith(CleanupTimeoutMessage, StringComparison.Ordinal))
+            {
+                _timeoutLogged.TrySetResult();
+            }
+        }
+
+        public Task WaitForTimeoutAsync(TimeSpan timeout) => _timeoutLogged.Task.WaitAsync(timeout);
     }
 
     private sealed class ControlledReplayDurableStore(IOptions<DurableQueueOptions> options) : IDurableQueueStore

--- a/src/Tests/Bolt.Tests/CommunicationsBoltTopicAuthorizerPostgreSqlTests.cs
+++ b/src/Tests/Bolt.Tests/CommunicationsBoltTopicAuthorizerPostgreSqlTests.cs
@@ -1,0 +1,194 @@
+using System.Security.Claims;
+using Bolt.Hub.Installers;
+using Bolt.Hub.Services;
+using Bolt.Server;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NSubstitute;
+using NUnit.Framework;
+using Testcontainers.PostgreSql;
+using XFramework.Integration.Abstractions;
+
+namespace Bolt.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class CommunicationsBoltTopicAuthorizerPostgreSqlTests
+{
+    private const string ExternalConnectionStringEnvironmentVariable = "BOLT_TEST_POSTGRES_CONNECTION";
+    private const string ExpectedDatabaseName = "bolt_authorization_test";
+
+    private PostgreSqlContainer? postgres;
+    private string connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task StartPostgreSql()
+    {
+        var externalConnectionString = Environment.GetEnvironmentVariable(
+            ExternalConnectionStringEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(externalConnectionString))
+        {
+            connectionString = externalConnectionString;
+        }
+        else
+        {
+            try
+            {
+                postgres = new PostgreSqlBuilder()
+                    .WithDatabase(ExpectedDatabaseName)
+                    .WithUsername("bolt_test")
+                    .WithPassword("bolt_test_password")
+                    .Build();
+                await postgres.StartAsync();
+                connectionString = postgres.GetConnectionString();
+            }
+            catch (Exception ex) when (
+                ex is ArgumentException or TypeInitializationException ||
+                ex.Message.Contains("Docker", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Bolt PostgreSQL tests require a Testcontainers-compatible Docker endpoint or a dedicated test database in {ExternalConnectionStringEnvironmentVariable}.",
+                    ex);
+            }
+        }
+
+        EnsureDedicatedTestDatabase(connectionString);
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        await using var provider = CreateProvider(principal);
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+        await db.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS \"Identity\"");
+        await db.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS \"Communications\"");
+        await db.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TABLE IF NOT EXISTS "Identity"."IdentityCredential" (
+                "ID" uuid PRIMARY KEY,
+                "TenantId" uuid NOT NULL,
+                "IsEnabled" boolean NOT NULL,
+                "IsDeleted" boolean NOT NULL
+            )
+            """);
+        await db.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TABLE IF NOT EXISTS "Communications"."MessageThreadMember" (
+                "ID" uuid PRIMARY KEY,
+                "TenantId" uuid NOT NULL,
+                "MessageThreadId" uuid NOT NULL,
+                "CredentialId" uuid NOT NULL,
+                "IsEnabled" boolean NOT NULL,
+                "IsDeleted" boolean NOT NULL
+            )
+            """);
+    }
+
+    [OneTimeTearDown]
+    public async Task StopPostgreSql()
+    {
+        if (postgres is not null)
+            await postgres.DisposeAsync();
+    }
+
+    [TestCase(true, false, false, true)]
+    [TestCase(false, false, false, false)]
+    [TestCase(true, true, false, false)]
+    [TestCase(true, false, true, false)]
+    public async Task ThreadSubscription_RequiresActiveMembershipInTopicTenant(
+        bool memberEnabled,
+        bool memberDeleted,
+        bool wrongMemberTenant,
+        bool expected)
+    {
+        var topicTenantId = Guid.NewGuid();
+        var credentialId = Guid.NewGuid();
+        var threadId = Guid.NewGuid();
+        var servicePrincipal = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, "XFramework.Proxy")],
+            "Test"));
+        var actorPrincipal = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, credentialId.ToString("N")),
+                new Claim("tenantId", topicTenantId.ToString("D"))
+            ],
+            "Test"));
+        await using var provider = CreateProvider(servicePrincipal);
+
+        await using (var seedScope = provider.CreateAsyncScope())
+        {
+            var db = seedScope.ServiceProvider.GetRequiredService<DbContext>();
+            await db.Database.ExecuteSqlRawAsync("TRUNCATE TABLE \"Communications\".\"MessageThreadMember\"");
+            await db.Database.ExecuteSqlRawAsync("TRUNCATE TABLE \"Identity\".\"IdentityCredential\"");
+            await db.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO "Identity"."IdentityCredential" ("ID", "TenantId", "IsEnabled", "IsDeleted")
+                VALUES ({credentialId}, {topicTenantId}, {true}, {false})
+                """);
+            var memberTenantId = wrongMemberTenant ? Guid.NewGuid() : topicTenantId;
+            await db.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO "Communications"."MessageThreadMember"
+                    ("ID", "TenantId", "MessageThreadId", "CredentialId", "IsEnabled", "IsDeleted")
+                VALUES ({Guid.NewGuid()}, {memberTenantId}, {threadId}, {credentialId}, {memberEnabled}, {memberDeleted})
+                """);
+        }
+
+        var jwtService = Substitute.For<IJwtService>();
+        jwtService.DecodeJwtToken("actor-token")
+            .Returns(Task.FromResult((actorPrincipal, new System.IdentityModel.Tokens.Jwt.JwtSecurityToken())));
+        var authorizer = new CommunicationsBoltTopicAuthorizer(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            jwtService,
+            NullLogger<CommunicationsBoltTopicAuthorizer>.Instance);
+        var context = new BoltTopicAuthorizationContext(
+            BoltTopicOperation.Subscribe,
+            $"communications.tenant.{topicTenantId:N}.thread.{threadId:N}.typing",
+            0,
+            false,
+            "client",
+            "actor-token",
+            "connection",
+            "client",
+            "Client",
+            servicePrincipal);
+
+        var allowed = await authorizer.AuthorizeAsync(context);
+
+        allowed.Should().Be(expected);
+    }
+
+    private ServiceProvider CreateProvider(ClaimsPrincipal httpPrincipal)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DefaultDatabaseConnection"] = connectionString
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { User = httpPrincipal }
+        });
+        new DbInstaller().InstallServices<CommunicationsBoltTopicAuthorizerPostgreSqlTests>(
+            services,
+            configuration,
+            Substitute.For<IHostEnvironment>());
+        return services.BuildServiceProvider();
+    }
+
+    private static void EnsureDedicatedTestDatabase(string value)
+    {
+        var database = new NpgsqlConnectionStringBuilder(value).Database;
+        if (!string.Equals(database, ExpectedDatabaseName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Bolt PostgreSQL authorization tests run destructive setup and require database '{ExpectedDatabaseName}', but the configured database is '{database}'.");
+        }
+    }
+}

--- a/src/Tests/Bolt.Tests/CommunicationsBoltTopicAuthorizerTests.cs
+++ b/src/Tests/Bolt.Tests/CommunicationsBoltTopicAuthorizerTests.cs
@@ -2,10 +2,15 @@ using System.Security.Claims;
 using Bolt.Hub.Services;
 using Bolt.Server;
 using FluentAssertions;
+using IdentityServer.Domain.Shared.Contracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NUnit.Framework;
+using XFramework.Domain.Contexts;
 using XFramework.Integration.Abstractions;
 
 namespace Bolt.Tests;
@@ -160,6 +165,142 @@ public sealed class CommunicationsBoltTopicAuthorizerTests
         var action = async () => await authorizer.AuthorizeAsync(context);
 
         (await action.Should().NotThrowAsync()).Which.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task PresenceSubscription_EnabledCredentialInTopicTenant_IsAllowed()
+    {
+        var tenantId = Guid.NewGuid();
+        var credentialId = Guid.NewGuid();
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, credentialId.ToString("N")),
+                new Claim("tenantId", tenantId.ToString("D"))
+            ],
+            "Test"));
+        await using var provider = await CreateDatabaseProviderAsync(
+            principal,
+            new IdentityCredential
+            {
+                Id = credentialId,
+                TenantId = tenantId,
+                IdentityInfoId = Guid.NewGuid(),
+                IsEnabled = true,
+                IsDeleted = false
+            });
+
+        var jwtService = Substitute.For<IJwtService>();
+        var authorizer = CreateAuthorizer(provider.GetRequiredService<IServiceScopeFactory>(), jwtService);
+        var context = CreateContext(
+            $"communications.tenant.{tenantId:N}.presence",
+            subscriberId: "client",
+            user: principal);
+
+        var allowed = await authorizer.AuthorizeAsync(context);
+
+        allowed.Should().BeTrue();
+        _ = jwtService.DidNotReceive().DecodeJwtToken(Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task PresenceSubscription_ActorCredentialWithServiceHttpPrincipal_IsAllowed()
+    {
+        var tenantId = Guid.NewGuid();
+        var credentialId = Guid.NewGuid();
+        var servicePrincipal = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, "XFramework.Proxy")],
+            "Test"));
+        var actorPrincipal = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, credentialId.ToString("N")),
+                new Claim("tenantId", tenantId.ToString("D"))
+            ],
+            "Test"));
+        await using var provider = await CreateDatabaseProviderAsync(
+            servicePrincipal,
+            new IdentityCredential
+            {
+                Id = credentialId,
+                TenantId = tenantId,
+                IdentityInfoId = Guid.NewGuid(),
+                IsEnabled = true,
+                IsDeleted = false
+            });
+        var jwtService = Substitute.For<IJwtService>();
+        jwtService.DecodeJwtToken("actor-token")
+            .Returns(Task.FromResult((actorPrincipal, new System.IdentityModel.Tokens.Jwt.JwtSecurityToken())));
+        var authorizer = CreateAuthorizer(provider.GetRequiredService<IServiceScopeFactory>(), jwtService);
+        var context = CreateContext(
+            $"communications.tenant.{tenantId:N}.presence",
+            subscriberId: "client",
+            actorAccessToken: "actor-token",
+            user: servicePrincipal);
+
+        var allowed = await authorizer.AuthorizeAsync(context);
+
+        allowed.Should().BeTrue();
+        _ = jwtService.Received(1).DecodeJwtToken("actor-token");
+    }
+
+    [TestCase(false, false, false)]
+    [TestCase(true, true, false)]
+    [TestCase(true, false, true)]
+    public async Task PresenceSubscription_InvalidCredentialStateOrTenant_IsDenied(
+        bool enabled,
+        bool deleted,
+        bool wrongTenant)
+    {
+        var topicTenantId = Guid.NewGuid();
+        var credentialId = Guid.NewGuid();
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, credentialId.ToString("N")),
+                new Claim("tenantId", topicTenantId.ToString("D"))
+            ],
+            "Test"));
+        await using var provider = await CreateDatabaseProviderAsync(
+            principal,
+            new IdentityCredential
+            {
+                Id = credentialId,
+                TenantId = wrongTenant ? Guid.NewGuid() : topicTenantId,
+                IdentityInfoId = Guid.NewGuid(),
+                IsEnabled = enabled,
+                IsDeleted = deleted
+            });
+        var authorizer = CreateAuthorizer(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            Substitute.For<IJwtService>());
+        var context = CreateContext(
+            $"communications.tenant.{topicTenantId:N}.presence",
+            subscriberId: "client",
+            user: principal);
+
+        var allowed = await authorizer.AuthorizeAsync(context);
+
+        allowed.Should().BeFalse();
+    }
+
+    private static async Task<ServiceProvider> CreateDatabaseProviderAsync(
+        ClaimsPrincipal httpPrincipal,
+        IdentityCredential credential)
+    {
+        var services = new ServiceCollection();
+        var databaseName = $"bolt-topic-authorization-{Guid.NewGuid():N}";
+        services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { User = httpPrincipal }
+        });
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddDbContext<DbContext, AppDbContext>((_, options) =>
+            options.UseInMemoryDatabase(databaseName));
+
+        var provider = services.BuildServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+        db.Set<IdentityCredential>().Add(credential);
+        await db.SaveChangesAsync();
+        return provider;
     }
 
     private static CommunicationsBoltTopicAuthorizer CreateAuthorizer(


### PR DESCRIPTION
## Summary
- load the Identity and Communications model assemblies before Bolt Hub builds and caches `AppDbContext`
- make Communications topic authorization independent of a tenantless service `HttpContext` while retaining explicit tenant, enabled, and soft-delete predicates
- use existence queries and add production-model, in-memory authorization, and PostgreSQL translation coverage

## Root cause
The Hub service-discovery startup path could build the shared EF model before the Identity and Communications `Domain.Shared` assemblies were loaded. The later topic-authorizer query then failed because `IdentityCredential` was absent from the cached model. Ambient tenant filters also relied on an HTTP principal that is tenantless for service connections.

## Validation
- focused PostgreSQL fixture: 4/4 passed
- full `Bolt.Tests` with mandatory Redis and PostgreSQL Testcontainers: 319/319 passed, zero skipped
- `git diff --check`
- two independent final reviews: no findings

`BOLT_TEST_POSTGRES_CONNECTION` may target only a dedicated database named `bolt_authorization_test`; the fixture rejects any other database before destructive setup.