### PR TITLE
Fix Bolt staging synthetic service authorization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ BOLT_SYNTHETIC_DEVICE_ID=phase0-deployment-gate
 BOLT_SYNTHETIC_TARGET=wss://xeon-dev.tailed40e.ts.net:7000/bolt/ws
 BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH=./.secrets/bolt-phase0/communications-transport-token
 BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH=./.secrets/bolt-phase0/portal-transport-token
+BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH=./.secrets/bolt-phase0/portal-identity-service-token
 BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH=./.secrets/bolt-phase0/user-actor-token
 BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_PATH=./.secrets/bolt-phase0/expiry-transport-token
 BOLT_SYNTHETIC_IDENTITYSERVER_BASE_URL=https://xeon-dev.tailed40e.ts.net:8261

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -92,6 +92,7 @@ jobs:
       BOLT_SYNTHETIC_TARGET: wss://xeon-dev.tailed40e.ts.net:7000/bolt/ws
       BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-communications-transport-token
       BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-portal-transport-token
+      BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-portal-identity-service-token
       BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-user-actor-token
       BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-expiry-transport-token
 
@@ -205,6 +206,7 @@ jobs:
 
           install -m 600 /dev/null "$BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH"
           install -m 600 /dev/null "$BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH"
+          install -m 600 /dev/null "$BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH"
           install -m 600 /dev/null "$BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH"
           install -m 600 /dev/null "$BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_PATH"
           timeout --foreground --kill-after=10s 60s docker compose -f "$COMPOSE_FILE_PATH" config --quiet
@@ -302,6 +304,7 @@ jobs:
           install -d -m 700 "$token_dir"
           install -m 600 /dev/null "$token_dir/communications-transport-token"
           install -m 600 /dev/null "$token_dir/portal-transport-token"
+          install -m 600 /dev/null "$token_dir/portal-identity-service-token"
           install -m 600 /dev/null "$token_dir/user-actor-token"
           install -m 600 /dev/null "$token_dir/expiry-transport-token"
           python3 - "$XFRAMEWORK_ENV_FILE" "$REMOTE_CANDIDATE_ENV" "$IDENTITY_PUBLIC_URL" "$HUB_PUBLIC_URL" "$token_dir" <<'PY'
@@ -363,6 +366,7 @@ jobs:
               "BOLT_SYNTHETIC_TARGET": hub_websocket_url,
               "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH": f"{token_dir}/communications-transport-token",
               "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH": f"{token_dir}/portal-transport-token",
+              "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH": f"{token_dir}/portal-identity-service-token",
               "BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH": f"{token_dir}/user-actor-token",
               "BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_PATH": f"{token_dir}/expiry-transport-token",
           }
@@ -890,6 +894,7 @@ jobs:
           rm -f \
             "$REMOTE_RUN_DIR/synthetic-tokens/communications-transport-token" \
             "$REMOTE_RUN_DIR/synthetic-tokens/portal-transport-token" \
+            "$REMOTE_RUN_DIR/synthetic-tokens/portal-identity-service-token" \
             "$REMOTE_RUN_DIR/synthetic-tokens/user-actor-token" \
             "$REMOTE_RUN_DIR/synthetic-tokens/expiry-transport-token"
           rmdir "$REMOTE_RUN_DIR/synthetic-tokens"
@@ -950,6 +955,7 @@ jobs:
           install -d -m 700 "$token_dir"
           install -m 600 /dev/null "$token_dir/communications-transport-token"
           install -m 600 /dev/null "$token_dir/portal-transport-token"
+          install -m 600 /dev/null "$token_dir/portal-identity-service-token"
           install -m 600 /dev/null "$token_dir/user-actor-token"
           install -m 600 /dev/null "$token_dir/expiry-transport-token"
           printf '%s\n' "$IMAGE_TAG" > "$REMOTE_RUN_DIR/commit"
@@ -976,6 +982,7 @@ jobs:
             rm -f \
               "$REMOTE_RUN_DIR/synthetic-tokens/communications-transport-token" \
               "$REMOTE_RUN_DIR/synthetic-tokens/portal-transport-token" \
+              "$REMOTE_RUN_DIR/synthetic-tokens/portal-identity-service-token" \
               "$REMOTE_RUN_DIR/synthetic-tokens/user-actor-token" \
               "$REMOTE_RUN_DIR/synthetic-tokens/expiry-transport-token"
             rmdir "$REMOTE_RUN_DIR/synthetic-tokens" 2>/dev/null || true
@@ -1097,5 +1104,6 @@ jobs:
           rm -f \
             "$BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH" \
             "$BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH" \
+            "$BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH" \
             "$BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH" \
             "$BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_PATH"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -676,6 +676,7 @@ services:
       BOLT_SYNTHETIC_DEVICE_ID: ${BOLT_SYNTHETIC_DEVICE_ID:-phase0-deployment-gate}
       BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_FILE: /run/secrets/bolt-synthetic-communications-transport-token
       BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_FILE: /run/secrets/bolt-synthetic-portal-transport-token
+      BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_FILE: /run/secrets/bolt-synthetic-portal-identity-service-token
       BOLT_SYNTHETIC_USER_ACTOR_TOKEN_FILE: /run/secrets/bolt-synthetic-user-actor-token
       BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_FILE: /run/secrets/bolt-synthetic-expiry-transport-token
     secrets:
