### PR TITLE
Centralize Bolt transport identity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,8 @@ DB_PASSWORD=change-me-local-db-password
 
 # Token signing
 JWT_SECRET=change-me-local-jwt-secret-with-at-least-64-characters
-BOLT_SIGNATURE=change-me-local-bolt-signature-with-at-least-64-characters
+# Rollback-only until the first centralized-identity LKG is sealed. New services do not receive this value.
+BOLT_SIGNATURE=change-me-legacy-rollback-bolt-signature-with-at-least-64-characters
 JWT_ISSUER=xframework
 JWT_AUDIENCE=xframework
 CREDENTIAL_GENERATION_ID=local-development-g1

--- a/.github/workflows/deploy-xeon-dev-identityserver.yml
+++ b/.github/workflows/deploy-xeon-dev-identityserver.yml
@@ -35,6 +35,6 @@ jobs:
     uses: ./.github/workflows/deploy-xeon-dev-service.yml
     with:
       service: identityserver
-      health_url: http://localhost:8261/health/ready
+      health_url: https://xeon-dev.tailed40e.ts.net:8261/health/live
       diagnostics_services: bolt-hub identityserver
     secrets: inherit

--- a/.github/workflows/deploy-xeon-dev-service.yml
+++ b/.github/workflows/deploy-xeon-dev-service.yml
@@ -340,6 +340,62 @@ jobs:
             "$DEPLOY_HOST:$remote_evidence" "$evidence_dir/pinned-manifest-remote.json" || true
           exit "$status"
 
+      - name: Preflight centralized identity plane for Bolt clients
+        if: inputs.service != 'identityserver'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" "bash -s" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+          metadata_body="$(mktemp)"
+          jwks_body="$(mktemp)"
+          cleanup() { rm -f "$metadata_body" "$jwks_body"; }
+          trap cleanup EXIT
+
+          identity_ready=0
+          for attempt in $(seq 1 60); do
+            if /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/health/live >/dev/null \
+              && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/openid-configuration > "$metadata_body" \
+              && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/bolt-transport-jwks.json > "$jwks_body" \
+              && python3 - "$metadata_body" "$jwks_body" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import urllib.parse
+
+          metadata = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          jwks = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+          jwks_uri = metadata.get("jwks_uri")
+          if metadata.get("issuer") != "XFramework.IdentityServer":
+              raise SystemExit("IdentityServer metadata issuer is invalid")
+          if jwks_uri != "http://identityserver:8080/.well-known/bolt-transport-jwks.json":
+              raise SystemExit("IdentityServer metadata JWKS URI is invalid")
+          if "RS256" not in metadata.get("id_token_signing_alg_values_supported", []):
+              raise SystemExit("IdentityServer metadata does not advertise RS256")
+          keys = jwks.get("keys")
+          if not isinstance(keys, list) or not any(
+              key.get("kty") == "RSA"
+              and key.get("use") == "sig"
+              and key.get("alg") == "RS256"
+              and all(key.get(field) for field in ("kid", "n", "e"))
+              for key in keys
+          ):
+              raise SystemExit("IdentityServer JWKS has no usable RSA signing key")
+          PY
+            then
+              identity_ready=1
+              break
+            fi
+            echo "IdentityServer identity plane not ready; attempt ${attempt}/60"
+            sleep 5
+          done
+          test "$identity_ready" -eq 1
+          REMOTE_SCRIPT
+
       - name: Deploy service on xeon-dev
         shell: bash
         run: |
@@ -360,6 +416,59 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          if [ "$SERVICE_NAME" = "identityserver" ]; then
+            ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" "bash -s" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+          metadata_body="$(mktemp)"
+          jwks_body="$(mktemp)"
+          cleanup() { rm -f "$metadata_body" "$jwks_body"; }
+          trap cleanup EXIT
+
+          identity_ready=0
+          for attempt in $(seq 1 60); do
+            if /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/health/live >/dev/null \
+              && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/openid-configuration > "$metadata_body" \
+              && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/bolt-transport-jwks.json > "$jwks_body" \
+              && python3 - "$metadata_body" "$jwks_body" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import urllib.parse
+
+          metadata = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          jwks = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+          jwks_uri = metadata.get("jwks_uri")
+          if metadata.get("issuer") != "XFramework.IdentityServer":
+              raise SystemExit("IdentityServer metadata issuer is invalid")
+          if jwks_uri != "http://identityserver:8080/.well-known/bolt-transport-jwks.json":
+              raise SystemExit("IdentityServer metadata JWKS URI is invalid")
+          if "RS256" not in metadata.get("id_token_signing_alg_values_supported", []):
+              raise SystemExit("IdentityServer metadata does not advertise RS256")
+          keys = jwks.get("keys")
+          if not isinstance(keys, list) or not any(
+              key.get("kty") == "RSA"
+              and key.get("use") == "sig"
+              and key.get("alg") == "RS256"
+              and all(key.get(field) for field in ("kid", "n", "e"))
+              for key in keys
+          ):
+              raise SystemExit("IdentityServer JWKS has no usable RSA signing key")
+          PY
+            then
+              identity_ready=1
+              break
+            fi
+            echo "IdentityServer identity plane not ready; attempt ${attempt}/60"
+            sleep 5
+          done
+          test "$identity_ready" -eq 1
+          REMOTE_SCRIPT
+            exit 0
+          fi
 
           if [ "$SERVICE_NAME" = "bolt-hub" ]; then
             ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -616,6 +616,90 @@ jobs:
               raise SystemExit("bound Phase 0 run preparation failed")
           PY
 
+      - name: Verify current sealed LKG renders with protected credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "REMOTE_RUN_DIR='$REMOTE_RUN_DIR' REMOTE_LKG_DIR='$REMOTE_LKG_DIR' XFRAMEWORK_ENV_FILE='$XFRAMEWORK_ENV_FILE' bash -s" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+          umask 077
+          status_path="$REMOTE_RUN_DIR/lkg-compatibility-status"
+          test ! -e "$status_path"
+          test ! -L "$status_path"
+          pointer="$REMOTE_LKG_DIR/current"
+          if [ ! -e "$pointer" ]; then
+            test ! -L "$pointer"
+            printf '%s\n' not_applicable_no_prior_lkg > "$status_path"
+            echo "No sealed LKG exists; bootstrap recovery remains fail-closed with Bolt Hub stopped."
+            exit 0
+          fi
+
+          test -f "$pointer"
+          test ! -L "$pointer"
+          test "$(stat -Lc '%a:%h' -- "$pointer")" = "644:1"
+          lkg_run="$(python3 - "$pointer" "$REMOTE_RUN_DIR" <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          pointer = pathlib.Path(sys.argv[1])
+          run_root = pathlib.Path(sys.argv[2]).parent
+          raw = pointer.read_bytes()
+          if raw.count(b"\n") != 1 or not raw.endswith(b"\n"):
+              raise SystemExit("sealed LKG pointer is invalid")
+          try:
+              run = pathlib.Path(raw[:-1].decode("utf-8", errors="strict"))
+          except UnicodeDecodeError:
+              raise SystemExit("sealed LKG pointer is not UTF-8") from None
+          if run.parent != run_root or not re.fullmatch(r"[1-9][0-9]{0,31}-[1-9][0-9]{0,5}", run.name):
+              raise SystemExit("sealed LKG pointer leaves the trusted run root")
+          print(run)
+          PY
+          )"
+          test -d "$lkg_run"
+          test ! -L "$lkg_run"
+          test "$(readlink -e -- "$lkg_run")" = "$lkg_run"
+          test "$(stat -Lc '%a' -- "$lkg_run")" = 550
+          for artifact in docker-compose.yml pinned-compose.override.json image-pins.json security-qualified qualified-commit; do
+            path="$lkg_run/$artifact"
+            test -f "$path"
+            test ! -L "$path"
+            test "$(readlink -e -- "$path")" = "$path"
+            test "$(stat -Lc '%a:%h' -- "$path")" = "440:1"
+          done
+
+          /usr/bin/timeout --foreground --kill-after=10s 120s \
+            docker compose --env-file "$XFRAMEWORK_ENV_FILE" \
+              -f "$lkg_run/docker-compose.yml" \
+              -f "$lkg_run/pinned-compose.override.json" \
+              --project-name xframework config --quiet
+
+          pins="$(
+            python3 - "$lkg_run/image-pins.json" <<'PY'
+          import json
+          import pathlib
+          import re
+          import sys
+
+          document = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          pins = document.get("pins")
+          pattern = re.compile(r"[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}")
+          if document.get("schema") != "xframework.bolt.phase0.image-pins.v2" or not isinstance(pins, dict) or not pins:
+              raise SystemExit("sealed LKG image pins are invalid")
+          if any(not isinstance(pin, str) or not pattern.fullmatch(pin) for pin in pins.values()):
+              raise SystemExit("sealed LKG contains a non-canonical image pin")
+          print("\n".join(sorted(pins.values())))
+          PY
+          )"
+          test -n "$pins"
+          while IFS= read -r pin; do
+            /usr/bin/timeout --foreground --kill-after=10s 60s \
+              docker image inspect "$pin" >/dev/null
+          done <<< "$pins"
+          printf '%s\n' rendered > "$status_path"
+          REMOTE_SCRIPT
+
       - name: Install reviewed Phase 0 synthetic hooks
         shell: bash
         run: |
@@ -1450,6 +1534,152 @@ jobs:
             "${compose[@]}" up --no-build --no-deps --force-recreate --abort-on-container-exit --exit-code-from migrate migrate
           REMOTE_SCRIPT
 
+      - name: Deploy IdentityServer identity plane
+        shell: bash
+        run: |
+          set -euo pipefail
+          remote_env="COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' REGISTRY_HOST='$REGISTRY_HOST' REGISTRY_NAMESPACE='$REGISTRY_NAMESPACE' IMAGE_TAG='$IMAGE_TAG' XFRAMEWORK_ENV_FILE='$XFRAMEWORK_ENV_FILE' REMOTE_COMPOSE_FILE='$REMOTE_COMPOSE_FILE' REMOTE_PIN_OVERRIDE='$REMOTE_PIN_OVERRIDE' REMOTE_RUN_DIR='$REMOTE_RUN_DIR' REMOTE_LEASE_MANAGER='$REMOTE_LEASE_MANAGER' RUN_ID='$GITHUB_RUN_ID' RUN_ATTEMPT='$GITHUB_RUN_ATTEMPT'"
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "$remote_env bash -s" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+          test -d "$REMOTE_RUN_DIR"
+          test ! -L "$REMOTE_RUN_DIR"
+          test "$(readlink -e -- "$REMOTE_RUN_DIR")" = "$REMOTE_RUN_DIR"
+          test "$(stat -Lc '%u:%g:%a:%F' -- "$REMOTE_RUN_DIR")" = \
+            "$(id -u):$(id -g):700:directory"
+          deployment_uid="$(id -u)"
+          compose=(docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$REMOTE_COMPOSE_FILE" -f "$REMOTE_PIN_OVERRIDE")
+          python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$deployment_uid" \
+            supervise --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" --phase identity-rollout --mutation-began \
+            --timeout-seconds 540 -- /usr/bin/timeout --foreground --kill-after=30s 510s \
+            "${compose[@]}" up -d --no-build --no-deps identityserver
+          REMOTE_SCRIPT
+
+      - name: Verify IdentityServer live discovery plane
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "REMOTE_LEASE_MANAGER='$REMOTE_LEASE_MANAGER' COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' RUN_ID='$GITHUB_RUN_ID' RUN_ATTEMPT='$GITHUB_RUN_ATTEMPT' bash -s" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+          deployment_uid="$(id -u)"
+          heartbeat_parent_pid=$$
+          heartbeat_failed="$(mktemp)"
+          heartbeat_ready="$(mktemp)"
+          metadata_body="$(mktemp)"
+          jwks_body="$(mktemp)"
+          rm -f "$heartbeat_failed" "$heartbeat_ready"
+          heartbeat_pid=
+          heartbeat() {
+            python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$deployment_uid" \
+              heartbeat --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" --phase identity-readiness --mutation-began >/dev/null
+          }
+          heartbeat_loop() {
+            trap 'exit 0' TERM INT HUP
+            while true; do
+              if ! heartbeat; then
+                : > "$heartbeat_failed"
+                kill -TERM "$heartbeat_parent_pid" >/dev/null 2>&1 || true
+                return 1
+              fi
+              : > "$heartbeat_ready"
+              sleep 30 & wait $! || return 0
+            done
+          }
+          cleanup_heartbeat() {
+            status=$?
+            heartbeat_was_alive=false
+            trap - EXIT TERM INT HUP
+            if [ -n "$heartbeat_pid" ]; then
+              if kill -0 "$heartbeat_pid" >/dev/null 2>&1; then
+                heartbeat_was_alive=true
+                kill "$heartbeat_pid" >/dev/null 2>&1 || true
+              fi
+              wait "$heartbeat_pid" 2>/dev/null || true
+              if [ "$status" -eq 0 ] && { [ "$heartbeat_was_alive" != true ] || [ -e "$heartbeat_failed" ]; }; then
+                echo "IdentityServer readiness lease heartbeat stopped unexpectedly" >&2
+                status=1
+              fi
+            fi
+            rm -f "$heartbeat_failed" "$heartbeat_ready" "$metadata_body" "$jwks_body"
+            exit "$status"
+          }
+          trap cleanup_heartbeat EXIT
+          trap 'exit 1' TERM INT HUP
+          heartbeat_loop & heartbeat_pid=$!
+          for _ in $(seq 1 100); do
+            [ -e "$heartbeat_ready" ] && break
+            if [ -e "$heartbeat_failed" ] || ! kill -0 "$heartbeat_pid" >/dev/null 2>&1; then
+              echo "IdentityServer readiness lease heartbeat failed to start" >&2
+              exit 1
+            fi
+            sleep 0.1
+          done
+          test -e "$heartbeat_ready"
+
+          identity_ready=0
+          for attempt in $(seq 1 60); do
+            if /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/health/live >/dev/null \
+              && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/openid-configuration > "$metadata_body" \
+              && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/bolt-transport-jwks.json > "$jwks_body" \
+              && python3 - "$metadata_body" "$jwks_body" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import urllib.parse
+
+          metadata = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          jwks = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+          jwks_uri = metadata.get("jwks_uri")
+          if metadata.get("issuer") != "XFramework.IdentityServer":
+              raise SystemExit("IdentityServer metadata issuer is invalid")
+          if jwks_uri != "http://identityserver:8080/.well-known/bolt-transport-jwks.json":
+              raise SystemExit("IdentityServer metadata JWKS URI is invalid")
+          if "RS256" not in metadata.get("id_token_signing_alg_values_supported", []):
+              raise SystemExit("IdentityServer metadata does not advertise RS256")
+          keys = jwks.get("keys")
+          if not isinstance(keys, list) or not any(
+              key.get("kty") == "RSA"
+              and key.get("use") == "sig"
+              and key.get("alg") == "RS256"
+              and all(key.get(field) for field in ("kid", "n", "e"))
+              for key in keys
+          ):
+              raise SystemExit("IdentityServer JWKS has no usable RSA signing key")
+          PY
+            then
+              identity_ready=1
+              break
+            fi
+            echo "IdentityServer identity plane not ready; attempt ${attempt}/60"
+            sleep 5
+          done
+          test "$identity_ready" -eq 1
+          REMOTE_SCRIPT
+
+      - name: Verify staged runtime after IdentityServer deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/bolt-phase0-evidence"
+          remote_verifier="$REMOTE_RUNTIME_VERIFIER"
+          remote_evidence="$REMOTE_RUN_DIR/runtime-staged-identityserver.json"
+          services=(migrate identityserver)
+          service_args="$(printf '%q ' "${services[@]}")"
+
+          scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes \
+            scripts/verify-bolt-phase0-runtime.py "$DEPLOY_HOST:$remote_verifier"
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" "rm -f '$remote_evidence'"
+          status=0
+          ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
+            "python3 '$REMOTE_LEASE_MANAGER' --project-name '$COMPOSE_PROJECT_NAME' --deployment-uid \"\$(id -u)\" supervise --run-id '$GITHUB_RUN_ID' --run-attempt '$GITHUB_RUN_ATTEMPT' --phase runtime-staged-identityserver --mutation-began --timeout-seconds 540 --quiet -- /usr/bin/timeout --foreground --kill-after=30s 510s python3 '$remote_verifier' --compose-file '$REMOTE_COMPOSE_FILE' --compose-file '$REMOTE_PIN_OVERRIDE' --env-file '$XFRAMEWORK_ENV_FILE' --project-name '$COMPOSE_PROJECT_NAME' --output '$remote_evidence' --pins-file '$REMOTE_PINS_FILE' --allow-staged-inventory --services $service_args" || status=$?
+          scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes \
+            "$DEPLOY_HOST:$remote_evidence" "$evidence_dir/runtime-staged-identityserver.json" || true
+          exit "$status"
+
       - name: Deploy Bolt Hub only
         shell: bash
         run: |
@@ -1573,7 +1803,7 @@ jobs:
           evidence_dir="$RUNNER_TEMP/bolt-phase0-evidence"
           remote_verifier="$REMOTE_RUNTIME_VERIFIER"
           remote_evidence="$REMOTE_RUN_DIR/runtime-staged-hub.json"
-          services=(migrate bolt-hub)
+          services=(migrate identityserver bolt-hub)
           service_args="$(printf '%q ' "${services[@]}")"
 
           scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes \
@@ -1586,7 +1816,7 @@ jobs:
             "$DEPLOY_HOST:$remote_evidence" "$evidence_dir/runtime-staged-hub.json" || true
           exit "$status"
 
-      - name: Deploy IdentityServer and Communications canary
+      - name: Deploy Communications canary
         shell: bash
         run: |
           set -euo pipefail
@@ -1603,7 +1833,7 @@ jobs:
           python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$deployment_uid" \
             supervise --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" --phase canary-rollout --mutation-began \
             --timeout-seconds 540 -- /usr/bin/timeout --foreground --kill-after=30s 510s \
-            "${compose[@]}" up -d --no-build --no-deps identityserver communications
+            "${compose[@]}" up -d --no-build --no-deps communications
           REMOTE_SCRIPT
 
       - name: Wait for canary readiness
@@ -1665,17 +1895,10 @@ jobs:
             sleep 0.1
           done
           test -e "$heartbeat_ready"
-          read_env() { python3 "$ENV_PARSER" --file "$XFRAMEWORK_ENV_FILE" --key "$1"; }
-          identity_host="$(read_env IDENTITYSERVER_PUBLIC_HOSTNAME)"
-          identity_port="$(read_env IDENTITYSERVER_PUBLIC_HTTPS_PORT)"
-          identity_ca="$(read_env IDENTITYSERVER_TLS_CA_PATH)"
           for attempt in $(seq 1 60); do
-            identity_status="$(curl -sS --connect-timeout 5 --max-time 15 --noproxy "$identity_host" \
-              --cacert "$identity_ca" -o /dev/null -w '%{http_code}' \
-              "https://${identity_host}:${identity_port}/health/ready" || true)"
             communications_status="$(curl -sS --connect-timeout 5 --max-time 15 \
               -o /dev/null -w '%{http_code}' http://127.0.0.1:5148/health/ready || true)"
-            if [ "$identity_status" = 200 ] && [ "$communications_status" = 200 ]; then
+            if [ "$communications_status" = 200 ]; then
               exit 0
             fi
             sleep 5
@@ -1690,7 +1913,7 @@ jobs:
           evidence_dir="$RUNNER_TEMP/bolt-phase0-evidence"
           remote_verifier="$REMOTE_RUNTIME_VERIFIER"
           remote_evidence="$REMOTE_RUN_DIR/runtime-staged-canary.json"
-          services=(migrate bolt-hub identityserver communications)
+          services=(migrate identityserver bolt-hub communications)
           service_args="$(printf '%q ' "${services[@]}")"
 
           ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" "rm -f '$remote_evidence'"
@@ -1750,8 +1973,8 @@ jobs:
             python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$deployment_uid" \
               heartbeat --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" --phase canary-observation --mutation-began >/dev/null
           }
-          containers=(xframework-bolt-hub xframework-identityserver xframework-communications)
-          services=(bolt-hub identityserver communications)
+          containers=(xframework-identityserver xframework-bolt-hub xframework-communications)
+          services=(identityserver bolt-hub communications)
           for sample_number in $(seq 1 "$MINIMUM_SAMPLES"); do
             heartbeat
             sample_dir="$(mktemp -d /dev/shm/bolt-phase0-observation.XXXXXXXX)"
@@ -1768,7 +1991,7 @@ jobs:
           import datetime, json, pathlib, sys
           root = pathlib.Path(sys.argv[1])
           services = {}
-          for service in ("bolt-hub", "identityserver", "communications"):
+          for service in ("identityserver", "bolt-hub", "communications"):
               health = json.loads((root / f"{service}.json").read_text(encoding="utf-8"))
               services[service] = {"http_status": 200, "health": health}
           sample = {
@@ -1822,7 +2045,7 @@ jobs:
             "wallets inventario pos"
             "portal operations-dashboard"
           )
-          cumulative_services=(migrate bolt-hub identityserver communications)
+          cumulative_services=(migrate identityserver bolt-hub communications)
           remote_verifier="$REMOTE_RUNTIME_VERIFIER"
           batch_number=0
           for batch in "${batches[@]}"; do
@@ -1957,8 +2180,8 @@ jobs:
           done
           identity_status="$(curl -sS --connect-timeout 5 --max-time 15 \
             --noproxy "$IDENTITYSERVER_PUBLIC_HOSTNAME" --cacert "$IDENTITYSERVER_TLS_CA_PATH" \
-            -o /tmp/xframework-identityserver-ready.json -w '%{http_code}' \
-            "https://${IDENTITYSERVER_PUBLIC_HOSTNAME}:${IDENTITYSERVER_PUBLIC_HTTPS_PORT}/health/ready" || true)"
+            -o /tmp/xframework-identityserver-live.json -w '%{http_code}' \
+            "https://${IDENTITYSERVER_PUBLIC_HOSTNAME}:${IDENTITYSERVER_PUBLIC_HTTPS_PORT}/health/live" || true)"
           test "$identity_status" = 200
           checks=(
             "communications=http://localhost:5148/health/ready"
@@ -2101,14 +2324,15 @@ jobs:
           scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes \
             "$DEPLOY_HOST:$remote_evidence" "$evidence_dir/rotation-activate.json"
 
-      - name: Roll G+1 through Hub, canary, and client batches
+      - name: Roll G+1 through identity, Hub, canary, and client batches
         shell: bash
         run: |
           set -euo pipefail
           remote_env="COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' XFRAMEWORK_ENV_FILE='$XFRAMEWORK_ENV_FILE' REMOTE_COMPOSE_FILE='$REMOTE_COMPOSE_FILE' REMOTE_PIN_OVERRIDE='$REMOTE_PIN_OVERRIDE' REMOTE_LEASE_MANAGER='$REMOTE_LEASE_MANAGER' RUN_ID='$GITHUB_RUN_ID' RUN_ATTEMPT='$GITHUB_RUN_ATTEMPT'"
           stages=(
+            "identity:identityserver"
             "hub:bolt-hub"
-            "canary:identityserver communications"
+            "canary:communications"
             "batch-1:notifications storage attendance smsgateway"
             "batch-2:wallets inventario pos"
             "batch-3:portal operations-dashboard"
@@ -2141,6 +2365,52 @@ jobs:
             done
             test "$(/usr/bin/timeout --foreground --kill-after=10s 30s docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$container_id")" = healthy
           done
+          if [ "$1" = identityserver ]; then
+            metadata_body="$(mktemp)"
+            jwks_body="$(mktemp)"
+            trap 'rm -f "$metadata_body" "$jwks_body"' EXIT
+            identity_ready=0
+            for attempt in $(seq 1 60); do
+              heartbeat
+              if /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                  curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/health/live >/dev/null \
+                && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                  curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/openid-configuration > "$metadata_body" \
+                && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec xframework-identityserver \
+                  curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/bolt-transport-jwks.json > "$jwks_body" \
+                && python3 - "$metadata_body" "$jwks_body" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import urllib.parse
+
+          metadata = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          jwks = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+          jwks_uri = metadata.get("jwks_uri")
+          if metadata.get("issuer") != "XFramework.IdentityServer":
+              raise SystemExit("IdentityServer metadata issuer is invalid")
+          if jwks_uri != "http://identityserver:8080/.well-known/bolt-transport-jwks.json":
+              raise SystemExit("IdentityServer metadata JWKS URI is invalid")
+          if "RS256" not in metadata.get("id_token_signing_alg_values_supported", []):
+              raise SystemExit("IdentityServer metadata does not advertise RS256")
+          keys = jwks.get("keys")
+          if not isinstance(keys, list) or not any(
+              key.get("kty") == "RSA"
+              and key.get("use") == "sig"
+              and key.get("alg") == "RS256"
+              and all(key.get(field) for field in ("kid", "n", "e"))
+              for key in keys
+          ):
+              raise SystemExit("IdentityServer JWKS has no usable RSA signing key")
+          PY
+              then
+                identity_ready=1
+                break
+              fi
+              sleep 5
+            done
+            test "$identity_ready" -eq 1
+          fi
           REMOTE_SCRIPT
             read -r -a restarted_services <<< "$services"
             cumulative_services+=("${restarted_services[@]}")
@@ -2153,7 +2423,7 @@ jobs:
             scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes \
               "$DEPLOY_HOST:$remote_runtime" "$local_runtime" || true
             test "$status" -eq 0
-            if [ "$label" != hub ]; then
+            if [ "$label" != identity ] && [ "$label" != hub ]; then
               bash scripts/run-bolt-phase0-synthetics.sh "rotation-${label}"
             fi
             if [ "$label" = canary ]; then
@@ -2162,8 +2432,10 @@ jobs:
                   "REMOTE_LEASE_MANAGER='$REMOTE_LEASE_MANAGER' COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' RUN_ID='$GITHUB_RUN_ID' RUN_ATTEMPT='$GITHUB_RUN_ATTEMPT' bash -s" <<'REMOTE_OBSERVATION'
           set -euo pipefail
           for container in xframework-identityserver xframework-communications; do
+            endpoint=ready
+            if [ "$container" = xframework-identityserver ]; then endpoint=live; fi
             status="$(/usr/bin/timeout --foreground --kill-after=10s 30s docker exec "$container" curl -sS --connect-timeout 3 --max-time 10 \
-              -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/health/ready || true)"
+              -o /dev/null -w '%{http_code}' "http://127.0.0.1:8080/health/${endpoint}" || true)"
             test "$status" = 200
           done
           python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$(id -u)" \
@@ -2185,7 +2457,7 @@ jobs:
           remote_inventory="$REMOTE_RUN_DIR/rotation-generation-inventory.json"
           remote_evidence="$REMOTE_RUN_DIR/credential-convergence-dual-validation.json"
           remote_rotation_evidence="$REMOTE_RUN_DIR/rotation-convergence-evidence.json"
-          services=(bolt-hub identityserver communications notifications storage attendance smsgateway wallets inventario pos portal operations-dashboard)
+          services=(identityserver bolt-hub communications notifications storage attendance smsgateway wallets inventario pos portal operations-dashboard)
           service_args="$(printf '%q ' "${services[@]}")"
           scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes \
             scripts/verify-bolt-phase0-credential-convergence.py "$DEPLOY_HOST:$remote_verifier"
@@ -2294,8 +2566,10 @@ jobs:
               "REMOTE_LEASE_MANAGER='$REMOTE_LEASE_MANAGER' COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' RUN_ID='$GITHUB_RUN_ID' RUN_ATTEMPT='$GITHUB_RUN_ATTEMPT' bash -s" <<'REMOTE_SCRIPT'
           set -euo pipefail
           for container in xframework-identityserver xframework-communications; do
+            endpoint=ready
+            if [ "$container" = xframework-identityserver ]; then endpoint=live; fi
             http_status="$(/usr/bin/timeout --foreground --kill-after=10s 30s docker exec "$container" curl -sS --connect-timeout 3 --max-time 10 \
-              -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/health/ready || true)"
+              -o /dev/null -w '%{http_code}' "http://127.0.0.1:8080/health/${endpoint}" || true)"
             test "$http_status" = 200
           done
           python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$(id -u)" \
@@ -2331,7 +2605,7 @@ jobs:
           DEPLOY_SSH_OPERATION_TIMEOUT_SECONDS: 3900
         run: |
           set -euo pipefail
-          services=(bolt-hub identityserver communications notifications storage attendance smsgateway wallets inventario pos portal operations-dashboard)
+          services=(identityserver bolt-hub communications notifications storage attendance smsgateway wallets inventario pos portal operations-dashboard)
           service_args="$(printf '%q ' "${services[@]}")"
           remote_env="COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' XFRAMEWORK_ENV_FILE='$XFRAMEWORK_ENV_FILE' REMOTE_COMPOSE_FILE='$REMOTE_COMPOSE_FILE' REMOTE_PIN_OVERRIDE='$REMOTE_PIN_OVERRIDE' REMOTE_LEASE_MANAGER='$REMOTE_LEASE_MANAGER' RUN_ID='$GITHUB_RUN_ID' RUN_ATTEMPT='$GITHUB_RUN_ATTEMPT'"
           ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
@@ -2356,6 +2630,52 @@ jobs:
               sleep 5
             done
             test "$(/usr/bin/timeout --foreground --kill-after=10s 30s docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$container_id")" = healthy
+            if [ "$service" = identityserver ]; then
+              metadata_body="$(mktemp)"
+              jwks_body="$(mktemp)"
+              identity_ready=0
+              for attempt in $(seq 1 60); do
+                heartbeat
+                if /usr/bin/timeout --foreground --kill-after=10s 30s docker exec "$container_id" \
+                    curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/health/live >/dev/null \
+                  && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec "$container_id" \
+                    curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/openid-configuration > "$metadata_body" \
+                  && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec "$container_id" \
+                    curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/bolt-transport-jwks.json > "$jwks_body" \
+                  && python3 - "$metadata_body" "$jwks_body" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import urllib.parse
+
+          metadata = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          jwks = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+          jwks_uri = metadata.get("jwks_uri")
+          if metadata.get("issuer") != "XFramework.IdentityServer":
+              raise SystemExit("IdentityServer metadata issuer is invalid")
+          if jwks_uri != "http://identityserver:8080/.well-known/bolt-transport-jwks.json":
+              raise SystemExit("IdentityServer metadata JWKS URI is invalid")
+          if "RS256" not in metadata.get("id_token_signing_alg_values_supported", []):
+              raise SystemExit("IdentityServer metadata does not advertise RS256")
+          keys = jwks.get("keys")
+          if not isinstance(keys, list) or not any(
+              key.get("kty") == "RSA"
+              and key.get("use") == "sig"
+              and key.get("alg") == "RS256"
+              and all(key.get(field) for field in ("kid", "n", "e"))
+              for key in keys
+          ):
+              raise SystemExit("IdentityServer JWKS has no usable RSA signing key")
+          PY
+                then
+                  identity_ready=1
+                  break
+                fi
+                sleep 5
+              done
+              rm -f "$metadata_body" "$jwks_body"
+              test "$identity_ready" -eq 1
+            fi
           done
           REMOTE_SCRIPT
           bash scripts/run-bolt-phase0-synthetics.sh finalized
@@ -2368,7 +2688,7 @@ jobs:
           remote_verifier="$REMOTE_RUN_DIR/verify-bolt-phase0-credential-convergence.py"
           remote_input="$REMOTE_RUN_DIR/credential-convergence-finalized-input.json"
           remote_evidence="$REMOTE_RUN_DIR/credential-convergence-finalized.json"
-          services=(bolt-hub identityserver communications notifications storage attendance smsgateway wallets inventario pos portal operations-dashboard)
+          services=(identityserver bolt-hub communications notifications storage attendance smsgateway wallets inventario pos portal operations-dashboard)
           service_args="$(printf '%q ' "${services[@]}")"
           ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
             "COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' XFRAMEWORK_ENV_FILE='$XFRAMEWORK_ENV_FILE' ENV_PARSER='$REMOTE_ENV_PARSER' REMOTE_COMPOSE_FILE='$REMOTE_COMPOSE_FILE' REMOTE_PIN_OVERRIDE='$REMOTE_PIN_OVERRIDE' REMOTE_ROTATION_STATE='$REMOTE_ROTATION_STATE' REMOTE_MANAGER='$REMOTE_ROTATION_MANAGER' INPUT='$remote_input' EVIDENCE='$remote_evidence' VERIFIER='$remote_verifier' REMOTE_LEASE_MANAGER='$REMOTE_LEASE_MANAGER' RUN_ID='$GITHUB_RUN_ID' RUN_ATTEMPT='$GITHUB_RUN_ATTEMPT' bash -s -- $service_args" <<'REMOTE_SCRIPT'
@@ -2441,8 +2761,8 @@ jobs:
           remote_pins="$REMOTE_PINS_FILE"
           services=(
             migrate
-            bolt-hub
             identityserver
+            bolt-hub
             communications
             notifications
             storage
@@ -2468,7 +2788,7 @@ jobs:
             "$DEPLOY_HOST:$remote_evidence" "$evidence_dir/runtime.json" || true
           exit "$status"
 
-      - name: Exercise digest-pinned rollback under G+1
+      - name: Exercise candidate digest-pinned restart under G+1
         shell: bash
         env:
           DEPLOY_SSH_OPERATION_TIMEOUT_SECONDS: 3900
@@ -2478,7 +2798,7 @@ jobs:
           remote_runtime_verifier="$REMOTE_RUNTIME_VERIFIER"
           remote_runtime="$REMOTE_RUN_DIR/rollback-runtime-evidence.json"
           remote_drill="$REMOTE_RUN_DIR/rollback-drill-evidence.json"
-          services=(migrate bolt-hub identityserver communications notifications storage attendance smsgateway wallets inventario pos portal operations-dashboard)
+          services=(migrate identityserver bolt-hub communications notifications storage attendance smsgateway wallets inventario pos portal operations-dashboard)
           service_args="$(printf '%q ' "${services[@]}")"
           ssh -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST" \
             "COMPOSE_PROJECT_NAME='$COMPOSE_PROJECT_NAME' XFRAMEWORK_ENV_FILE='$XFRAMEWORK_ENV_FILE' REMOTE_COMPOSE_FILE='$REMOTE_COMPOSE_FILE' REMOTE_PIN_OVERRIDE='$REMOTE_PIN_OVERRIDE' REMOTE_PINS_FILE='$REMOTE_PINS_FILE' REMOTE_RUN_DIR='$REMOTE_RUN_DIR' REMOTE_RUNTIME='$remote_runtime' REMOTE_DRILL='$remote_drill' REMOTE_RUNTIME_VERIFIER='$remote_runtime_verifier' REMOTE_ROTATION_STATE='$REMOTE_ROTATION_STATE' REMOTE_ROTATION_MANAGER='$REMOTE_ROTATION_MANAGER' REMOTE_LEASE_MANAGER='$REMOTE_LEASE_MANAGER' RUN_ID='$GITHUB_RUN_ID' RUN_ATTEMPT='$GITHUB_RUN_ATTEMPT' SOURCE_COMMIT='$GITHUB_SHA' bash -s -- $service_args" <<'REMOTE_SCRIPT'
@@ -2492,13 +2812,11 @@ jobs:
               heartbeat --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" --phase rollback-drill --mutation-began >/dev/null
           }
           compose=(docker compose --env-file "$XFRAMEWORK_ENV_FILE" -f "$REMOTE_COMPOSE_FILE" -f "$REMOTE_PIN_OVERRIDE" --project-name "$COMPOSE_PROJECT_NAME")
