### PR TITLE
Fix staging synthetic WebSocket target

### DIFF
--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -496,8 +496,6 @@ jobs:
                 -f "$selected_release/docker-compose.yml"
                 -f "$selected_release/pinned-compose.override.json"
               )
-              test -x /usr/local/sbin/xframework-bolt-phase0-root
-              sudo -n -l /usr/local/sbin/xframework-bolt-phase0-root ensure-watchdog >/dev/null
             fi
             /usr/bin/timeout --foreground --kill-after=10s 120s \
               docker compose --project-name "$COMPOSE_PROJECT_NAME" \
@@ -1056,9 +1054,6 @@ jobs:
             done
             test "$ready" -eq 1
           done
-          if [ "$kind" = legacy ]; then
-            sudo -n /usr/local/sbin/xframework-bolt-phase0-root ensure-watchdog >/dev/null
-          fi
           install -m 600 "$release/docker-compose.yml" "$REMOTE_COMPOSE_FILE"
           rm -f "$REMOTE_RUN_DIR/complete"
           if [ "$kind" = normal ]; then

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -353,11 +353,14 @@ jobs:
           }
           for name in superseded:
               values.pop(name, None)
+          if not hub_url.startswith("https://"):
+              raise SystemExit("Hub public URL must use HTTPS")
+          hub_websocket_url = f"wss://{hub_url.removeprefix('https://').rstrip('/')}/bolt/ws"
           overrides = {
               "BOLT_HUB_EXPOSE_PORT": "7000",
               "IDENTITYSERVER_EXPOSE_PORT": "8261",
               "BOLT_SYNTHETIC_IDENTITYSERVER_BASE_URL": identity_url,
-              "BOLT_SYNTHETIC_TARGET": f"{hub_url}/bolt/ws",
+              "BOLT_SYNTHETIC_TARGET": hub_websocket_url,
               "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH": f"{token_dir}/communications-transport-token",
               "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH": f"{token_dir}/portal-transport-token",
               "BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH": f"{token_dir}/user-actor-token",

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -296,7 +296,7 @@ public sealed class ServiceIdentityComposeContractTests
         workflow.Should().Contain("\"--profile\", \"phase0-verification\", \"--env-file\", env_file");
         workflow.Should().Contain("os.replace(temporary, path)");
         workflow.Should().Contain("$REMOTE_RUN_DIR/legacy-previous.env");
-        workflow.Should().Contain("sudo -n -l /usr/local/sbin/xframework-bolt-phase0-root ensure-watchdog");
+        workflow.Should().NotContain("xframework-bolt-phase0-root ensure-watchdog");
         workflow.Should().NotContain("xframework-bolt-phase0-root verify-bootstrap");
         workflow.Should().Contain("systemctl is-active xframework-bolt-phase0-watchdog.service");
         workflow.Should().Contain("flock -n 9");

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -259,8 +259,11 @@ public sealed class ServiceIdentityComposeContractTests
             "?Set the external Tailscale Serve WSS endpoint}");
         envExample.Should().Contain(
             "BOLT_SYNTHETIC_TARGET=wss://xeon-dev.tailed40e.ts.net:7000/bolt/ws");
+        workflow.Should().Contain("if not hub_url.startswith(\"https://\"):");
         workflow.Should().Contain(
-            "\"BOLT_SYNTHETIC_TARGET\": f\"{hub_url}/bolt/ws\"");
+            "hub_websocket_url = f\"wss://{hub_url.removeprefix('https://').rstrip('/')}" +
+            "/bolt/ws\"");
+        workflow.Should().Contain("\"BOLT_SYNTHETIC_TARGET\": hub_websocket_url");
         workflow.Should().Contain("Verify diagnostic sink marker absence");
         workflow.Should().Contain("verify-bolt-phase0-diagnostic-sinks.py");
         workflow.Should().Contain("--seq-base-url");


### PR DESCRIPTION
﻿## Summary
- derive the Bolt synthetic target as `wss://` from the Tailscale Serve `https://` Hub URL
- fail candidate staging early if the configured public Hub URL is not HTTPS
- remove the retired root-watchdog prerequisite and rollback hook from the simplified Tailscale deployment
- cover the forward and rollback wiring in the deployment contract test

## Verification
- `dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj -c Release --no-restore --filter FullyQualifiedName~ServiceIdentityComposeContractTests` (`4 passed`)
- `git diff --check`
- restored the legacy staging stack after failed run `30427424700`; all containers and external IdentityServer/Bolt readiness endpoints are healthy

The canonical Bolt plan and results documents were reviewed before merge and already match the implemented authentication, rate-limit, Push, and topic-authorization behavior. The superseded Phase 0 deployment document already identifies the root watchdog as retired machinery.
