### PR TITLE
Include synthetic profile in deployment verification

### DIFF
--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -574,7 +574,7 @@ jobs:
           env_file, compose_file, *service_names = sys.argv[2:]
           rendered = subprocess.run(
               [
-                  "docker", "compose", "--env-file", env_file,
+                  "docker", "compose", "--profile", "phase0-verification", "--env-file", env_file,
                   "-f", compose_file, "-f", str(path), "config", "--format", "json",
               ],
               check=True,

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -290,6 +290,7 @@ public sealed class ServiceIdentityComposeContractTests
         workflow.Should().Contain("docker inspect --format '{{.Image}}'");
         workflow.Should().Contain("docker image inspect \"$value\"");
         workflow.Should().Contain("docker pull \"$value\"");
+        workflow.Should().Contain("\"--profile\", \"phase0-verification\", \"--env-file\", env_file");
         workflow.Should().Contain("os.replace(temporary, path)");
         workflow.Should().Contain("$REMOTE_RUN_DIR/legacy-previous.env");
         workflow.Should().Contain("sudo -n -l /usr/local/sbin/xframework-bolt-phase0-root ensure-watchdog");


### PR DESCRIPTION
## Summary

- render the candidate Compose model with the phase0-verification profile enabled
- retain image-ID pinning for the profile-gated Bolt synthetic runner
- update the deployment contract test

## Validation

- ServiceIdentityComposeContractTests: 4 passed
- the prior deployment pulled all candidate images and stopped before mutation only because the profile-gated service was omitted from rendered verification