@@ -684,6 +685,9 @@ services:
         mode: 0400
       - source: bolt-synthetic-portal-transport-token
         target: /run/secrets/bolt-synthetic-portal-transport-token
+        mode: 0400
+      - source: bolt-synthetic-portal-identity-service-token
+        target: /run/secrets/bolt-synthetic-portal-identity-service-token
         mode: 0400
       - source: bolt-synthetic-user-actor-token
         target: /run/secrets/bolt-synthetic-user-actor-token
@@ -727,6 +731,8 @@ secrets:
     file: ${BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH:?Set BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH in the protected deployment env}
   bolt-synthetic-portal-transport-token:
     file: ${BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH:?Set BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH in the protected deployment env}
+  bolt-synthetic-portal-identity-service-token:
+    file: ${BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH:?Set BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH in the protected deployment env}
   bolt-synthetic-user-actor-token:
     file: ${BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH:?Set BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH in the protected deployment env}
   bolt-synthetic-expiry-transport-token:

--- a/scripts/refresh-bolt-phase0-synthetic-tokens-test.py
+++ b/scripts/refresh-bolt-phase0-synthetic-tokens-test.py
@@ -41,6 +41,7 @@ PASSWORD = "synthetic-user-password-that-must-not-leak"
 CLIENT_SECRET = "communications-client-secret-that-must-never-leak-123456789"
 PORTAL_CLIENT_SECRET = "portal-client-secret-that-must-never-leak-123456789012345"
 TRANSPORT_KEY_ID = "bolt-test-signing-key"
+SERVICE_KEY_ID = "service-test-signing-key"
 
 
 def private_directory(path: Path) -> Path:
@@ -81,6 +82,20 @@ def transport_jwt(
     return f"{encoded_header}.{encoded_claims}.{signature}"
 
 
+def identity_service_jwt(
+    claims: dict[str, Any],
+    *,
+    algorithm: str = "RS256",
+    key_id: str = SERVICE_KEY_ID,
+    token_type: str = "JWT",
+) -> str:
+    header = {"alg": algorithm, "kid": key_id, "typ": token_type}
+    encoded_header = b64url(json.dumps(header, separators=(",", ":"), sort_keys=True).encode())
+    encoded_claims = b64url(json.dumps(claims, separators=(",", ":"), sort_keys=True).encode())
+    signature = b64url(("service-signature-" + str(claims.get("jti", "missing"))).encode())
+    return f"{encoded_header}.{encoded_claims}.{signature}"
+
+
 def service_claims(
     now: int,
     jti: str,
@@ -98,6 +113,23 @@ def service_claims(
         "client_id": client_id,
         "service": client_id,
         "sub": client_id,
+        "scope": "bolt.service",
+    }
+    claims.update(overrides)
+    return claims
+
+
+def identity_service_claims(now: int, jti: str, **overrides: Any) -> dict[str, Any]:
+    claims = {
+        "iss": "XFramework.IdentityServer",
+        "aud": "XFramework.IdentityServer",
+        "exp": now + 120,
+        "nbf": now - 1,
+        "iat": now - 1,
+        "jti": jti,
+        "client_credential_generation": GENERATION,
+        "client_id": "XFramework.Portal",
+        "sub": "XFramework.Portal",
         "scope": "bolt.service",
     }
     claims.update(overrides)
@@ -125,6 +157,15 @@ def user_claims(now: int, jti: str, **overrides: Any) -> dict[str, Any]:
 def service_response(claims: dict[str, Any]) -> dict[str, Any]:
     expiration = refresh._format_expiration(claims["exp"])
     return {"accessToken": transport_jwt(claims), "tokenType": "Bearer", "expiresAtUtc": expiration}
+
+
+def identity_service_response(claims: dict[str, Any]) -> dict[str, Any]:
+    expiration = refresh._format_expiration(claims["exp"])
+    return {
+        "accessToken": identity_service_jwt(claims),
+        "tokenType": "Bearer",
+        "expiresAtUtc": expiration,
+    }
 
 
 def user_response(claims: dict[str, Any]) -> dict[str, Any]:
@@ -196,6 +237,7 @@ class Workspace:
         self.env = self.private / "protected.env"
         self.communications_transport = self.private / "communications-transport.jwt"
         self.portal_transport = self.private / "portal-transport.jwt"
+        self.portal_identity_service = self.private / "portal-identity-service.jwt"
         self.user_actor = self.private / "user-actor.jwt"
         self.expiry_transport = self.private / "expiry-transport.jwt"
         self.receipt = self.private / "receipt.json"
@@ -219,6 +261,9 @@ class Workspace:
                 self.communications_transport
             ),
             "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH": str(self.portal_transport),
+            "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH": str(
+                self.portal_identity_service
+            ),
             "BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH": str(self.user_actor),
             "BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_PATH": str(self.expiry_transport),
         }
@@ -494,6 +539,49 @@ class RefreshTokenHookTests(unittest.TestCase):
                         expiry=False,
                     )
 