-          python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$deployment_uid" \
-            supervise --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" --phase rollback-drill --mutation-began \
-            --timeout-seconds 540 -- /usr/bin/timeout --foreground --kill-after=30s 510s \
-            "${compose[@]}" up -d --no-build --no-deps --force-recreate \
-            bolt-hub identityserver communications notifications storage attendance \
-            smsgateway wallets inventario pos portal operations-dashboard
           for service in "${@:2}"; do
+            python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$deployment_uid" \
+              supervise --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" --phase rollback-drill --mutation-began \
+              --timeout-seconds 540 -- /usr/bin/timeout --foreground --kill-after=30s 510s \
+              "${compose[@]}" up -d --no-build --no-deps --force-recreate "$service"
             container_id="$(/usr/bin/timeout --foreground --kill-after=10s 30s "${compose[@]}" ps --quiet "$service")"
             test -n "$container_id"
             for attempt in $(seq 1 60); do
@@ -2508,6 +2826,52 @@ jobs:
               sleep 5
             done
             test "$(/usr/bin/timeout --foreground --kill-after=10s 30s docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$container_id")" = healthy
+            if [ "$service" = identityserver ]; then
+              metadata_body="$(mktemp)"
+              jwks_body="$(mktemp)"
+              identity_ready=0
+              for attempt in $(seq 1 60); do
+                heartbeat
+                if /usr/bin/timeout --foreground --kill-after=10s 30s docker exec "$container_id" \
+                    curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/health/live >/dev/null \
+                  && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec "$container_id" \
+                    curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/openid-configuration > "$metadata_body" \
+                  && /usr/bin/timeout --foreground --kill-after=10s 30s docker exec "$container_id" \
+                    curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8080/.well-known/bolt-transport-jwks.json > "$jwks_body" \
+                  && python3 - "$metadata_body" "$jwks_body" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import urllib.parse
+
+          metadata = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          jwks = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+          jwks_uri = metadata.get("jwks_uri")
+          if metadata.get("issuer") != "XFramework.IdentityServer":
+              raise SystemExit("IdentityServer metadata issuer is invalid")
+          if jwks_uri != "http://identityserver:8080/.well-known/bolt-transport-jwks.json":
+              raise SystemExit("IdentityServer metadata JWKS URI is invalid")
+          if "RS256" not in metadata.get("id_token_signing_alg_values_supported", []):
+              raise SystemExit("IdentityServer metadata does not advertise RS256")
+          keys = jwks.get("keys")
+          if not isinstance(keys, list) or not any(
+              key.get("kty") == "RSA"
+              and key.get("use") == "sig"
+              and key.get("alg") == "RS256"
+              and all(key.get(field) for field in ("kid", "n", "e"))
+              for key in keys
+          ):
+              raise SystemExit("IdentityServer JWKS has no usable RSA signing key")
+          PY
+                then
+                  identity_ready=1
+                  break
+                fi
+                sleep 5
+              done
+              rm -f "$metadata_body" "$jwks_body"
+              test "$identity_ready" -eq 1
+            fi
           done
           python3 "$REMOTE_LEASE_MANAGER" --project-name "$COMPOSE_PROJECT_NAME" --deployment-uid "$deployment_uid" \
             supervise --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" --phase rollback-verification --mutation-began \
@@ -2534,9 +2898,13 @@ jobs:
           root = pathlib.Path(root)
           runtime = pathlib.Path(runtime_text)
           synthetic = root / "rollback-synthetics-finalized.json"
+          lkg_compatibility_path = root / "lkg-compatibility-status"
+          lkg_compatibility = lkg_compatibility_path.read_text(encoding="utf-8").strip()
+          if lkg_compatibility not in {"rendered", "not_applicable_no_prior_lkg"}:
+              raise SystemExit("LKG compatibility status is invalid")
           def digest(path): return hashlib.sha256(path.read_bytes()).hexdigest()
           document = {
-              "schema": "xframework.bolt.phase0.rollback-drill.v1",
+              "schema": "xframework.bolt.phase0.candidate-restart.v1",
               "status": "passed",
               "run_id": run_id,
               "run_attempt": int(attempt),
@@ -2545,13 +2913,14 @@ jobs:
               "started_at_utc": (root / "rollback-drill-started").read_text(encoding="utf-8").strip(),
               "completed_at_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z"),
               "credential_generation_id": generation,
+              "lkg_compatibility": lkg_compatibility,
               "manifest_sha256": digest(root / "docker-compose.yml"),
               "override_sha256": digest(root / "pinned-compose.override.json"),
               "pins_sha256": digest(root / "image-pins.json"),
               "runtime_evidence_sha256": digest(runtime),
               "synthetic_evidence_sha256": digest(synthetic),
               "checks": {
-                  "restore_applied": True,
+                  "candidate_digest_recreate_applied": True,
                   "full_runtime_verified": True,
                   "authenticated_finalized_synthetic": True,
                   "current_generation_preserved": True,
@@ -2567,6 +2936,7 @@ jobs:
               stream.flush(); os.fsync(stream.fileno())
           os.replace(temporary_name, output)
           (root / "rollback-drill-started").unlink()
+          lkg_compatibility_path.unlink()
           PY
           REMOTE_SCRIPT
           scp -i "$DEPLOY_SSH_KEY" -o BatchMode=yes "$DEPLOY_HOST:$remote_runtime" "$evidence_dir/rollback-runtime-evidence.json"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,12 @@ x-common-env: &common-env
   JwtOptions__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
   JwtOptions__ValidAudience: ${JWT_AUDIENCE:-xframework}
   JwtOptions__ValidIssuer: ${JWT_ISSUER:-xframework}
-  BoltConfiguration__Signature: ${BOLT_SIGNATURE:?Set BOLT_SIGNATURE in .env}
   BoltConfiguration__ServerUrls__0: wss://bolt-hub:8443/bolt/ws
   BoltConfiguration__RequireSecureTransport: true
+  BoltConfiguration__GenerateServiceAccessToken: false
   ServiceIdentity__Issuer: XFramework.IdentityServer
+  ServiceIdentity__Authority: http://identityserver:8080
+  ServiceIdentity__AllowInsecureHttp: true
   ServiceIdentity__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
   CREDENTIAL_GENERATION_ID: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
   Seq__ApiKey: ${SEQ_API_KEY:-}
@@ -143,6 +145,10 @@ services:
       BoltConfiguration__MaxDurableSubscribersPerTopic: 128
       BoltConfiguration__MaxConnectionLifetimeSeconds: 1800
       BoltConfiguration__RegistrationIdentityBindingMode: Enforce
+      BoltTransportAuthentication__MetadataAddress: http://identityserver:8080/.well-known/openid-configuration
+      BoltTransportAuthentication__Issuer: XFramework.IdentityServer
+      BoltTransportAuthentication__Audience: XFramework.Bolt.Hub
+      BoltTransportAuthentication__RequireHttpsMetadata: false
     labels:
       org.xframework.bolt.security-baseline: phase0-v1
       org.xframework.bolt.single-replica: required
@@ -168,6 +174,8 @@ services:
         required: false
       redis:
         condition: service_healthy
+      identityserver:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/health/live >/dev/null && curl -fsS http://127.0.0.1:8080/health/ready >/dev/null"]
       interval: 5s
@@ -186,8 +194,8 @@ services:
         PROJECT_PATH: src/Modules/XFramework.IdentityServer/IdentityServer.Api/IdentityServer.Api.csproj
     environment:
       <<: *common-env
-      ASPNETCORE_URLS: http://127.0.0.1:8080;https://+:8443
-      Kestrel__Endpoints__Http__Url: http://127.0.0.1:8080
+      ASPNETCORE_URLS: http://+:8080;https://+:8443
+      Kestrel__Endpoints__Http__Url: http://0.0.0.0:8080
       Kestrel__Endpoints__Https__Url: https://0.0.0.0:8443
       Kestrel__Endpoints__Https__Certificate__Path: /run/secrets/identityserver-tls-fullchain.pem
       Kestrel__Endpoints__Https__Certificate__KeyPath: /run/secrets/identityserver-tls-private-key.pem
@@ -198,6 +206,7 @@ services:
       ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__BoltTransportTokenIssuer__Enabled: true
       ServiceIdentity__BoltTransportTokenIssuer__LifetimeSeconds: 120
+      ServiceIdentity__BoltTransportTokenIssuer__SigningKeyPath: /var/lib/xframework/identity/bolt-transport-signing-key.pem
       ServiceIdentity__Clients__0__ClientId: XFramework.IdentityServer
       ServiceIdentity__Clients__0__ClientSecret: ${IDENTITYSERVER_SERVICE_IDENTITY_SECRET:?Set IDENTITYSERVER_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__Clients__0__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
@@ -307,10 +316,14 @@ services:
       - source: identityserver-tls-private-key
         target: /run/secrets/identityserver-tls-private-key.pem
         mode: 0400
+    volumes:
+      - identity-keydata:/var/lib/xframework/identity
     ports:
       - "${IDENTITYSERVER_PUBLIC_HTTPS_PORT:-8261}:8443"
     depends_on:
-      bolt-hub:
+      migrate:
+        condition: service_completed_successfully
+      postgres:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/health/live >/dev/null || exit 1"]
@@ -341,6 +354,8 @@ services:
     depends_on:
       bolt-hub:
         condition: service_healthy
+      identityserver:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
       interval: 5s
@@ -369,6 +384,8 @@ services:
       - "${NOTIFICATIONS_EXPOSE_PORT:-5166}:8080"
     depends_on:
       bolt-hub:
+        condition: service_healthy
+      identityserver:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
@@ -409,6 +426,8 @@ services:
     depends_on:
       bolt-hub:
         condition: service_healthy
+      identityserver:
+        condition: service_healthy
       postgres:
         condition: service_healthy
         required: false
@@ -442,6 +461,8 @@ services:
     depends_on:
       bolt-hub:
         condition: service_healthy
+      identityserver:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
       interval: 5s
@@ -470,6 +491,8 @@ services:
       - "${SMSGATEWAY_EXPOSE_PORT:-5274}:8080"
     depends_on:
       bolt-hub:
+        condition: service_healthy
+      identityserver:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
@@ -500,6 +523,8 @@ services:
     depends_on:
       bolt-hub:
         condition: service_healthy
+      identityserver:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
       interval: 5s
@@ -529,6 +554,8 @@ services:
     depends_on:
       bolt-hub:
         condition: service_healthy
+      identityserver:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -so /dev/null -w '' http://localhost:8080/health/live || exit 1"]
       interval: 5s
@@ -557,6 +584,8 @@ services:
       - "${POS_EXPOSE_PORT:-8115}:8080"
     depends_on:
       bolt-hub:
+        condition: service_healthy
+      identityserver:
         condition: service_healthy
       inventario:
         condition: service_healthy
@@ -630,6 +659,7 @@ services:
       BoltConfiguration__ClientName: XFramework.Operations.Dashboard
       BoltConfiguration__ServerUrls__0: wss://bolt-hub:8443/bolt/ws
       BoltConfiguration__RequireSecureTransport: true
+      BoltConfiguration__GenerateServiceAccessToken: false
       BoltConfiguration__RpcTimeoutSeconds: 30
       JwtOptions__Secret: ${JWT_SECRET:?Set JWT_SECRET in .env}
       JwtOptions__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
@@ -639,6 +669,8 @@ services:
       JwtOptions__ValidAudience: ${JWT_AUDIENCE:-xframework}
       JwtOptions__ValidIssuer: ${JWT_ISSUER:-xframework}
       ServiceIdentity__Issuer: XFramework.IdentityServer
+      ServiceIdentity__Authority: http://identityserver:8080
+      ServiceIdentity__AllowInsecureHttp: true
       ServiceIdentity__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
       CREDENTIAL_GENERATION_ID: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
       ServiceIdentity__ClientSecret: ${OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET:?Set OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET in .env}
@@ -657,6 +689,8 @@ services:
       - "${OPERATIONS_DASHBOARD_EXPOSE_PORT:-5050}:8080"
     depends_on:
       bolt-hub:
+        condition: service_healthy
+      identityserver:
         condition: service_healthy
       seq:
         condition: service_started
@@ -756,3 +790,4 @@ volumes:
   redisdata:
   miniodata:
   seqdata:
+  identity-keydata:

--- a/scripts/manage-bolt-phase0-rotation-test.py
+++ b/scripts/manage-bolt-phase0-rotation-test.py
@@ -107,6 +107,10 @@ class BootstrapTests(RotationFixture):
         ) + "\n"
         self.env_path.write_text(content, encoding="utf-8")
 
+    def test_bolt_signatures_remain_rotation_credentials_for_legacy_rollback(self) -> None:
+        self.assertIn("BOLT_SIGNATURE", MODULE.PRIMARY_SECRET_NAMES)
+        self.assertIn("BOLT_SIGNATURE_SECONDARY", MODULE.SECONDARY_SECRET_NAMES)
+
     def test_validate_bootstrap_is_read_only_when_generation_is_missing(self) -> None:
         self.remove_generation()
         before = self.env_path.read_bytes()

--- a/scripts/run-bolt-phase0-watchdog-test.py
+++ b/scripts/run-bolt-phase0-watchdog-test.py
@@ -32,6 +32,7 @@ TIMER = ROOT / "deploy" / "systemd" / "xframework-bolt-phase0-watchdog.timer"
 WORKFLOW = ROOT / ".github" / "workflows" / "deploy-xeon-dev.yml"
 PHASE0_CI_WORKFLOW = ROOT / ".github" / "workflows" / "bolt-phase0-ci.yml"
 LEGACY_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-xeon-dev-service.yml"
+IDENTITYSERVER_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-xeon-dev-identityserver.yml"
 PINNED_KNOWN_HOSTS = ROOT / ".github" / "known_hosts" / "xeon-dev"
 ROOT_HELPER = ROOT / "scripts" / "manage-bolt-phase0-root.py"
 BOOTSTRAP = ROOT / "deploy" / "bootstrap-xframework-bolt-phase0-root.sh"
@@ -1231,6 +1232,139 @@ class WatchdogContractTests(unittest.TestCase):
         self.assertNotIn("ssh-keyscan", active)
         self.assertIn("if: ${{ false }}", legacy)
 
+    def test_centralized_identity_activation_precedes_hub_and_clients(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        legacy = LEGACY_WORKFLOW.read_text(encoding="utf-8")
+        identity_workflow = IDENTITYSERVER_WORKFLOW.read_text(encoding="utf-8")
+
+        lkg_compatibility = workflow.index(
+            "- name: Verify current sealed LKG renders with protected credentials"
+        )
+        identity_deploy = workflow.index("- name: Deploy IdentityServer identity plane")
+        identity_ready = workflow.index("- name: Verify IdentityServer live discovery plane")
+        identity_runtime = workflow.index(
+            "- name: Verify staged runtime after IdentityServer deployment"
+        )
+        hub_deploy = workflow.index("- name: Deploy Bolt Hub only")
+        hub_ready = workflow.index("- name: Verify Hub TLS and plaintext boundary")
+        communications_deploy = workflow.index("- name: Deploy Communications canary")
+        remaining_deploy = workflow.index("- name: Promote remaining clients in bounded batches")
+        self.assertLess(lkg_compatibility, identity_deploy)
+        self.assertLess(identity_deploy, identity_ready)
+        self.assertLess(identity_ready, identity_runtime)
+        self.assertLess(identity_runtime, hub_deploy)
+        self.assertLess(hub_deploy, hub_ready)
+        self.assertLess(hub_ready, communications_deploy)
+        self.assertLess(communications_deploy, remaining_deploy)
+
+        lkg_compatibility_block = workflow[
+            lkg_compatibility:workflow.index("- name: Install reviewed Phase 0 synthetic hooks")
+        ]
+        for required in (
+            'pointer="$REMOTE_LKG_DIR/current"',
+            'test ! -L "$pointer"',
+            'test ! -L "$lkg_run"',
+            '"$lkg_run/docker-compose.yml"',
+            '"$lkg_run/pinned-compose.override.json"',
+            'docker compose --env-file "$XFRAMEWORK_ENV_FILE"',
+            "--project-name xframework config --quiet",
+            'pins="$(',
+            'done <<< "$pins"',
+            'docker image inspect "$pin"',
+            'printf \'%s\\n\' rendered > "$status_path"',
+            "not_applicable_no_prior_lkg",
+        ):
+            self.assertIn(required, lkg_compatibility_block)
+        self.assertNotIn('done < <(python3 - "$lkg_run/image-pins.json"', lkg_compatibility_block)
+        self.assertNotIn(" up ", lkg_compatibility_block)
+
+        identity_deploy_block = workflow[identity_deploy:identity_ready]
+        self.assertIn(
+            '"${compose[@]}" up -d --no-build --no-deps identityserver',
+            identity_deploy_block,
+        )
+        identity_ready_block = workflow[identity_ready:identity_runtime]
+        for required in (
+            "docker exec xframework-identityserver",
+            "http://127.0.0.1:8080/health/live",
+            "http://127.0.0.1:8080/.well-known/openid-configuration",
+            "http://127.0.0.1:8080/.well-known/bolt-transport-jwks.json",
+            'metadata.get("issuer") != "XFramework.IdentityServer"',
+            'key.get("alg") == "RS256"',
+        ):
+            self.assertIn(required, identity_ready_block)
+        self.assertNotIn("/health/ready", identity_ready_block)
+        self.assertNotIn("bolt-hub", identity_ready_block.lower())
+
+        identity_runtime_block = workflow[
+            identity_runtime:workflow.index("- name: Deploy Bolt Hub only", identity_runtime)
+        ]
+        self.assertIn("services=(migrate identityserver)", identity_runtime_block)
+        hub_runtime = workflow[
+            workflow.index("- name: Verify staged runtime after Hub deployment"):
+            communications_deploy
+        ]
+        self.assertIn("services=(migrate identityserver bolt-hub)", hub_runtime)
+
+        rotation = workflow[
+            workflow.index("- name: Roll G+1 through identity, Hub, canary, and client batches"):
+            workflow.index("- name: Prove G+1 runtime convergence")
+        ]
+        self.assertRegex(
+            rotation,
+            r'stages=\(\n\s+"identity:identityserver"\n\s+"hub:bolt-hub"\n'
+            r'\s+"canary:communications"',
+        )
+        self.assertIn('if [ "$1" = identityserver ]; then', rotation)
+
+        fallback = workflow[
+            workflow.index("- name: Restart without fallback credentials and rerun synthetics"):
+            workflow.index("- name: Prove finalized credential convergence")
+        ]
+        self.assertIn(
+            "services=(identityserver bolt-hub communications notifications storage attendance "
+            "smsgateway wallets inventario pos portal operations-dashboard)",
+            fallback,
+        )
+        self.assertIn('if [ "$service" = identityserver ]; then', fallback)
+
+        rollback = workflow[
+            workflow.index("- name: Exercise candidate digest-pinned restart under G+1"):
+            workflow.index("- name: Quarantine, root-qualify, seal, and activate recovery bundle")
+        ]
+        self.assertIn(
+            "services=(migrate identityserver bolt-hub communications notifications storage "
+            "attendance smsgateway wallets inventario pos portal operations-dashboard)",
+            rollback,
+        )
+        self.assertIn('for service in "${@:2}"; do', rollback)
+        self.assertIn(
+            '"${compose[@]}" up -d --no-build --no-deps --force-recreate "$service"',
+            rollback,
+        )
+        self.assertNotIn("bolt-hub identityserver communications", rollback)
+        self.assertIn('"schema": "xframework.bolt.phase0.candidate-restart.v1"', rollback)
+        self.assertIn('"candidate_digest_recreate_applied": True', rollback)
+        self.assertNotIn('"restore_applied": True', rollback)
+
+        preflight = legacy[
+            legacy.index("- name: Preflight centralized identity plane for Bolt clients"):
+            legacy.index("- name: Deploy service on xeon-dev")
+        ]
+        self.assertIn("if: inputs.service != 'identityserver'", preflight)
+        self.assertIn("/health/live", preflight)
+        self.assertIn("/.well-known/openid-configuration", preflight)
+        self.assertIn("/.well-known/bolt-transport-jwks.json", preflight)
+
+        self.assertNotIn("http://localhost:8261", identity_workflow)
+        self.assertIn(
+            "health_url: https://xeon-dev.tailed40e.ts.net:8261/health/live",
+            identity_workflow,
+        )
+        for content in (workflow, legacy):
+            self.assertIn("BOLT_SIGNATURE: compose-validation-placeholder", content)
+        self.assertNotIn("BOLT_SIGNATURE", identity_workflow)
+
     def test_active_workflow_fail_closed_ssh_key_metadata_preflight(self) -> None:
         content = WORKFLOW.read_text(encoding="utf-8")
         setup = content[
@@ -1595,6 +1729,7 @@ class WatchdogContractTests(unittest.TestCase):
     def test_every_long_readiness_stage_has_a_fail_closed_heartbeat_supervisor(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         stages = (
+            ("- name: Verify IdentityServer live discovery plane", "- name: Verify staged runtime after IdentityServer deployment"),
             ("- name: Verify Hub TLS and plaintext boundary", "- name: Verify staged runtime after Hub deployment"),
             ("- name: Wait for canary readiness", "- name: Verify staged runtime after canary deployment"),
             ("- name: Wait for readiness", "- name: Capture retiring generation token evidence"),
@@ -1618,7 +1753,7 @@ class WatchdogContractTests(unittest.TestCase):
                     block.index("for attempt"),
                 )
 
-        self.assertEqual(3, workflow.count("trap cleanup_heartbeat EXIT"))
+        self.assertEqual(4, workflow.count("trap cleanup_heartbeat EXIT"))
         batch = workflow[
             workflow.index("- name: Promote remaining clients in bounded batches"):
             workflow.index("- name: Wait for readiness")
@@ -1628,13 +1763,14 @@ class WatchdogContractTests(unittest.TestCase):
     def test_all_long_mutation_paths_use_fixed_supervision_and_bounded_docker(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         stages = (
-            ("- name: Run migration before service mutation", "- name: Deploy Bolt Hub only"),
+            ("- name: Run migration before service mutation", "- name: Deploy IdentityServer identity plane"),
+            ("- name: Deploy IdentityServer identity plane", "- name: Verify IdentityServer live discovery plane"),
             ("- name: Deploy Bolt Hub only", "- name: Verify Hub TLS and plaintext boundary"),
-            ("- name: Deploy IdentityServer and Communications canary", "- name: Wait for canary readiness"),
+            ("- name: Deploy Communications canary", "- name: Wait for canary readiness"),
             ("- name: Promote remaining clients in bounded batches", "- name: Wait for readiness"),
-            ("- name: Roll G+1 through Hub, canary, and client batches", "- name: Prove G+1 runtime convergence"),
+            ("- name: Roll G+1 through identity, Hub, canary, and client batches", "- name: Prove G+1 runtime convergence"),
             ("- name: Restart without fallback credentials and rerun synthetics", "- name: Prove finalized credential convergence"),
-            ("- name: Exercise digest-pinned rollback under G+1", "- name: Quarantine, root-qualify, seal, and activate recovery bundle"),
+            ("- name: Exercise candidate digest-pinned restart under G+1", "- name: Quarantine, root-qualify, seal, and activate recovery bundle"),
         )
         for start, end in stages:
             with self.subTest(stage=start):

--- a/scripts/verify-bolt-phase0-compose-test.py
+++ b/scripts/verify-bolt-phase0-compose-test.py
@@ -83,6 +83,7 @@ class Phase0ComposeTests(unittest.TestCase):
         common_environment = {
             "BoltConfiguration__RequireSecureTransport": "true",
             "BoltConfiguration__ServerUrls__0": MODULE.SECURE_URL,
+            **MODULE.COMMON_CENTRAL_IDENTITY_ENV,
         }
         services = {
             name: {
@@ -101,6 +102,9 @@ class Phase0ComposeTests(unittest.TestCase):
                         "mode": "0444",
                     }
                 ],
+                "depends_on": {
+                    "identityserver": {"condition": "service_healthy"},
+                },
             }
             for name in MODULE.CLIENT_SERVICES
         }
@@ -122,6 +126,9 @@ class Phase0ComposeTests(unittest.TestCase):
             "profiles": ["phase0-verification"],
             "restart": "no",
             "environment": {"BOLT_SYNTHETIC_TARGET": MODULE.SECURE_URL},
+            "depends_on": {
+                "identityserver": {"condition": "service_healthy"},
+            },
             "secrets": [
                 {
                     "source": MODULE.CA_SECRET,
@@ -135,12 +142,24 @@ class Phase0ComposeTests(unittest.TestCase):
                 "environment": {
                     **common_environment,
                     "ServiceIdentity__DefaultScopes__0": "bolt.service",
-                    "ASPNETCORE_URLS": "http://127.0.0.1:8080;https://+:8443",
+                    "ASPNETCORE_URLS": "http://+:8080;https://+:8443",
                     **MODULE.IDENTITY_EXPECTED_ENDPOINT_ENV,
                     **MODULE.IDENTITY_ISSUER_ENV,
                     **identity_client_environment,
                 },
                 "ports": [{"target": 8443, "published": "8444", "protocol": "tcp"}],
+                "volumes": [
+                    {
+                        "type": "volume",
+                        "source": MODULE.IDENTITY_KEYDATA_VOLUME,
+                        "target": MODULE.IDENTITY_KEYDATA_DIRECTORY,
+                        "read_only": False,
+                    }
+                ],
+                "depends_on": {
+                    "migrate": {"condition": "service_completed_successfully"},
+                    "postgres": {"condition": "service_healthy"},
+                },
                 "secrets": [
                     {
                         "source": MODULE.CA_SECRET,
@@ -177,6 +196,8 @@ class Phase0ComposeTests(unittest.TestCase):
             "BoltConfiguration__RequireSecureTransport": "true",
             "BoltConfiguration__MediaEnabled": "false",
             "BoltConfiguration__RegistrationIdentityBindingMode": "Enforce",
+            **MODULE.COMMON_CENTRAL_IDENTITY_ENV,
+            **MODULE.HUB_TRANSPORT_AUTHENTICATION_ENV,
             **MODULE.PHASE0_QUOTAS,
         }
         services["bolt-hub"].update({
@@ -187,6 +208,9 @@ class Phase0ComposeTests(unittest.TestCase):
                 "ServiceIdentity__DefaultScopes__0": "bolt.service",
             },
             "ports": [{"target": 8443, "published": "7443", "protocol": "tcp"}],
+            "depends_on": {
+                "identityserver": {"condition": "service_healthy"},
+            },
             "secrets": [
                 {
                     "source": MODULE.CA_SECRET,
@@ -222,6 +246,7 @@ class Phase0ComposeTests(unittest.TestCase):
                 MODULE.IDENTITY_FULLCHAIN_SECRET: {"file": str(self.identity_fullchain)},
                 MODULE.IDENTITY_PRIVATE_KEY_SECRET: {"file": str(self.identity_private_key)},
             },
+            "volumes": {MODULE.IDENTITY_KEYDATA_VOLUME: {}},
         }
 
     def errors(self, manifest: dict, args: SimpleNamespace | None = None) -> list[str]:
@@ -243,6 +268,98 @@ class Phase0ComposeTests(unittest.TestCase):
             },
             gate.checks["identityserver-exact-client-scope-matrix"]["detail"]["observed"],
         )
+
+    def test_central_identity_configuration_and_legacy_signature_fail_closed(self) -> None:
+        for service, key, value, check in (
+            (
+                "portal",
+                "ServiceIdentity__Authority",
+                "https://identity.example.test",
+                "common-central-service-identity-configuration:",
+            ),
+            (
+                "bolt-hub",
+                "BoltTransportAuthentication__Audience",
+                "wrong-audience",
+                "hub-central-transport-authentication:",
+            ),
+            (
+                "communications",
+                "BoltConfiguration__Signature",
+                "legacy-shared-signature",
+                "bolt-signature-configuration-absent:",
+            ),
+            (
+                "notifications",
+                "boltconfiguration:signature",
+                "legacy-shared-signature",
+                "bolt-signature-configuration-absent:",
+            ),
+        ):
+            with self.subTest(service=service, key=key):
+                manifest = self.manifest()
+                manifest["services"][service]["environment"][key] = value
+                self.assertTrue(any(error.startswith(check) for error in self.errors(manifest)))
+
+    def test_identityserver_uses_container_http_and_persistent_signing_key_volume(self) -> None:
+        manifest = self.manifest()
+        identity = manifest["services"]["identityserver"]
+        identity["environment"]["Kestrel__Endpoints__Http__Url"] = "http://127.0.0.1:8080"
+        self.assertTrue(any(
+            error.startswith("identityserver-effective-kestrel-endpoints:")
+            for error in self.errors(manifest)
+        ))
+
+        invalid_mounts = (
+            [],
+            [{
+                "type": "volume",
+                "source": MODULE.IDENTITY_KEYDATA_VOLUME,
+                "target": MODULE.IDENTITY_KEYDATA_DIRECTORY,
+                "read_only": True,
+            }],
+            [{
+                "type": "volume",
+                "source": "ephemeral-keydata",
+                "target": MODULE.IDENTITY_KEYDATA_DIRECTORY,
+                "read_only": False,
+            }],
+        )
+        for mounts in invalid_mounts:
+            with self.subTest(mounts=mounts):
+                manifest = self.manifest()
+                manifest["services"]["identityserver"]["volumes"] = mounts
+                self.assertTrue(any(
+                    error.startswith("identityserver-persistent-writable-signing-key-volume:")
+                    for error in self.errors(manifest)
+                ))
+
+        manifest = self.manifest()
+        del manifest["volumes"][MODULE.IDENTITY_KEYDATA_VOLUME]
+        self.assertTrue(any(
+            error.startswith("identityserver-persistent-writable-signing-key-volume:")
+            for error in self.errors(manifest)
+        ))
+
+    def test_identityserver_dependency_direction_and_health_are_required(self) -> None:
+        manifest = self.manifest()
+        manifest["services"]["identityserver"]["depends_on"]["bolt-hub"] = {
+            "condition": "service_healthy"
+        }
+        del manifest["services"]["identityserver"]["depends_on"]["migrate"]
+        manifest["services"]["portal"]["depends_on"]["identityserver"] = {
+            "condition": "service_started"
+        }
+        errors = self.errors(manifest)
+
+        self.assertTrue(any(
+            error.startswith("identityserver-depends-on-database-bootstrap-not-hub:")
+            for error in errors
+        ))
+        self.assertTrue(any(
+            error.startswith("token-consumers-depend-on-healthy-identityserver:")
+            for error in errors
+        ))
 
     def test_identityserver_client_scope_matrix_rejects_cross_module_privilege(self) -> None:
         cases = (

--- a/scripts/verify-bolt-phase0-compose.py
+++ b/scripts/verify-bolt-phase0-compose.py
@@ -89,6 +89,12 @@ def write_private_json(path: Path, value: Any) -> None:
             os.close(descriptor)
         temporary.unlink(missing_ok=True)
 INACTIVE_SERVICES = ("bolt-phase0-synthetics",)
+CENTRAL_IDENTITY_SERVICES = ("bolt-hub", *CLIENT_SERVICES)
+IDENTITY_DEPENDENT_SERVICES = (
+    "bolt-hub",
+    *(service for service in CLIENT_SERVICES if service != "identityserver"),
+    *INACTIVE_SERVICES,
+)
 SECURE_URL = "wss://bolt-hub:8443/bolt/ws"
 DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
@@ -113,6 +119,22 @@ IDENTITY_CA_SECRET = "identityserver-ca"
 IDENTITY_FULLCHAIN_SECRET = "identityserver-tls-fullchain"
 IDENTITY_PRIVATE_KEY_SECRET = "identityserver-tls-private-key"
 IDENTITY_TOKEN_PATH = "/api/service-identity/bolt-transport-token"
+IDENTITY_KEYDATA_VOLUME = "identity-keydata"
+IDENTITY_KEYDATA_DIRECTORY = "/var/lib/xframework/identity"
+IDENTITY_SIGNING_KEY_PATH = f"{IDENTITY_KEYDATA_DIRECTORY}/bolt-transport-signing-key.pem"
+COMMON_CENTRAL_IDENTITY_ENV = {
+    "BoltConfiguration__GenerateServiceAccessToken": "false",
+    "ServiceIdentity__Authority": "http://identityserver:8080",
+    "ServiceIdentity__AllowInsecureHttp": "true",
+}
+HUB_TRANSPORT_AUTHENTICATION_ENV = {
+    "BoltTransportAuthentication__MetadataAddress": (
+        "http://identityserver:8080/.well-known/openid-configuration"
+    ),
+    "BoltTransportAuthentication__Issuer": "XFramework.IdentityServer",
+    "BoltTransportAuthentication__Audience": "XFramework.Bolt.Hub",
+    "BoltTransportAuthentication__RequireHttpsMetadata": "false",
+}
 EXPECTED_ENDPOINT_ENV = {
     "Kestrel__Endpoints__Http__Url": "http://127.0.0.1:8080",
     "Kestrel__Endpoints__Https__Url": "https://0.0.0.0:8443",
@@ -121,15 +143,16 @@ EXPECTED_ENDPOINT_ENV = {
 }
 EXPECTED_ASPNETCORE_URLS = {"http://127.0.0.1:8080", "https://+:8443"}
 IDENTITY_EXPECTED_ENDPOINT_ENV = {
-    "Kestrel__Endpoints__Http__Url": "http://127.0.0.1:8080",
+    "Kestrel__Endpoints__Http__Url": "http://0.0.0.0:8080",
     "Kestrel__Endpoints__Https__Url": "https://0.0.0.0:8443",
     "Kestrel__Endpoints__Https__Certificate__Path": "/run/secrets/identityserver-tls-fullchain.pem",
     "Kestrel__Endpoints__Https__Certificate__KeyPath": "/run/secrets/identityserver-tls-private-key.pem",
 }
-IDENTITY_EXPECTED_ASPNETCORE_URLS = {"http://127.0.0.1:8080", "https://+:8443"}
+IDENTITY_EXPECTED_ASPNETCORE_URLS = {"http://+:8080", "https://+:8443"}
 IDENTITY_ISSUER_ENV = {
     "ServiceIdentity__BoltTransportTokenIssuer__Enabled": "true",
     "ServiceIdentity__BoltTransportTokenIssuer__LifetimeSeconds": "120",
+    "ServiceIdentity__BoltTransportTokenIssuer__SigningKeyPath": IDENTITY_SIGNING_KEY_PATH,
 }
 PHASE0_QUOTAS = {
     "BoltConfiguration__QueueDepth": "256",
@@ -648,6 +671,22 @@ def health_command(service: dict[str, Any]) -> str:
     return " ".join(str(item) for item in test) if isinstance(test, list) else str(test)
 
 
+def dependencies(service: dict[str, Any]) -> dict[str, str]:
+    value = service.get("depends_on") or {}
+    if isinstance(value, list):
+        return {str(name): "service_started" for name in value}
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, str] = {}
+    for name, configuration in value.items():
+        result[str(name)] = (
+            str(configuration.get("condition", "service_started"))
+            if isinstance(configuration, dict)
+            else "service_started"
+        )
+    return result
+
+
 def secrets(service: dict[str, Any]) -> list[dict[str, Any]]:
     result = []
     for item in service.get("secrets") or []:
@@ -689,6 +728,16 @@ def verify(manifest: dict[str, Any], args: argparse.Namespace, gate: Gate) -> di
     hub_env = environment(hub)
     identityserver = services["identityserver"]
     identityserver_env = environment(identityserver)
+    signature_keys = {
+        name: sorted(
+            key
+            for key in environment(service)
+            if configuration_key(key) == "boltconfiguration:signature"
+        )
+        for name, service in services.items()
+    }
+    signature_keys = {name: keys for name, keys in signature_keys.items() if keys}
+    gate.check("bolt-signature-configuration-absent", not signature_keys, signature_keys)
     try:
         identity_inputs, identity_input_detail = load_identityserver_environment(args)
     except (OSError, ValueError) as error:
@@ -708,6 +757,8 @@ def verify(manifest: dict[str, Any], args: argparse.Namespace, gate: Gate) -> di
         "BoltConfiguration__MediaEnabled",
         "BoltConfiguration__RegistrationIdentityBindingMode",
         "ServiceIdentity__DefaultScopes__0",
+        *COMMON_CENTRAL_IDENTITY_ENV,
+        *HUB_TRANSPORT_AUTHENTICATION_ENV,
         *EXPECTED_ENDPOINT_ENV,
         *PHASE0_QUOTAS,
     }
@@ -716,6 +767,7 @@ def verify(manifest: dict[str, Any], args: argparse.Namespace, gate: Gate) -> di
         "ASPNETCORE_HTTP_PORTS",
         "ASPNETCORE_HTTPS_PORTS",
         "DOTNET_URLS",
+        *COMMON_CENTRAL_IDENTITY_ENV,
         *IDENTITY_EXPECTED_ENDPOINT_ENV,
         *IDENTITY_ISSUER_ENV,
         *(
@@ -733,6 +785,7 @@ def verify(manifest: dict[str, Any], args: argparse.Namespace, gate: Gate) -> di
                 {
                     "BoltConfiguration__RequireSecureTransport",
                     "BoltConfiguration__ServerUrls__0",
+                    *COMMON_CENTRAL_IDENTITY_ENV,
                     *(
                         f"ServiceIdentity__DefaultScopes__{index}"
                         for index in range(len(SERVICE_IDENTITY_RUNTIME_DEFAULT_SCOPES[name]))
@@ -766,6 +819,52 @@ def verify(manifest: dict[str, Any], args: argparse.Namespace, gate: Gate) -> di
         "hub-registration-enforcement",
         hub_env.get("BoltConfiguration__RegistrationIdentityBindingMode") == "Enforce",
         {"value": hub_env.get("BoltConfiguration__RegistrationIdentityBindingMode")},
+    )
+
+    central_identity_configuration = {
+        name: {
+            key: environment(services[name]).get(key)
+            for key in COMMON_CENTRAL_IDENTITY_ENV
+        }
+        for name in CENTRAL_IDENTITY_SERVICES
+    }
+    gate.check(
+        "common-central-service-identity-configuration",
+        all(
+            values == COMMON_CENTRAL_IDENTITY_ENV
+            for values in central_identity_configuration.values()
+        ),
+        central_identity_configuration,
+    )
+
+    hub_transport_authentication = {
+        key: hub_env.get(key) for key in HUB_TRANSPORT_AUTHENTICATION_ENV
+    }
+    gate.check(
+        "hub-central-transport-authentication",
+        hub_transport_authentication == HUB_TRANSPORT_AUTHENTICATION_ENV,
+        hub_transport_authentication,
+    )
+
+    identity_dependencies = dependencies(identityserver)
+    identity_bootstrap_ok = (
+        "bolt-hub" not in identity_dependencies
+        and identity_dependencies.get("migrate") == "service_completed_successfully"
+        and identity_dependencies.get("postgres") == "service_healthy"
+    )
+    gate.check(
+        "identityserver-depends-on-database-bootstrap-not-hub",
+        identity_bootstrap_ok,
+        identity_dependencies,
+    )
+    identity_dependents = {
+        name: dependencies(services[name]).get("identityserver")
+        for name in IDENTITY_DEPENDENT_SERVICES
+    }
+    gate.check(
+        "token-consumers-depend-on-healthy-identityserver",
+        all(condition == "service_healthy" for condition in identity_dependents.values()),
+        identity_dependents,
     )
 
     quota_evidence = {
@@ -1022,6 +1121,43 @@ def verify(manifest: dict[str, Any], args: argparse.Namespace, gate: Gate) -> di
         "identityserver-only-tls-publication",
         identity_only_tls_port,
         {"ports": identity_ports, "expected": expected_identity_port},
+    )
+
+    identity_keydata_mounts = [
+        item
+        for item in volumes(identityserver)
+        if item["source"] == IDENTITY_KEYDATA_VOLUME
+        or item["target"] == IDENTITY_KEYDATA_DIRECTORY
+    ]
+    declared_volumes = manifest.get("volumes") or {}
+    identity_keydata_ok = (
+        isinstance(declared_volumes, dict)
+        and IDENTITY_KEYDATA_VOLUME in declared_volumes
+        and identityserver_env.get(
+            "ServiceIdentity__BoltTransportTokenIssuer__SigningKeyPath"
+        ) == IDENTITY_SIGNING_KEY_PATH
+        and identity_keydata_mounts == [
+            {
+                "type": "volume",
+                "source": IDENTITY_KEYDATA_VOLUME,
+                "target": IDENTITY_KEYDATA_DIRECTORY,
+                "read_only": False,
+            }
+        ]
+    )
+    gate.check(
+        "identityserver-persistent-writable-signing-key-volume",
+        identity_keydata_ok,
+        {
+            "volume_declared": (
+                isinstance(declared_volumes, dict)
+                and IDENTITY_KEYDATA_VOLUME in declared_volumes
+            ),
+            "mounts": identity_keydata_mounts,
+            "signing_key_path": identityserver_env.get(
+                "ServiceIdentity__BoltTransportTokenIssuer__SigningKeyPath"
+            ),
+        },
     )
 
     health = health_command(hub)
@@ -1286,7 +1422,7 @@ def verify(manifest: dict[str, Any], args: argparse.Namespace, gate: Gate) -> di
             "security_environment": {
                 key: value
                 for key, value in environment(services[name]).items()
-                if key in {"ASPNETCORE_URLS", "BOLT_SYNTHETIC_TARGET", "BoltConfiguration__MediaEnabled", "BoltConfiguration__RegistrationIdentityBindingMode", "BoltConfiguration__RequireSecureTransport", "BoltConfiguration__ServerUrls__0", *EXPECTED_ENDPOINT_ENV, *IDENTITY_EXPECTED_ENDPOINT_ENV, *IDENTITY_ISSUER_ENV, *PHASE0_QUOTAS}
+                if key in {"ASPNETCORE_URLS", "BOLT_SYNTHETIC_TARGET", "BoltConfiguration__MediaEnabled", "BoltConfiguration__RegistrationIdentityBindingMode", "BoltConfiguration__RequireSecureTransport", "BoltConfiguration__ServerUrls__0", *COMMON_CENTRAL_IDENTITY_ENV, *HUB_TRANSPORT_AUTHENTICATION_ENV, *EXPECTED_ENDPOINT_ENV, *IDENTITY_EXPECTED_ENDPOINT_ENV, *IDENTITY_ISSUER_ENV, *PHASE0_QUOTAS}
             },
             "security_secrets": [
                 {"source": item["source"], "target": item["target"], "mode": item["mode"]}

--- a/scripts/verify-bolt-phase0-qualification-test.py
+++ b/scripts/verify-bolt-phase0-qualification-test.py
@@ -310,7 +310,7 @@ class EvidenceFactory:
             }]
         elif service == "identityserver":
             item["listeners"] = [
-                {"family": "ipv4", "scope": "loopback", "port": 8080},
+                {"family": "ipv4", "scope": "wildcard", "port": 8080},
                 {"family": "ipv4", "scope": "wildcard", "port": 8443},
             ]
             item["published_port"] = {
@@ -318,12 +318,20 @@ class EvidenceFactory:
                 "published_port": 7443,
                 "protocol": "tcp",
             }
-            item["private_key_mounts"] = [{
-                "resolved_source": "<expected-private-key>",
-                "relation": "exact",
-                "target": "/run/secrets/identityserver-tls-private-key.pem",
-                "read_only": True,
-            }]
+            item["private_key_mounts"] = [
+                {
+                    "resolved_source": "<expected-private-key>",
+                    "relation": "exact",
+                    "target": "/run/secrets/identityserver-tls-private-key.pem",
+                    "read_only": True,
+                },
+                {
+                    "resolved_source": "<identity-signing-key-volume>",
+                    "relation": "persistent-volume",
+                    "target": "/var/lib/xframework/identity",
+                    "read_only": False,
+                },
+            ]
         return item
 
     def runtime(self, services: tuple[str, ...], minute: float, mode: str) -> dict:
@@ -609,7 +617,7 @@ class EvidenceFactory:
         secure_json(
             self.run / "rollback-drill-evidence.json",
             {
-                "schema": MODULE.ROLLBACK_DRILL_SCHEMA,
+                "schema": MODULE.CANDIDATE_RESTART_SCHEMA,
                 "status": "passed",
                 "run_id": self.run_id,
                 "run_attempt": self.attempt,
@@ -618,12 +626,13 @@ class EvidenceFactory:
                 "started_at_utc": self.at(-6),
                 "completed_at_utc": self.at(-4),
                 "credential_generation_id": "generation-g1",
+                "lkg_compatibility": "rendered",
                 "manifest_sha256": digests["docker-compose.yml"],
                 "override_sha256": digests["pinned-compose.override.json"],
                 "pins_sha256": digests["image-pins.json"],
                 "runtime_evidence_sha256": digests["rollback-runtime-evidence.json"],
                 "synthetic_evidence_sha256": digests["rollback-synthetics-finalized.json"],
-                "checks": {name: True for name in MODULE.ROLLBACK_CHECK_KEYS},
+                "checks": {name: True for name in MODULE.CANDIDATE_RESTART_CHECK_KEYS},
                 "errors": [],
             },
         )
@@ -1063,11 +1072,36 @@ class QualificationTests(unittest.TestCase):
         self.factory.create()
         self.factory.mutate(
             "runtime-evidence.json",
+            lambda document: document["services"]["identityserver"]["published_port"].update(
+                container_port=8080
+            ),
+        )
+        self.assert_code("invalid-tls-service-publication")
+        self.factory.create()
+        self.factory.mutate(
+            "runtime-evidence.json",
             lambda document: document["services"]["identityserver"]["private_key_mounts"][0].update(
                 target="/run/secrets/bolt-hub-tls-private-key.pem"
             ),
         )
         self.assert_code("invalid-tls-service-private-key-mount")
+        self.factory.create()
+        self.factory.mutate(
+            "runtime-evidence.json",
+            lambda document: document["services"]["identityserver"]["private_key_mounts"][1].update(
+                read_only=True
+            ),
+        )
+        self.assert_code("invalid-tls-service-private-key-mount")
+
+    def test_rejects_identityserver_loopback_http_listener(self) -> None:
+        self.factory.mutate(
+            "runtime-evidence.json",
+            lambda document: document["services"]["identityserver"]["listeners"][0].update(
+                scope="loopback"
+            ),
+        )
+        self.assert_code("invalid-tls-service-listeners")
 
     def test_rejects_missing_and_unexpected_runtime_inventory(self) -> None:
         (self.factory.run / "runtime-staged-batch-3.json").unlink()
@@ -1183,9 +1217,15 @@ class QualificationTests(unittest.TestCase):
         self.factory.create()
         self.factory.mutate(
             "rollback-drill-evidence.json",
-            lambda document: document["checks"].update(restore_applied=False),
+            lambda document: document["checks"].update(candidate_digest_recreate_applied=False),
         )
         self.assert_code("rollback-drill-check-failed")
+        self.factory.create()
+        self.factory.mutate(
+            "rollback-drill-evidence.json",
+            lambda document: document.update(lkg_compatibility="unverified"),
+        )
+        self.assert_code("rollback-drill-binding-mismatch")
 
     def test_rejects_tampered_recovery_tool(self) -> None:
         secure_executable(

--- a/scripts/verify-bolt-phase0-qualification.py
+++ b/scripts/verify-bolt-phase0-qualification.py
@@ -39,7 +39,7 @@ SYNTHETIC_SCHEMA = "bolt-phase0-synthetic-evidence/v1"
 SYNTHETIC_CORE_SCHEMA = "bolt-phase0-synthetic-report/v1"
 POST_RUN_SCHEMA = "bolt-phase0-post-run-evidence/v1"
 PROBE_SCHEMA = "bolt-phase0-probe-receipt/v1"
-ROLLBACK_DRILL_SCHEMA = "xframework.bolt.phase0.rollback-drill.v1"
+CANDIDATE_RESTART_SCHEMA = "xframework.bolt.phase0.candidate-restart.v1"
 PROXY_MODE_LOGS = "logs"
 PROXY_MODE_DIRECT_KESTREL = "direct-kestrel"
 SYNTHETIC_PROXY_MODES = frozenset({PROXY_MODE_LOGS, PROXY_MODE_DIRECT_KESTREL})
@@ -226,18 +226,18 @@ REQUIRED_OPERATIONS = {
     "durable_offline_publish", "durable_ordered_replay", "durable_ack", "durable_no_redelivery",
     "durable_unregister",
 }
-ROLLBACK_KEYS = {
+CANDIDATE_RESTART_KEYS = {
     "schema", "status", "run_id", "run_attempt", "source_commit", "project_name", "started_at_utc",
-    "completed_at_utc", "credential_generation_id", "manifest_sha256", "override_sha256", "pins_sha256",
+    "completed_at_utc", "credential_generation_id", "lkg_compatibility", "manifest_sha256", "override_sha256", "pins_sha256",
     "runtime_evidence_sha256", "synthetic_evidence_sha256", "checks", "errors",
 }
-ROLLBACK_CHECK_KEYS = {
-    "restore_applied", "full_runtime_verified", "authenticated_finalized_synthetic",
+CANDIDATE_RESTART_CHECK_KEYS = {
+    "candidate_digest_recreate_applied", "full_runtime_verified", "authenticated_finalized_synthetic",
     "current_generation_preserved",
 }
 QUALIFICATION_CHECK_KEYS = {
     "artifact_security", "schema_and_status", "identity_and_digest_binding",
-    "rotation_and_convergence", "canary_observation", "rollback_drill",
+    "rotation_and_convergence", "canary_observation", "candidate_restart",
 }
 
 RUN_ID = re.compile(r"[1-9][0-9]{0,31}")
@@ -1014,17 +1014,9 @@ def validate_runtime_service(
             if listener["family"] not in {"ipv4", "ipv6"}:
                 raise QualificationError("invalid-tls-service-listeners")
             normalized_listeners.append((listener["port"], listener["scope"]))
-        ports = set(normalized_listeners)
-        if (
-            (8080, "loopback") not in ports
-            or (8443, "wildcard") not in ports
-            or any(
-                (port == 8080 and scope != "loopback")
-                or (port == 8443 and scope != "wildcard")
-                or port not in {8080, 8443}
-                for port, scope in normalized_listeners
-            )
-        ):
+        expected_http_scope = "loopback" if service == "bolt-hub" else "wildcard"
+        expected_listeners = {(8080, expected_http_scope), (8443, "wildcard")}
+        if len(normalized_listeners) != 2 or set(normalized_listeners) != expected_listeners:
             raise QualificationError("invalid-tls-service-listeners")
         publication = exact_object(
             item["published_port"], {"container_port", "published_port", "protocol"},
@@ -1042,16 +1034,24 @@ def validate_runtime_service(
             if service == "bolt-hub"
             else "/run/secrets/identityserver-tls-private-key.pem"
         )
-        if (
-            not isinstance(mounts, list)
-            or len(mounts) != 1
-            or mounts[0] != {
+        expected_mounts = [
+            {
                 "resolved_source": "<expected-private-key>",
                 "relation": "exact",
                 "target": expected_target,
                 "read_only": True,
             }
-        ):
+        ]
+        if service == "identityserver":
+            expected_mounts.append(
+                {
+                    "resolved_source": "<identity-signing-key-volume>",
+                    "relation": "persistent-volume",
+                    "target": "/var/lib/xframework/identity",
+                    "read_only": False,
+                }
+            )
+        if not isinstance(mounts, list) or mounts != expected_mounts:
             raise QualificationError("invalid-tls-service-private-key-mount")
     elif item["listeners"] != [] or item["published_port"] is not None or item["private_key_mounts"] != []:
         raise QualificationError("unexpected-runtime-boundary-evidence")
@@ -1475,7 +1475,7 @@ def validate_observation(
     return generated
 
 
-def validate_rollback_drill(
+def validate_candidate_restart(
     document: dict[str, Any],
     run_id: str,
     attempt: int,
@@ -1486,9 +1486,9 @@ def validate_rollback_drill(
     now: dt.datetime,
     maximum_age_seconds: int,
 ) -> tuple[dt.datetime, dt.datetime]:
-    exact_object(document, ROLLBACK_KEYS, "invalid-rollback-drill")
+    exact_object(document, CANDIDATE_RESTART_KEYS, "invalid-rollback-drill")
     if (
-        document["schema"] != ROLLBACK_DRILL_SCHEMA
+        document["schema"] != CANDIDATE_RESTART_SCHEMA
         or document["status"] != "passed"
         or document["errors"] != []
         or document["run_id"] != run_id
@@ -1496,6 +1496,7 @@ def validate_rollback_drill(
         or document["source_commit"] != commit
         or document["project_name"] != project_name
         or document["credential_generation_id"] != target_generation
+        or document["lkg_compatibility"] not in {"rendered", "not_applicable_no_prior_lkg"}
     ):
         raise QualificationError("rollback-drill-binding-mismatch")
     started = fresh_timestamp(document["started_at_utc"], "invalid-rollback-time", now, maximum_age_seconds)
@@ -1511,7 +1512,7 @@ def validate_rollback_drill(
     }
     if any(document[field] != value for field, value in expected_digests.items()):
         raise QualificationError("rollback-drill-digest-mismatch")
-    checks = exact_object(document["checks"], ROLLBACK_CHECK_KEYS, "invalid-rollback-checks")
+    checks = exact_object(document["checks"], CANDIDATE_RESTART_CHECK_KEYS, "invalid-rollback-checks")
     if any(value is not True for value in checks.values()):
         raise QualificationError("rollback-drill-check-failed")
     return started, completed
@@ -1573,7 +1574,7 @@ def qualification_failure(
             "identity_and_digest_binding": False,
             "rotation_and_convergence": False,
             "canary_observation": False,
-            "rollback_drill": False,
+            "candidate_restart": False,
         },
         "errors": [code],
     }
@@ -1783,7 +1784,7 @@ def verify_qualification(
         documents["rollback-runtime-evidence.json"], PHASE0_SERVICES, pins, "complete", now,
         maximum_age_seconds, expected_published_ports,
     )
-    rollback_started, rollback_completed = validate_rollback_drill(
+    rollback_started, rollback_completed = validate_candidate_restart(
         documents["rollback-drill-evidence.json"], expected_run_id, expected_attempt, expected_commit,
         common["target_generation_id"], project_name, digests, now, maximum_age_seconds,
     )
@@ -1820,7 +1821,7 @@ def verify_qualification(
             "identity_and_digest_binding": True,
             "rotation_and_convergence": True,
             "canary_observation": True,
-            "rollback_drill": True,
+            "candidate_restart": True,
         },
         "errors": [],
     }

--- a/scripts/verify-bolt-phase0-runtime-test.py
+++ b/scripts/verify-bolt-phase0-runtime-test.py
@@ -145,6 +145,17 @@ def inspector(
     return inspect
 
 
+def identity_keydata_mount(**overrides: object) -> dict:
+    return {
+        "Type": "volume",
+        "Name": f"{PROJECT}_{MODULE.IDENTITY_KEYDATA_VOLUME}",
+        "Source": "/var/lib/docker/volumes/xframework_identity-keydata/_data",
+        "Destination": MODULE.IDENTITY_KEYDATA_DIRECTORY,
+        "RW": True,
+        **overrides,
+    }
+
+
 class Phase0RuntimeTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
@@ -168,6 +179,60 @@ class Phase0RuntimeTests(unittest.TestCase):
             7443,
             inspector(self.private_key, **kwargs),
             listener_runner(tcp, resolv_conf, process_sockets),
+        )
+
+    def collect_identity(
+        self,
+        *,
+        mounts: list[dict] | None = None,
+        tcp: str | None = None,
+        ports: dict | None = None,
+        port_bindings: dict | None = None,
+    ):
+        identity_runtime_ports = ports or {
+            "8080/tcp": None,
+            "8443/tcp": [
+                {"HostIp": "0.0.0.0", "HostPort": "8261"},
+                {"HostIp": "::", "HostPort": "8261"},
+            ],
+        }
+        identity_configured_ports = port_bindings or {
+            "8443/tcp": [{"HostIp": "", "HostPort": "8261"}]
+        }
+        identity_mounts = mounts if mounts is not None else [
+            {
+                "Type": "bind",
+                "Source": str(self.identity_private_key),
+                "Destination": "/run/secrets/identityserver-tls-private-key.pem",
+                "RW": False,
+            },
+            identity_keydata_mount(),
+        ]
+        base = inspector(
+            self.private_key,
+            mounts=identity_mounts,
+            ports=identity_runtime_ports,
+            port_bindings=identity_configured_ports,
+        )
+
+        def identity_inspector(command: list[str]) -> dict:
+            result = base(command)
+            if command[1:2] == ["inspect"]:
+                result["container_name"] = "/xframework-identityserver"
+                result["labels"]["com.docker.compose.service"] = "identityserver"
+            return result
+
+        return MODULE.collect_service(
+            "identityserver",
+            CONTAINER_ID,
+            EXPECTED,
+            PROJECT,
+            self.private_key,
+            7443,
+            identity_inspector,
+            listener_runner(tcp or proc_tcp(health_scope="wildcard")),
+            identity_private_key=self.identity_private_key,
+            identity_expected_published_port=8261,
         )
 
     def test_inspect_template_handles_a_missing_health_object_without_dot_lookup(self) -> None:
@@ -340,85 +405,64 @@ class Phase0RuntimeTests(unittest.TestCase):
         self.assertEqual("exact", evidence["private_key_mounts"][0]["relation"])
 
     def test_identityserver_requires_its_distinct_key_and_tls_only_publication(self) -> None:
-        identity_runtime_ports = {
-            "8080/tcp": None,
-            "8443/tcp": [
-                {"HostIp": "0.0.0.0", "HostPort": "8261"},
-                {"HostIp": "::", "HostPort": "8261"},
-            ],
-        }
-        identity_configured_ports = {
-            "8443/tcp": [{"HostIp": "", "HostPort": "8261"}]
-        }
-        base = inspector(
-            self.private_key,
-            mounts=[
-                {
-                    "Type": "bind",
-                    "Source": str(self.identity_private_key),
-                    "Destination": "/run/secrets/identityserver-tls-private-key.pem",
-                    "RW": False,
-                }
-            ],
-            ports=identity_runtime_ports,
-            port_bindings=identity_configured_ports,
-        )
-
-        def identity_inspector(command: list[str]) -> dict:
-            result = base(command)
-            if command[1:2] == ["inspect"]:
-                result["container_name"] = "/xframework-identityserver"
-                result["labels"]["com.docker.compose.service"] = "identityserver"
-            return result
-
-        evidence, errors = MODULE.collect_service(
-            "identityserver",
-            CONTAINER_ID,
-            EXPECTED,
-            PROJECT,
-            self.private_key,
-            7443,
-            identity_inspector,
-            listener_runner(proc_tcp()),
-            identity_private_key=self.identity_private_key,
-            identity_expected_published_port=8261,
-        )
+        evidence, errors = self.collect_identity()
         self.assertEqual([], errors)
         self.assertEqual(8261, evidence["published_port"]["published_port"])
+        self.assertEqual("wildcard", evidence["listeners"][0]["scope"])
+        self.assertEqual(2, len(evidence["private_key_mounts"]))
+        self.assertEqual(
+            "<identity-signing-key-volume>",
+            evidence["private_key_mounts"][1]["resolved_source"],
+        )
 
-        cross_mounted = inspector(
-            self.private_key,
+        _, cross_errors = self.collect_identity(
             mounts=[
                 {
                     "Type": "bind",
                     "Source": str(self.private_key),
                     "Destination": "/run/secrets/identityserver-tls-private-key.pem",
                     "RW": False,
-                }
-            ],
-            ports=identity_runtime_ports,
-            port_bindings=identity_configured_ports,
-        )
-
-        def cross_inspector(command: list[str]) -> dict:
-            result = cross_mounted(command)
-            if command[1:2] == ["inspect"]:
-                result["labels"]["com.docker.compose.service"] = "identityserver"
-            return result
-
-        _, cross_errors = MODULE.collect_service(
-            "identityserver",
-            CONTAINER_ID,
-            EXPECTED,
-            PROJECT,
-            self.private_key,
-            7443,
-            cross_inspector,
-            listener_runner(proc_tcp()),
-            identity_private_key=self.identity_private_key,
-            identity_expected_published_port=8261,
+                },
+                identity_keydata_mount(),
+            ]
         )
         self.assertTrue(any("private-key mount" in error for error in cross_errors))
+
+    def test_identityserver_loopback_http_or_public_8080_fails_closed(self) -> None:
+        _, listener_errors = self.collect_identity(tcp=proc_tcp(health_scope="loopback"))
+        self.assertTrue(any("0.0.0.0" in error for error in listener_errors))
+
+        public_ports = {
+            "8080/tcp": [
+                {"HostIp": "0.0.0.0", "HostPort": "8080"},
+                {"HostIp": "::", "HostPort": "8080"},
+            ],
+            "8443/tcp": [
+                {"HostIp": "0.0.0.0", "HostPort": "8261"},
+                {"HostIp": "::", "HostPort": "8261"},
+            ],
+        }
+        evidence, publication_errors = self.collect_identity(ports=public_ports)
+        self.assertTrue(any("runtime network publication" in error for error in publication_errors))
+        self.assertIsNone(evidence["published_port"])
+
+    def test_identityserver_signing_key_volume_must_be_persistent_and_writable(self) -> None:
+        tls_mount = {
+            "Type": "bind",
+            "Source": str(self.identity_private_key),
+            "Destination": "/run/secrets/identityserver-tls-private-key.pem",
+            "RW": False,
+        }
+        invalid_mounts = (
+            [tls_mount],
+            [tls_mount, identity_keydata_mount(RW=False)],
+            [tls_mount, identity_keydata_mount(Name="xframework_ephemeral-keydata")],
+            [tls_mount, identity_keydata_mount(Type="bind", Name="")],
+        )
+        for mounts in invalid_mounts:
+            with self.subTest(mounts=mounts):
+                _, errors = self.collect_identity(mounts=mounts)
+                self.assertTrue(any("signing-key volume" in error for error in errors))
 
     def test_mutable_image_and_wrong_repository_digest_fail_closed(self) -> None:
         _, mutable = self.collect(configured_image="registry.example/xframework/bolt-hub:develop")

--- a/scripts/verify-bolt-phase0-runtime.py
+++ b/scripts/verify-bolt-phase0-runtime.py
@@ -51,6 +51,8 @@ CONTAINER_FORMAT = (
 IMAGE_FORMAT = '{"local_image_id":{{json .Id}},"repo_digests":{{json .RepoDigests}}}'
 SUBPROCESS_TIMEOUT_SECONDS = 30
 DOCKER_EMBEDDED_DNS_ADDRESS = "127.0.0.11"
+IDENTITY_KEYDATA_VOLUME = "identity-keydata"
+IDENTITY_KEYDATA_DIRECTORY = "/var/lib/xframework/identity"
 
 
 def write_private_json(path: Path, value: Any) -> None:
@@ -269,10 +271,10 @@ def verify_tls_service_listeners(service: str, listeners: list[dict[str, Any]]) 
         }
         for item in listeners
     ]
-    expected_health = {
-        "address": "127.0.0.1",
+    expected_http = {
+        "address": "127.0.0.1" if service == "bolt-hub" else "0.0.0.0",
         "family": "ipv4",
-        "scope": "loopback",
+        "scope": "loopback" if service == "bolt-hub" else "wildcard",
         "port": 8080,
     }
     expected_tls = {
@@ -281,14 +283,17 @@ def verify_tls_service_listeners(service: str, listeners: list[dict[str, Any]]) 
         "scope": "wildcard",
         "port": 8443,
     }
-    health = [item for item in normalized if item["port"] == 8080]
+    http = [item for item in normalized if item["port"] == 8080]
     tls = [item for item in normalized if item["port"] == 8443]
-    if health != [expected_health]:
-        errors.append(f"{service}: actual port 8080 listener is not exactly IPv4 127.0.0.1")
+    if http != [expected_http]:
+        expected_address = expected_http["address"]
+        errors.append(
+            f"{service}: actual port 8080 listener is not exactly IPv4 {expected_address}"
+        )
     if tls != [expected_tls]:
         errors.append(f"{service}: actual port 8443 listener is not exactly IPv4 wildcard TLS")
     if len(normalized) != 2 or any(
-        item not in (expected_health, expected_tls) for item in normalized
+        item not in (expected_http, expected_tls) for item in normalized
     ):
         errors.append(f"{service}: unexpected actual TCP listener topology is present")
     return errors
@@ -386,6 +391,41 @@ def private_key_mounts(container: dict[str, Any], private_key: Path) -> tuple[li
     return evidence, errors
 
 
+def identity_signing_key_mounts(
+    container: dict[str, Any], project_name: str
+) -> list[dict[str, Any]]:
+    evidence: list[dict[str, Any]] = []
+    mounts = container.get("mounts")
+    if not isinstance(mounts, list):
+        return evidence
+    expected_name = f"{project_name}_{IDENTITY_KEYDATA_VOLUME}"
+    for mount in mounts:
+        if not isinstance(mount, dict):
+            continue
+        name = str(mount.get("Name", ""))
+        target = str(mount.get("Destination", ""))
+        if name != expected_name and target != IDENTITY_KEYDATA_DIRECTORY:
+            continue
+        exact = (
+            str(mount.get("Type", "")).lower() == "volume"
+            and name == expected_name
+            and target == IDENTITY_KEYDATA_DIRECTORY
+        )
+        evidence.append(
+            {
+                "resolved_source": (
+                    "<identity-signing-key-volume>"
+                    if exact
+                    else "<unexpected-signing-key-mount>"
+                ),
+                "relation": "persistent-volume" if exact else "invalid",
+                "target": target,
+                "read_only": not bool(mount.get("RW", True)),
+            }
+        )
+    return evidence
+
+
 def collect_service(
     service: str,
     container_id: str,
@@ -440,6 +480,7 @@ def collect_service(
     if identity_private_key is not None:
         identity_mounts, identity_mount_errors = private_key_mounts(container, identity_private_key)
         errors.extend(f"{service}: IdentityServer key {error}" for error in identity_mount_errors)
+    signing_key_mounts = identity_signing_key_mounts(container, project_name)
     if service == "bolt-hub":
         key_mount_ok = (
             len(hub_mounts) == 1
@@ -447,6 +488,7 @@ def collect_service(
             and hub_mounts[0]["target"] == "/run/secrets/bolt-hub-tls-private-key.pem"
             and hub_mounts[0]["read_only"] is True
             and not identity_mounts
+            and not signing_key_mounts
         )
         if not key_mount_ok:
             errors.append("bolt-hub: resolved private-key mount is missing, broad, duplicated, writable, or mis-targeted")
@@ -461,8 +503,20 @@ def collect_service(
         )
         if not key_mount_ok:
             errors.append("identityserver: resolved private-key mount is missing, broad, duplicated, writable, cross-mounted, or mis-targeted")
-    elif hub_mounts or identity_mounts:
-        errors.append(f"{service}: resolved runtime mount exposes a TLS private key")
+        signing_key_mount_ok = signing_key_mounts == [
+            {
+                "resolved_source": "<identity-signing-key-volume>",
+                "relation": "persistent-volume",
+                "target": IDENTITY_KEYDATA_DIRECTORY,
+                "read_only": False,
+            }
+        ]
+        if not signing_key_mount_ok:
+            errors.append(
+                "identityserver: persistent writable signing-key volume is missing, duplicated, read-only, or mis-targeted"
+            )
+    elif hub_mounts or identity_mounts or signing_key_mounts:
+        errors.append(f"{service}: resolved runtime mount exposes private signing material")
 
     listener_evidence: list[dict[str, Any]] = []
     publication_evidence: dict[str, Any] | None = None
@@ -501,7 +555,7 @@ def collect_service(
         "health": health,
         "listeners": listener_evidence,
         "published_port": publication_evidence,
-        "private_key_mounts": [*hub_mounts, *identity_mounts],
+        "private_key_mounts": [*hub_mounts, *identity_mounts, *signing_key_mounts],
     }
     return evidence, errors
 

--- a/src/Infrastructure/XFramework.Integration/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/XFramework.Integration/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,4 @@
-using System.IdentityModel.Tokens.Jwt;
 using System.Reflection;
-using System.Security.Claims;
 using Bolt.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.Configurations;
 using XFramework.Domain.Shared.DataContext;
@@ -37,13 +34,23 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration,
         bool autoConnect = true,
-        IHostEnvironment? hostEnvironment = null)
+        IHostEnvironment? hostEnvironment = null,
+        bool connectAfterApplicationStarted = false)
     {
         services.Configure<BoltConfiguration>(configuration.GetSection("BoltConfiguration"));
+        var boltConfig = configuration.GetSection("BoltConfiguration").Get<BoltConfiguration>()
+            ?? throw new InvalidOperationException("BoltConfiguration section is missing or empty in configuration.");
+
+        if (boltConfig.ServerUrls is null || boltConfig.ServerUrls.Count == 0)
+            throw new InvalidOperationException("BoltConfiguration:ServerUrls must contain at least one URL.");
+
+        ValidateTransportIdentityModes(boltConfig, hostEnvironment);
+
         services.TryAddSingleton(TimeProvider.System);
         services.AddCredentialGenerationHealthCheck();
-        services.AddBoltClientTransportHealthCheck();
-        services.AddOptions<ServiceIdentityOptions>()
+        if (!connectAfterApplicationStarted)
+            services.AddBoltClientTransportHealthCheck();
+        var serviceIdentityOptions = services.AddOptions<ServiceIdentityOptions>()
             .Configure(options =>
             {
                 configuration.GetSection(ServiceIdentityOptions.SectionName).Bind(options);
@@ -53,18 +60,23 @@ public static class ServiceCollectionExtensions
 
                 if (options.DefaultScopes.Count == 0)
                     options.DefaultScopes = XFrameworkServiceScopes.AdminDefaults.ToList();
-            })
-            .ValidateOnStart();
+            });
+        if (UsesCentralTransportIdentity(boltConfig))
+            serviceIdentityOptions.ValidateOnStart();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<ServiceIdentityOptions>, ServiceIdentityOptionsValidator>());
+        services.AddHttpClient(ServiceIdentityHttpClient.Name, (serviceProvider, client) =>
+        {
+            client.BaseAddress = serviceProvider
+                .GetRequiredService<IOptions<ServiceIdentityOptions>>()
+                .Value
+                .ResolveAuthority();
+            client.Timeout = Timeout.InfiniteTimeSpan;
+        });
+        services.TryAddSingleton<IBoltTransportTokenProvider, IdentityServerBoltTransportTokenProvider>();
+        services.TryAddSingleton<IServiceTokenProvider, IdentityServerServiceTokenProvider>();
         services.Configure<BoltServiceDiscoveryOptions>(
             configuration.GetSection(BoltServiceDiscoveryOptions.SectionName));
-
-        var boltConfig = configuration.GetSection("BoltConfiguration").Get<BoltConfiguration>()
-            ?? throw new InvalidOperationException("BoltConfiguration section is missing or empty in configuration.");
-
-        if (boltConfig.ServerUrls is null || boltConfig.ServerUrls.Count == 0)
-            throw new InvalidOperationException("BoltConfiguration:ServerUrls must contain at least one URL.");
 
         var requireSecureTransport = boltConfig.RequireSecureTransport ||
                                      hostEnvironment is not null && !hostEnvironment.IsDevelopment();
@@ -114,25 +126,27 @@ public static class ServiceCollectionExtensions
                     options.ScaleUpThreshold = boltConfig.ScaleUpThreshold > 0
                         ? boltConfig.ScaleUpThreshold
                         : options.ScaleUpThreshold;
-
-                    if (!string.IsNullOrWhiteSpace(boltConfig.AccessToken))
-                    {
-                        options.AccessToken = boltConfig.AccessToken;
-                    }
-                    else if (!boltConfig.Anonymous && boltConfig.GenerateServiceAccessToken)
-                    {
-                        options.AccessTokenProvider = _ =>
-                            new ValueTask<string?>(GenerateBoltServiceAccessToken(configuration, clientName));
-                    }
                 });
 
-            if (!autoConnect)
+            if (!string.IsNullOrWhiteSpace(boltConfig.AccessToken))
+            {
+                builder.WithAccessToken(boltConfig.AccessToken);
+            }
+            else if (!boltConfig.Anonymous)
+            {
+                builder.WithAccessTokenProvider<IBoltTransportTokenProvider>(
+                    async (provider, ct) => await provider.GetTokenAsync(ct));
+            }
+
+            if (!autoConnect || connectAfterApplicationStarted)
                 builder.DisableAutoConnect();
         });
 
+        if (autoConnect && connectAfterApplicationStarted)
+            services.AddHostedService<ApplicationStartedBoltClientHostedService>();
+
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IBoltServiceManifestProvider, ConfigurationBoltServiceManifestProvider>());
         services.AddHostedService<BoltServiceManifestAdvertisementHostedService>();
-        services.TryAddSingleton<IServiceTokenProvider, IdentityServerServiceTokenProvider>();
         services.TryAddSingleton<IIdentitySigningKeyProvider, IdentityServerSigningKeyProvider>();
         services.TryAddSingleton<IServiceTokenValidator, ServiceTokenValidator>();
         services.TryAddSingleton<ITrustedServiceInvocationResolver, TrustedServiceInvocationResolver>();
@@ -141,38 +155,34 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    private static string GenerateBoltServiceAccessToken(IConfiguration configuration, string clientName)
+    private static bool UsesCentralTransportIdentity(BoltConfiguration boltConfig) =>
+        !boltConfig.Anonymous && string.IsNullOrWhiteSpace(boltConfig.AccessToken);
+
+    private static void ValidateTransportIdentityModes(
+        BoltConfiguration boltConfig,
+        IHostEnvironment? hostEnvironment)
     {
-        var jwtOptions = configuration.GetSection(nameof(JwtOptions)).Get<JwtOptions>()
-            ?? throw new InvalidOperationException("JwtOptions is required to generate Bolt service access tokens.");
-        JwtCredentialSet.Validate(jwtOptions, TimeProvider.System.GetUtcNow());
+        var isDevelopment = hostEnvironment?.IsDevelopment() == true;
 
-        var lifetime = TimeSpan.TryParse(jwtOptions.AccessTokenLifespan, out var parsedLifetime)
-            ? parsedLifetime
-            : TimeSpan.FromMinutes(30);
+        if (boltConfig.Anonymous && !isDevelopment)
+        {
+            throw new InvalidOperationException(
+                "BoltConfiguration:Anonymous is permitted only when the host environment is Development.");
+        }
 
-        List<Claim> claims =
-        [
-            new("client_id", clientName),
-            new("service", clientName),
-            new("scope", "bolt.service"),
-            new(JwtCredentialSet.GenerationClaim, jwtOptions.GenerationId.Trim()),
-            new(ClaimTypes.Name, clientName),
-            new(JwtRegisteredClaimNames.Sub, clientName),
-            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
-            new(JwtRegisteredClaimNames.AuthTime, DateTime.UtcNow.ToString("O"))
-        ];
+        if (boltConfig.GenerateServiceAccessToken)
+        {
+            throw new InvalidOperationException(
+                "BoltConfiguration:GenerateServiceAccessToken is no longer supported. " +
+                "Use IdentityServer-issued Bolt transport tokens.");
+        }
 
-        var securityKey = JwtCredentialSet.CreateCurrentSigningKey(jwtOptions);
-        var token = new JwtSecurityToken(
-            issuer: jwtOptions.ValidIssuer,
-            audience: jwtOptions.ValidAudience,
-            claims: claims,
-            notBefore: DateTime.UtcNow,
-            expires: DateTime.UtcNow.Add(lifetime),
-            signingCredentials: new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha512));
-
-        return new JwtSecurityTokenHandler().WriteToken(token);
+        if (!string.IsNullOrWhiteSpace(boltConfig.AccessToken) &&
+            boltConfig.Anonymous)
+        {
+            throw new InvalidOperationException(
+                "BoltConfiguration:AccessToken cannot be combined with anonymous transport identity mode.");
+        }
     }
 
     public static IServiceCollection AddBoltServiceManifestProvider<TProvider>(this IServiceCollection services)
@@ -251,4 +261,83 @@ internal sealed class BoltHandlerRegistrationHostedService : IHostedService
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+internal sealed class ApplicationStartedBoltClientHostedService(
+    BoltClient client,
+    IHostApplicationLifetime applicationLifetime,
+    ILogger<ApplicationStartedBoltClientHostedService> logger) : IHostedService
+{
+    private readonly object _gate = new();
+    private CancellationTokenSource? _stoppingCts;
+    private CancellationTokenRegistration _applicationStartedRegistration;
+    private Task _connectTask = Task.CompletedTask;
+
+    public Task StartAsync(CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(applicationLifetime.ApplicationStopping);
+        _applicationStartedRegistration = applicationLifetime.ApplicationStarted.Register(StartConnection);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken ct)
+    {
+        _applicationStartedRegistration.Dispose();
+        _stoppingCts?.Cancel();
+
+        Task connectTask;
+        lock (_gate)
+            connectTask = _connectTask;
+
+        try
+        {
+            await connectTask.WaitAsync(ct);
+        }
+        catch (OperationCanceledException) when (_stoppingCts?.IsCancellationRequested == true || ct.IsCancellationRequested)
+        {
+        }
+
+        await client.DisposeAsync();
+        _stoppingCts?.Dispose();
+    }
+
+    private void StartConnection()
+    {
+        lock (_gate)
+        {
+            if (!_connectTask.IsCompleted || _stoppingCts is null || _stoppingCts.IsCancellationRequested)
+                return;
+
+            _connectTask = ConnectAsync(_stoppingCts.Token);
+        }
+    }
+
+    private async Task ConnectAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                logger.LogInformation("Bolt client connecting after application startup...");
+                await client.ConnectWithRetryAsync(ct);
+                if (client.IsConnected)
+                {
+                    logger.LogInformation("Bolt client connected after application startup");
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                logger.LogDebug("Bolt client connection canceled during application shutdown");
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Bolt client startup retry cycle failed; retrying until shutdown");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+        }
+    }
 }

--- a/src/Infrastructure/XFramework.Integration/Security/IBoltTransportTokenProvider.cs
+++ b/src/Infrastructure/XFramework.Integration/Security/IBoltTransportTokenProvider.cs
@@ -1,0 +1,6 @@
+namespace XFramework.Integration.Security;
+
+public interface IBoltTransportTokenProvider
+{
+    ValueTask<string> GetTokenAsync(CancellationToken ct = default);
+}

--- a/src/Infrastructure/XFramework.Integration/Security/IdentityServerBoltTransportTokenProvider.cs
+++ b/src/Infrastructure/XFramework.Integration/Security/IdentityServerBoltTransportTokenProvider.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace XFramework.Integration.Security;
+
+public sealed class IdentityServerBoltTransportTokenProvider : IBoltTransportTokenProvider
+{
+    private const string CacheKey = "bolt-transport";
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceIdentityOptions> _serviceIdentityOptions;
+    private readonly TimeProvider _timeProvider;
+    private readonly IdentityServerTokenCache _tokenCache;
+
+    public IdentityServerBoltTransportTokenProvider(
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceIdentityOptions> serviceIdentityOptions,
+        TimeProvider timeProvider,
+        ILogger<IdentityServerBoltTransportTokenProvider> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _serviceIdentityOptions = serviceIdentityOptions;
+        _timeProvider = timeProvider;
+        _tokenCache = new IdentityServerTokenCache(serviceIdentityOptions, timeProvider, logger);
+    }
+
+    public ValueTask<string> GetTokenAsync(CancellationToken ct = default) =>
+        _tokenCache.GetTokenAsync(CacheKey, "Bolt transport", AcquireTokenAsync, ct);
+
+    private Task<XFramework.Domain.Shared.ServiceIdentity.ServiceTokenResponse> AcquireTokenAsync(CancellationToken ct)
+    {
+        var options = _serviceIdentityOptions.Value;
+        var clientId = ResolveClientId(options);
+        ValidateCurrentCredential(options);
+
+        return ServiceIdentityHttpClient.PostForTokenAsync(
+            _httpClientFactory,
+            options,
+            ServiceIdentityHttpClient.BoltTransportTokenPath,
+            new BoltTransportTokenRequest(clientId, options.ClientSecret!),
+            ct);
+    }
+
+    private static string ResolveClientId(ServiceIdentityOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.ClientId))
+            return options.ClientId.Trim();
+
+        throw new InvalidOperationException("ServiceIdentity:ClientId is required.");
+    }
+
+    private void ValidateCurrentCredential(ServiceIdentityOptions options) =>
+        CredentialGenerationValidator.Validate(
+            ServiceIdentityOptions.SectionName,
+            new CredentialGenerationDescriptor(
+                options.GenerationId ?? string.Empty,
+                options.ClientSecret ?? string.Empty),
+            validationFallback: null,
+            _timeProvider.GetUtcNow());
+
+    private sealed record BoltTransportTokenRequest(string ClientId, string ClientSecret);
+}

--- a/src/Infrastructure/XFramework.Integration/Security/IdentityServerServiceTokenProvider.cs
+++ b/src/Infrastructure/XFramework.Integration/Security/IdentityServerServiceTokenProvider.cs
@@ -1,27 +1,30 @@
-using System.Collections.Concurrent;
-using System.Threading;
-using Bolt.Client;
-using MemoryPack;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using XFramework.Domain.Shared.BusinessObjects;
-using XFramework.Domain.Shared.Configurations;
 using XFramework.Domain.Shared.ServiceIdentity;
 
 namespace XFramework.Integration.Security;
 
-public sealed class IdentityServerServiceTokenProvider(
-    BoltClient boltClient,
-    IOptions<ServiceIdentityOptions> serviceIdentityOptions,
-    IOptions<BoltConfiguration> boltConfigurationOptions,
-    TimeProvider timeProvider,
-    ILogger<IdentityServerServiceTokenProvider> logger)
-    : IServiceTokenProvider
+public sealed class IdentityServerServiceTokenProvider : IServiceTokenProvider
 {
-    private readonly ConcurrentDictionary<string, CachedToken> _cache = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, Lazy<Task<string>>> _inflight = new(StringComparer.Ordinal);
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceIdentityOptions> _serviceIdentityOptions;
+    private readonly TimeProvider _timeProvider;
+    private readonly IdentityServerTokenCache _tokenCache;
 
-    public async ValueTask<string> GetTokenAsync(
+    public IdentityServerServiceTokenProvider(
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceIdentityOptions> serviceIdentityOptions,
+        TimeProvider timeProvider,
+        ILogger<IdentityServerServiceTokenProvider> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _serviceIdentityOptions = serviceIdentityOptions;
+        _timeProvider = timeProvider;
+        _tokenCache = new IdentityServerTokenCache(serviceIdentityOptions, timeProvider, logger);
+    }
+
+    public ValueTask<string> GetTokenAsync(
         string audience,
         IReadOnlyCollection<string>? scopes = null,
         CancellationToken ct = default)
@@ -30,134 +33,49 @@ public sealed class IdentityServerServiceTokenProvider(
             throw new InvalidOperationException("Service token audience is required.");
 
         var requestedScopes = NormalizeScopes(scopes);
-        var cacheKey = $"{audience}|{string.Join(' ', requestedScopes)}";
-        var now = timeProvider.GetUtcNow().UtcDateTime;
-        var options = serviceIdentityOptions.Value;
-        var refreshSkew = TimeSpan.FromSeconds(Math.Clamp(options.TokenRefreshSkewSeconds, 10, 600));
+        var normalizedAudience = audience.Trim();
+        var cacheKey = $"{normalizedAudience}|{string.Join(' ', requestedScopes)}";
 
-        if (_cache.TryGetValue(cacheKey, out var cached) &&
-            cached.ExpiresAtUtc > now.Add(refreshSkew))
-        {
-            return cached.AccessToken;
-        }
-
-        ct.ThrowIfCancellationRequested();
-
-        var acquisition = _inflight.GetOrAdd(
+        return _tokenCache.GetTokenAsync(
             cacheKey,
-            _ => CreateAcquisition(audience, requestedScopes, cacheKey));
-
-        return await acquisition.Value.WaitAsync(ct);
+            "service",
+            acquisitionCt => AcquireTokenAsync(normalizedAudience, requestedScopes, acquisitionCt),
+            ct);
     }
 
-    private Lazy<Task<string>> CreateAcquisition(
+    private Task<ServiceTokenResponse> AcquireTokenAsync(
         string audience,
         IReadOnlyCollection<string> requestedScopes,
-        string cacheKey)
-    {
-        Lazy<Task<string>>? acquisition = null;
-        acquisition = new Lazy<Task<string>>(
-            async () =>
-            {
-                try
-                {
-                    var timeout = ResolveTokenAcquisitionTimeout();
-                    using var timeoutCts = new CancellationTokenSource(timeout);
-                    try
-                    {
-                        return await AcquireTokenAsync(audience, requestedScopes, cacheKey, timeoutCts.Token);
-                    }
-                    catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested)
-                    {
-                        throw new TimeoutException(
-                            $"Service token acquisition for audience '{audience}' timed out after {timeout.TotalSeconds:0} seconds.",
-                            ex);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(
-                        ex,
-                        "Service token acquisition failed. ClientId={ClientId} Audience={Audience} Scopes={Scopes}",
-                        ResolveClientIdOrDefault(),
-                        audience,
-                        string.Join(' ', requestedScopes));
-                    throw;
-                }
-                finally
-                {
-                    if (_inflight.TryGetValue(cacheKey, out var current) && ReferenceEquals(current, acquisition))
-                        _inflight.TryRemove(cacheKey, out _);
-                }
-            },
-            LazyThreadSafetyMode.ExecutionAndPublication);
-
-        return acquisition;
-    }
-
-    private async Task<string> AcquireTokenAsync(
-        string audience,
-        IReadOnlyCollection<string> requestedScopes,
-        string cacheKey,
         CancellationToken ct)
     {
-        var now = timeProvider.GetUtcNow().UtcDateTime;
-        var options = serviceIdentityOptions.Value;
-        var refreshSkew = TimeSpan.FromSeconds(Math.Clamp(options.TokenRefreshSkewSeconds, 10, 600));
-
-        if (_cache.TryGetValue(cacheKey, out var cached) &&
-            cached.ExpiresAtUtc > now.Add(refreshSkew))
-        {
-            return cached.AccessToken;
-        }
-
-        var clientId = ResolveClientId();
+        var options = _serviceIdentityOptions.Value;
+        var clientId = ResolveClientId(options);
         var request = CreateCurrentCredentialRequest(
             options,
             clientId,
             audience,
             requestedScopes,
-            timeProvider.GetUtcNow());
+            _timeProvider.GetUtcNow());
 
-        var targetClient = XFrameworkServiceNames.IdentityServer.ToSha256();
-        var (status, data) = await boltClient.InvokeAsync(
-            targetClient,
-            nameof(IssueServiceTokenRequest),
-            MemoryPackSerializer.Serialize(request),
+        return ServiceIdentityHttpClient.PostForTokenAsync(
+            _httpClientFactory,
+            options,
+            ServiceIdentityHttpClient.ServiceTokenPath,
+            request,
             ct);
-
-        if ((int)status < 200 || (int)status >= 300)
-            throw new InvalidOperationException($"Service token request failed with status {(int)status} ({status}).");
-
-        var response = MemoryPackSerializer.Deserialize<QueryResponse<ServiceTokenResponse>>(data.Span)
-            ?? throw new InvalidOperationException("Service token response could not be deserialized.");
-
-        if (!response.IsSuccess || response.Response is null || string.IsNullOrWhiteSpace(response.Response.AccessToken))
-        {
-            throw new InvalidOperationException(
-                response.Message ?? "IdentityServer did not issue a service token.");
-        }
-
-        _cache[cacheKey] = new CachedToken(response.Response.AccessToken, response.Response.ExpiresAtUtc);
-        return response.Response.AccessToken;
     }
 
-    private string ResolveClientId()
+    private static string ResolveClientId(ServiceIdentityOptions options)
     {
-        var configured = serviceIdentityOptions.Value.ClientId;
-        if (!string.IsNullOrWhiteSpace(configured))
-            return configured.Trim();
+        if (!string.IsNullOrWhiteSpace(options.ClientId))
+            return options.ClientId.Trim();
 
-        var boltName = boltConfigurationOptions.Value.ClientName;
-        if (!string.IsNullOrWhiteSpace(boltName))
-            return boltName.Trim();
-
-        throw new InvalidOperationException("ServiceIdentity:ClientId or BoltConfiguration:ClientName is required.");
+        throw new InvalidOperationException("ServiceIdentity:ClientId is required.");
     }
 
     private List<string> NormalizeScopes(IReadOnlyCollection<string>? scopes)
     {
-        var defaults = serviceIdentityOptions.Value.DefaultScopes;
+        var defaults = _serviceIdentityOptions.Value.DefaultScopes;
         var source = scopes is { Count: > 0 } ? scopes : defaults;
 
         return source
@@ -182,16 +100,11 @@ public sealed class IdentityServerServiceTokenProvider(
                 options.ClientSecret ?? string.Empty),
             validationFallback: null,
             nowUtc);
-        if (string.IsNullOrWhiteSpace(options.ClientSecret))
-        {
-            throw new InvalidOperationException(
-                $"ServiceIdentity:ClientSecret is required for service client '{clientId}'.");
-        }
 
         return new IssueServiceTokenRequest
         {
             ClientId = clientId,
-            ClientSecret = options.ClientSecret,
+            ClientSecret = options.ClientSecret!,
             Audience = audience,
             Scopes = scopes.ToList(),
             Metadata = new RequestMetadata
@@ -201,28 +114,4 @@ public sealed class IdentityServerServiceTokenProvider(
             }
         };
     }
-
-    private TimeSpan ResolveTokenAcquisitionTimeout()
-    {
-        var options = serviceIdentityOptions.Value;
-        var timeoutSeconds = options.TokenAcquisitionTimeoutSeconds > 0
-            ? options.TokenAcquisitionTimeoutSeconds
-            : Math.Max(1, boltConfigurationOptions.Value.RpcTimeoutSeconds + 5);
-
-        return TimeSpan.FromSeconds(Math.Clamp(timeoutSeconds, 1, 300));
-    }
-
-    private string ResolveClientIdOrDefault()
-    {
-        try
-        {
-            return ResolveClientId();
-        }
-        catch
-        {
-            return "<unresolved>";
-        }
-    }
-
-    private sealed record CachedToken(string AccessToken, DateTime ExpiresAtUtc);
 }

--- a/src/Infrastructure/XFramework.Integration/Security/ServiceIdentityHttpClient.cs
+++ b/src/Infrastructure/XFramework.Integration/Security/ServiceIdentityHttpClient.cs
@@ -1,0 +1,189 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using XFramework.Domain.Shared.ServiceIdentity;
+
+namespace XFramework.Integration.Security;
+
+public static class ServiceIdentityHttpClient
+{
+    public const string Name = "XFramework.ServiceIdentity";
+
+    internal const string BoltTransportTokenPath = "/api/service-identity/bolt-transport-token";
+    internal const string ServiceTokenPath = "/api/service-identity/token";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    internal static async Task<ServiceTokenResponse> PostForTokenAsync<TRequest>(
+        IHttpClientFactory httpClientFactory,
+        ServiceIdentityOptions options,
+        string path,
+        TRequest request,
+        CancellationToken ct)
+    {
+        var authority = options.ResolveAuthority();
+        var endpoint = new Uri(authority, path);
+        var client = httpClientFactory.CreateClient(Name);
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = JsonContent.Create(request, options: JsonOptions)
+        };
+        using var response = await client.SendAsync(
+            httpRequest,
+            HttpCompletionOption.ResponseHeadersRead,
+            ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"IdentityServer token request failed with HTTP status {(int)response.StatusCode} ({response.StatusCode}).");
+        }
+
+        var token = await response.Content.ReadFromJsonAsync<ServiceTokenResponse>(JsonOptions, ct)
+            ?? throw new InvalidOperationException("IdentityServer token response was empty.");
+
+        if (string.IsNullOrWhiteSpace(token.AccessToken))
+            throw new InvalidOperationException("IdentityServer did not issue a token.");
+
+        return token;
+    }
+}
+
+internal sealed class IdentityServerTokenCache(
+    IOptions<ServiceIdentityOptions> serviceIdentityOptions,
+    TimeProvider timeProvider,
+    ILogger logger)
+{
+    private static readonly TimeSpan FailureRetryBackoff = TimeSpan.FromMilliseconds(500);
+    private readonly ConcurrentDictionary<string, CachedToken> _cache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Lazy<Task<string>>> _inflight = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _retryNotBefore = new(StringComparer.Ordinal);
+
+    public async ValueTask<string> GetTokenAsync(
+        string cacheKey,
+        string tokenKind,
+        Func<CancellationToken, Task<ServiceTokenResponse>> acquireToken,
+        CancellationToken ct)
+    {
+        if (TryGetCachedToken(cacheKey, out var accessToken))
+            return accessToken;
+
+        ct.ThrowIfCancellationRequested();
+        var acquisition = _inflight.GetOrAdd(
+            cacheKey,
+            _ => CreateAcquisition(cacheKey, tokenKind, acquireToken));
+
+        return await acquisition.Value.WaitAsync(ct);
+    }
+
+    private Lazy<Task<string>> CreateAcquisition(
+        string cacheKey,
+        string tokenKind,
+        Func<CancellationToken, Task<ServiceTokenResponse>> acquireToken)
+    {
+        Lazy<Task<string>>? acquisition = null;
+        acquisition = new Lazy<Task<string>>(
+            async () =>
+            {
+                try
+                {
+                    var timeout = ResolveTokenAcquisitionTimeout();
+                    using var timeoutCts = new CancellationTokenSource(timeout);
+                    try
+                    {
+                        await WaitForFailureBackoffAsync(cacheKey, timeoutCts.Token);
+                        var token = await AcquireAndCacheTokenAsync(cacheKey, acquireToken, timeoutCts.Token);
+                        _retryNotBefore.TryRemove(cacheKey, out _);
+                        return token;
+                    }
+                    catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested)
+                    {
+                        throw new TimeoutException(
+                            $"IdentityServer {tokenKind} token acquisition timed out after {timeout.TotalSeconds:0} seconds.",
+                            ex);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    _retryNotBefore[cacheKey] = timeProvider.GetUtcNow().Add(FailureRetryBackoff);
+                    logger.LogWarning(
+                        exception,
+                        "IdentityServer token acquisition failed. TokenKind={TokenKind}",
+                        tokenKind);
+                    throw;
+                }
+                finally
+                {
+                    if (_inflight.TryGetValue(cacheKey, out var current) && ReferenceEquals(current, acquisition))
+                        _inflight.TryRemove(cacheKey, out _);
+                }
+            },
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        return acquisition;
+    }
+
+    private async Task WaitForFailureBackoffAsync(string cacheKey, CancellationToken ct)
+    {
+        if (!_retryNotBefore.TryGetValue(cacheKey, out var retryNotBefore))
+            return;
+
+        var delay = retryNotBefore - timeProvider.GetUtcNow();
+        if (delay > TimeSpan.Zero)
+            await Task.Delay(delay, timeProvider, ct);
+    }
+
+    private async Task<string> AcquireAndCacheTokenAsync(
+        string cacheKey,
+        Func<CancellationToken, Task<ServiceTokenResponse>> acquireToken,
+        CancellationToken ct)
+    {
+        if (TryGetCachedToken(cacheKey, out var cachedAccessToken))
+            return cachedAccessToken;
+
+        var response = await acquireToken(ct);
+        var expiresAtUtc = ToUtc(response.ExpiresAtUtc);
+        if (expiresAtUtc <= timeProvider.GetUtcNow())
+            throw new InvalidOperationException("IdentityServer issued a token without a future expiry.");
+
+        _cache[cacheKey] = new CachedToken(response.AccessToken, expiresAtUtc);
+        return response.AccessToken;
+    }
+
+    private bool TryGetCachedToken(string cacheKey, out string accessToken)
+    {
+        var refreshSkew = TimeSpan.FromSeconds(
+            Math.Clamp(serviceIdentityOptions.Value.TokenRefreshSkewSeconds, 0, 600));
+        var validAfterUtc = timeProvider.GetUtcNow().Add(refreshSkew);
+        if (_cache.TryGetValue(cacheKey, out var cached) && cached.ExpiresAtUtc > validAfterUtc)
+        {
+            accessToken = cached.AccessToken;
+            return true;
+        }
+
+        accessToken = string.Empty;
+        return false;
+    }
+
+    private TimeSpan ResolveTokenAcquisitionTimeout()
+    {
+        var configuredSeconds = serviceIdentityOptions.Value.TokenAcquisitionTimeoutSeconds;
+        var timeoutSeconds = Math.Clamp(configuredSeconds > 0 ? configuredSeconds : 30, 1, 300);
+        return TimeSpan.FromSeconds(timeoutSeconds);
+    }
+
+    private static DateTimeOffset ToUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => new DateTimeOffset(value),
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Utc))
+    };
+
+    private sealed record CachedToken(string AccessToken, DateTimeOffset ExpiresAtUtc);
+}

--- a/src/Infrastructure/XFramework.Integration/Security/ServiceIdentityOptions.cs
+++ b/src/Infrastructure/XFramework.Integration/Security/ServiceIdentityOptions.cs
@@ -6,6 +6,8 @@ public sealed class ServiceIdentityOptions
 {
     public const string SectionName = "ServiceIdentity";
 
+    public string? Authority { get; set; }
+    public bool AllowInsecureHttp { get; set; }
     public string? ClientId { get; set; }
     public string? GenerationId { get; set; }
     public string? ClientSecret { get; set; }
@@ -42,6 +44,43 @@ public sealed class ServiceIdentityOptions
             fallback,
             nowUtc);
     }
+
+    public Uri ResolveAuthority()
+    {
+        if (string.IsNullOrWhiteSpace(Authority) ||
+            !Uri.TryCreate(Authority.Trim(), UriKind.Absolute, out var authority))
+        {
+            throw new InvalidOperationException(
+                $"{SectionName}:Authority must be a valid absolute HTTP or HTTPS URI.");
+        }
+
+        if (!string.IsNullOrEmpty(authority.UserInfo) ||
+            !string.IsNullOrEmpty(authority.Query) ||
+            !string.IsNullOrEmpty(authority.Fragment) ||
+            authority.AbsolutePath is not ("" or "/"))
+        {
+            throw new InvalidOperationException(
+                $"{SectionName}:Authority must be an origin without user information, a path, a query, or a fragment.");
+        }
+
+        if (string.Equals(authority.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            return authority;
+
+        if (string.Equals(authority.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+            AllowInsecureHttp)
+        {
+            return authority;
+        }
+
+        if (string.Equals(authority.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"{SectionName}:Authority must use HTTPS unless {SectionName}:AllowInsecureHttp is explicitly true.");
+        }
+
+        throw new InvalidOperationException(
+            $"{SectionName}:Authority must use the HTTP or HTTPS scheme.");
+    }
 }
 
 public sealed class ServiceIdentityValidationFallbackOptions
@@ -58,6 +97,10 @@ public sealed class ServiceIdentityOptionsValidator(TimeProvider timeProvider)
     {
         try
         {
+            if (string.IsNullOrWhiteSpace(options.ClientId))
+                return ValidateOptionsResult.Fail($"{ServiceIdentityOptions.SectionName}:ClientId is required.");
+
+            options.ResolveAuthority();
             options.ValidateClientCredential(timeProvider.GetUtcNow());
             return ValidateOptionsResult.Success;
         }

--- a/src/Infrastructure/XFramework.Integration/XFramework.Integration.csproj
+++ b/src/Infrastructure/XFramework.Integration/XFramework.Integration.csproj
@@ -38,6 +38,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
         <PackageReference Include="System.Net.Http.Json" />

--- a/src/Kernel/XFramework.Core/Extensions/InstallerExtensions.cs
+++ b/src/Kernel/XFramework.Core/Extensions/InstallerExtensions.cs
@@ -129,7 +129,7 @@ public static class InstallerExtensions
                 {
                     OnMessageReceived = context =>
                     {
-                        var accessToken = BoltAccessTokenRedactionMiddleware.TakeAccessToken(context.HttpContext)
+                        var accessToken = BoltAccessTokenRedactionMiddleware.GetAccessToken(context.HttpContext)
                             ?? context.Request.Query["access_token"].ToString();
                         var path = context.HttpContext.Request.Path;
                         if (!string.IsNullOrWhiteSpace(accessToken)

--- a/src/Kernel/XFramework.Core/Middlewares/BoltAccessTokenRedactionMiddleware.cs
+++ b/src/Kernel/XFramework.Core/Middlewares/BoltAccessTokenRedactionMiddleware.cs
@@ -39,14 +39,13 @@ public sealed class BoltAccessTokenRedactionMiddleware(RequestDelegate next)
         }
     }
 
-    internal static string? TakeAccessToken(HttpContext context)
+    public static string? GetAccessToken(HttpContext context)
     {
         if (!context.Items.TryGetValue(AccessTokenItemKey, out var value))
         {
             return null;
         }
 
-        context.Items.Remove(AccessTokenItemKey);
         return value as string;
     }
 

--- a/src/Libraries/Bolt/Bolt.Client/BoltClientExtensions.cs
+++ b/src/Libraries/Bolt/Bolt.Client/BoltClientExtensions.cs
@@ -13,6 +13,7 @@ public class BoltClientBuilder
     internal BoltClientOptions Options { get; } = new();
     internal readonly List<(string Command, Func<ReadOnlyMemory<byte>, Guid, Task<(System.Net.HttpStatusCode, ReadOnlyMemory<byte>)>> Handler)> Handlers = [];
     internal readonly List<(string Command, Func<BoltStream, Task> Handler)> StreamHandlers = [];
+    internal Func<IServiceProvider, CancellationToken, ValueTask<string?>>? ServiceProviderAccessTokenProvider { get; private set; }
     internal bool AutoConnect { get; private set; } = true;
 
     /// <summary>Set the Bolt server URI. Required.</summary>
@@ -60,14 +61,45 @@ public class BoltClientBuilder
     public BoltClientBuilder WithAccessToken(string? accessToken)
     {
         Options.AccessToken = accessToken;
+        Options.AccessTokenProvider = null;
+        ServiceProviderAccessTokenProvider = null;
         return this;
     }
 
     /// <summary>Use a per-connection bearer token provider for Bolt handshakes.</summary>
     public BoltClientBuilder WithAccessTokenProvider(Func<CancellationToken, ValueTask<string?>> provider)
     {
+        ArgumentNullException.ThrowIfNull(provider);
+        Options.AccessToken = null;
+        ServiceProviderAccessTokenProvider = null;
         Options.AccessTokenProvider = provider;
         return this;
+    }
+
+    /// <summary>
+    /// Use a DI-aware per-connection bearer token provider for Bolt handshakes.
+    /// The callback and its dependencies are resolved only when a connection requests a token.
+    /// </summary>
+    public BoltClientBuilder WithAccessTokenProvider(
+        Func<IServiceProvider, CancellationToken, ValueTask<string?>> provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        Options.AccessToken = null;
+        Options.AccessTokenProvider = null;
+        ServiceProviderAccessTokenProvider = provider;
+        return this;
+    }
+
+    /// <summary>
+    /// Resolve a DI service only when a connection requests a bearer token.
+    /// </summary>
+    public BoltClientBuilder WithAccessTokenProvider<TProvider>(
+        Func<TProvider, CancellationToken, ValueTask<string?>> provider)
+        where TProvider : notnull
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        return WithAccessTokenProvider((serviceProvider, ct) =>
+            provider(serviceProvider.GetRequiredService<TProvider>(), ct));
     }
 
     /// <summary>Send the bearer token as ?access_token= for browser WebSocket clients.</summary>
@@ -126,7 +158,17 @@ public static class BoltClientExtensions
         services.AddSingleton(sp =>
         {
             var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<BoltClient>();
-            var client = new BoltClient(builder.ServerUri, builder.ClientId, builder.ClientName, builder.Options, logger);
+            var options = builder.Options.Clone();
+            if (builder.ServiceProviderAccessTokenProvider is { } accessTokenProvider)
+            {
+                options.AccessTokenProvider = async ct =>
+                {
+                    await using var scope = sp.CreateAsyncScope();
+                    return await accessTokenProvider(scope.ServiceProvider, ct);
+                };
+            }
+
+            var client = new BoltClient(builder.ServerUri, builder.ClientId, builder.ClientName, options, logger);
 
             foreach (var (cmd, handler) in builder.Handlers)
                 client.RegisterHandler(cmd, handler);

--- a/src/Libraries/Bolt/Bolt.Client/BoltClientOptions.cs
+++ b/src/Libraries/Bolt/Bolt.Client/BoltClientOptions.cs
@@ -9,6 +9,13 @@ namespace Bolt.Client;
 /// </summary>
 public class BoltClientOptions
 {
+    internal BoltClientOptions Clone()
+    {
+        var clone = (BoltClientOptions)MemberwiseClone();
+        clone.PreferredTransports = [.. PreferredTransports];
+        return clone;
+    }
+
     /// <summary>
     /// Preferred transport order. The negotiator tries each in sequence, using the first
     /// that succeeds. Transports unavailable on the current platform are auto-skipped.

--- a/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceIdentity/ServiceIdentityContracts.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Domain.Shared/Contracts/ServiceIdentity/ServiceIdentityContracts.cs
@@ -6,8 +6,7 @@ using XFramework.Domain.Shared.Contracts.Requests;
 namespace XFramework.Domain.Shared.ServiceIdentity;
 
 [MemoryPackable]
-public partial record IssueServiceTokenRequest : RequestBase,
-    IBoltRequest<IssueServiceTokenRequest, QueryResponse<ServiceTokenResponse>>
+public partial record IssueServiceTokenRequest : RequestBase
 {
     [MemoryPackOrder(1)] public string ClientId { get; set; } = string.Empty;
     [MemoryPackOrder(2)] public string ClientSecret { get; set; } = string.Empty;

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Configurations/BoltTransportAuthentication.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Configurations/BoltTransportAuthentication.cs
@@ -1,0 +1,15 @@
+namespace Bolt.Hub.Configurations;
+
+public sealed class BoltTransportAuthentication
+{
+    public const string SectionName = nameof(BoltTransportAuthentication);
+    public const string Scheme = "BoltTransportBearer";
+    public const string ExpectedIssuer = "XFramework.IdentityServer";
+    public const string ExpectedAudience = "XFramework.Bolt.Hub";
+    public const string ExpectedTokenType = "bolt+jwt";
+
+    public string MetadataAddress { get; set; } = string.Empty;
+    public string Issuer { get; set; } = ExpectedIssuer;
+    public string Audience { get; set; } = ExpectedAudience;
+    public bool RequireHttpsMetadata { get; set; } = true;
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Extensions/ApplicationBuilderExtension.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Extensions/ApplicationBuilderExtension.cs
@@ -18,7 +18,7 @@ public static class ApplicationBuilderExtension
 
         // Bolt thin-protocol WebSocket endpoint
         app.UseWebSockets();
-        app.MapBolt("/bolt/ws").RequireAuthorization();
+        app.MapBolt("/bolt/ws").RequireAuthorization(BoltAuthorizationPolicies.Transport);
 
         if (app.Configuration.GetValue<bool>("BoltServiceDiscovery:ExposeHttpEndpoints"))
         {

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Health/BoltTransportIdentityHealthCheck.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Health/BoltTransportIdentityHealthCheck.cs
@@ -1,0 +1,61 @@
+using Bolt.Hub.Configurations;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Bolt.Hub.Health;
+
+public sealed class BoltTransportIdentityHealthCheck(
+    IOptionsMonitor<JwtBearerOptions> bearerOptions) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var options = bearerOptions.Get(BoltTransportAuthentication.Scheme);
+            var configurationManager = options.ConfigurationManager;
+            if (configurationManager is null)
+                return HealthCheckResult.Unhealthy("Bolt transport metadata manager is unavailable.");
+
+            var configuration = await configurationManager.GetConfigurationAsync(cancellationToken);
+            if (!string.Equals(
+                    configuration.Issuer,
+                    BoltTransportAuthentication.ExpectedIssuer,
+                    StringComparison.Ordinal))
+            {
+                return HealthCheckResult.Unhealthy("Bolt transport metadata issuer is invalid.");
+            }
+
+            var hasRsaSigningKey = configuration.SigningKeys.Any(static key => key switch
+            {
+                RsaSecurityKey rsa => rsa.KeySize >= 2048,
+                JsonWebKey jsonWebKey =>
+                    string.Equals(jsonWebKey.Kty, JsonWebAlgorithmsKeyTypes.RSA, StringComparison.Ordinal) &&
+                    string.Equals(jsonWebKey.Use, "sig", StringComparison.Ordinal) &&
+                    string.Equals(jsonWebKey.Alg, SecurityAlgorithms.RsaSha256, StringComparison.Ordinal) &&
+                    !string.IsNullOrWhiteSpace(jsonWebKey.Kid) &&
+                    !string.IsNullOrWhiteSpace(jsonWebKey.N) &&
+                    !string.IsNullOrWhiteSpace(jsonWebKey.E) &&
+                    jsonWebKey.KeySize >= 2048,
+                _ => false
+            });
+
+            return hasRsaSigningKey
+                ? HealthCheckResult.Healthy("Bolt transport identity metadata is available.")
+                : HealthCheckResult.Unhealthy("Bolt transport metadata contains no usable RSA signing key.");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            return HealthCheckResult.Unhealthy(
+                "Bolt transport identity metadata could not be resolved.",
+                exception);
+        }
+    }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/BoltInstaller.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/BoltInstaller.cs
@@ -59,11 +59,19 @@ public sealed class BoltInstaller : IInstaller
         services.AddSingleton<IBoltServicePresenceTracker, BoltServicePresenceTracker>();
         services.AddScoped<IBoltServiceDiscoveryRegistry, BoltServiceDiscoveryRegistry>();
         services.AddHostedService<BoltServiceDiscoveryHostedService>();
-        services.AddAuthorization(BoltAuthorizationPolicies.AddServiceDiscoveryReaderPolicy);
+        services.AddAuthorization(options =>
+        {
+            BoltAuthorizationPolicies.AddTransportPolicy(options);
+            BoltAuthorizationPolicies.AddServiceDiscoveryReaderPolicy(options);
+        });
         services.AddHealthChecks().AddCheck<BoltTransportHealthCheck>(
             "Bolt-transport",
             failureStatus: HealthStatus.Unhealthy,
             tags: ["bolt", "transport", "ready"]);
+        services.AddHealthChecks().AddCheck<BoltTransportIdentityHealthCheck>(
+            "Bolt-transport-identity",
+            failureStatus: HealthStatus.Unhealthy,
+            tags: ["bolt", "identity", "ready"]);
 
         // Durable queue store (Redis required outside Development)
         services.Configure<Bolt.Server.Durable.DurableQueueOptions>(configuration.GetSection("BoltConfiguration:Durable"));

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/BoltTransportAuthenticationInstaller.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Installers/BoltTransportAuthenticationInstaller.cs
@@ -1,0 +1,144 @@
+using Bolt.Hub.Configurations;
+using XFramework.Core.Middlewares;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using XFramework.Domain.Shared.Interfaces;
+
+namespace Bolt.Hub.Installers;
+
+public sealed class BoltTransportAuthenticationInstaller : IInstaller
+{
+    private static readonly TimeSpan ClockSkew = TimeSpan.FromSeconds(30);
+
+    public void InstallServices<TApp>(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment)
+    {
+        var authentication = new BoltTransportAuthentication();
+        configuration.GetSection(BoltTransportAuthentication.SectionName).Bind(authentication);
+        Validate(authentication);
+
+        services.AddSingleton(authentication);
+        services.AddAuthentication()
+            .AddJwtBearer(
+                BoltTransportAuthentication.Scheme,
+                options => ConfigureBearer(options, authentication));
+    }
+
+    private static void ConfigureBearer(
+        JwtBearerOptions options,
+        BoltTransportAuthentication authentication)
+    {
+        options.Authority = null;
+        options.Audience = authentication.Audience;
+        options.MetadataAddress = authentication.MetadataAddress;
+        options.RequireHttpsMetadata = authentication.RequireHttpsMetadata;
+        options.RefreshOnIssuerKeyNotFound = true;
+        options.MapInboundClaims = false;
+        options.SaveToken = true;
+        options.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = context =>
+            {
+                var accessToken = BoltAccessTokenRedactionMiddleware.GetAccessToken(context.HttpContext)
+                    ?? context.Request.Query["access_token"].ToString();
+                if (!string.IsNullOrWhiteSpace(accessToken) &&
+                    context.HttpContext.Request.Path.StartsWithSegments("/bolt/ws"))
+                {
+                    context.Token = accessToken;
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            AudienceValidator = (audiences, _, _) =>
+                HasExactAudience(audiences, authentication.Audience),
+            ClockSkew = ClockSkew,
+            IssuerValidator = (issuer, _, _) =>
+                ValidateIssuer(issuer, authentication.Issuer),
+            RequireAudience = true,
+            RequireExpirationTime = true,
+            RequireSignedTokens = true,
+            TryAllIssuerSigningKeys = true,
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidateIssuerSigningKey = true,
+            ValidateLifetime = true,
+            ValidAlgorithms = [SecurityAlgorithms.RsaSha256],
+            ValidAudience = authentication.Audience,
+            ValidIssuer = authentication.Issuer,
+            ValidTypes = [BoltTransportAuthentication.ExpectedTokenType]
+        };
+    }
+
+    private static bool HasExactAudience(IEnumerable<string>? audiences, string expectedAudience)
+    {
+        if (audiences is null)
+            return false;
+
+        using var enumerator = audiences.GetEnumerator();
+        return enumerator.MoveNext() &&
+               string.Equals(enumerator.Current, expectedAudience, StringComparison.Ordinal) &&
+               !enumerator.MoveNext();
+    }
+
+    private static string ValidateIssuer(string? issuer, string expectedIssuer)
+    {
+        if (!string.Equals(issuer, expectedIssuer, StringComparison.Ordinal))
+        {
+            throw new SecurityTokenInvalidIssuerException(
+                $"Bolt transport token issuer must be '{expectedIssuer}'.");
+        }
+
+        return expectedIssuer;
+    }
+
+    private static void Validate(BoltTransportAuthentication authentication)
+    {
+        if (string.IsNullOrWhiteSpace(authentication.MetadataAddress))
+        {
+            throw new InvalidOperationException(
+                $"{BoltTransportAuthentication.SectionName}:MetadataAddress is required.");
+        }
+
+        authentication.MetadataAddress = authentication.MetadataAddress.Trim();
+        if (!Uri.TryCreate(authentication.MetadataAddress, UriKind.Absolute, out var metadataUri) ||
+            (!string.Equals(metadataUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+             !string.Equals(metadataUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"{BoltTransportAuthentication.SectionName}:MetadataAddress must be an absolute HTTP or HTTPS URI.");
+        }
+
+        if (metadataUri.Scheme == Uri.UriSchemeHttp && authentication.RequireHttpsMetadata)
+        {
+            throw new InvalidOperationException(
+                $"{BoltTransportAuthentication.SectionName}:MetadataAddress must use HTTPS unless " +
+                $"{BoltTransportAuthentication.SectionName}:RequireHttpsMetadata is explicitly configured as false.");
+        }
+
+        if (!string.Equals(
+                authentication.Issuer,
+                BoltTransportAuthentication.ExpectedIssuer,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"{BoltTransportAuthentication.SectionName}:Issuer must be " +
+                $"'{BoltTransportAuthentication.ExpectedIssuer}'.");
+        }
+
+        if (!string.Equals(
+                authentication.Audience,
+                BoltTransportAuthentication.ExpectedAudience,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"{BoltTransportAuthentication.SectionName}:Audience must be " +
+                $"'{BoltTransportAuthentication.ExpectedAudience}'.");
+        }
+    }
+}

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/Security/BoltAuthorizationPolicies.cs
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/Security/BoltAuthorizationPolicies.cs
@@ -1,16 +1,31 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using System.Security.Claims;
+using Bolt.Hub.Configurations;
 using XFramework.Domain.Shared.ServiceIdentity;
 
 namespace Bolt.Hub.Security;
 
 public static class BoltAuthorizationPolicies
 {
+    public const string Transport = "BoltTransport";
     public const string ServiceDiscoveryReader = "BoltServiceDiscoveryReader";
+
+    public static void AddTransportPolicy(AuthorizationOptions options) =>
+        options.AddPolicy(Transport, policy =>
+        {
+            policy.AddAuthenticationSchemes(BoltTransportAuthentication.Scheme);
+            policy.RequireAuthenticatedUser();
+            policy.RequireAssertion(context =>
+                HasScope(context.User, XFrameworkServiceScopes.BoltService));
+        });
 
     public static void AddServiceDiscoveryReaderPolicy(AuthorizationOptions options) =>
         options.AddPolicy(ServiceDiscoveryReader, policy =>
         {
+            policy.AddAuthenticationSchemes(
+                JwtBearerDefaults.AuthenticationScheme,
+                BoltTransportAuthentication.Scheme);
             policy.RequireAuthenticatedUser();
             policy.RequireAssertion(context => IsServiceDiscoveryReader(context.User));
         });

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Development.json
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Development.json
@@ -31,6 +31,12 @@
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },
+  "BoltTransportAuthentication": {
+    "MetadataAddress": "http://localhost:8261/.well-known/openid-configuration",
+    "Issuer": "XFramework.IdentityServer",
+    "Audience": "XFramework.Bolt.Hub",
+    "RequireHttpsMetadata": false
+  },
   "BoltConfiguration": {
     "QueueDepth": 256,
     "QueueMessages": true,

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Docker.json
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Docker.json
@@ -5,6 +5,11 @@
   "Seq": {
     "Url": "http://seq:80"
   },
+  "BoltTransportAuthentication": {
+    "MetadataAddress": "https://identityserver:8443/.well-known/openid-configuration",
+    "Issuer": "XFramework.IdentityServer",
+    "Audience": "XFramework.Bolt.Hub"
+  },
   "BoltConfiguration": {
     "MediaEnabled": false,
     "MaxFrameBytes": 8388608,

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Staging.json
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.Staging.json
@@ -28,6 +28,11 @@
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },
+  "BoltTransportAuthentication": {
+    "MetadataAddress": "https://identityserver:8443/.well-known/openid-configuration",
+    "Issuer": "XFramework.IdentityServer",
+    "Audience": "XFramework.Bolt.Hub"
+  },
   "BoltConfiguration": {
     "QueueDepth": 256,
     "QueueMessages": true,

--- a/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.json
+++ b/src/Modules/XFramework.Bolt/Bolt.Hub/appsettings.json
@@ -28,6 +28,11 @@
     "AccessTokenLifespan": "00:30:00",
     "RefreshTokenLifespan": "00:30:00"
   },
+  "BoltTransportAuthentication": {
+    "MetadataAddress": "https://localhost:8262/.well-known/openid-configuration",
+    "Issuer": "XFramework.IdentityServer",
+    "Audience": "XFramework.Bolt.Hub"
+  },
   "BoltConfiguration": {
     "QueueDepth": 256,
     "QueueMessages": true,

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/GetBoltTransportJwks/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/GetBoltTransportJwks/Endpoint.cs
@@ -1,0 +1,21 @@
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.ServiceIdentity.GetBoltTransportJwks;
+
+public static class GetBoltTransportJwksEndpoint
+{
+    [MapGet("/.well-known/bolt-transport-jwks.json", Tags = ["Service Identity"],
+        Summary = "Get Bolt transport signing keys",
+        Description = "Returns the public RSA key used to validate Bolt transport JWTs.",
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<BoltTransportJsonWebKeySet>> Handle(
+        GetBoltTransportJwksRequest request,
+        IBoltTransportTokenSigner signer,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(Result<BoltTransportJsonWebKeySet>.Success(signer.GetJsonWebKeySet()));
+    }
+}
+
+public sealed class GetBoltTransportJwksRequest;

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/GetBoltTransportMetadata/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/GetBoltTransportMetadata/Endpoint.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+using XFramework.Integration.Attributes;
+
+namespace IdentityServer.Api.Features.ServiceIdentity.GetBoltTransportMetadata;
+
+public static class GetBoltTransportMetadataEndpoint
+{
+    [MapGet("/.well-known/openid-configuration", Tags = ["Service Identity"],
+        Summary = "Get Bolt transport token metadata",
+        Description = "Returns public issuer and signing-key discovery metadata for Bolt transport JWT validation.",
+        ExcludeFromOpenApi = true)]
+    public static Task<Result<BoltTransportMetadataResponse>> Handle(
+        GetBoltTransportMetadataRequest request,
+        ServiceIdentityConfiguration configuration,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (configuration.BoltTransportDiscoveryAuthority is not { } authority)
+        {
+            return Task.FromResult(Result<BoltTransportMetadataResponse>.Failure(
+                "Bolt transport token discovery is unavailable",
+                503));
+        }
+
+        return Task.FromResult(Result<BoltTransportMetadataResponse>.Success(new BoltTransportMetadataResponse
+        {
+            Issuer = configuration.Issuer,
+            JsonWebKeySetUri = new Uri(authority, BoltTransportTokenConstants.JsonWebKeySetPath).AbsoluteUri,
+            TokenEndpoint = new Uri(authority, BoltTransportTokenConstants.TokenEndpointPath).AbsoluteUri,
+            SigningAlgorithms = [BoltTransportTokenConstants.Algorithm]
+        }));
+    }
+}
+
+public sealed class GetBoltTransportMetadataRequest;
+
+public sealed record BoltTransportMetadataResponse
+{
+    [JsonPropertyName("issuer")]
+    public required string Issuer { get; init; }
+
+    [JsonPropertyName("jwks_uri")]
+    public required string JsonWebKeySetUri { get; init; }
+
+    [JsonPropertyName("token_endpoint")]
+    public required string TokenEndpoint { get; init; }
+
+    [JsonPropertyName("id_token_signing_alg_values_supported")]
+    public required IReadOnlyList<string> SigningAlgorithms { get; init; }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/IssueBoltTransportToken/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/IssueBoltTransportToken/Endpoint.cs
@@ -13,10 +13,11 @@ public static class IssueBoltTransportTokenEndpoint
     public static async Task<Result<ServiceTokenResponse>> Handle(
         IssueBoltTransportTokenRequest request,
         HttpRequest httpRequest,
+        ServiceIdentityConfiguration configuration,
         IServiceIdentityService serviceIdentityService,
         CancellationToken ct)
     {
-        if (!httpRequest.IsHttps)
+        if (!configuration.AllowInsecureHttp && !httpRequest.IsHttps)
             return Result<ServiceTokenResponse>.Failure("HTTPS is required", 400);
 
         return await serviceIdentityService.IssueBoltTransportTokenAsync(

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/IssueToken/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/IssueToken/Endpoint.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
@@ -5,16 +6,20 @@ namespace IdentityServer.Api.Features.ServiceIdentity.IssueToken;
 
 public static class IssueServiceTokenEndpoint
 {
-    [BoltHandler]
     [MapPost("/api/service-identity/token", Tags = ["Service Identity"],
         Summary = "Issue service token",
         Description = "Issues a short-lived internal service token for a target XFramework service.",
         ExcludeFromOpenApi = true)]
     public static async Task<Result<ServiceTokenResponse>> Handle(
         IssueServiceTokenRequest request,
+        HttpRequest httpRequest,
+        ServiceIdentityConfiguration configuration,
         IServiceIdentityService serviceIdentityService,
         CancellationToken ct)
     {
+        if (!configuration.AllowInsecureHttp && !httpRequest.IsHttps)
+            return Result<ServiceTokenResponse>.Failure("HTTPS is required", 400);
+
         return await serviceIdentityService.IssueTokenAsync(request, ct);
     }
 }

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Installers/WrapperInstaller.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Installers/WrapperInstaller.cs
@@ -7,7 +7,10 @@ public class WrapperInstaller : IInstaller
 {
     public virtual void InstallServices<TApp>(IServiceCollection services, IConfiguration configuration, IHostEnvironment hostEnvironment)
     {
-        services.AddXFrameworkBoltClient(configuration, hostEnvironment: hostEnvironment);
+        services.AddXFrameworkBoltClient(
+            configuration,
+            connectAfterApplicationStarted: true,
+            hostEnvironment: hostEnvironment);
         services.AddSingleton<ICommunicationsServiceWrapper, CommunicationsServiceWrapper>();
     }
 }

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Program.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddScoped<IServiceIdentityService, ServiceIdentityService>();
 builder.Services.AddSingleton(serviceProvider => ServiceIdentityConfiguration.FromConfiguration(
     serviceProvider.GetRequiredService<IConfiguration>(),
     serviceProvider.GetRequiredService<TimeProvider>().GetUtcNow()));
+builder.Services.AddSingleton<IBoltTransportTokenSigner, FileBackedBoltTransportTokenSigner>();
 builder.Services.AddSingleton<IIdentitySigningKeyProvider, IdentityServerLocalSigningKeyProvider>();
 
 // Register FluentValidation validators from this assembly
@@ -45,7 +46,9 @@ builder.Services.AddOpenApi("v1", options =>
 });
 
 var app = (WebApplication)builder.Build();
-_ = app.Services.GetRequiredService<ServiceIdentityConfiguration>();
+var serviceIdentityConfiguration = app.Services.GetRequiredService<ServiceIdentityConfiguration>();
+if (serviceIdentityConfiguration.BoltTransportTokenIssuerEnabled)
+    _ = app.Services.GetRequiredService<IBoltTransportTokenSigner>();
 
 app.UseCorrelationId();
 app.UseXFrameworkRateLimiting();

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/BoltTransportTokenSigner.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/BoltTransportTokenSigner.cs
@@ -1,0 +1,223 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Json.Serialization;
+using Microsoft.IdentityModel.Tokens;
+using XFramework.Domain.Shared.ServiceIdentity;
+
+namespace IdentityServer.Api.Services;
+
+public static class BoltTransportTokenConstants
+{
+    public const string Algorithm = SecurityAlgorithms.RsaSha256;
+    public const string Audience = XFrameworkServiceNames.BoltHub;
+    public const string Scope = XFrameworkServiceScopes.BoltService;
+    public const string TokenType = "bolt+jwt";
+    public const string MetadataPath = "/.well-known/openid-configuration";
+    public const string JsonWebKeySetPath = "/.well-known/bolt-transport-jwks.json";
+    public const string TokenEndpointPath = "/api/service-identity/bolt-transport-token";
+}
+
+public interface IBoltTransportTokenSigner
+{
+    string KeyId { get; }
+
+    string Sign(
+        string clientId,
+        string clientCredentialGenerationId,
+        DateTimeOffset issuedAtUtc,
+        DateTimeOffset expiresAtUtc);
+
+    BoltTransportJsonWebKeySet GetJsonWebKeySet();
+}
+
+public sealed class FileBackedBoltTransportTokenSigner : IBoltTransportTokenSigner
+{
+    private const int KeySizeBits = 3072;
+    private static readonly JwtSecurityTokenHandler TokenHandler = new();
+    private readonly SigningCredentials? _signingCredentials;
+    private readonly BoltTransportJsonWebKey? _publicKey;
+    private readonly ServiceIdentityConfiguration _configuration;
+
+    public FileBackedBoltTransportTokenSigner(ServiceIdentityConfiguration configuration)
+    {
+        _configuration = configuration;
+        var signingKeyPath = configuration.BoltTransportSigningKeyPath;
+        if (string.IsNullOrWhiteSpace(signingKeyPath))
+            return;
+
+        var privateKeyParameters = LoadOrCreatePrivateKey(signingKeyPath);
+        using var rsa = RSA.Create();
+        rsa.ImportParameters(privateKeyParameters);
+        var publicParameters = rsa.ExportParameters(includePrivateParameters: false);
+
+        KeyId = $"bolt-{Base64UrlEncoder.Encode(SHA256.HashData(rsa.ExportSubjectPublicKeyInfo()))}";
+        _signingCredentials = new SigningCredentials(
+            new RsaSecurityKey(privateKeyParameters) { KeyId = KeyId },
+            BoltTransportTokenConstants.Algorithm);
+        _publicKey = new BoltTransportJsonWebKey
+        {
+            KeyType = "RSA",
+            Use = "sig",
+            KeyId = KeyId,
+            Algorithm = BoltTransportTokenConstants.Algorithm,
+            Modulus = Base64UrlEncoder.Encode(publicParameters.Modulus!),
+            Exponent = Base64UrlEncoder.Encode(publicParameters.Exponent!)
+        };
+    }
+
+    public string KeyId { get; } = string.Empty;
+
+    public string Sign(
+        string clientId,
+        string clientCredentialGenerationId,
+        DateTimeOffset issuedAtUtc,
+        DateTimeOffset expiresAtUtc)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientCredentialGenerationId);
+        if (expiresAtUtc <= issuedAtUtc)
+            throw new ArgumentOutOfRangeException(nameof(expiresAtUtc), "Token expiry must be after issuance.");
+        if (_signingCredentials is null)
+        {
+            throw new InvalidOperationException(
+                "Bolt transport signing is unavailable because no signing key path is configured.");
+        }
+
+        List<Claim> claims =
+        [
+            new("client_id", clientId),
+            new("service", clientId),
+            new(JwtRegisteredClaimNames.Sub, clientId),
+            new("scope", BoltTransportTokenConstants.Scope),
+            new("client_credential_generation", clientCredentialGenerationId),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            new(
+                JwtRegisteredClaimNames.Iat,
+                EpochTime.GetIntDate(issuedAtUtc.UtcDateTime).ToString(),
+                ClaimValueTypes.Integer64)
+        ];
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration.Issuer,
+            audience: BoltTransportTokenConstants.Audience,
+            claims: claims,
+            notBefore: issuedAtUtc.UtcDateTime,
+            expires: expiresAtUtc.UtcDateTime,
+            signingCredentials: _signingCredentials);
+        token.Header["typ"] = BoltTransportTokenConstants.TokenType;
+
+        return TokenHandler.WriteToken(token);
+    }
+
+    public BoltTransportJsonWebKeySet GetJsonWebKeySet() => new()
+    {
+        Keys = _publicKey is null ? [] : [_publicKey]
+    };
+
+    private static RSAParameters LoadOrCreatePrivateKey(string signingKeyPath)
+    {
+        var directoryPath = Path.GetDirectoryName(signingKeyPath)
+            ?? throw new InvalidOperationException("Bolt transport signing key path must include a directory.");
+        Directory.CreateDirectory(directoryPath);
+
+        if (!File.Exists(signingKeyPath))
+            CreatePrivateKeyAtomically(signingKeyPath, directoryPath);
+
+        RestrictUnixFilePermissions(signingKeyPath);
+        var privateKeyPem = File.ReadAllText(signingKeyPath, Encoding.ASCII);
+        using var rsa = RSA.Create();
+        try
+        {
+            rsa.ImportFromPem(privateKeyPem);
+        }
+        catch (CryptographicException exception)
+        {
+            throw new InvalidOperationException("Bolt transport signing key is not a valid RSA PEM private key.", exception);
+        }
+
+        if (rsa.KeySize != KeySizeBits)
+        {
+            throw new InvalidOperationException(
+                $"Bolt transport signing key must be RSA-{KeySizeBits}; configured key is RSA-{rsa.KeySize}.");
+        }
+
+        return rsa.ExportParameters(includePrivateParameters: true);
+    }
+
+    private static void CreatePrivateKeyAtomically(string signingKeyPath, string directoryPath)
+    {
+        using var rsa = RSA.Create(KeySizeBits);
+        var privateKeyBytes = Encoding.ASCII.GetBytes(rsa.ExportPkcs8PrivateKeyPem());
+        var temporaryPath = Path.Combine(
+            directoryPath,
+            $".{Path.GetFileName(signingKeyPath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            var streamOptions = new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None
+            };
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() || OperatingSystem.IsFreeBSD())
+                streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+            using (var stream = new FileStream(temporaryPath, streamOptions))
+            {
+                stream.Write(privateKeyBytes);
+                stream.Flush(flushToDisk: true);
+            }
+
+            RestrictUnixFilePermissions(temporaryPath);
+            try
+            {
+                File.Move(temporaryPath, signingKeyPath, overwrite: false);
+            }
+            catch (IOException) when (File.Exists(signingKeyPath))
+            {
+                // Another process won the atomic create. Its complete key is loaded below.
+            }
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(privateKeyBytes);
+            if (File.Exists(temporaryPath))
+                File.Delete(temporaryPath);
+        }
+    }
+
+    private static void RestrictUnixFilePermissions(string path)
+    {
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() || OperatingSystem.IsFreeBSD())
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+}
+
+public sealed record BoltTransportJsonWebKeySet
+{
+    [JsonPropertyName("keys")]
+    public required IReadOnlyList<BoltTransportJsonWebKey> Keys { get; init; }
+}
+
+public sealed record BoltTransportJsonWebKey
+{
+    [JsonPropertyName("kty")]
+    public required string KeyType { get; init; }
+
+    [JsonPropertyName("use")]
+    public required string Use { get; init; }
+
+    [JsonPropertyName("kid")]
+    public required string KeyId { get; init; }
+
+    [JsonPropertyName("alg")]
+    public required string Algorithm { get; init; }
+
+    [JsonPropertyName("n")]
+    public required string Modulus { get; init; }
+
+    [JsonPropertyName("e")]
+    public required string Exponent { get; init; }
+}

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityConfiguration.cs
@@ -14,14 +14,20 @@ public sealed class ServiceIdentityConfiguration
     private ServiceIdentityConfiguration(
         string issuer,
         int tokenLifetimeMinutes,
+        bool allowInsecureHttp,
+        Uri? boltTransportDiscoveryAuthority,
         bool boltTransportTokenIssuerEnabled,
         int boltTransportTokenLifetimeSeconds,
+        string? boltTransportSigningKeyPath,
         IReadOnlyDictionary<string, ServiceClientDefinition> clients)
     {
         Issuer = issuer;
         TokenLifetimeMinutes = tokenLifetimeMinutes;
+        AllowInsecureHttp = allowInsecureHttp;
+        BoltTransportDiscoveryAuthority = boltTransportDiscoveryAuthority;
         BoltTransportTokenIssuerEnabled = boltTransportTokenIssuerEnabled;
         BoltTransportTokenLifetimeSeconds = boltTransportTokenLifetimeSeconds;
+        BoltTransportSigningKeyPath = boltTransportSigningKeyPath;
         _clients = clients;
         ValidationGenerationIdsByClient = clients.ToDictionary(
             static pair => pair.Key,
@@ -31,8 +37,11 @@ public sealed class ServiceIdentityConfiguration
 
     public string Issuer { get; }
     public int TokenLifetimeMinutes { get; }
+    public bool AllowInsecureHttp { get; }
+    public Uri? BoltTransportDiscoveryAuthority { get; }
     public bool BoltTransportTokenIssuerEnabled { get; }
     public int BoltTransportTokenLifetimeSeconds { get; }
+    public string? BoltTransportSigningKeyPath { get; }
     public IReadOnlyDictionary<string, IReadOnlyList<string>> ValidationGenerationIdsByClient { get; }
 
     internal ServiceClientDefinition? FindClient(string? clientId) =>
@@ -62,6 +71,38 @@ public sealed class ServiceIdentityConfiguration
         if (string.IsNullOrWhiteSpace(issuer))
             issuer = XFrameworkServiceNames.IdentityServer;
 
+        var allowInsecureHttp = configuration.GetValue<bool>("ServiceIdentity:AllowInsecureHttp");
+        var boltTransportTokenIssuerEnabled = configuration.GetValue<bool>(
+            "ServiceIdentity:BoltTransportTokenIssuer:Enabled");
+        var authorityValue = configuration["ServiceIdentity:Authority"]?.Trim();
+        Uri? boltTransportDiscoveryAuthority = null;
+        if (!string.IsNullOrWhiteSpace(authorityValue))
+        {
+            if (!Uri.TryCreate(authorityValue, UriKind.Absolute, out var authority) ||
+                (authority.Scheme != Uri.UriSchemeHttps && authority.Scheme != Uri.UriSchemeHttp) ||
+                !string.IsNullOrEmpty(authority.UserInfo) ||
+                !string.IsNullOrEmpty(authority.Query) ||
+                !string.IsNullOrEmpty(authority.Fragment) ||
+                authority.AbsolutePath is not ("" or "/"))
+            {
+                throw new InvalidOperationException(
+                    "ServiceIdentity:Authority must be an absolute HTTP or HTTPS origin.");
+            }
+
+            if (authority.Scheme == Uri.UriSchemeHttp && !allowInsecureHttp)
+            {
+                throw new InvalidOperationException(
+                    "ServiceIdentity:Authority must use HTTPS unless ServiceIdentity:AllowInsecureHttp is explicitly true.");
+            }
+
+            boltTransportDiscoveryAuthority = authority;
+        }
+
+        if (boltTransportTokenIssuerEnabled && boltTransportDiscoveryAuthority is null)
+        {
+            throw new InvalidOperationException(
+                "ServiceIdentity:Authority is required when Bolt transport token issuance is enabled.");
+        }
         var boltTransportTokenLifetimeSeconds = configuration.GetValue(
             "ServiceIdentity:BoltTransportTokenIssuer:LifetimeSeconds",
             DefaultBoltTransportTokenLifetimeSeconds);
@@ -73,11 +114,25 @@ public sealed class ServiceIdentityConfiguration
                 $"{MinimumBoltTransportTokenLifetimeSeconds} and {MaximumBoltTransportTokenLifetimeSeconds} seconds.");
         }
 
+        var boltTransportSigningKeyPath = configuration[
+            "ServiceIdentity:BoltTransportTokenIssuer:SigningKeyPath"]?.Trim();
+        if (boltTransportTokenIssuerEnabled && string.IsNullOrWhiteSpace(boltTransportSigningKeyPath))
+        {
+            throw new InvalidOperationException(
+                "ServiceIdentity:BoltTransportTokenIssuer:SigningKeyPath is required when Bolt transport token issuance is enabled.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(boltTransportSigningKeyPath))
+            boltTransportSigningKeyPath = Path.GetFullPath(boltTransportSigningKeyPath);
+
         return new ServiceIdentityConfiguration(
             issuer,
             Math.Clamp(configuration.GetValue("ServiceIdentity:TokenLifetimeMinutes", 10), 1, 60),
-            configuration.GetValue<bool>("ServiceIdentity:BoltTransportTokenIssuer:Enabled"),
+            allowInsecureHttp,
+            boltTransportDiscoveryAuthority,
+            boltTransportTokenIssuerEnabled,
             boltTransportTokenLifetimeSeconds,
+            boltTransportSigningKeyPath,
             clients);
     }
 }

--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityService.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityService.cs
@@ -16,7 +16,7 @@ public sealed class ServiceIdentityService(
     IDataContext dataContext,
     IConfiguration configuration,
     ServiceIdentityConfiguration serviceIdentityConfiguration,
-    JwtOptions jwtOptions,
+    IBoltTransportTokenSigner boltTransportTokenSigner,
     TimeProvider timeProvider,
     ILogger<ServiceIdentityService> logger,
     IHttpContextAccessor? httpContextAccessor = null,
@@ -133,34 +133,16 @@ public sealed class ServiceIdentityService(
 
         var issuedAt = DateTimeOffset.FromUnixTimeSeconds(now.ToUnixTimeSeconds()).UtcDateTime;
         var expiresAt = issuedAt.AddSeconds(serviceIdentityConfiguration.BoltTransportTokenLifetimeSeconds);
-        List<Claim> claims =
-        [
-            new("client_id", client.ClientId),
-            new("service", client.ClientId),
-            new(JwtRegisteredClaimNames.Sub, client.ClientId),
-            new("scope", XFrameworkServiceScopes.BoltService),
-            new(JwtCredentialSet.GenerationClaim, jwtOptions.GenerationId.Trim()),
-            new("client_credential_generation", clientCredentialGenerationId!),
-            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
-            new(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(issuedAt).ToString(), ClaimValueTypes.Integer64)
-        ];
-
-        var token = new JwtSecurityToken(
-            issuer: jwtOptions.ValidIssuer,
-            audience: jwtOptions.ValidAudience,
-            claims: claims,
-            notBefore: issuedAt,
-            expires: expiresAt,
-            signingCredentials: new SigningCredentials(
-                JwtCredentialSet.CreateCurrentSigningKey(jwtOptions),
-                SecurityAlgorithms.HmacSha512));
-
-        var accessToken = TokenHandler.WriteToken(token);
+        var accessToken = boltTransportTokenSigner.Sign(
+            client.ClientId,
+            clientCredentialGenerationId!,
+            new DateTimeOffset(issuedAt, TimeSpan.Zero),
+            new DateTimeOffset(expiresAt, TimeSpan.Zero));
         logger.LogDebug(
-            "Issued Bolt transport token. ClientId={ClientId} ClientCredentialGenerationId={ClientCredentialGenerationId} SigningGenerationId={SigningGenerationId} LifetimeSeconds={LifetimeSeconds}",
+            "Issued Bolt transport token. ClientId={ClientId} ClientCredentialGenerationId={ClientCredentialGenerationId} KeyId={KeyId} LifetimeSeconds={LifetimeSeconds}",
             client.ClientId,
             clientCredentialGenerationId,
-            jwtOptions.GenerationId.Trim(),
+            boltTransportTokenSigner.KeyId,
             serviceIdentityConfiguration.BoltTransportTokenLifetimeSeconds);
 
         return Task.FromResult(Result<ServiceTokenResponse>.Success(new ServiceTokenResponse

--- a/src/Shared/XFramework.Domain.Shared/Configurations/BoltConfiguration.cs
+++ b/src/Shared/XFramework.Domain.Shared/Configurations/BoltConfiguration.cs
@@ -14,7 +14,7 @@ public class BoltConfiguration
     public bool Anonymous { get; set; }
     public string? AccessToken { get; set; }
     public bool SendAccessTokenAsQueryString { get; set; }
-    public bool GenerateServiceAccessToken { get; set; } = true;
+    public bool GenerateServiceAccessToken { get; set; }
     public int RpcTimeoutSeconds { get; set; } = 30;
     public int MaxFrameBytes { get; set; } = 8 * 1024 * 1024;
     public int SendQueueCapacity { get; set; }

--- a/src/Tests/Bolt.Tests/BoltClientOptionsTests.cs
+++ b/src/Tests/Bolt.Tests/BoltClientOptionsTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using Bolt.Client;
+using Bolt.Protocol.Transport;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Bolt.Tests;
+
+[TestFixture]
+public sealed class BoltClientOptionsTests
+{
+    [Test]
+    public void Clone_PreferredTransportsArray_IsIsolatedFromSource()
+    {
+        var source = new BoltClientOptions
+        {
+            PreferredTransports = [BoltTransport.Quic, BoltTransport.WebSocket]
+        };
+        var cloneMethod = typeof(BoltClientOptions).GetMethod(
+            "Clone",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        cloneMethod.Should().NotBeNull();
+        var clone = cloneMethod!.Invoke(source, null).Should().BeOfType<BoltClientOptions>().Which;
+
+        clone.PreferredTransports.Should().NotBeSameAs(source.PreferredTransports);
+        clone.PreferredTransports.Should().Equal(source.PreferredTransports);
+
+        clone.PreferredTransports[0] = BoltTransport.WebTransport;
+        source.PreferredTransports[1] = BoltTransport.Quic;
+
+        source.PreferredTransports.Should().Equal(BoltTransport.Quic, BoltTransport.Quic);
+        clone.PreferredTransports.Should().Equal(BoltTransport.WebTransport, BoltTransport.WebSocket);
+    }
+}

--- a/src/Tests/Bolt.Tests/BoltRpcReadinessTests.cs
+++ b/src/Tests/Bolt.Tests/BoltRpcReadinessTests.cs
@@ -9,11 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using NUnit.Framework;
-using XFramework.Domain.Shared.Configurations;
-using XFramework.Domain.Shared.ServiceIdentity;
-using XFramework.Integration.Security;
 
 namespace Bolt.Tests;
 
@@ -21,7 +17,6 @@ namespace Bolt.Tests;
 [CancelAfter(30000)]
 public class BoltRpcReadinessTests
 {
-    private const string ServiceIdentityTestSecret = "bolt-readiness-service-identity-secret-g0";
     private WebApplication _serverApp = null!;
     private ILoggerFactory _loggerFactory = null!;
     private static int _portCounter = 19700;
@@ -422,114 +417,6 @@ public class BoltRpcReadinessTests
             .GetField("_pendingCalls", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(client)!;
         pendingCalls.Should().BeEmpty();
-
-        connection.CompleteSendChannel();
-    }
-
-    [Test]
-    public async Task IdentityServerServiceTokenProvider_WhenTokenRpcNeverCompletes_TimesOutAndClearsInflight()
-    {
-        await using var client = new BoltClient(
-            new Uri($"ws://localhost:{_port}/bolt"),
-            "token_timeout_caller",
-            "TokenTimeoutCaller",
-            new BoltClientOptions { RpcTimeoutSeconds = 30, SendQueueCapacity = 4 },
-            _loggerFactory.CreateLogger<BoltClient>());
-        var connection = new BoltConnection(new NoopBoltConnection(), sendQueueCapacity: 4);
-
-        var connections = (List<BoltConnection>)typeof(BoltClient)
-            .GetField("_connections", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(client)!;
-        connections.Add(connection);
-        typeof(BoltClient)
-            .GetField("_isRegistered", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .SetValue(client, true);
-
-        var provider = new IdentityServerServiceTokenProvider(
-            client,
-            Options.Create(new ServiceIdentityOptions
-            {
-                ClientId = XFrameworkServiceNames.Portal,
-                GenerationId = "test-g0",
-                ClientSecret = ServiceIdentityTestSecret,
-                DefaultScopes = [XFrameworkServiceScopes.IdentityAdmin],
-                TokenAcquisitionTimeoutSeconds = 1
-            }),
-            Options.Create(new BoltConfiguration
-            {
-                ClientName = XFrameworkServiceNames.Portal,
-                RpcTimeoutSeconds = 30
-            }),
-            TimeProvider.System,
-            _loggerFactory.CreateLogger<IdentityServerServiceTokenProvider>());
-
-        var started = DateTime.UtcNow;
-        Func<Task> getToken = async () => await provider.GetTokenAsync(XFrameworkServiceNames.IdentityServer);
-
-        await getToken.Should().ThrowAsync<TimeoutException>();
-        (DateTime.UtcNow - started).Should().BeLessThan(TimeSpan.FromSeconds(5));
-
-        var inflight = (ConcurrentDictionary<string, Lazy<Task<string>>>)typeof(IdentityServerServiceTokenProvider)
-            .GetField("_inflight", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(provider)!;
-        inflight.Should().BeEmpty();
-
-        connection.CompleteSendChannel();
-    }
-
-    [Test]
-    public async Task IdentityServerServiceTokenProvider_WhenCallerCancelsTokenRpc_PreservesSharedAcquisition()
-    {
-        await using var client = new BoltClient(
-            new Uri($"ws://localhost:{_port}/bolt"),
-            "token_cancel_caller",
-            "TokenCancelCaller",
-            new BoltClientOptions { RpcTimeoutSeconds = 30, SendQueueCapacity = 4 },
-            _loggerFactory.CreateLogger<BoltClient>());
-        var connection = new BoltConnection(new NoopBoltConnection(), sendQueueCapacity: 4);
-
-        var connections = (List<BoltConnection>)typeof(BoltClient)
-            .GetField("_connections", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(client)!;
-        connections.Add(connection);
-        typeof(BoltClient)
-            .GetField("_isRegistered", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .SetValue(client, true);
-
-        var provider = new IdentityServerServiceTokenProvider(
-            client,
-            Options.Create(new ServiceIdentityOptions
-            {
-                ClientId = XFrameworkServiceNames.Portal,
-                GenerationId = "test-g0",
-                ClientSecret = ServiceIdentityTestSecret,
-                DefaultScopes = [XFrameworkServiceScopes.IdentityAdmin],
-                TokenAcquisitionTimeoutSeconds = 1
-            }),
-            Options.Create(new BoltConfiguration
-            {
-                ClientName = XFrameworkServiceNames.Portal,
-                RpcTimeoutSeconds = 30
-            }),
-            TimeProvider.System,
-            _loggerFactory.CreateLogger<IdentityServerServiceTokenProvider>());
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(75));
-        Func<Task> getToken = async () => await provider.GetTokenAsync(
-            XFrameworkServiceNames.IdentityServer,
-            ct: cts.Token);
-
-        await getToken.Should().ThrowAsync<OperationCanceledException>();
-
-        var inflight = (ConcurrentDictionary<string, Lazy<Task<string>>>)typeof(IdentityServerServiceTokenProvider)
-            .GetField("_inflight", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(provider)!;
-        inflight.Should().ContainSingle();
-
-        Func<Task> awaitSharedAcquisition = async () =>
-            await provider.GetTokenAsync(XFrameworkServiceNames.IdentityServer);
-        await awaitSharedAcquisition.Should().ThrowAsync<TimeoutException>();
-        inflight.Should().BeEmpty();
 
         connection.CompleteSendChannel();
     }

--- a/src/Tests/Bolt.Tests/BoltServiceDiscoveryHttpEndpointTests.cs
+++ b/src/Tests/Bolt.Tests/BoltServiceDiscoveryHttpEndpointTests.cs
@@ -1,9 +1,11 @@
 using Bolt.Hub.Extensions;
+using Bolt.Hub.Configurations;
 using Bolt.Hub.Security;
 using Bolt.Hub.Services;
 using Bolt.Server;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
@@ -24,7 +26,6 @@ namespace Bolt.Tests;
 [CancelAfter(30000)]
 public sealed class BoltServiceDiscoveryHttpEndpointTests
 {
-    private const string TestScheme = "BoltDiscoveryTest";
     private static int _portCounter = 20300;
     private WebApplication _app = null!;
     private int _port;
@@ -47,8 +48,13 @@ public sealed class BoltServiceDiscoveryHttpEndpointTests
         builder.Services.AddSingleton<IBoltServicePresenceTracker, BoltServicePresenceTracker>();
         builder.Services.AddScoped<IBoltServiceDiscoveryRegistry, BoltServiceDiscoveryRegistry>();
         builder.Services
-            .AddAuthentication(TestScheme)
-            .AddScheme<AuthenticationSchemeOptions, BoltDiscoveryTestAuthHandler>(TestScheme, _ => { });
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddScheme<AuthenticationSchemeOptions, BoltDiscoveryTestAuthHandler>(
+                JwtBearerDefaults.AuthenticationScheme,
+                _ => { })
+            .AddScheme<AuthenticationSchemeOptions, BoltDiscoveryTestAuthHandler>(
+                BoltTransportAuthentication.Scheme,
+                _ => { });
         builder.Services.AddAuthorization(BoltAuthorizationPolicies.AddServiceDiscoveryReaderPolicy);
         builder.Logging.SetMinimumLevel(LogLevel.Warning);
 

--- a/src/Tests/Bolt.Tests/BoltTransportAuthenticationConfigurationTests.cs
+++ b/src/Tests/Bolt.Tests/BoltTransportAuthenticationConfigurationTests.cs
@@ -1,0 +1,191 @@
+using Bolt.Hub.Configurations;
+using Bolt.Hub.Installers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+using XFramework.Core.Extensions;
+
+namespace Bolt.Tests;
+
+[TestFixture]
+public sealed class BoltTransportAuthenticationConfigurationTests
+{
+    private const string MetadataAddress = "https://identity.test/.well-known/openid-configuration";
+
+    [Test]
+    public void InstallServices_MissingMetadataAddress_FailsClosed()
+    {
+        var installer = new BoltTransportAuthenticationInstaller();
+        var services = new ServiceCollection();
+
+        var act = () => installer.InstallServices<BoltTransportAuthenticationConfigurationTests>(
+            services,
+            BuildConfiguration([]),
+            new TestHostEnvironment());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*BoltTransportAuthentication:MetadataAddress*required*");
+    }
+
+    [TestCase("metadata", true)]
+    [TestCase("ftp://identity.test/metadata", true)]
+    [TestCase("http://identity.test/metadata", true)]
+    public void InstallServices_InvalidMetadataAddress_FailsClosed(
+        string metadataAddress,
+        bool requireHttpsMetadata)
+    {
+        var installer = new BoltTransportAuthenticationInstaller();
+        var services = new ServiceCollection();
+        var configuration = BuildTransportConfiguration(
+            metadataAddress,
+            requireHttpsMetadata: requireHttpsMetadata);
+
+        var act = () => installer.InstallServices<BoltTransportAuthenticationConfigurationTests>(
+            services,
+            configuration,
+            new TestHostEnvironment());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*BoltTransportAuthentication:MetadataAddress*");
+    }
+
+    [TestCase("Wrong.Issuer", BoltTransportAuthentication.ExpectedAudience, "Issuer")]
+    [TestCase(BoltTransportAuthentication.ExpectedIssuer, "Wrong.Audience", "Audience")]
+    public void InstallServices_NonCanonicalIssuerOrAudience_FailsClosed(
+        string issuer,
+        string audience,
+        string invalidSetting)
+    {
+        var installer = new BoltTransportAuthenticationInstaller();
+        var services = new ServiceCollection();
+        var configuration = BuildTransportConfiguration(
+            MetadataAddress,
+            issuer: issuer,
+            audience: audience);
+
+        var act = () => installer.InstallServices<BoltTransportAuthenticationConfigurationTests>(
+            services,
+            configuration,
+            new TestHostEnvironment());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*BoltTransportAuthentication:{invalidSetting}*");
+    }
+
+    [Test]
+    public void InstallServices_HttpMetadataExplicitlyAllowed_ConfiguresBearer()
+    {
+        const string httpMetadataAddress = "http://identity.test/.well-known/openid-configuration";
+        var configuration = BuildTransportConfiguration(
+            httpMetadataAddress,
+            requireHttpsMetadata: false);
+        var services = new ServiceCollection();
+
+        new BoltTransportAuthenticationInstaller()
+            .InstallServices<BoltTransportAuthenticationConfigurationTests>(
+                services,
+                configuration,
+                new TestHostEnvironment());
+        services.InstallJwt(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(BoltTransportAuthentication.Scheme);
+
+        options.MetadataAddress.Should().Be(httpMetadataAddress);
+        options.RequireHttpsMetadata.Should().BeFalse();
+    }
+
+    [Test]
+    public void InstallServices_DedicatedBearer_UsesRsaAndPreservesSharedBearer()
+    {
+        var configuration = BuildTransportConfiguration(MetadataAddress);
+        var services = new ServiceCollection();
+
+        // Match Hub startup order: assembly installers run before InstallJwt.
+        new BoltTransportAuthenticationInstaller()
+            .InstallServices<BoltTransportAuthenticationConfigurationTests>(
+                services,
+                configuration,
+                new TestHostEnvironment());
+        services.InstallJwt(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var monitor = provider.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>();
+        var options = monitor.Get(BoltTransportAuthentication.Scheme);
+        var sharedOptions = monitor.Get(JwtBearerDefaults.AuthenticationScheme);
+        var validation = options.TokenValidationParameters;
+
+        options.MetadataAddress.Should().Be(MetadataAddress);
+        options.RequireHttpsMetadata.Should().BeTrue();
+        options.RefreshOnIssuerKeyNotFound.Should().BeTrue();
+        options.MapInboundClaims.Should().BeFalse();
+        options.Events.OnMessageReceived.Should().NotBeNull(
+            "the shared Bolt query-token redaction handoff must remain installed");
+
+        validation.ValidateIssuerSigningKey.Should().BeTrue();
+        validation.RequireSignedTokens.Should().BeTrue();
+        validation.ValidateIssuer.Should().BeTrue();
+        validation.ValidIssuer.Should().Be(BoltTransportAuthentication.ExpectedIssuer);
+        validation.ValidateAudience.Should().BeTrue();
+        validation.ValidAudience.Should().Be(BoltTransportAuthentication.ExpectedAudience);
+        validation.RequireExpirationTime.Should().BeTrue();
+        validation.ValidateLifetime.Should().BeTrue();
+        validation.ClockSkew.Should().Be(TimeSpan.FromSeconds(30));
+        validation.ValidTypes.Should().Equal(BoltTransportAuthentication.ExpectedTokenType);
+        validation.ValidAlgorithms.Should().Equal(SecurityAlgorithms.RsaSha256);
+
+        validation.IssuerSigningKey.Should().BeNull();
+        validation.IssuerSigningKeys.Should().BeNullOrEmpty();
+        validation.IssuerSigningKeyResolver.Should().BeNull();
+        validation.IssuerSigningKeyValidator.Should().BeNull();
+        validation.ValidAlgorithms.Should().NotContain(SecurityAlgorithms.HmacSha512);
+
+        sharedOptions.MetadataAddress.Should().BeNull();
+        sharedOptions.TokenValidationParameters.IssuerSigningKeyResolver.Should().NotBeNull();
+        sharedOptions.TokenValidationParameters.IssuerSigningKeyValidator.Should().NotBeNull();
+        sharedOptions.TokenValidationParameters.ValidAlgorithms.Should().Contain(SecurityAlgorithms.HmacSha512);
+        sharedOptions.TokenValidationParameters.ValidIssuer.Should().Be("shared-issuer");
+        sharedOptions.TokenValidationParameters.ValidAudience.Should().Be("shared-audience");
+    }
+
+    private static IConfiguration BuildTransportConfiguration(
+        string metadataAddress,
+        bool requireHttpsMetadata = true,
+        string issuer = BoltTransportAuthentication.ExpectedIssuer,
+        string audience = BoltTransportAuthentication.ExpectedAudience)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["BoltTransportAuthentication:MetadataAddress"] = metadataAddress,
+            ["BoltTransportAuthentication:Issuer"] = issuer,
+            ["BoltTransportAuthentication:Audience"] = audience,
+            ["BoltTransportAuthentication:RequireHttpsMetadata"] = requireHttpsMetadata.ToString(),
+            ["JwtOptions:GenerationId"] = "shared-hmac-g0",
+            ["JwtOptions:Secret"] = new string('h', 64),
+            ["JwtOptions:ValidIssuer"] = "shared-issuer",
+            ["JwtOptions:ValidAudience"] = "shared-audience"
+        };
+
+        return BuildConfiguration(values);
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "Bolt.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/src/Tests/Bolt.Tests/BoltTransportAuthenticationHandshakeTests.cs
+++ b/src/Tests/Bolt.Tests/BoltTransportAuthenticationHandshakeTests.cs
@@ -1,0 +1,260 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Bolt.Client;
+using Bolt.Hub.Configurations;
+using Bolt.Hub.Installers;
+using Bolt.Hub.Security;
+using Bolt.Server;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+using XFramework.Core.Extensions;
+using XFramework.Core.Middlewares;
+using XFramework.Domain.Shared.ServiceIdentity;
+
+namespace Bolt.Tests;
+
+[TestFixture]
+[CancelAfter(30000)]
+public sealed class BoltTransportAuthenticationHandshakeTests
+{
+    private const string SigningKeyId = "bolt-rsa-g1";
+    private const string ServiceName = "XFramework.IdentityServer";
+    private const string MetadataAddress = "https://identity.test/.well-known/openid-configuration";
+    private static int _portCounter = 21900;
+    private RSA _signingRsa = null!;
+    private RsaSecurityKey _signingKey = null!;
+    private WebApplication _app = null!;
+    private int _port;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _signingRsa = RSA.Create(2048);
+        _signingKey = new RsaSecurityKey(_signingRsa) { KeyId = SigningKeyId };
+        await StartServerAsync();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        try { await _app.StopAsync(); } catch { }
+        try { await _app.DisposeAsync(); } catch { }
+        _signingRsa.Dispose();
+    }
+
+    [Test]
+    public async Task BoltHandshake_ValidRsaTransportToken_Connects()
+    {
+        await using var client = CreateClient(
+            ServiceName,
+            CreateToken(new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256)));
+
+        await client.ConnectAsync();
+
+        client.IsConnected.Should().BeTrue();
+    }
+
+    [TestCase(RejectedToken.Hmac)]
+    [TestCase(RejectedToken.WrongSignature)]
+    [TestCase(RejectedToken.WrongIssuer)]
+    [TestCase(RejectedToken.WrongAudience)]
+    [TestCase(RejectedToken.WrongType)]
+    [TestCase(RejectedToken.MissingScope)]
+    [TestCase(RejectedToken.Expired)]
+    public async Task BoltHandshake_InvalidTransportToken_IsRejected(RejectedToken rejectedToken)
+    {
+        var token = CreateRejectedToken(rejectedToken);
+        using var socket = new ClientWebSocket();
+        var uri = new Uri(
+            $"ws://localhost:{_port}/bolt/ws?access_token={Uri.EscapeDataString(token)}");
+
+        var connect = async () => await socket.ConnectAsync(uri, CancellationToken.None);
+
+        await connect.Should().ThrowAsync<WebSocketException>();
+    }
+
+    [Test]
+    public async Task BoltHandshake_MismatchedRegisteredIdentity_IsRejected()
+    {
+        const string registeredServiceName = "XFramework.Portal";
+        await using var client = CreateClient(
+            registeredServiceName,
+            CreateToken(new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256)));
+
+        var connect = async () => await client.ConnectAsync();
+
+        await connect.Should().ThrowAsync<InvalidOperationException>();
+        client.IsConnected.Should().BeFalse();
+    }
+
+    private async Task StartServerAsync()
+    {
+        _port = Interlocked.Increment(ref _portCounter);
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls($"http://localhost:{_port}");
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["BoltTransportAuthentication:MetadataAddress"] = MetadataAddress,
+            ["BoltTransportAuthentication:Issuer"] = BoltTransportAuthentication.ExpectedIssuer,
+            ["BoltTransportAuthentication:Audience"] = BoltTransportAuthentication.ExpectedAudience,
+            ["JwtOptions:GenerationId"] = "shared-hmac-g0",
+            ["JwtOptions:Secret"] = new string('h', 64),
+            ["JwtOptions:ValidIssuer"] = "shared-issuer",
+            ["JwtOptions:ValidAudience"] = "shared-audience"
+        });
+
+        new BoltTransportAuthenticationInstaller()
+            .InstallServices<BoltTransportAuthenticationHandshakeTests>(
+                builder.Services,
+                builder.Configuration,
+                builder.Environment);
+        builder.Services.InstallJwt(builder.Configuration);
+        builder.Services.PostConfigure<JwtBearerOptions>(
+            BoltTransportAuthentication.Scheme,
+            options => options.ConfigurationManager = CreateConfigurationManager());
+        builder.Services.AddBoltServer(options =>
+        {
+            options.RegistrationIdentityBindingMode = BoltRegistrationIdentityBindingMode.Enforce;
+            options.ReservedServiceNames.AddRange(XFrameworkServiceNames.All);
+            options.ReservedServiceNamePrefixes.Add("XFramework.");
+        });
+        builder.Services.AddAuthorization(BoltAuthorizationPolicies.AddTransportPolicy);
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+        _app = builder.Build();
+        _app.UseMiddleware<BoltAccessTokenRedactionMiddleware>();
+        _app.UseRouting();
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+        _app.UseWebSockets();
+        _app.MapBolt("/bolt/ws")
+            .RequireAuthorization(BoltAuthorizationPolicies.Transport);
+
+        await _app.StartAsync();
+    }
+
+    private IConfigurationManager<OpenIdConnectConfiguration> CreateConfigurationManager()
+    {
+        var configuration = new OpenIdConnectConfiguration
+        {
+            Issuer = BoltTransportAuthentication.ExpectedIssuer
+        };
+        configuration.SigningKeys.Add(_signingKey);
+        return new StaticConfigurationManager<OpenIdConnectConfiguration>(configuration);
+    }
+
+    private BoltClient CreateClient(string registeredServiceName, string token) =>
+        new(
+            new Uri($"ws://localhost:{_port}/bolt/ws"),
+            Sha256Hex(registeredServiceName),
+            registeredServiceName,
+            new BoltClientOptions
+            {
+                AccessToken = token,
+                SendAccessTokenAsQueryString = true,
+                RpcTimeoutSeconds = 5
+            },
+            NullLogger<BoltClient>.Instance);
+
+    private string CreateRejectedToken(RejectedToken rejectedToken)
+    {
+        if (rejectedToken == RejectedToken.Hmac)
+        {
+            var hmacKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('h', 64)))
+            {
+                KeyId = "shared-hmac-g0"
+            };
+            return CreateToken(new SigningCredentials(hmacKey, SecurityAlgorithms.HmacSha512));
+        }
+
+        if (rejectedToken == RejectedToken.WrongSignature)
+        {
+            using var wrongRsa = RSA.Create(2048);
+            var wrongKey = new RsaSecurityKey(wrongRsa) { KeyId = SigningKeyId };
+            return CreateToken(new SigningCredentials(wrongKey, SecurityAlgorithms.RsaSha256));
+        }
+
+        return rejectedToken switch
+        {
+            RejectedToken.WrongIssuer => CreateToken(
+                new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256),
+                issuer: "Wrong.Issuer"),
+            RejectedToken.WrongAudience => CreateToken(
+                new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256),
+                audience: "Wrong.Audience"),
+            RejectedToken.WrongType => CreateToken(
+                new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256),
+                tokenType: "JWT"),
+            RejectedToken.MissingScope => CreateToken(
+                new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256),
+                includeScope: false),
+            RejectedToken.Expired => CreateToken(
+                new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256),
+                notBefore: DateTime.UtcNow.AddMinutes(-5),
+                expires: DateTime.UtcNow.AddMinutes(-2)),
+            _ => throw new ArgumentOutOfRangeException(nameof(rejectedToken), rejectedToken, null)
+        };
+    }
+
+    private static string CreateToken(
+        SigningCredentials signingCredentials,
+        string issuer = BoltTransportAuthentication.ExpectedIssuer,
+        string audience = BoltTransportAuthentication.ExpectedAudience,
+        string tokenType = BoltTransportAuthentication.ExpectedTokenType,
+        bool includeScope = true,
+        DateTime? notBefore = null,
+        DateTime? expires = null)
+    {
+        var now = DateTime.UtcNow;
+        List<Claim> claims =
+        [
+            new("client_id", ServiceName),
+            new("service", ServiceName),
+            new("sub", ServiceName)
+        ];
+        if (includeScope)
+            claims.Add(new Claim("scope", XFrameworkServiceScopes.BoltService));
+
+        var header = new JwtHeader(signingCredentials)
+        {
+            [JwtHeaderParameterNames.Typ] = tokenType
+        };
+        var payload = new JwtPayload(
+            issuer,
+            audience,
+            claims,
+            notBefore ?? now.AddSeconds(-5),
+            expires ?? now.AddMinutes(2),
+            now);
+
+        return new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(header, payload));
+    }
+
+    private static string Sha256Hex(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+
+    public enum RejectedToken
+    {
+        Hmac,
+        WrongSignature,
+        WrongIssuer,
+        WrongAudience,
+        WrongType,
+        MissingScope,
+        Expired
+    }
+}

--- a/src/Tests/Bolt.Tests/BoltTransportIdentityHealthCheckTests.cs
+++ b/src/Tests/Bolt.Tests/BoltTransportIdentityHealthCheckTests.cs
@@ -1,0 +1,112 @@
+using System.Security.Cryptography;
+using Bolt.Hub.Configurations;
+using Bolt.Hub.Health;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Bolt.Tests;
+
+[TestFixture]
+public sealed class BoltTransportIdentityHealthCheckTests
+{
+    [Test]
+    public async Task CheckHealthAsync_ExactIssuerAndUsableRsaKey_ReturnsHealthy()
+    {
+        var configuration = CreateConfiguration(
+            BoltTransportAuthentication.ExpectedIssuer,
+            CreateRsaSecurityKey(2048));
+        var check = CreateHealthCheck(
+            new StaticConfigurationManager<OpenIdConnectConfiguration>(configuration));
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        result.Description.Should().Be("Bolt transport identity metadata is available.");
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_WrongIssuer_ReturnsUnhealthy()
+    {
+        var configuration = CreateConfiguration(
+            "XFramework.WrongIssuer",
+            CreateRsaSecurityKey(2048));
+        var check = CreateHealthCheck(
+            new StaticConfigurationManager<OpenIdConnectConfiguration>(configuration));
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Be("Bolt transport metadata issuer is invalid.");
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_NoUsableRsaSigningKeys_ReturnsUnhealthy()
+    {
+        var configuration = CreateConfiguration(
+            BoltTransportAuthentication.ExpectedIssuer,
+            CreateRsaSecurityKey(1024),
+            new SymmetricSecurityKey(RandomNumberGenerator.GetBytes(32)));
+        var check = CreateHealthCheck(
+            new StaticConfigurationManager<OpenIdConnectConfiguration>(configuration));
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Be("Bolt transport metadata contains no usable RSA signing key.");
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_MetadataOrJwksFetchFails_ReturnsUnhealthy()
+    {
+        var exception = new InvalidOperationException("Metadata/JWKS fetch failed.");
+        var configurationManager = Substitute.For<IConfigurationManager<OpenIdConnectConfiguration>>();
+        configurationManager.GetConfigurationAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<OpenIdConnectConfiguration>(exception));
+        var check = CreateHealthCheck(configurationManager);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Be("Bolt transport identity metadata could not be resolved.");
+        result.Exception.Should().BeSameAs(exception);
+    }
+
+    private static BoltTransportIdentityHealthCheck CreateHealthCheck(
+        IConfigurationManager<OpenIdConnectConfiguration> configurationManager)
+    {
+        var optionsMonitor = Substitute.For<IOptionsMonitor<JwtBearerOptions>>();
+        optionsMonitor.Get(BoltTransportAuthentication.Scheme).Returns(new JwtBearerOptions
+        {
+            ConfigurationManager = configurationManager
+        });
+
+        return new BoltTransportIdentityHealthCheck(optionsMonitor);
+    }
+
+    private static OpenIdConnectConfiguration CreateConfiguration(
+        string issuer,
+        params SecurityKey[] signingKeys)
+    {
+        var configuration = new OpenIdConnectConfiguration { Issuer = issuer };
+        foreach (var signingKey in signingKeys)
+            configuration.SigningKeys.Add(signingKey);
+
+        return configuration;
+    }
+
+    private static RsaSecurityKey CreateRsaSecurityKey(int keySize)
+    {
+        using var rsa = RSA.Create(keySize);
+        return new RsaSecurityKey(rsa.ExportParameters(false))
+        {
+            KeyId = $"test-rsa-{keySize}"
+        };
+    }
+}

--- a/src/Tests/Bolt.Tests/IdentityServerTokenProviderTests.cs
+++ b/src/Tests/Bolt.Tests/IdentityServerTokenProviderTests.cs
@@ -1,0 +1,431 @@
+using System.Diagnostics;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Bolt.Client;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Security;
+
+namespace Bolt.Tests;
+
+[TestFixture]
+[CancelAfter(15000)]
+public sealed class IdentityServerTokenProviderTests
+{
+    private const string ClientId = "XFramework.TestClient";
+    private const string ClientSecret = "test-client-secret-material-at-least-32-bytes";
+
+    [Test]
+    public async Task BoltTransportProvider_ValidToken_CachesUntilRefreshWindow()
+    {
+        var now = new DateTimeOffset(2026, 7, 14, 0, 0, 0, TimeSpan.Zero);
+        var timeProvider = new MutableTimeProvider(now);
+        var requestCount = 0;
+        using var factory = CreateFactory((_, _) =>
+        {
+            Interlocked.Increment(ref requestCount);
+            return Task.FromResult(CreateTokenResponse("transport-token", now.AddMinutes(2)));
+        });
+        var options = CreateOptions(refreshSkewSeconds: 60);
+        var provider = CreateTransportProvider(factory, options, timeProvider);
+
+        var first = await provider.GetTokenAsync();
+        var second = await provider.GetTokenAsync();
+        timeProvider.Advance(TimeSpan.FromSeconds(61));
+        var refreshed = await provider.GetTokenAsync();
+
+        first.Should().Be("transport-token");
+        second.Should().Be("transport-token");
+        refreshed.Should().Be("transport-token");
+        requestCount.Should().Be(2);
+    }
+
+    [Test]
+    public async Task BoltTransportProvider_ConcurrentCallers_UsesSingleHttpRequest()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCount = 0;
+        using var factory = CreateFactory(async (_, ct) =>
+        {
+            Interlocked.Increment(ref requestCount);
+            entered.TrySetResult();
+            await release.Task.WaitAsync(ct);
+            return CreateTokenResponse("shared-token", DateTimeOffset.UtcNow.AddMinutes(5));
+        });
+        var provider = CreateTransportProvider(factory, CreateOptions());
+
+        var calls = Enumerable.Range(0, 20)
+            .Select(_ => provider.GetTokenAsync().AsTask())
+            .ToArray();
+        await entered.Task;
+        requestCount.Should().Be(1);
+        release.TrySetResult();
+
+        var tokens = await Task.WhenAll(calls);
+
+        tokens.Should().OnlyContain(token => token == "shared-token");
+        requestCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task BoltTransportProvider_CallerCancels_PreservesSharedAcquisition()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCount = 0;
+        using var factory = CreateFactory(async (_, ct) =>
+        {
+            Interlocked.Increment(ref requestCount);
+            entered.TrySetResult();
+            await release.Task.WaitAsync(ct);
+            return CreateTokenResponse("shared-token", DateTimeOffset.UtcNow.AddMinutes(5));
+        });
+        var provider = CreateTransportProvider(factory, CreateOptions());
+        using var callerCts = new CancellationTokenSource();
+
+        var canceledCall = provider.GetTokenAsync(callerCts.Token).AsTask();
+        await entered.Task;
+        callerCts.Cancel();
+        var sharedCall = provider.GetTokenAsync().AsTask();
+
+        var awaitCanceledCall = async () => await canceledCall;
+        await awaitCanceledCall.Should().ThrowAsync<OperationCanceledException>();
+        release.TrySetResult();
+        (await sharedCall).Should().Be("shared-token");
+        requestCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task BoltTransportProvider_HttpFailure_ClearsSingleFlightForRetry()
+    {
+        var requestCount = 0;
+        using var factory = CreateFactory((_, _) =>
+        {
+            var attempt = Interlocked.Increment(ref requestCount);
+            return Task.FromResult(attempt == 1
+                ? new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                : CreateTokenResponse("retry-token", DateTimeOffset.UtcNow.AddMinutes(5)));
+        });
+        var provider = CreateTransportProvider(factory, CreateOptions());
+
+        var firstCall = async () => await provider.GetTokenAsync();
+        await firstCall.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*HTTP status 401*");
+
+        var retryStopwatch = Stopwatch.StartNew();
+        (await provider.GetTokenAsync()).Should().Be("retry-token");
+        retryStopwatch.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(400));
+        retryStopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+        requestCount.Should().Be(2);
+    }
+
+    [Test]
+    public async Task BoltTransportProvider_RequestExceedsDeadline_ThrowsTimeoutAndAllowsRetry()
+    {
+        var requestCount = 0;
+        using var factory = CreateFactory(async (_, ct) =>
+        {
+            var attempt = Interlocked.Increment(ref requestCount);
+            if (attempt == 1)
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+
+            return CreateTokenResponse("retry-token", DateTimeOffset.UtcNow.AddMinutes(5));
+        });
+        var provider = CreateTransportProvider(
+            factory,
+            CreateOptions(tokenAcquisitionTimeoutSeconds: 1));
+        var stopwatch = Stopwatch.StartNew();
+
+        var timedOutCall = async () => await provider.GetTokenAsync();
+        await timedOutCall.Should().ThrowAsync<TimeoutException>();
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(4));
+
+        (await provider.GetTokenAsync()).Should().Be("retry-token");
+        requestCount.Should().Be(2);
+    }
+
+    [Test]
+    public async Task BoltTransportProvider_Request_UsesIdentityServerHttpContract()
+    {
+        HttpMethod? method = null;
+        Uri? requestUri = null;
+        string? authorization = null;
+        JsonElement body = default;
+        using var factory = CreateFactory(async (request, ct) =>
+        {
+            method = request.Method;
+            requestUri = request.RequestUri;
+            authorization = request.Headers.Authorization?.ToString();
+            body = JsonDocument.Parse(await request.Content!.ReadAsStringAsync(ct)).RootElement.Clone();
+            return CreateTokenResponse("transport-token", DateTimeOffset.UtcNow.AddMinutes(5));
+        });
+        var provider = CreateTransportProvider(factory, CreateOptions());
+
+        await provider.GetTokenAsync();
+
+        factory.RequestedClientNames.Should().Equal(ServiceIdentityHttpClient.Name);
+        method.Should().Be(HttpMethod.Post);
+        requestUri.Should().Be("https://identity.test/api/service-identity/bolt-transport-token");
+        authorization.Should().BeNull();
+        body.GetProperty("clientId").GetString().Should().Be(ClientId);
+        body.GetProperty("clientSecret").GetString().Should().Be(ClientSecret);
+    }
+
+    [Test]
+    public async Task ServiceTokenProvider_Request_UsesHttpAndCachesByNormalizedAudienceAndScopes()
+    {
+        var requestCount = 0;
+        Uri? requestUri = null;
+        JsonElement body = default;
+        using var factory = CreateFactory(async (request, ct) =>
+        {
+            Interlocked.Increment(ref requestCount);
+            requestUri = request.RequestUri;
+            body = JsonDocument.Parse(await request.Content!.ReadAsStringAsync(ct)).RootElement.Clone();
+            return CreateTokenResponse("service-token", DateTimeOffset.UtcNow.AddMinutes(5));
+        });
+        var provider = CreateServiceProvider(factory, CreateOptions());
+
+        var first = await provider.GetTokenAsync(
+            XFrameworkServiceNames.IdentityServer,
+            [XFrameworkServiceScopes.IdentityAdmin, " custom.scope ", XFrameworkServiceScopes.IdentityAdmin]);
+        var second = await provider.GetTokenAsync(
+            XFrameworkServiceNames.IdentityServer,
+            ["custom.scope", XFrameworkServiceScopes.IdentityAdmin]);
+
+        first.Should().Be("service-token");
+        second.Should().Be("service-token");
+        requestCount.Should().Be(1);
+        requestUri.Should().Be("https://identity.test/api/service-identity/token");
+        body.GetProperty("clientId").GetString().Should().Be(ClientId);
+        body.GetProperty("clientSecret").GetString().Should().Be(ClientSecret);
+        body.GetProperty("audience").GetString().Should().Be(XFrameworkServiceNames.IdentityServer);
+        body.GetProperty("scopes").EnumerateArray().Select(item => item.GetString()).Should().Equal(
+            "custom.scope",
+            XFrameworkServiceScopes.IdentityAdmin);
+    }
+
+    [Test]
+    public async Task TokenProvider_ServerErrorContainingSensitiveValues_DoesNotLogThem()
+    {
+        const string issuedToken = "sensitive-issued-token";
+        var logger = new RecordingLogger<IdentityServerBoltTransportTokenProvider>();
+        using var factory = CreateFactory((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent($"{ClientSecret} {issuedToken}")
+        }));
+        var provider = CreateTransportProvider(factory, CreateOptions(), logger: logger);
+
+        var call = async () => await provider.GetTokenAsync();
+        await call.Should().ThrowAsync<InvalidOperationException>();
+
+        logger.Messages.Should().NotContain(message =>
+            message.Contains(ClientSecret, StringComparison.Ordinal) ||
+            message.Contains(issuedToken, StringComparison.Ordinal));
+    }
+
+    [Test]
+    public void ServiceTokenProvider_Constructors_DoNotDependOnBoltClient()
+    {
+        var parameterTypes = typeof(IdentityServerServiceTokenProvider)
+            .GetConstructors()
+            .SelectMany(constructor => constructor.GetParameters())
+            .Select(parameter => parameter.ParameterType);
+
+        parameterTypes.Should().NotContain(typeof(BoltClient));
+    }
+
+    [TestCase("https://identity.test/api")]
+    [TestCase("https://identity.test/api/")]
+    public void ResolveAuthority_AuthorityContainsPath_ThrowsInvalidOperationException(string authority)
+    {
+        var options = CreateOptions();
+        options.Authority = authority;
+
+        var resolve = options.ResolveAuthority;
+
+        resolve.Should().Throw<InvalidOperationException>()
+            .WithMessage("*must be an origin without user information, a path, a query, or a fragment*");
+    }
+
+    [Test]
+    public async Task DiAwareAccessTokenProvider_ScopedDisposableProvider_DisposesScopeAfterEachRequest()
+    {
+        var probe = new TokenProviderLifetimeProbe();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(probe);
+        services.AddScoped<ScopedDisposableTokenProvider>();
+        services.AddBoltClient(builder => builder
+            .WithServer("wss://bolt.test/bolt")
+            .WithAccessTokenProvider<ScopedDisposableTokenProvider>(
+                static (provider, ct) => provider.GetTokenAsync(ct))
+            .DisableAutoConnect());
+        await using var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetRequiredService<BoltClient>();
+        var accessTokenProvider = GetAccessTokenProvider(client);
+
+        var first = await accessTokenProvider(CancellationToken.None);
+        var second = await accessTokenProvider(CancellationToken.None);
+
+        first.Should().Be("scoped-token-1");
+        second.Should().Be("scoped-token-2");
+        probe.CreatedCount.Should().Be(2);
+        probe.DisposedCount.Should().Be(2);
+    }
+
+    private static IdentityServerBoltTransportTokenProvider CreateTransportProvider(
+        IHttpClientFactory factory,
+        ServiceIdentityOptions options,
+        TimeProvider? timeProvider = null,
+        ILogger<IdentityServerBoltTransportTokenProvider>? logger = null) =>
+        new(
+            factory,
+            Options.Create(options),
+            timeProvider ?? TimeProvider.System,
+            logger ?? NullLogger<IdentityServerBoltTransportTokenProvider>.Instance);
+
+    private static IdentityServerServiceTokenProvider CreateServiceProvider(
+        IHttpClientFactory factory,
+        ServiceIdentityOptions options) =>
+        new(
+            factory,
+            Options.Create(options),
+            TimeProvider.System,
+            NullLogger<IdentityServerServiceTokenProvider>.Instance);
+
+    private static ServiceIdentityOptions CreateOptions(
+        int tokenAcquisitionTimeoutSeconds = 5,
+        int refreshSkewSeconds = 30) => new()
+    {
+        Authority = "https://identity.test",
+        ClientId = ClientId,
+        GenerationId = "test-g0",
+        ClientSecret = ClientSecret,
+        TokenAcquisitionTimeoutSeconds = tokenAcquisitionTimeoutSeconds,
+        TokenRefreshSkewSeconds = refreshSkewSeconds
+    };
+
+    private static StubHttpClientFactory CreateFactory(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) =>
+        new(new DelegateHttpMessageHandler(handler));
+
+    private static HttpResponseMessage CreateTokenResponse(string token, DateTimeOffset expiresAtUtc)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            accessToken = token,
+            tokenType = "Bearer",
+            expiresAtUtc
+        });
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private static Func<CancellationToken, ValueTask<string?>> GetAccessTokenProvider(BoltClient client)
+    {
+        var configField = typeof(BoltClient).GetField("_config", BindingFlags.Instance | BindingFlags.NonPublic);
+        configField.Should().NotBeNull();
+        var options = configField!.GetValue(client).Should().BeOfType<BoltClientOptions>().Which;
+        options.AccessTokenProvider.Should().NotBeNull();
+        return options.AccessTokenProvider!;
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory, IDisposable
+    {
+        private readonly HttpClient _client = new(handler, disposeHandler: false)
+        {
+            Timeout = Timeout.InfiniteTimeSpan
+        };
+
+        public List<string> RequestedClientNames { get; } = [];
+
+        public HttpClient CreateClient(string name)
+        {
+            RequestedClientNames.Add(name);
+            return _client;
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+            handler.Dispose();
+        }
+    }
+
+    private sealed class DelegateHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => handler(request, cancellationToken);
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+
+        public void Advance(TimeSpan amount) => utcNow = utcNow.Add(amount);
+    }
+
+    private sealed class TokenProviderLifetimeProbe
+    {
+        private int _createdCount;
+        private int _disposedCount;
+
+        public int CreatedCount => Volatile.Read(ref _createdCount);
+        public int DisposedCount => Volatile.Read(ref _disposedCount);
+
+        public int RecordCreated() => Interlocked.Increment(ref _createdCount);
+
+        public void RecordDisposed() => Interlocked.Increment(ref _disposedCount);
+    }
+
+    private sealed class ScopedDisposableTokenProvider(TokenProviderLifetimeProbe probe) : IAsyncDisposable
+    {
+        private readonly int _instanceId = probe.RecordCreated();
+
+        public ValueTask<string?> GetTokenAsync(CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<string?>($"scoped-token-{_instanceId}");
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            probe.RecordDisposed();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+            if (exception is not null)
+                Messages.Add(exception.ToString());
+        }
+    }
+}

--- a/src/Tests/Bolt.Tests/XFrameworkBoltClientConfigurationTests.cs
+++ b/src/Tests/Bolt.Tests/XFrameworkBoltClientConfigurationTests.cs
@@ -9,8 +9,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using XFramework.Domain.Shared.Configurations;
 using XFramework.Integration.Extensions;
 using XFramework.Integration.Health;
+using XFramework.Integration.Security;
 
 namespace Bolt.Tests;
 
@@ -98,8 +100,6 @@ public class XFrameworkBoltClientConfigurationTests
             {
                 ["BoltConfiguration:ServerUrls:0"] = "ws://localhost:9999/bolt",
                 ["BoltConfiguration:ClientName"] = "Bolt.TestClient",
-                ["BoltConfiguration:Anonymous"] = "true",
-                ["BoltConfiguration:GenerateServiceAccessToken"] = "false",
                 ["BoltConfiguration:MinConnections"] = "3",
                 ["BoltConfiguration:MaxConnections"] = "7",
                 ["BoltConfiguration:ScaleUpThreshold"] = "11"
@@ -165,6 +165,215 @@ public class XFrameworkBoltClientConfigurationTests
             "isHealthy");
     }
 
+    [Test]
+    public async Task AddXFrameworkBoltClient_DefaultTransportIdentity_ResolvesProviderAtConnectionTime()
+    {
+        var configuration = CreateConfiguration("wss://localhost:9999/bolt", requireSecureTransport: true);
+        var services = CreateServices();
+        var constructed = 0;
+        services.AddSingleton<IBoltTransportTokenProvider>(_ =>
+        {
+            Interlocked.Increment(ref constructed);
+            return new StubBoltTransportTokenProvider("central-token");
+        });
+
+        services.AddXFrameworkBoltClient(configuration, autoConnect: false);
+        await using var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetRequiredService<BoltClient>();
+        var options = GetOptions(client);
+
+        constructed.Should().Be(0);
+        options.AccessTokenProvider.Should().NotBeNull();
+        var token = await options.AccessTokenProvider!(CancellationToken.None);
+
+        token.Should().Be("central-token");
+        constructed.Should().Be(1);
+    }
+
+    [Test]
+    public async Task AddXFrameworkBoltClient_ServiceIdentityHttpClient_HasInfiniteBuiltInTimeout()
+    {
+        var configuration = CreateConfiguration("wss://localhost:9999/bolt", requireSecureTransport: true);
+        configuration["ServiceIdentity:Authority"] = "https://identity.test";
+        configuration["ServiceIdentity:ClientId"] = "Bolt.TestClient";
+        configuration["ServiceIdentity:GenerationId"] = "test-g0";
+        configuration["ServiceIdentity:ClientSecret"] = "test-client-secret-material-at-least-32-bytes";
+        var services = CreateServices();
+
+        services.AddXFrameworkBoltClient(configuration, autoConnect: false);
+        await using var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetRequiredService<IHttpClientFactory>()
+            .CreateClient(ServiceIdentityHttpClient.Name);
+
+        client.BaseAddress.Should().Be("https://identity.test/");
+        client.Timeout.Should().Be(Timeout.InfiniteTimeSpan);
+    }
+
+    [Test]
+    public async Task AddXFrameworkBoltClient_ConnectAfterApplicationStarted_StartsWithoutHubAndOmitsTransportReadiness()
+    {
+        var configuration = CreateConfiguration("wss://127.0.0.1:1/bolt", requireSecureTransport: true);
+        configuration["ServiceIdentity:Authority"] = "https://identity.test";
+        configuration["ServiceIdentity:ClientId"] = "Bolt.TestClient";
+        configuration["ServiceIdentity:GenerationId"] = "test-g0";
+        configuration["ServiceIdentity:ClientSecret"] = "test-client-secret-material-at-least-32-bytes";
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            EnvironmentName = Environments.Production
+        });
+
+        builder.Services.AddXFrameworkBoltClient(
+            configuration,
+            autoConnect: true,
+            hostEnvironment: builder.Environment,
+            connectAfterApplicationStarted: true);
+        using var host = builder.Build();
+
+        var hostedServiceNames = GetHostedServiceNames(builder.Services);
+        hostedServiceNames.Should().Contain("ApplicationStartedBoltClientHostedService");
+        hostedServiceNames.Should().NotContain("BoltClientHostedService");
+        host.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>()
+            .Value.Registrations.Should().NotContain(
+                registration => registration.Name == BoltClientTransportHealthCheckExtensions.RegistrationName);
+
+        var start = async () => await host.StartAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await start.Should().NotThrowAsync(
+            "IdentityServer must serve HTTP before its downstream Bolt Hub is available");
+        await host.StopAsync().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public void AddXFrameworkBoltClient_AutoConnectDisabled_DoesNotRegisterAnyConnector()
+    {
+        var configuration = CreateConfiguration("wss://localhost:9999/bolt", requireSecureTransport: true);
+        var services = CreateServices();
+
+        services.AddXFrameworkBoltClient(
+            configuration,
+            autoConnect: false,
+            connectAfterApplicationStarted: true);
+
+        var hostedServiceNames = GetHostedServiceNames(services);
+        hostedServiceNames.Should().NotContain("ApplicationStartedBoltClientHostedService");
+        hostedServiceNames.Should().NotContain("BoltClientHostedService");
+    }
+
+    [TestCase(null)]
+    [TestCase("Staging")]
+    [TestCase("Production")]
+    public void AddXFrameworkBoltClient_AnonymousOutsideDevelopment_Throws(string? environmentName)
+    {
+        var configuration = CreateConfiguration("wss://localhost:9999/bolt", requireSecureTransport: true);
+        configuration["BoltConfiguration:Anonymous"] = "true";
+        var services = CreateServices();
+        IHostEnvironment? environment = environmentName is null
+            ? null
+            : new TestHostEnvironment(environmentName);
+
+        var act = () => services.AddXFrameworkBoltClient(
+            configuration,
+            autoConnect: false,
+            hostEnvironment: environment);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Anonymous*only*Development*");
+    }
+
+    [Test]
+    public async Task AddXFrameworkBoltClient_AnonymousInDevelopment_HostStartsWithoutServiceIdentityConfiguration()
+    {
+        var configuration = CreateConfiguration("ws://localhost:9999/bolt", requireSecureTransport: false);
+        configuration["BoltConfiguration:Anonymous"] = "true";
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            EnvironmentName = Environments.Development
+        });
+
+        builder.Services.AddXFrameworkBoltClient(
+            configuration,
+            autoConnect: false,
+            hostEnvironment: builder.Environment);
+        using var host = builder.Build();
+        var act = () => host.StartAsync();
+
+        await act.Should().NotThrowAsync();
+        await host.StopAsync();
+    }
+
+    [TestCase("Development")]
+    [TestCase("Production")]
+    public void AddXFrameworkBoltClient_GenerateServiceAccessTokenInAnyEnvironment_Throws(
+        string environmentName)
+    {
+        var configuration = CreateConfiguration("wss://localhost:9999/bolt", requireSecureTransport: true);
+        configuration["BoltConfiguration:GenerateServiceAccessToken"] = "true";
+        var services = CreateServices();
+
+        var act = () => services.AddXFrameworkBoltClient(
+            configuration,
+            autoConnect: false,
+            hostEnvironment: new TestHostEnvironment(environmentName));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*GenerateServiceAccessToken*no longer supported*IdentityServer-issued*");
+    }
+
+    [Test]
+    public async Task AddXFrameworkBoltClient_StaticAccessToken_HostStartsWithoutServiceIdentityConfiguration()
+    {
+        var configuration = CreateConfiguration("wss://localhost:9999/bolt", requireSecureTransport: true);
+        configuration["BoltConfiguration:AccessToken"] = "centrally-issued-synthetic";
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            EnvironmentName = Environments.Production
+        });
+
+        builder.Services.AddXFrameworkBoltClient(
+            configuration,
+            autoConnect: false,
+            hostEnvironment: builder.Environment);
+        using var host = builder.Build();
+        var act = () => host.StartAsync();
+
+        await act.Should().NotThrowAsync();
+
+        var options = GetOptions(host.Services.GetRequiredService<BoltClient>());
+        options.AccessToken.Should().Be("centrally-issued-synthetic");
+        options.AccessTokenProvider.Should().BeNull();
+        await host.StopAsync();
+    }
+
+    [Test]
+    public void BoltConfiguration_GenerateServiceAccessToken_DefaultsToFalse()
+    {
+        new BoltConfiguration().GenerateServiceAccessToken.Should().BeFalse();
+    }
+
+    [TestCase("http://identity.test", false, false)]
+    [TestCase("http://identity.test", true, true)]
+    [TestCase("https://identity.test", false, true)]
+    public void ServiceIdentityOptionsValidator_AuthorityPolicy_ReturnsExpectedResult(
+        string authority,
+        bool allowInsecureHttp,
+        bool expectedSuccess)
+    {
+        var options = new ServiceIdentityOptions
+        {
+            Authority = authority,
+            AllowInsecureHttp = allowInsecureHttp,
+            ClientId = "Bolt.TestClient",
+            GenerationId = "test-g0",
+            ClientSecret = "test-client-secret-material-at-least-32-bytes"
+        };
+        var validator = new ServiceIdentityOptionsValidator(TimeProvider.System);
+
+        var result = validator.Validate(null, options);
+
+        result.Succeeded.Should().Be(expectedSuccess);
+        if (!expectedSuccess)
+            result.FailureMessage.Should().Contain("must use HTTPS");
+    }
+
     private static IConfigurationRoot CreateConfiguration(string serverUrl, bool requireSecureTransport)
     {
         return new ConfigurationBuilder()
@@ -172,8 +381,6 @@ public class XFrameworkBoltClientConfigurationTests
             {
                 ["BoltConfiguration:ServerUrls:0"] = serverUrl,
                 ["BoltConfiguration:ClientName"] = "Bolt.TestClient",
-                ["BoltConfiguration:Anonymous"] = "true",
-                ["BoltConfiguration:GenerateServiceAccessToken"] = "false",
                 ["BoltConfiguration:RequireSecureTransport"] = requireSecureTransport.ToString()
             })
             .Build();
@@ -191,6 +398,23 @@ public class XFrameworkBoltClientConfigurationTests
         var field = typeof(BoltClient).GetField("_config", BindingFlags.Instance | BindingFlags.NonPublic);
         field.Should().NotBeNull();
         return (BoltClientOptions)field!.GetValue(client)!;
+    }
+
+    private static IReadOnlyCollection<string> GetHostedServiceNames(IServiceCollection services) =>
+        services
+            .Where(descriptor => descriptor.ServiceType == typeof(IHostedService))
+            .Select(descriptor => descriptor.ImplementationType?.Name)
+            .Where(static name => name is not null)
+            .Cast<string>()
+            .ToArray();
+
+    private sealed class StubBoltTransportTokenProvider(string token) : IBoltTransportTokenProvider
+    {
+        public ValueTask<string> GetTokenAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(token);
+        }
     }
 
     private sealed class TestHostEnvironment(string environmentName) : IHostEnvironment

--- a/src/Tests/IdentityServer.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
@@ -9,6 +9,7 @@ using Communications.Integration.Drivers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using Bolt.Hub.Extensions;
 using Storage.Domain.Shared.Contracts.Requests;
@@ -53,6 +54,13 @@ public class IntegrationTestFixture
     private const string TestServiceClientSecret = "IdentityServerIntegrationTestSecret-2026";
     private const string TestHostServiceGenerationId = "test-host-service-g1";
     private const string TestHostServiceClientSecret = "IdentityServerHostIntegrationSecret-2026";
+    private static readonly string TransportSigningKeyDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "XFramework.IdentityServer.IntegrationTests",
+        Guid.NewGuid().ToString("N"));
+    private static readonly string TransportSigningKeyPath = Path.Combine(
+        TransportSigningKeyDirectory,
+        "bolt-transport-signing-key.pem");
 
     /// <summary>
     /// Service wrapper that calls IdentityServer through the actual Bolt transport.
@@ -92,6 +100,7 @@ public class IntegrationTestFixture
         // 4. Start IdentityServer (connects to Bolt as "IdentityServer" client)
         _identityServerApp = StartIdentityServer();
         await WaitForHealth($"{IdentityServerUrl}/health/live", _identityServerTask);
+        await VerifyCentralTransportIdentity();
 
         // 5. Seed the in-memory tenant cache
         var cache = _identityServerApp.Services.GetRequiredService<IMemoryCache>();
@@ -118,6 +127,8 @@ public class IntegrationTestFixture
         try { if (_identityServerApp != null) await _identityServerApp.StopAsync(); } catch { }
         try { if (_streamFlowApp != null) await _streamFlowApp.StopAsync(); } catch { }
         if (_postgres != null) await _postgres.DisposeAsync();
+        if (Directory.Exists(TransportSigningKeyDirectory))
+            Directory.Delete(TransportSigningKeyDirectory, recursive: true);
     }
 
     private static WebApplication StartBolt()
@@ -183,6 +194,7 @@ public class IntegrationTestFixture
         builder.Services.AddSingleton(serviceProvider => ServiceIdentityConfiguration.FromConfiguration(
             serviceProvider.GetRequiredService<IConfiguration>(),
             serviceProvider.GetRequiredService<TimeProvider>().GetUtcNow()));
+        builder.Services.AddSingleton<IBoltTransportTokenSigner, FileBackedBoltTransportTokenSigner>();
         builder.Services.AddSingleton<IIdentitySigningKeyProvider, IdentityServerLocalSigningKeyProvider>();
         builder.Services.AddValidatorsFromAssemblyContaining<AuthService>();
         builder.Services.AddXFrameworkBoltClient(builder.Configuration, autoConnect: false);
@@ -227,7 +239,10 @@ public class IntegrationTestFixture
             ["BoltConfiguration:ClientName"] = "TestClient",
             ["BoltConfiguration:ClientGuid"] = Guid.NewGuid().ToString(),
             ["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/bolt/ws",
+            ["BoltConfiguration:GenerateServiceAccessToken"] = "false",
             ["ServiceIdentity:ClientId"] = TestServiceClientId,
+            ["ServiceIdentity:Authority"] = IdentityServerUrl,
+            ["ServiceIdentity:AllowInsecureHttp"] = "true",
             ["ServiceIdentity:GenerationId"] = TestServiceGenerationId,
             ["ServiceIdentity:ClientSecret"] = TestServiceClientSecret,
             ["Tenant:DefaultId"] = TestTenantId.ToString(),
@@ -302,6 +317,23 @@ public class IntegrationTestFixture
         throw new TimeoutException("IdentityServer Bolt clients failed to connect within 15s");
     }
 
+    private static async Task VerifyCentralTransportIdentity()
+    {
+        using var client = new HttpClient { BaseAddress = new Uri(IdentityServerUrl) };
+        using var metadata = await client.GetAsync(BoltTransportTokenConstants.MetadataPath);
+        metadata.EnsureSuccessStatusCode();
+        using var jwks = await client.GetAsync(BoltTransportTokenConstants.JsonWebKeySetPath);
+        jwks.EnsureSuccessStatusCode();
+        using var token = await client.PostAsJsonAsync(
+            BoltTransportTokenConstants.TokenEndpointPath,
+            new
+            {
+                ClientId = XFrameworkServiceNames.IdentityServer,
+                ClientSecret = TestHostServiceClientSecret
+            });
+        token.EnsureSuccessStatusCode();
+    }
+
     private static async Task ConnectBoltClient(BoltClient client, string clientName)
     {
         if (client.IsConnected)
@@ -330,9 +362,14 @@ public class IntegrationTestFixture
             ["DefaultDatabaseConnection"] = ConnectionString,
             ["BoltConfiguration:ClientGuid"] = clientGuid,
             ["BoltConfiguration:ClientName"] = clientName,
+            ["BoltConfiguration:GenerateServiceAccessToken"] = "false",
             ["ServiceIdentity:ClientId"] = clientName,
+            ["ServiceIdentity:Authority"] = IdentityServerUrl,
+            ["ServiceIdentity:AllowInsecureHttp"] = "true",
             ["ServiceIdentity:GenerationId"] = TestHostServiceGenerationId,
             ["ServiceIdentity:ClientSecret"] = TestHostServiceClientSecret,
+            ["ServiceIdentity:BoltTransportTokenIssuer:Enabled"] = "true",
+            ["ServiceIdentity:BoltTransportTokenIssuer:SigningKeyPath"] = TransportSigningKeyPath,
             ["ServiceIdentity:Clients:0:ClientId"] = TestServiceClientId,
             ["ServiceIdentity:Clients:0:GenerationId"] = TestServiceGenerationId,
             ["ServiceIdentity:Clients:0:ClientSecret"] = TestServiceClientSecret,
@@ -348,6 +385,11 @@ public class IntegrationTestFixture
             ["JwtOptions:Secret"] = "Mm1VFHaqZ7MoVJyZd1zrAKxTpsXbYG6RqSMKYG2cV7RBBUdmsm97HOfKyA7MZ1LUl77ZklJPJfnegohyHqJIoQ983fTKmJcY",
             ["JwtOptions:AccessTokenLifespan"] = "00:30:00",
             ["JwtOptions:RefreshTokenLifespan"] = "00:30:00",
+            ["BoltTransportAuthentication:MetadataAddress"] =
+                $"{IdentityServerUrl}{BoltTransportTokenConstants.MetadataPath}",
+            ["BoltTransportAuthentication:Issuer"] = XFrameworkServiceNames.IdentityServer,
+            ["BoltTransportAuthentication:Audience"] = XFrameworkServiceNames.BoltHub,
+            ["BoltTransportAuthentication:RequireHttpsMetadata"] = "false",
             ["Logging:LogLevel:Default"] = "Warning"
         });
     }

--- a/src/Tests/IdentityServer.UnitTests/BoltTransportTokenIssuerTests.cs
+++ b/src/Tests/IdentityServer.UnitTests/BoltTransportTokenIssuerTests.cs
@@ -1,7 +1,13 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Bolt.Domain.Shared.Contracts.Requests;
 using FluentAssertions;
+using IdentityServer.Api.Features.ServiceIdentity.GetBoltTransportJwks;
+using IdentityServer.Api.Features.ServiceIdentity.GetBoltTransportMetadata;
 using IdentityServer.Api.Features.ServiceIdentity.IssueBoltTransportToken;
+using IdentityServer.Api.Features.ServiceIdentity.IssueToken;
 using IdentityServer.Api.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -10,7 +16,6 @@ using Microsoft.IdentityModel.Tokens;
 using Moq;
 using NUnit.Framework;
 using XFramework.Core.Patterns;
-using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
@@ -26,20 +31,40 @@ public sealed class BoltTransportTokenIssuerTests
     private const string FallbackClientGeneration = "service-g0";
     private const string CurrentClientSecret = "current-service-credential-material-1111111111111111111111111111";
     private const string FallbackClientSecret = "fallback-service-credential-material-0000000000000000000000000000";
-    private const string CurrentJwtGeneration = "jwt-g1";
-    private const string FallbackJwtGeneration = "jwt-g0";
-    private const string CurrentJwtSecret = "current-jwt-signing-material-111111111111111111111111111111111111111111111111";
-    private const string FallbackJwtSecret = "fallback-jwt-signing-material-000000000000000000000000000000000000000000000000";
-    private const string Issuer = "https://identity.test";
-    private const string Audience = "https://bolt.test";
+    private const string Issuer = XFrameworkServiceNames.IdentityServer;
+
+    private string _temporaryDirectory = null!;
+    private string _signingKeyPath = null!;
+    private IBoltTransportTokenSigner _signer = null!;
+
+    [OneTimeSetUp]
+    public void CreateTemporaryDirectory()
+    {
+        _temporaryDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "XFramework.IdentityServer.UnitTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_temporaryDirectory);
+        _signingKeyPath = Path.Combine(_temporaryDirectory, "bolt-transport-signing-key.pem");
+        var now = DateTimeOffset.Parse("2026-07-13T00:00:00Z");
+        var configuration = ServiceIdentityConfiguration.FromConfiguration(CreateConfiguration(now), now);
+        _signer = new FileBackedBoltTransportTokenSigner(configuration);
+    }
+
+    [OneTimeTearDown]
+    public void DeleteTemporaryDirectory()
+    {
+        if (Directory.Exists(_temporaryDirectory))
+            Directory.Delete(_temporaryDirectory, recursive: true);
+    }
 
     [Test]
     public async Task IssueBoltTransportToken_DisabledByDefault_FailsClosed()
     {
         var clock = new MutableTimeProvider(DateTimeOffset.Parse("2026-07-13T01:00:00Z"));
-        var service = CreateService(clock, enabled: null);
+        var fixture = CreateService(clock, enabled: null, includeSigningKeyPath: false);
 
-        var result = await service.IssueBoltTransportTokenAsync(ClientId, CurrentClientSecret);
+        var result = await fixture.Service.IssueBoltTransportTokenAsync(ClientId, CurrentClientSecret);
 
         result.IsSuccess.Should().BeFalse();
         result.StatusCode.Should().Be(503);
@@ -47,8 +72,43 @@ public sealed class BoltTransportTokenIssuerTests
     }
 
     [Test]
-    public async Task Endpoint_InsecureHttp_RejectsBeforeCredentialValidation()
+    public void Configuration_EnabledWithoutSigningKeyPath_FailsStartup()
     {
+        var now = DateTimeOffset.Parse("2026-07-13T01:00:00Z");
+        var configuration = CreateConfiguration(now, enabled: true, includeSigningKeyPath: false);
+
+        var parse = () => ServiceIdentityConfiguration.FromConfiguration(configuration, now);
+
+        parse.Should().Throw<InvalidOperationException>()
+            .WithMessage("*SigningKeyPath is required*");
+    }
+
+    [Test]
+    public void Configuration_AllowInsecureHttp_DefaultsToFalseAndCanBeExplicitlyEnabled()
+    {
+        var now = DateTimeOffset.Parse("2026-07-13T01:00:00Z");
+        var secureByDefault = ServiceIdentityConfiguration.FromConfiguration(
+            CreateConfiguration(now, enabled: false, includeSigningKeyPath: false),
+            now);
+        var explicitlyInsecure = ServiceIdentityConfiguration.FromConfiguration(
+            CreateConfiguration(
+                now,
+                enabled: false,
+                allowInsecureHttp: true,
+                includeSigningKeyPath: false),
+            now);
+
+        secureByDefault.AllowInsecureHttp.Should().BeFalse();
+        explicitlyInsecure.AllowInsecureHttp.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task BoltTransportEndpoint_InsecureHttp_RejectsBeforeCredentialValidation()
+    {
+        var fixture = CreateService(
+            new MutableTimeProvider(DateTimeOffset.Parse("2026-07-13T01:00:00Z")),
+            enabled: false,
+            includeSigningKeyPath: false);
         var service = new Mock<IServiceIdentityService>(MockBehavior.Strict);
         var context = new DefaultHttpContext();
         context.Request.Scheme = "http";
@@ -60,6 +120,7 @@ public sealed class BoltTransportTokenIssuerTests
                 ClientSecret = CurrentClientSecret
             },
             context.Request,
+            fixture.Configuration,
             service.Object,
             CancellationToken.None);
 
@@ -70,8 +131,43 @@ public sealed class BoltTransportTokenIssuerTests
     }
 
     [Test]
-    public async Task Endpoint_Https_DelegatesOnlySubmittedClientCredentials()
+    public async Task ServiceTokenEndpoint_InsecureHttp_RejectsBeforeCredentialValidation()
     {
+        var fixture = CreateService(
+            new MutableTimeProvider(DateTimeOffset.Parse("2026-07-13T01:00:00Z")),
+            enabled: false,
+            includeSigningKeyPath: false);
+        var request = new IssueServiceTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = CurrentClientSecret,
+            Audience = XFrameworkServiceNames.IdentityServer
+        };
+        var service = new Mock<IServiceIdentityService>(MockBehavior.Strict);
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "http";
+
+        var result = await IssueServiceTokenEndpoint.Handle(
+            request,
+            context.Request,
+            fixture.Configuration,
+            service.Object,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(400);
+        result.Message.Should().Be("HTTPS is required");
+        service.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task BoltTransportEndpoint_AllowInsecureHttp_DelegatesSubmittedCredentials()
+    {
+        var fixture = CreateService(
+            new MutableTimeProvider(DateTimeOffset.Parse("2026-07-13T01:00:00Z")),
+            enabled: false,
+            allowInsecureHttp: true,
+            includeSigningKeyPath: false);
         var expected = Result<ServiceTokenResponse>.Success(new ServiceTokenResponse());
         var service = new Mock<IServiceIdentityService>(MockBehavior.Strict);
         service.Setup(candidate => candidate.IssueBoltTransportTokenAsync(
@@ -80,7 +176,7 @@ public sealed class BoltTransportTokenIssuerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
         var context = new DefaultHttpContext();
-        context.Request.Scheme = "https";
+        context.Request.Scheme = "http";
 
         var result = await IssueBoltTransportTokenEndpoint.Handle(
             new IssueBoltTransportTokenRequest
@@ -89,6 +185,7 @@ public sealed class BoltTransportTokenIssuerTests
                 ClientSecret = CurrentClientSecret
             },
             context.Request,
+            fixture.Configuration,
             service.Object,
             CancellationToken.None);
 
@@ -97,30 +194,33 @@ public sealed class BoltTransportTokenIssuerTests
     }
 
     [Test]
-    public void Endpoint_IsHttpOnlyAndExcludedFromOpenApi()
+    public void CredentialEndpoints_AreHttpOnlyAndExcludedFromOpenApi()
     {
-        var method = typeof(IssueBoltTransportTokenEndpoint).GetMethod(
-            nameof(IssueBoltTransportTokenEndpoint.Handle),
-            BindingFlags.Public | BindingFlags.Static);
-
-        method.Should().NotBeNull();
-        var endpointMethod = method!;
-        endpointMethod.GetCustomAttribute<BoltHandlerAttribute>().Should().BeNull();
-        var mapPost = endpointMethod.GetCustomAttribute<MapPostAttribute>();
-        mapPost.Should().NotBeNull();
-        mapPost!.Route.Should().Be("/api/service-identity/bolt-transport-token");
-        mapPost.ExcludeFromOpenApi.Should().BeTrue();
+        AssertCredentialEndpoint(
+            typeof(IssueBoltTransportTokenEndpoint),
+            BoltTransportTokenConstants.TokenEndpointPath);
+        AssertCredentialEndpoint(
+            typeof(IssueServiceTokenEndpoint),
+            "/api/service-identity/token");
     }
 
     [Test]
-    public async Task IssueBoltTransportToken_CurrentCredential_IssuesExactCurrentGenerationIdentityAndClaims()
+    public void ServiceTokenCredentialRequest_IsNotBoltRoutable()
+    {
+        typeof(IssueServiceTokenRequest).GetInterfaces()
+            .Should().NotContain(interfaceType =>
+                interfaceType.IsGenericType &&
+                interfaceType.GetGenericTypeDefinition() == typeof(IBoltRequest<,>));
+    }
+
+    [Test]
+    public async Task IssueBoltTransportToken_CurrentCredential_IssuesValidatedRs256TransportIdentity()
     {
         var now = DateTimeOffset.Parse("2026-07-13T01:02:03Z");
         var clock = new MutableTimeProvider(now);
-        var jwtOptions = CreateJwtOptions(now);
-        var service = CreateService(clock, jwtOptions: jwtOptions, lifetimeSeconds: 120);
+        var fixture = CreateService(clock, lifetimeSeconds: 120);
 
-        var result = await service.IssueBoltTransportTokenAsync(ClientId, CurrentClientSecret);
+        var result = await fixture.Service.IssueBoltTransportTokenAsync(ClientId, CurrentClientSecret);
 
         result.IsSuccess.Should().BeTrue();
         result.Data.Should().NotBeNull();
@@ -128,57 +228,160 @@ public sealed class BoltTransportTokenIssuerTests
         result.Data.ExpiresAtUtc.Should().Be(now.UtcDateTime.AddSeconds(120));
 
         var token = new JwtSecurityTokenHandler().ReadJwtToken(result.Data.AccessToken);
-        token.Header.Alg.Should().Be(SecurityAlgorithms.HmacSha512);
-        token.Header.Kid.Should().Be(CurrentJwtGeneration);
+        token.Header.Alg.Should().Be(BoltTransportTokenConstants.Algorithm);
+        token.Header.Typ.Should().Be(BoltTransportTokenConstants.TokenType);
+        token.Header.Kid.Should().Be(fixture.Signer.KeyId);
         token.Issuer.Should().Be(Issuer);
-        token.Audiences.Should().Equal(Audience);
+        token.Audiences.Should().Equal(BoltTransportTokenConstants.Audience);
         Claim(token, "client_id").Should().Be(ClientId);
         Claim(token, "service").Should().Be(ClientId);
         Claim(token, JwtRegisteredClaimNames.Sub).Should().Be(ClientId);
-        Claim(token, "scope").Should().Be(XFrameworkServiceScopes.BoltService);
-        Claim(token, JwtCredentialSet.GenerationClaim).Should().Be(CurrentJwtGeneration);
+        Claim(token, "scope").Should().Be(BoltTransportTokenConstants.Scope);
         Claim(token, "client_credential_generation").Should().Be(CurrentClientGeneration);
+        token.Claims.Should().NotContain(claim => claim.Type == JwtCredentialSet.GenerationClaim);
         Claim(token, JwtRegisteredClaimNames.Jti).Should().NotBeNullOrWhiteSpace();
         Claim(token, JwtRegisteredClaimNames.Iat).Should().Be(now.ToUnixTimeSeconds().ToString());
         Claim(token, JwtRegisteredClaimNames.Nbf).Should().Be(now.ToUnixTimeSeconds().ToString());
         Claim(token, JwtRegisteredClaimNames.Exp).Should().Be(now.AddSeconds(120).ToUnixTimeSeconds().ToString());
 
+        using var validationRsa = CreatePublicRsa(fixture.Signer.GetJsonWebKeySet().Keys.Single());
         var validate = () => new JwtSecurityTokenHandler().ValidateToken(
             result.Data.AccessToken,
-            JwtCredentialSet.CreateValidationParameters(jwtOptions, validateLifetime: false, clock),
+            new TokenValidationParameters
+            {
+                ClockSkew = TimeSpan.Zero,
+                IssuerSigningKey = new RsaSecurityKey(validationRsa)
+                {
+                    KeyId = fixture.Signer.KeyId,
+                    CryptoProviderFactory = new CryptoProviderFactory { CacheSignatureProviders = false }
+                },
+                RequireAudience = true,
+                RequireExpirationTime = true,
+                RequireSignedTokens = true,
+                ValidateAudience = true,
+                ValidateIssuer = true,
+                ValidateIssuerSigningKey = true,
+                ValidateLifetime = false,
+                ValidAlgorithms = [BoltTransportTokenConstants.Algorithm],
+                ValidAudience = BoltTransportTokenConstants.Audience,
+                ValidIssuer = Issuer,
+                ValidTypes = [BoltTransportTokenConstants.TokenType]
+            },
             out _);
         validate.Should().NotThrow();
     }
 
     [Test]
-    public async Task IssueBoltTransportToken_FallbackClientCredentialBeforeDeadline_StillUsesCurrentJwtGeneration()
+    public async Task IssueBoltTransportToken_SignerConcurrentCallers_RemainsThreadSafe()
+    {
+        const int callerCount = 16;
+        var now = DateTimeOffset.Parse("2026-07-13T01:30:00Z");
+        var fixture = CreateService(new MutableTimeProvider(now));
+        var warmUpTokens = new List<string>();
+        for (var index = 0; index < 4; index++)
+        {
+            var warmUp = await fixture.Service.IssueBoltTransportTokenAsync(ClientId, CurrentClientSecret);
+            warmUp.IsSuccess.Should().BeTrue();
+            warmUp.Data.Should().NotBeNull();
+            warmUpTokens.Add(warmUp.Data!.AccessToken);
+        }
+
+        using var ready = new CountdownEvent(callerCount);
+        using var release = new ManualResetEventSlim();
+        var calls = Enumerable.Range(0, callerCount)
+            .Select(_ => Task.Factory.StartNew(
+                () =>
+                {
+                    ready.Signal();
+                    release.Wait();
+                    return fixture.Service
+                        .IssueBoltTransportTokenAsync(ClientId, CurrentClientSecret)
+                        .GetAwaiter()
+                        .GetResult();
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default))
+            .ToArray();
+
+        ready.Wait();
+        release.Set();
+        var results = await Task.WhenAll(calls);
+        var followUp = await fixture.Service.IssueBoltTransportTokenAsync(ClientId, CurrentClientSecret);
+
+        results.Should().OnlyContain(result => result.IsSuccess && result.Data != null);
+        followUp.IsSuccess.Should().BeTrue();
+        followUp.Data.Should().NotBeNull();
+        var accessTokens = warmUpTokens
+            .Concat(results.Select(result => result.Data!.AccessToken))
+            .Append(followUp.Data!.AccessToken)
+            .ToArray();
+        accessTokens.Should().OnlyHaveUniqueItems();
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var parsedTokens = accessTokens.Select(tokenHandler.ReadJwtToken).ToArray();
+        parsedTokens.Select(token => Claim(token, JwtRegisteredClaimNames.Jti))
+            .Should().OnlyHaveUniqueItems();
+        parsedTokens.Should().OnlyContain(token => token.Header.Kid == fixture.Signer.KeyId);
+
+        using var validationRsa = CreatePublicRsa(fixture.Signer.GetJsonWebKeySet().Keys.Single());
+        var validationParameters = new TokenValidationParameters
+        {
+            ClockSkew = TimeSpan.Zero,
+            IssuerSigningKey = new RsaSecurityKey(validationRsa)
+            {
+                KeyId = fixture.Signer.KeyId,
+                CryptoProviderFactory = new CryptoProviderFactory { CacheSignatureProviders = false }
+            },
+            RequireAudience = true,
+            RequireExpirationTime = true,
+            RequireSignedTokens = true,
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidateIssuerSigningKey = true,
+            ValidateLifetime = false,
+            ValidAlgorithms = [BoltTransportTokenConstants.Algorithm],
+            ValidAudience = BoltTransportTokenConstants.Audience,
+            ValidIssuer = Issuer,
+            ValidTypes = [BoltTransportTokenConstants.TokenType]
+        };
+        for (var index = 0; index < accessTokens.Length; index++)
+        {
+            var validate = () => tokenHandler.ValidateToken(accessTokens[index], validationParameters, out _);
+            validate.Should().NotThrow("token index {0} must remain valid after concurrent signing", index);
+        }
+    }
+
+    [Test]
+    public async Task IssueBoltTransportToken_FallbackCredential_UsesAuthenticatedCredentialGeneration()
     {
         var now = DateTimeOffset.Parse("2026-07-13T02:00:00Z");
-        var clock = new MutableTimeProvider(now);
-        var service = CreateService(clock, fallbackValidUntilUtc: now.AddMinutes(5));
+        var fixture = CreateService(
+            new MutableTimeProvider(now),
+            fallbackValidUntilUtc: now.AddMinutes(5));
 
-        var result = await service.IssueBoltTransportTokenAsync(ClientId, FallbackClientSecret);
+        var result = await fixture.Service.IssueBoltTransportTokenAsync(ClientId, FallbackClientSecret);
 
         result.IsSuccess.Should().BeTrue();
         var token = new JwtSecurityTokenHandler().ReadJwtToken(result.Data!.AccessToken);
-        token.Header.Kid.Should().Be(CurrentJwtGeneration);
-        Claim(token, JwtCredentialSet.GenerationClaim).Should().Be(CurrentJwtGeneration);
+        token.Header.Kid.Should().Be(fixture.Signer.KeyId);
         Claim(token, "client_credential_generation").Should().Be(FallbackClientGeneration);
         Claim(token, "client_id").Should().Be(ClientId);
         Claim(token, "service").Should().Be(ClientId);
         Claim(token, JwtRegisteredClaimNames.Sub).Should().Be(ClientId);
+        token.Claims.Should().NotContain(claim => claim.Type == JwtCredentialSet.GenerationClaim);
     }
 
     [Test]
-    public async Task IssueBoltTransportToken_FallbackClientCredentialAtDeadline_IsRejected()
+    public async Task IssueBoltTransportToken_FallbackCredentialAtDeadline_IsRejected()
     {
         var now = DateTimeOffset.Parse("2026-07-13T03:00:00Z");
         var deadline = now.AddMinutes(5);
         var clock = new MutableTimeProvider(now);
-        var service = CreateService(clock, fallbackValidUntilUtc: deadline);
+        var fixture = CreateService(clock, fallbackValidUntilUtc: deadline);
         clock.SetUtcNow(deadline);
 
-        var result = await service.IssueBoltTransportTokenAsync(ClientId, FallbackClientSecret);
+        var result = await fixture.Service.IssueBoltTransportTokenAsync(ClientId, FallbackClientSecret);
 
         result.IsSuccess.Should().BeFalse();
         result.StatusCode.Should().Be(401);
@@ -190,7 +393,7 @@ public sealed class BoltTransportTokenIssuerTests
     public void Configuration_LifetimeOutsideBound_FailsStartup(int lifetimeSeconds)
     {
         var now = DateTimeOffset.Parse("2026-07-13T04:00:00Z");
-        var configuration = CreateConfiguration(now, enabled: true, lifetimeSeconds: lifetimeSeconds);
+        var configuration = CreateConfiguration(now, lifetimeSeconds: lifetimeSeconds);
 
         var parse = () => ServiceIdentityConfiguration.FromConfiguration(configuration, now);
 
@@ -203,12 +406,91 @@ public sealed class BoltTransportTokenIssuerTests
     public void Configuration_LifetimeAtBound_IsAccepted(int lifetimeSeconds)
     {
         var now = DateTimeOffset.Parse("2026-07-13T04:00:00Z");
-        var configuration = CreateConfiguration(now, enabled: true, lifetimeSeconds: lifetimeSeconds);
+        var configuration = CreateConfiguration(now, lifetimeSeconds: lifetimeSeconds);
 
         var parsed = ServiceIdentityConfiguration.FromConfiguration(configuration, now);
 
         parsed.BoltTransportTokenIssuerEnabled.Should().BeTrue();
         parsed.BoltTransportTokenLifetimeSeconds.Should().Be(lifetimeSeconds);
+        parsed.BoltTransportSigningKeyPath.Should().Be(Path.GetFullPath(_signingKeyPath));
+    }
+
+    [Test]
+    public void FileBackedSigner_ReloadsStablePublicKeyAndKeyId()
+    {
+        var now = DateTimeOffset.Parse("2026-07-13T04:30:00Z");
+        var signingKeyPath = Path.Combine(_temporaryDirectory, $"reload-{Guid.NewGuid():N}.pem");
+        var configuration = ServiceIdentityConfiguration.FromConfiguration(
+            CreateConfiguration(now, signingKeyPath: signingKeyPath),
+            now);
+
+        var first = new FileBackedBoltTransportTokenSigner(configuration);
+        var firstFile = File.ReadAllBytes(signingKeyPath);
+        var second = new FileBackedBoltTransportTokenSigner(configuration);
+
+        File.Exists(signingKeyPath).Should().BeTrue();
+        File.ReadAllText(signingKeyPath).Should().Contain("BEGIN PRIVATE KEY");
+        File.ReadAllBytes(signingKeyPath).Should().Equal(firstFile);
+        second.KeyId.Should().Be(first.KeyId);
+        second.GetJsonWebKeySet().Should().BeEquivalentTo(first.GetJsonWebKeySet());
+
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() || OperatingSystem.IsFreeBSD())
+        {
+            File.GetUnixFileMode(signingKeyPath).Should().Be(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+    }
+
+    [Test]
+    public async Task JwksEndpoint_ReturnsOnlyRsa3072PublicMaterial()
+    {
+        var fixture = CreateService(new MutableTimeProvider(DateTimeOffset.Parse("2026-07-13T04:45:00Z")));
+
+        var result = await GetBoltTransportJwksEndpoint.Handle(
+            new GetBoltTransportJwksRequest(),
+            fixture.Signer,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.Keys.Should().ContainSingle();
+        var key = result.Data.Keys.Single();
+        key.KeyId.Should().Be(fixture.Signer.KeyId);
+        key.Algorithm.Should().Be(BoltTransportTokenConstants.Algorithm);
+        key.Use.Should().Be("sig");
+        Base64UrlEncoder.DecodeBytes(key.Modulus).Should().HaveCount(384);
+
+        var json = JsonSerializer.Serialize(result.Data);
+        using var document = JsonDocument.Parse(json);
+        var publicKeyProperties = document.RootElement
+            .GetProperty("keys")[0]
+            .EnumerateObject()
+            .Select(static property => property.Name);
+        publicKeyProperties.Should().BeEquivalentTo("kty", "use", "kid", "alg", "n", "e");
+        json.Should().NotContain("PRIVATE KEY");
+        json.Should().NotContain("\"d\"");
+        json.Should().NotContain("\"p\"");
+        json.Should().NotContain("\"q\"");
+    }
+
+    [Test]
+    public async Task MetadataEndpoint_ReturnsJwtBearerDiscoveryDocument()
+    {
+        var fixture = CreateService(
+            new MutableTimeProvider(DateTimeOffset.Parse("2026-07-13T04:50:00Z")),
+            enabled: false,
+            includeSigningKeyPath: false);
+        var result = await GetBoltTransportMetadataEndpoint.Handle(
+            new GetBoltTransportMetadataRequest(),
+            fixture.Configuration,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.Issuer.Should().Be(Issuer);
+        result.Data.JsonWebKeySetUri.Should().Be(
+            $"https://identity.test:8443{BoltTransportTokenConstants.JsonWebKeySetPath}");
+        result.Data.TokenEndpoint.Should().Be(
+            $"https://identity.test:8443{BoltTransportTokenConstants.TokenEndpointPath}");
+        result.Data.SigningAlgorithms.Should().Equal(BoltTransportTokenConstants.Algorithm);
     }
 
     [Test]
@@ -216,12 +498,11 @@ public sealed class BoltTransportTokenIssuerTests
     {
         const string invalidSecret = "invalid-supplied-secret-that-must-never-be-logged";
         var now = DateTimeOffset.Parse("2026-07-13T05:00:00Z");
-        var clock = new MutableTimeProvider(now);
         var logger = new CapturingLogger<ServiceIdentityService>();
-        var service = CreateService(clock, logger: logger);
+        var fixture = CreateService(new MutableTimeProvider(now), logger: logger);
 
-        var denied = await service.IssueBoltTransportTokenAsync(ClientId, invalidSecret);
-        var issued = await service.IssueBoltTransportTokenAsync(ClientId, FallbackClientSecret);
+        var denied = await fixture.Service.IssueBoltTransportTokenAsync(ClientId, invalidSecret);
+        var issued = await fixture.Service.IssueBoltTransportTokenAsync(ClientId, FallbackClientSecret);
 
         denied.IsSuccess.Should().BeFalse();
         issued.IsSuccess.Should().BeTrue();
@@ -229,10 +510,9 @@ public sealed class BoltTransportTokenIssuerTests
         {
             CurrentClientSecret,
             FallbackClientSecret,
-            CurrentJwtSecret,
-            FallbackJwtSecret,
             invalidSecret,
-            issued.Data!.AccessToken
+            issued.Data!.AccessToken,
+            File.ReadAllText(_signingKeyPath)
         };
         foreach (var value in sensitiveValues)
         {
@@ -243,41 +523,54 @@ public sealed class BoltTransportTokenIssuerTests
         logger.Messages.Should().ContainSingle(message =>
             message.Contains(ClientId, StringComparison.Ordinal)
             && message.Contains(FallbackClientGeneration, StringComparison.Ordinal)
-            && message.Contains(CurrentJwtGeneration, StringComparison.Ordinal));
+            && message.Contains(fixture.Signer.KeyId, StringComparison.Ordinal));
     }
 
-    private static ServiceIdentityService CreateService(
+    private ServiceFixture CreateService(
         MutableTimeProvider clock,
         bool? enabled = true,
         int? lifetimeSeconds = 120,
         DateTimeOffset? fallbackValidUntilUtc = null,
-        JwtOptions? jwtOptions = null,
+        bool? allowInsecureHttp = null,
+        bool includeSigningKeyPath = true,
         ILogger<ServiceIdentityService>? logger = null)
     {
         var configuration = CreateConfiguration(
             clock.GetUtcNow(),
             enabled,
             lifetimeSeconds,
-            fallbackValidUntilUtc);
+            fallbackValidUntilUtc,
+            allowInsecureHttp,
+            includeSigningKeyPath);
         var parsed = ServiceIdentityConfiguration.FromConfiguration(configuration, clock.GetUtcNow());
+        var signer = includeSigningKeyPath
+            ? _signer
+            : new FileBackedBoltTransportTokenSigner(parsed);
 
-        return new ServiceIdentityService(
+        var service = new ServiceIdentityService(
             new Mock<IDataContext>(MockBehavior.Strict).Object,
             configuration,
             parsed,
-            jwtOptions ?? CreateJwtOptions(clock.GetUtcNow()),
+            signer,
             clock,
             logger ?? Mock.Of<ILogger<ServiceIdentityService>>());
+
+        return new ServiceFixture(service, parsed, signer);
     }
 
-    private static IConfiguration CreateConfiguration(
+    private IConfiguration CreateConfiguration(
         DateTimeOffset now,
-        bool? enabled,
-        int? lifetimeSeconds,
-        DateTimeOffset? fallbackValidUntilUtc = null)
+        bool? enabled = true,
+        int? lifetimeSeconds = 120,
+        DateTimeOffset? fallbackValidUntilUtc = null,
+        bool? allowInsecureHttp = null,
+        bool includeSigningKeyPath = true,
+        string? signingKeyPath = null)
     {
         var values = new Dictionary<string, string?>
         {
+            ["ServiceIdentity:Authority"] = "https://identity.test:8443",
+            ["ServiceIdentity:Issuer"] = Issuer,
             ["ServiceIdentity:Clients:0:ClientId"] = ClientId,
             ["ServiceIdentity:Clients:0:GenerationId"] = CurrentClientGeneration,
             ["ServiceIdentity:Clients:0:ClientSecret"] = CurrentClientSecret,
@@ -285,30 +578,55 @@ public sealed class BoltTransportTokenIssuerTests
             ["ServiceIdentity:Clients:0:ValidationFallback:ClientSecret"] = FallbackClientSecret,
             ["ServiceIdentity:Clients:0:ValidationFallback:ValidUntilUtc"] =
                 (fallbackValidUntilUtc ?? now.AddMinutes(10)).ToString("O"),
-            ["ServiceIdentity:Clients:0:AllowedScopes:0"] = XFrameworkServiceScopes.BoltService,
-            ["ServiceIdentity:BoltTransportTokenIssuer:Enabled"] = enabled?.ToString(),
-            ["ServiceIdentity:BoltTransportTokenIssuer:LifetimeSeconds"] = lifetimeSeconds?.ToString()
+            ["ServiceIdentity:Clients:0:AllowedScopes:0"] = XFrameworkServiceScopes.BoltService
         };
+
+        if (enabled.HasValue)
+            values["ServiceIdentity:BoltTransportTokenIssuer:Enabled"] = enabled.Value.ToString();
+        if (lifetimeSeconds.HasValue)
+            values["ServiceIdentity:BoltTransportTokenIssuer:LifetimeSeconds"] = lifetimeSeconds.Value.ToString();
+        if (allowInsecureHttp.HasValue)
+            values["ServiceIdentity:AllowInsecureHttp"] = allowInsecureHttp.Value.ToString();
+        if (includeSigningKeyPath)
+        {
+            values["ServiceIdentity:BoltTransportTokenIssuer:SigningKeyPath"] =
+                signingKeyPath ?? _signingKeyPath;
+        }
 
         return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
     }
 
-    private static JwtOptions CreateJwtOptions(DateTimeOffset now) => new()
+    private static void AssertCredentialEndpoint(Type endpointType, string route)
     {
-        GenerationId = CurrentJwtGeneration,
-        Secret = CurrentJwtSecret,
-        ValidationFallback = new JwtValidationFallbackOptions
+        var method = endpointType.GetMethod("Handle", BindingFlags.Public | BindingFlags.Static);
+
+        method.Should().NotBeNull();
+        var endpointMethod = method!;
+        endpointMethod.GetCustomAttribute<BoltHandlerAttribute>().Should().BeNull();
+        var mapPost = endpointMethod.GetCustomAttribute<MapPostAttribute>();
+        mapPost.Should().NotBeNull();
+        mapPost!.Route.Should().Be(route);
+        mapPost.ExcludeFromOpenApi.Should().BeTrue();
+    }
+
+    private static RSA CreatePublicRsa(BoltTransportJsonWebKey key)
+    {
+        var rsa = RSA.Create();
+        rsa.ImportParameters(new RSAParameters
         {
-            GenerationId = FallbackJwtGeneration,
-            Secret = FallbackJwtSecret,
-            ValidUntilUtc = now.AddMinutes(10)
-        },
-        ValidIssuer = Issuer,
-        ValidAudience = Audience
-    };
+            Modulus = Base64UrlEncoder.DecodeBytes(key.Modulus),
+            Exponent = Base64UrlEncoder.DecodeBytes(key.Exponent)
+        });
+        return rsa;
+    }
 
     private static string Claim(JwtSecurityToken token, string claimType) =>
         token.Claims.Single(claim => claim.Type == claimType).Value;
+
+    private sealed record ServiceFixture(
+        ServiceIdentityService Service,
+        ServiceIdentityConfiguration Configuration,
+        IBoltTransportTokenSigner Signer);
 
     private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
     {

--- a/src/Tests/IdentityServer.UnitTests/GeneratedTokenHttpAdapterTests.cs
+++ b/src/Tests/IdentityServer.UnitTests/GeneratedTokenHttpAdapterTests.cs
@@ -8,6 +8,7 @@ using IdentityServer.Domain.Shared.Contracts.Requests;
 using IdentityServer.Domain.Shared.Contracts.Responses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using NUnit.Framework;
@@ -85,6 +86,7 @@ public sealed class GeneratedTokenHttpAdapterTests
                 throwOnError: true)!,
             request,
             context.Request,
+            CreateServiceIdentityConfiguration(),
             service.Object,
             CancellationToken.None);
 
@@ -131,5 +133,20 @@ public sealed class GeneratedTokenHttpAdapterTests
 
         var result = generatedUnion!.GetType().GetProperty("Result")!.GetValue(generatedUnion);
         return result.Should().BeAssignableTo<IResult>().Subject;
+    }
+
+    private static ServiceIdentityConfiguration CreateServiceIdentityConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ServiceIdentity:Clients:0:ClientId"] = "test-client",
+                ["ServiceIdentity:Clients:0:GenerationId"] = "test-g1",
+                ["ServiceIdentity:Clients:0:ClientSecret"] =
+                    "test-service-credential-material-111111111111111111111111"
+            })
+            .Build();
+
+        return ServiceIdentityConfiguration.FromConfiguration(configuration, DateTimeOffset.UtcNow);
     }
 }

--- a/src/Tests/IdentityServer.UnitTests/ServiceIdentityCredentialGenerationTests.cs
+++ b/src/Tests/IdentityServer.UnitTests/ServiceIdentityCredentialGenerationTests.cs
@@ -222,13 +222,7 @@ public sealed class ServiceIdentityCredentialGenerationTests
             dataContext.Object,
             configuration,
             parsed,
-            new JwtOptions
-            {
-                GenerationId = "jwt-test-generation",
-                Secret = new string('j', JwtCredentialSet.MinimumHmacSha512SecretBytes),
-                ValidIssuer = "https://identity.test",
-                ValidAudience = "https://bolt.test"
-            },
+            Mock.Of<IBoltTransportTokenSigner>(),
             clock,
             logger ?? NullLogger<ServiceIdentityService>.Instance);
     }