+    def test_portal_identity_service_token_requires_exact_destination_identity_and_scopes(self) -> None:
+        now = int(time.time())
+        with tempfile.TemporaryDirectory() as temporary:
+            config = Workspace(Path(temporary)).config()
+            claims = identity_service_claims(now, uuid.uuid4().hex)
+            cases = {
+                "algorithm": identity_service_jwt(claims, algorithm="HS512"),
+                "type": identity_service_jwt(claims, token_type="bolt+jwt"),
+                "key": identity_service_jwt(claims, key_id=""),
+                "issuer": identity_service_jwt({**claims, "iss": "wrong"}),
+                "audience": identity_service_jwt({**claims, "aud": "XFramework.Bolt.Hub"}),
+                "client": identity_service_jwt({**claims, "client_id": "XFramework.Communications"}),
+                "subject": identity_service_jwt({**claims, "sub": "XFramework.Communications"}),
+                "generation": identity_service_jwt(
+                    {**claims, "client_credential_generation": "wrong-generation"}
+                ),
+                "missing-scope": identity_service_jwt({**claims, "scope": "identity.admin"}),
+                "extra-scope": identity_service_jwt(
+                    {**claims, "scope": "bolt.service identity.admin"}
+                ),
+                "duplicate-scope": identity_service_jwt(
+                    {**claims, "scope": "bolt.service bolt.service"}
+                ),
+                "expired": identity_service_jwt({**claims, "exp": now - 1}),
+                "future-nbf": identity_service_jwt({**claims, "nbf": now + 120}),
+            }
+            for name, token in cases.items():
+                with self.subTest(name=name), self.assertRaises(refresh.RefreshError):
+                    refresh._parse_service_token(
+                        {
+                            "accessToken": token,
+                            "tokenType": "Bearer",
+                            "expiresAtUtc": refresh._format_expiration(claims["exp"]),
+                        },
+                        config,
+                        now=now,
+                    )
+
+            mismatched_expiration = identity_service_response(claims)
+            mismatched_expiration["expiresAtUtc"] = refresh._format_expiration(now + 121)
+            with self.assertRaisesRegex(refresh.RefreshError, "RESPONSE_SCHEMA"):
+                refresh._parse_service_token(mismatched_expiration, config, now=now)
+
     def test_actor_token_is_validated_as_hs512_application_jwt_only(self) -> None:
         now = int(time.time())
         with tempfile.TemporaryDirectory() as temporary:
@@ -574,6 +662,7 @@ class RefreshTokenHookTests(unittest.TestCase):
             uuid.uuid4().hex,
             client_id="XFramework.Portal",
         )
+        portal_identity_claims = identity_service_claims(now, uuid.uuid4().hex)
         expiry_claims = service_claims(now, uuid.uuid4().hex, exp=now + 90)
         current_user_claims = user_claims(now, str(uuid.uuid4()))
         with tempfile.TemporaryDirectory() as temporary:
@@ -583,6 +672,7 @@ class RefreshTokenHookTests(unittest.TestCase):
                 [
                     FakeResponse(service_response(communications_claims)),
                     FakeResponse(service_response(portal_claims)),
+                    FakeResponse(identity_service_response(portal_identity_claims)),
                     FakeResponse(service_response(expiry_claims)),
                     FakeResponse(user_response(current_user_claims)),
                 ]
@@ -610,6 +700,10 @@ class RefreshTokenHookTests(unittest.TestCase):
                 transport_jwt(portal_claims),
             )
             self.assertEqual(
+                workspace.portal_identity_service.read_text().strip(),
+                identity_service_jwt(portal_identity_claims),
+            )
+            self.assertEqual(
                 workspace.expiry_transport.read_text().strip(),
                 transport_jwt(expiry_claims),
             )
@@ -625,16 +719,30 @@ class RefreshTokenHookTests(unittest.TestCase):
                     "status",
                     "transportIssuer",
                     "transportAudience",
+                    "serviceIssuer",
+                    "serviceAudience",
                     "actorIssuer",
                     "principalReference",
                     "refreshedAtUtc",
                     "tokenExpirationsUtc",
                 },
             )
-            self.assertEqual(receipt["schemaVersion"], "bolt-phase0-token-refresh/v2")
+            self.assertEqual(receipt["schemaVersion"], "bolt-phase0-token-refresh/v3")
             self.assertEqual(receipt["transportIssuer"], "XFramework.IdentityServer")
             self.assertEqual(receipt["transportAudience"], "XFramework.Bolt.Hub")
+            self.assertEqual(receipt["serviceIssuer"], "XFramework.IdentityServer")
+            self.assertEqual(receipt["serviceAudience"], "XFramework.IdentityServer")
             self.assertEqual(receipt["actorIssuer"], ISSUER)
+            self.assertEqual(
+                set(receipt["tokenExpirationsUtc"]),
+                {
+                    "communicationsTransport",
+                    "portalTransport",
+                    "portalIdentityService",
+                    "expiryTransport",
+                    "userActor",
+                },
+            )
             receipt_text = workspace.receipt.read_text()
             for secret in (
                 CLIENT_SECRET,
@@ -642,6 +750,7 @@ class RefreshTokenHookTests(unittest.TestCase):
                 PASSWORD,
                 transport_jwt(communications_claims),
                 transport_jwt(portal_claims),
+                identity_service_jwt(portal_identity_claims),
                 transport_jwt(expiry_claims),
                 actor_jwt(current_user_claims),
             ):
@@ -649,6 +758,7 @@ class RefreshTokenHookTests(unittest.TestCase):
             for path in (
                 workspace.communications_transport,
                 workspace.portal_transport,
+                workspace.portal_identity_service,
                 workspace.user_actor,
                 workspace.expiry_transport,
                 workspace.env,
@@ -657,16 +767,27 @@ class RefreshTokenHookTests(unittest.TestCase):
             self.assertEqual([request[4] for request in factory.requests], [
                 "/api/service-identity/bolt-transport-token",
                 "/api/service-identity/bolt-transport-token",
+                "/api/service-identity/token",
                 "/api/service-identity/bolt-transport-token",
                 "/api/auth/authenticate",
             ])
             first_body = json.loads(factory.requests[0][5])
             portal_body = json.loads(factory.requests[1][5])
-            user_body = json.loads(factory.requests[3][5])
+            portal_identity_body = json.loads(factory.requests[2][5])
+            user_body = json.loads(factory.requests[4][5])
             self.assertEqual(first_body, {"clientId": "XFramework.Communications", "clientSecret": CLIENT_SECRET})
             self.assertEqual(
                 portal_body,
                 {"clientId": "XFramework.Portal", "clientSecret": PORTAL_CLIENT_SECRET},
+            )
+            self.assertEqual(
+                portal_identity_body,
+                {
+                    "clientId": "XFramework.Portal",
+                    "clientSecret": PORTAL_CLIENT_SECRET,
+                    "audience": "XFramework.IdentityServer",
+                    "scopes": ["bolt.service"],
+                },
             )
             self.assertEqual(user_body["password"], PASSWORD)
             self.assertEqual(user_body["metadata"]["tenantId"], TENANT_ID)
@@ -692,6 +813,11 @@ class RefreshTokenHookTests(unittest.TestCase):
                             )
                         )
                     ),
+                    FakeResponse(
+                        identity_service_response(
+                            identity_service_claims(now, uuid.uuid4().hex)
+                        )
+                    ),
                     FakeResponse(service_response(service_claims(now, uuid.uuid4().hex, exp=now + 90))),
                     FakeResponse(user_response(user_claims(now, str(uuid.uuid4())))),
                 ]
@@ -707,7 +833,12 @@ class RefreshTokenHookTests(unittest.TestCase):
             self.assertEqual(workspace.expiry_transport.read_bytes(), b"")
             self.assertEqual(
                 set(json.loads(workspace.receipt.read_text())["tokenExpirationsUtc"]),
-                {"communicationsTransport", "portalTransport", "userActor"},
+                {
+                    "communicationsTransport",
+                    "portalTransport",
+                    "portalIdentityService",
+                    "userActor",
+                },
             )
             if refresh.ENFORCE_POSIX_PERMISSIONS:
                 self.assertEqual(

--- a/scripts/refresh-bolt-phase0-synthetic-tokens.py
+++ b/scripts/refresh-bolt-phase0-synthetic-tokens.py
@@ -32,9 +32,13 @@ TRANSPORT_AUDIENCE = "XFramework.Bolt.Hub"
 TRANSPORT_SCOPE = "bolt.service"
 TRANSPORT_ALGORITHM = "RS256"
 TRANSPORT_TOKEN_TYPE = "bolt+jwt"
+SERVICE_AUDIENCE = "XFramework.IdentityServer"
+SERVICE_ALGORITHM = "RS256"
+SERVICE_TOKEN_TYPE = "JWT"
+PORTAL_SERVICE_SCOPES = ("bolt.service",)
 ACTOR_ALGORITHM = "HS512"
 ACTOR_TOKEN_TYPE = "JWT"
-RECEIPT_SCHEMA = "bolt-phase0-token-refresh/v2"
+RECEIPT_SCHEMA = "bolt-phase0-token-refresh/v3"
 PRINCIPAL_REFERENCE = "bolt-phase0-synthetic"
 GENERATION_CLAIM = "credential_generation"
 MAX_EXPIRY_REMAINING_SECONDS = 570
@@ -87,6 +91,7 @@ class Config:
     minimum_lifetime_seconds: int
     communications_transport_path: str
     portal_transport_path: str
+    portal_identity_service_path: str
     user_actor_path: str
     expiry_transport_path: str
 
@@ -294,6 +299,9 @@ def load_config(values: dict[str, str]) -> Config:
             values, "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH"
         ),
         portal_transport_path=_required(values, "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH"),