--- a/src/Tests/IdentityServer.UnitTests/ServiceIdentityScopeIsolationTests.cs
+++ b/src/Tests/IdentityServer.UnitTests/ServiceIdentityScopeIsolationTests.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Domain.Shared.ServiceIdentity;
-using XFramework.Integration.Security;
 
 namespace IdentityServer.UnitTests;
 
@@ -106,13 +105,7 @@ public sealed class ServiceIdentityScopeIsolationTests
             new Mock<IDataContext>(MockBehavior.Strict).Object,
             configuration,
             serviceIdentityConfiguration,
-            new JwtOptions
-            {
-                GenerationId = "jwt-g1",
-                Secret = new string('j', JwtCredentialSet.MinimumHmacSha512SecretBytes),
-                ValidIssuer = "https://identity.test",
-                ValidAudience = "https://bolt.test"
-            },
+            Mock.Of<IBoltTransportTokenSigner>(),
             TimeProvider.System,
             NullLogger<ServiceIdentityService>.Instance);
     }

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -39,6 +39,38 @@ public sealed class ServiceIdentityComposeContractTests
         "XFramework.Operations.Dashboard"
     ];
 
+    private static readonly string[] IdentityDependentServices =
+    [
+        "bolt-hub",
+        "communications",
+        "notifications",
+        "storage",
+        "attendance",
+        "smsgateway",
+        "wallets",
+        "inventario",
+        "pos",
+        "portal",
+        "operations-dashboard",
+        "bolt-phase0-synthetics"
+    ];
+
+    private static readonly string[] CentralIdentityServices =
+    [
+        "bolt-hub",
+        "identityserver",
+        "communications",
+        "notifications",
+        "storage",
+        "attendance",
+        "smsgateway",
+        "wallets",
+        "inventario",
+        "pos",
+        "portal",
+        "operations-dashboard"
+    ];
+
     [Test]
     public void DockerCompose_UsesExplicitServiceIdentityClientsInsteadOfDevelopmentFallback()
     {
@@ -90,11 +122,120 @@ public sealed class ServiceIdentityComposeContractTests
         }
 
         compose.Should().Contain("x-service-identity-audiences:");
-        compose.Should().Contain("x-service-identity-scopes:");
         compose.Should().Contain("ServiceIdentity__Clients__");
         compose.Should().Contain("AllowedAudiences: *service-identity-audiences");
-        compose.Should().Contain("AllowedScopes: *service-identity-scopes");
+        compose.Should().Contain("AllowedScopes: bolt.service");
+        compose.Should().Contain("AllowedScopes: bolt.service,datacontext.query,datacontext.mutate,identity.admin");
     }
+
+    [Test]
+    public void DockerCompose_CentralizesBoltTransportIdentityInIdentityServer()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var compose = File.ReadAllText(Path.Combine(repositoryRoot.FullName, "docker-compose.yml"));
+        var envExample = File.ReadAllText(Path.Combine(repositoryRoot.FullName, ".env.example"));
+        var commonEnvironment = ExtractSection(compose, "x-common-env: &common-env", "services:");
+        var hub = ExtractService(compose, "bolt-hub");
+        var identityServer = ExtractService(compose, "identityserver");
+
+        compose.Should().NotContain("BoltConfiguration__Signature");
+        compose.Should().NotContain("BOLT_SIGNATURE");
+        envExample.Should().Contain(
+            "# Rollback-only until the first centralized-identity LKG is sealed. " +
+            "New services do not receive this value.");
+        envExample.Should().Contain("BOLT_SIGNATURE=change-me-legacy-rollback-");
+
+        commonEnvironment.Should().Contain("BoltConfiguration__GenerateServiceAccessToken: false");
+        commonEnvironment.Should().Contain("ServiceIdentity__Authority: http://identityserver:8080");
+        commonEnvironment.Should().Contain("ServiceIdentity__AllowInsecureHttp: true");
+        foreach (var service in CentralIdentityServices)
+        {
+            var serviceBlock = ExtractService(compose, service);
+            var hasEffectiveCentralIdentity = serviceBlock.Contains("      <<: *common-env", StringComparison.Ordinal)
+                || (serviceBlock.Contains(
+                        "BoltConfiguration__GenerateServiceAccessToken: false",
+                        StringComparison.Ordinal)
+                    && serviceBlock.Contains(
+                        "ServiceIdentity__Authority: http://identityserver:8080",
+                        StringComparison.Ordinal)
+                    && serviceBlock.Contains(
+                        "ServiceIdentity__AllowInsecureHttp: true",
+                        StringComparison.Ordinal));
+            hasEffectiveCentralIdentity.Should().BeTrue(
+                "Compose service {0} must receive the common central identity configuration",
+                service);
+        }
+
+        hub.Should().Contain(
+            "BoltTransportAuthentication__MetadataAddress: " +
+            "http://identityserver:8080/.well-known/openid-configuration");
+        hub.Should().Contain("BoltTransportAuthentication__Issuer: XFramework.IdentityServer");
+        hub.Should().Contain("BoltTransportAuthentication__Audience: XFramework.Bolt.Hub");
+        hub.Should().Contain("BoltTransportAuthentication__RequireHttpsMetadata: false");
+
+        identityServer.Should().Contain("Kestrel__Endpoints__Http__Url: http://0.0.0.0:8080");
+        identityServer.Should().Contain(
+            "ServiceIdentity__BoltTransportTokenIssuer__SigningKeyPath: " +
+            "/var/lib/xframework/identity/bolt-transport-signing-key.pem");
+        identityServer.Should().Contain("- identity-keydata:/var/lib/xframework/identity");
+
+        var identityPorts = ExtractSection(identityServer, "    ports:", "    depends_on:");
+        identityPorts.Should().Contain(":8443");
+        identityPorts.Should().NotContain("8080");
+
+        var identityDependencies = ExtractSection(
+            identityServer,
+            "    depends_on:",
+            "    healthcheck:");
+        identityDependencies.Should().Contain(
+            "      migrate:\n        condition: service_completed_successfully");
+        identityDependencies.Should().Contain(
+            "      postgres:\n        condition: service_healthy");
+        identityDependencies.Should().NotContain("      bolt-hub:");
+
+        foreach (var service in IdentityDependentServices)
+        {
+            ExtractService(compose, service).Should().Contain(
+                "      identityserver:\n        condition: service_healthy");
+        }
+    }
+
+    private static string ExtractService(string compose, string service)
+    {
+        var lines = NormalizeLines(compose).Split('\n');
+        var marker = $"  {service}:";
+        var start = Array.FindIndex(lines, line => line == marker);
+        if (start < 0)
+            throw new InvalidOperationException($"Could not locate Compose service '{service}'.");
+
+        var end = Array.FindIndex(
+            lines,
+            start + 1,
+            line => line.StartsWith("  ", StringComparison.Ordinal)
+                && !line.StartsWith("    ", StringComparison.Ordinal)
+                && line.EndsWith(':'));
+        if (end < 0)
+            end = lines.Length;
+
+        return string.Join('\n', lines[start..end]);
+    }
+
+    private static string ExtractSection(string text, string startMarker, string endMarker)
+    {
+        var normalized = NormalizeLines(text);
+        var start = normalized.IndexOf(startMarker, StringComparison.Ordinal);
+        if (start < 0)
+            throw new InvalidOperationException($"Could not locate section '{startMarker}'.");
+
+        var end = normalized.IndexOf($"\n{endMarker}", start, StringComparison.Ordinal);
+        if (end < 0)
+            throw new InvalidOperationException($"Could not locate section terminator '{endMarker}'.");
+
+        return normalized[start..end];
+    }
+
+    private static string NormalizeLines(string value) =>
+        value.Replace("\r\n", "\n", StringComparison.Ordinal);
 
     private static DirectoryInfo FindRepositoryRoot()
     {


### PR DESCRIPTION
## Summary
- centralize Bolt transport-token issuance in IdentityServer with persisted RSA-3072 signing keys, RS256 tokens, metadata, and JWKS discovery
- validate transport identity in Bolt Hub with a dedicated authentication scheme while preserving the shared application Bearer scheme
- acquire transport and RPC service tokens over bounded HTTP calls with per-key single-flight caching and failure backoff
- break the IdentityServer/Hub readiness cycle through deferred Bolt startup and deploy IdentityServer before Hub and clients
- harden Phase 0 qualification with sealed-LKG compatibility validation and an explicit candidate-restart evidence contract

## Why
Services previously retained a local shared-secret token path and token renewal could block or stampede around Bolt bootstrap. This change makes IdentityServer the authority for service and transport identity, removes local self-minting, and keeps connection startup and readiness bounded.

## Validation
- Release solution build: passed
- Bolt tests: 366 passed, 0 skipped
- IdentityServer unit tests: 31 passed
- XFramework Core tests: 195 passed
- IdentityServer live integration tests: 80 passed
- Portal Compose contract tests: 2 passed
- all 19 Phase 0 Python test files: passed
- focused deployment closure suites: 101 passed, 13 platform-specific skips
- Docker Compose configuration, workflow YAML parsing, and git diff checks: passed

## Scope note
Per-service application TLS remains unchanged in this PR. Removing it in favor of the existing Tailscale deployment boundary is intentionally a separate follow-up phase.