+        portal_identity_service_path=_required(
+            values, "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH"
+        ),
         user_actor_path=_required(values, "BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH"),
         expiry_transport_path=_required(
             values, "BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_PATH"
@@ -520,6 +528,47 @@ def _validate_transport_jwt(
     return evidence, claims
 
 
+def _validate_service_jwt(
+    token: Any,
+    config: Config,
+    *,
+    now: int,
+) -> TokenEvidence:
+    value, header, claims = _read_jwt(token)
+    if set(header) != {"alg", "kid", "typ"}:
+        _raise("TOKEN_HEADER")
+    key_id = header.get("kid")
+    if (
+        header.get("alg") != SERVICE_ALGORITHM
+        or header.get("typ") != SERVICE_TOKEN_TYPE
+        or not isinstance(key_id, str)
+        or not re.fullmatch(r"[A-Za-z0-9_.:-]{1,256}", key_id)
+    ):
+        _raise("TOKEN_HEADER")
+    evidence = _validate_temporal_claims(
+        value,
+        claims,
+        expected_issuer=TRANSPORT_ISSUER,
+        expected_audience=SERVICE_AUDIENCE,
+        now=now,
+        minimum_remaining=config.minimum_lifetime_seconds,
+        require_issued_at=True,
+    )
+    scopes = claims.get("scope")
+    if not isinstance(scopes, str):
+        _raise("TOKEN_IDENTITY")
+    normalized_scopes = scopes.split()
+    if (
+        claims.get("client_id") != PORTAL_CLIENT_ID
+        or claims.get("sub") != PORTAL_CLIENT_ID
+        or claims.get("client_credential_generation") != config.credential_generation
+        or len(normalized_scopes) != len(PORTAL_SERVICE_SCOPES)
+        or set(normalized_scopes) != set(PORTAL_SERVICE_SCOPES)
+    ):
+        _raise("TOKEN_IDENTITY")
+    return evidence
+
+
 def _validate_actor_jwt(
     token: Any,
     config: Config,
@@ -567,6 +616,27 @@ def _parse_transport_token(
         minimum_remaining=2 if expiry else config.minimum_lifetime_seconds,
         maximum_remaining=MAX_EXPIRY_REMAINING_SECONDS if expiry else None,
     )
+    try:
+        response_expiration = dt.datetime.fromisoformat(
+            data["expiresAtUtc"].replace("Z", "+00:00")
+        )
+    except ValueError:
+        _raise("RESPONSE_SCHEMA")
+    if response_expiration.tzinfo is None or int(response_expiration.timestamp()) != evidence.expiration:
+        _raise("RESPONSE_SCHEMA")
+    return evidence
+
+
+def _parse_service_token(
+    document: dict[str, Any],
+    config: Config,
+    *,
+    now: int,
+) -> TokenEvidence:
+    data = _response_data(document, SERVICE_DATA_KEYS)
+    if data.get("tokenType") != "Bearer" or not isinstance(data.get("expiresAtUtc"), str):
+        _raise("RESPONSE_SCHEMA")
+    evidence = _validate_service_jwt(data.get("accessToken"), config, now=now)
     try:
         response_expiration = dt.datetime.fromisoformat(
             data["expiresAtUtc"].replace("Z", "+00:00")
@@ -749,6 +819,7 @@ def execute(
         [
             config.communications_transport_path,
             config.portal_transport_path,
+            config.portal_identity_service_path,
             config.user_actor_path,
             config.expiry_transport_path,
             receipt_path,
@@ -784,6 +855,22 @@ def execute(
         expected_client_id=PORTAL_CLIENT_ID,
         now=now,
         expiry=False,
+    )
+    portal_identity_service = _parse_service_token(
+        _post_json(
+            config,
+            "/api/service-identity/token",
+            {
+                "clientId": PORTAL_CLIENT_ID,
+                "clientSecret": config.portal_secret,
+                "audience": SERVICE_AUDIENCE,
+                "scopes": list(PORTAL_SERVICE_SCOPES),
+            },
+            connection_factory=connection_factory,
+            context_factory=context_factory,
+        ),
+        config,
+        now=now,
     )
     expiry_transport = _parse_transport_token(
         _post_json(
@@ -826,7 +913,13 @@ def execute(
         config,
         now=now,
     )
-    tokens = [communications_transport, portal_transport, expiry_transport, user_actor]
+    tokens = [
+        communications_transport,
+        portal_transport,
+        portal_identity_service,
+        expiry_transport,
+        user_actor,
+    ]
     if len({token.value for token in tokens}) != len(tokens) or len({token.jti for token in tokens}) != len(tokens):
         _raise("TOKEN_DISTINCTNESS")
 
@@ -834,6 +927,7 @@ def execute(
     if (
         communications_transport.expiration < final_validation_time + config.minimum_lifetime_seconds
         or portal_transport.expiration < final_validation_time + config.minimum_lifetime_seconds
+        or portal_identity_service.expiration < final_validation_time + config.minimum_lifetime_seconds
         or user_actor.expiration < final_validation_time + config.minimum_lifetime_seconds
     ):
         _raise("TOKEN_LIFETIME")
@@ -851,6 +945,10 @@ def execute(
         config.portal_transport_path,
         portal_transport.value.encode("ascii") + b"\n",
     )
+    atomic_replace(
+        config.portal_identity_service_path,
+        portal_identity_service.value.encode("ascii") + b"\n",
+    )
     atomic_replace(config.user_actor_path, user_actor.value.encode("ascii") + b"\n")
     atomic_replace(
         config.expiry_transport_path,
@@ -860,6 +958,7 @@ def execute(
     expirations = {
         "communicationsTransport": _format_expiration(communications_transport.expiration),
         "portalTransport": _format_expiration(portal_transport.expiration),
+        "portalIdentityService": _format_expiration(portal_identity_service.expiration),
         "userActor": _format_expiration(user_actor.expiration),
     }
     if expiry_enabled:
@@ -870,6 +969,8 @@ def execute(
         "status": "passed",
         "transportIssuer": TRANSPORT_ISSUER,
         "transportAudience": TRANSPORT_AUDIENCE,
+        "serviceIssuer": TRANSPORT_ISSUER,
+        "serviceAudience": SERVICE_AUDIENCE,
         "actorIssuer": config.actor_issuer,
         "principalReference": PRINCIPAL_REFERENCE,
         "refreshedAtUtc": refreshed_at.isoformat().replace("+00:00", "Z"),

--- a/src/Tests/Bolt.Phase0Synthetics.Tests/IdentityHealthCheckProbeIntegrationTests.cs
+++ b/src/Tests/Bolt.Phase0Synthetics.Tests/IdentityHealthCheckProbeIntegrationTests.cs
@@ -46,12 +46,14 @@ public sealed class IdentityHealthCheckProbeIntegrationTests
                 Sha256Hex("XFramework.IdentityServer"),
                 "XFramework.IdentityServer");
             string? actorAccessToken = null;
+            string? serviceAccessToken = null;
             identityService.RegisterHandler(
                 nameof(HealthCheckRequest),
                 (payload, _) =>
                 {
                     var request = MemoryPackSerializer.Deserialize<HealthCheckRequest>(payload.Span);
                     actorAccessToken = request?.Metadata?.ActorAccessToken;
+                    serviceAccessToken = request?.Metadata?.ServiceAccessToken;
                     var response = new QueryResponse<HealthCheckResponse>
                     {
                         HttpStatusCode = HttpStatusCode.OK,
@@ -78,6 +80,7 @@ public sealed class IdentityHealthCheckProbeIntegrationTests
 
             IdentityHealthCheckProbe.CommandName.Should().Be(nameof(HealthCheckRequest));
             actorAccessToken.Should().Be("user-actor-test-token");
+            serviceAccessToken.Should().Be("portal-identity-service-test-token");
         }
         finally
         {
@@ -107,6 +110,7 @@ public sealed class IdentityHealthCheckProbeIntegrationTests
             "integration-test",
             new SecretToken("communications-transport-test-token"),
             new SecretToken("portal-transport-test-token"),
+            new SecretToken("portal-identity-service-test-token"),
             new SecretToken("user-actor-test-token"),
             TimeSpan.FromSeconds(5),
             null,

--- a/src/Tests/Bolt.Phase0Synthetics.Tests/SyntheticOptionsParserTests.cs
+++ b/src/Tests/Bolt.Phase0Synthetics.Tests/SyntheticOptionsParserTests.cs
@@ -21,6 +21,7 @@ public sealed class SyntheticOptionsParserTests
         options.DeviceId.Should().Be("phase0_device");
         options.CommunicationsTransportToken.ToString().Should().Be("[REDACTED]");
         options.PortalTransportToken.ToString().Should().Be("[REDACTED]");
+        options.PortalIdentityServiceToken.ToString().Should().Be("[REDACTED]");
         options.UserActorToken.ToString().Should().Be("[REDACTED]");
     }
 
@@ -103,6 +104,8 @@ public sealed class SyntheticOptionsParserTests
             "/run/secrets/communications-transport";
         environment[SyntheticOptionsParser.PortalTransportTokenFileEnvironmentVariable] =
             "/run/secrets/portal-transport";
+        environment[SyntheticOptionsParser.PortalIdentityServiceTokenFileEnvironmentVariable] =
+            "/run/secrets/portal-identity-service";
         environment[SyntheticOptionsParser.UserActorTokenFileEnvironmentVariable] = "/run/secrets/user-actor";
         environment[SyntheticOptionsParser.ExpiryTransportTokenFileEnvironmentVariable] =
             "/run/secrets/expiry-transport";
@@ -120,6 +123,7 @@ public sealed class SyntheticOptionsParserTests
         reads.Should().Equal(
             "/run/secrets/communications-transport",
             "/run/secrets/portal-transport",
+            "/run/secrets/portal-identity-service",
             "/run/secrets/user-actor",
             "/run/secrets/expiry-transport");
         reads.Should().OnlyHaveUniqueItems();
@@ -128,6 +132,8 @@ public sealed class SyntheticOptionsParserTests
             .Be(new SecretToken("file-token-communications-transport").Sha256Prefix);
         options.PortalTransportToken.Sha256Prefix.Should()
             .Be(new SecretToken("file-token-portal-transport").Sha256Prefix);
+        options.PortalIdentityServiceToken.Sha256Prefix.Should()
+            .Be(new SecretToken("file-token-portal-identity-service").Sha256Prefix);
         options.ExpiryTransportToken!.Sha256Prefix.Should()
             .Be(new SecretToken("file-token-expiry-transport").Sha256Prefix);
     }
@@ -209,6 +215,8 @@ public sealed class SyntheticOptionsParserTests
                 "communications-transport-secret-token",
             [SyntheticOptionsParser.DefaultPortalTransportTokenEnvironmentVariable] =
                 "portal-transport-secret-token",
+            [SyntheticOptionsParser.DefaultPortalIdentityServiceTokenEnvironmentVariable] =
+                "portal-identity-service-secret-token",
             [SyntheticOptionsParser.DefaultUserActorTokenEnvironmentVariable] = "user-actor-secret-token"
         };
 }

--- a/src/Tests/Bolt.Phase0Synthetics.Tests/SyntheticReportValidatorTests.cs
+++ b/src/Tests/Bolt.Phase0Synthetics.Tests/SyntheticReportValidatorTests.cs
@@ -39,6 +39,7 @@ public sealed class SyntheticReportValidatorTests
             {
                 ["communications_transport"] = "0123456789ab",
                 ["portal_transport"] = "123456789abc",
+                ["portal_identity_service"] = "456789abcdef",
                 ["user_actor"] = "23456789abcd",
                 ["rejected_portal_transport"] = "3456789abcde"
             }
@@ -94,6 +95,7 @@ public sealed class SyntheticReportValidatorTests
             {
                 ["communications_transport"] = "0123456789ab",
                 ["portal_transport"] = "123456789abc",
+                ["portal_identity_service"] = "456789abcdef",
                 ["user_actor"] = "23456789abcd"
             },
             started,

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -207,6 +207,9 @@ public sealed class ServiceIdentityComposeContractTests
             "BOLT_SYNTHETIC_IDENTITYSERVER_BASE_URL=https://xeon-dev.tailed40e.ts.net:8261");
         envExample.Should().Contain(
             "BOLT_SYNTHETIC_TARGET=wss://xeon-dev.tailed40e.ts.net:7000/bolt/ws");
+        envExample.Should().Contain(
+            "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH=" +
+            "./.secrets/bolt-phase0/portal-identity-service-token");
         envExample.Should().NotContain("BOLT_SYNTHETIC_PROXY_");
         envExample.Should().NotContain("BOLT_SYNTHETIC_PLAINTEXT_REJECTION_COMMAND_PATH");
         envExample.Should().NotContain("BOLT_SYNTHETIC_REDIS_INTERRUPTION_COMMAND_PATH");
@@ -215,9 +218,13 @@ public sealed class ServiceIdentityComposeContractTests
         operationsDashboard.Should().Contain(
             "BoltConfiguration__ServerUrls__0: ws://bolt-hub:8080/bolt/ws");
         operationsDashboard.Should().Contain("BoltConfiguration__RequireSecureTransport: false");
-        ExtractService(compose, "bolt-phase0-synthetics").Should().Contain(
+        var synthetics = ExtractService(compose, "bolt-phase0-synthetics");
+        synthetics.Should().Contain(
             "BOLT_SYNTHETIC_TARGET: ${BOLT_SYNTHETIC_TARGET:" +
             "?Set the external Tailscale Serve WSS endpoint}");
+        synthetics.Should().Contain(
+            "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_FILE: " +
+            "/run/secrets/bolt-synthetic-portal-identity-service-token");
 
         var identityDependencies = ExtractSection(
             identityServer,

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/BoltPhase0SyntheticRunner.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/BoltPhase0SyntheticRunner.cs
@@ -708,6 +708,7 @@ public sealed class BoltPhase0SyntheticRunner
         {
             ["communications_transport"] = options.CommunicationsTransportToken.Sha256Prefix,
             ["portal_transport"] = options.PortalTransportToken.Sha256Prefix,
+            ["portal_identity_service"] = options.PortalIdentityServiceToken.Sha256Prefix,
             ["user_actor"] = options.UserActorToken.Sha256Prefix
         };
         if (options.ExpiryTransportToken is not null)

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/IdentityHealthCheckProbe.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/IdentityHealthCheckProbe.cs
@@ -30,7 +30,8 @@ public static class IdentityHealthCheckProbe
                 Name = "Bolt Phase 0 Synthetic",
                 DeviceName = options.DeviceId,
                 DeviceAgent = "XFramework.Bolt.Phase0Synthetics",
-                ActorAccessToken = options.UserActorToken.Reveal()
+                ActorAccessToken = options.UserActorToken.Reveal(),
+                ServiceAccessToken = options.PortalIdentityServiceToken.Reveal()
             }
         };
         var payload = MemoryPackSerializer.Serialize(request);

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/README.md
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/README.md
@@ -15,22 +15,23 @@ Required non-secret inputs can be supplied through environment variables or matc
 | `BOLT_SYNTHETIC_CREDENTIAL_ID` | `--credential-id` |
 | `BOLT_SYNTHETIC_DEVICE_ID` | `--device-id` |
 
-The synthetic consumes four role-specific credentials:
+The synthetic consumes five role-specific credentials:
 
 - `BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_FILE`: an RS256 `typ=bolt+jwt` token for `XFramework.Communications`.
 - `BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_FILE`: an RS256 `typ=bolt+jwt` token for `XFramework.Portal`. Every user-side Bolt connection registers with this service identity.
+- `BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_FILE`: an IdentityServer-issued service token for caller `XFramework.Portal` and audience `XFramework.IdentityServer`. The health RPC sends it as `ServiceAccessToken`, independently of the user actor token.
 - `BOLT_SYNTHETIC_USER_ACTOR_TOKEN_FILE`: the ordinary HS512 user application JWT. It is never used for WebSocket transport authentication; it is supplied as `ActorAccessToken` on user-authorized RPC metadata and pub/sub subscribe, detach, acknowledgement, and permanent-unregister frames.
 - `BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_FILE`: a second short-lived Communications transport token used only for the optional disconnect-on-expiry check.
 
 Token files must be absolute, regular, non-linked files no larger than 16 KiB. On Unix they must be owner-readable with no group, other, or execute permissions. On Windows, readable access is limited to the current identity, Local System, and Administrators. Token values and file paths are never written to the report.
 
-For local compatibility only, the tool can read `BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN`, `BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN`, `BOLT_SYNTHETIC_USER_ACTOR_TOKEN`, and `BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN`. The matching `--*-token-env` options select alternative environment variable names; they never accept token values directly.
+For local compatibility only, the tool can read `BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN`, `BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN`, `BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN`, `BOLT_SYNTHETIC_USER_ACTOR_TOKEN`, and `BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN`. The matching `--*-token-env` options select alternative environment variable names; they never accept token values directly.
 
 Set `BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_FILE` to enable the optional expiration-disconnect check. The token must identify `XFramework.Communications` and expire within the bounded wait configured by `BOLT_SYNTHETIC_EXPIRY_MAX_WAIT_SECONDS`; grace is configured by `BOLT_SYNTHETIC_EXPIRY_GRACE_SECONDS`.
 
 Set `BOLT_SYNTHETIC_REJECTED_COMMUNICATIONS_TRANSPORT_TOKEN_FILE` or `BOLT_SYNTHETIC_REJECTED_PORTAL_TRANSPORT_TOKEN_FILE` to verify that retired transport JWTs receive an explicit registration rejection. A timeout or unrelated transport failure does not pass this check.
 
-The deployment workflow refreshes all four credentials directly from IdentityServer over its Tailscale HTTPS endpoint immediately before invoking this tool. The refresh helper uses platform trust only. It validates transport tokens as RS256, `typ=bolt+jwt`, issuer `XFramework.IdentityServer`, audience `XFramework.Bolt.Hub`, scope `bolt.service`, and the requested service plus credential generation. It validates the actor JWT separately as the configured HS512 application token. Bolt does not manage certificates, private CAs, root watchdogs, deployment leases, or certificate-rotation evidence.
+The deployment workflow refreshes all five credentials directly from IdentityServer over its Tailscale HTTPS endpoint immediately before invoking this tool. The refresh helper uses platform trust only. It validates transport tokens as RS256, `typ=bolt+jwt`, issuer `XFramework.IdentityServer`, audience `XFramework.Bolt.Hub`, scope `bolt.service`, and the requested service plus credential generation. It separately validates the Portal service token's caller and `XFramework.IdentityServer` audience, and validates the actor JWT as the configured HS512 application token. Bolt does not manage certificates, private CAs, root watchdogs, deployment leases, or certificate-rotation evidence.
 
 ```powershell
 dotnet run --project src/Tools/XFramework.Bolt.Phase0Synthetics -- `

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticOptions.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticOptions.cs
@@ -7,6 +7,7 @@ public sealed record SyntheticOptions(
     string DeviceId,
     SecretToken CommunicationsTransportToken,
     SecretToken PortalTransportToken,
+    SecretToken PortalIdentityServiceToken,
     SecretToken UserActorToken,
     TimeSpan OperationTimeout,
     SecretToken? ExpiryTransportToken,

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticOptionsParser.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticOptionsParser.cs
@@ -18,11 +18,15 @@ public sealed class SyntheticOptionsParser(
     public const string DefaultCommunicationsTransportTokenEnvironmentVariable =
         "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN";
     public const string DefaultPortalTransportTokenEnvironmentVariable = "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN";
+    public const string DefaultPortalIdentityServiceTokenEnvironmentVariable =
+        "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN";
     public const string DefaultUserActorTokenEnvironmentVariable = "BOLT_SYNTHETIC_USER_ACTOR_TOKEN";
     public const string DefaultExpiryTransportTokenEnvironmentVariable = "BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN";
     public const string CommunicationsTransportTokenFileEnvironmentVariable =
         "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_FILE";
     public const string PortalTransportTokenFileEnvironmentVariable = "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_FILE";
+    public const string PortalIdentityServiceTokenFileEnvironmentVariable =
+        "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_FILE";
     public const string UserActorTokenFileEnvironmentVariable = "BOLT_SYNTHETIC_USER_ACTOR_TOKEN_FILE";
     public const string ExpiryTransportTokenFileEnvironmentVariable =
         "BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_FILE";
@@ -83,6 +87,10 @@ public sealed class SyntheticOptionsParser(
                 PortalTransportTokenEnvironmentNameVariable,
                 DefaultPortalTransportTokenEnvironmentVariable),
             "missing_portal_transport_token");
+        var portalIdentityServiceToken = ReadToken(
+            PortalIdentityServiceTokenFileEnvironmentVariable,
+            DefaultPortalIdentityServiceTokenEnvironmentVariable,
+            "missing_portal_identity_service_token");
         var userActorToken = ReadToken(
             UserActorTokenFileEnvironmentVariable,
             TokenEnvironmentName(
@@ -114,6 +122,7 @@ public sealed class SyntheticOptionsParser(
             deviceId,
             communicationsTransportToken,
             portalTransportToken,
+            portalIdentityServiceToken,
             userActorToken,
             operationTimeout,
             expiryTransportToken,

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticReportValidator.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticReportValidator.cs
@@ -52,6 +52,7 @@ public static partial class SyntheticReportValidator
         {
             "communications_transport",
             "portal_transport",
+            "portal_identity_service",
             "user_actor",
             "expiry_transport",
             "rejected_communications_transport",
@@ -93,6 +94,7 @@ public static partial class SyntheticReportValidator
                 !RequiredPassedOperations.IsSubsetOf(names) ||
                 !report.TokenSha256Prefixes.ContainsKey("communications_transport") ||
                 !report.TokenSha256Prefixes.ContainsKey("portal_transport") ||
+                !report.TokenSha256Prefixes.ContainsKey("portal_identity_service") ||
                 !report.TokenSha256Prefixes.ContainsKey("user_actor"))
             {
                 throw new InvalidOperationException("A passing synthetic report is incomplete.");


### PR DESCRIPTION
## Summary
- issue a least-privileged Portal-to-IdentityServer service token for the Bolt staging synthetic
- attach the service token to the generated-handler health RPC independently of the actor and transport tokens
- wire the fifth credential through Compose and the deployment workflow
- update synthetic documentation, evidence validation, and regression coverage

## Verification
- python scripts/refresh-bolt-phase0-synthetic-tokens-test.py (21 passed)
- dotnet test src/Tests/Bolt.Phase0Synthetics.Tests/Bolt.Phase0Synthetics.Tests.csproj -c Release --no-restore (41 passed, 1 platform skip)
- dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj -c Release --no-restore --filter FullyQualifiedName~ServiceIdentityComposeContractTests (4 passed)