### PR TITLE
Fix Communications Bolt synthetic authorization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ BOLT_SYNTHETIC_CREDENTIAL_ID=00000000-0000-0000-0000-000000000000
 BOLT_SYNTHETIC_DEVICE_ID=phase0-deployment-gate
 BOLT_SYNTHETIC_TARGET=wss://xeon-dev.tailed40e.ts.net:7000/bolt/ws
 BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH=./.secrets/bolt-phase0/communications-transport-token
+BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH=./.secrets/bolt-phase0/communications-identity-service-token
 BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH=./.secrets/bolt-phase0/portal-transport-token
 BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH=./.secrets/bolt-phase0/portal-identity-service-token
 BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH=./.secrets/bolt-phase0/user-actor-token

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -91,6 +91,7 @@ jobs:
       BOLT_SYNTHETIC_CREDENTIAL_ID: 00000000-0000-0000-0000-000000000002
       BOLT_SYNTHETIC_TARGET: wss://xeon-dev.tailed40e.ts.net:7000/bolt/ws
       BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-communications-transport-token
+      BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-communications-identity-service-token
       BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-portal-transport-token
       BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-portal-identity-service-token
       BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH: /tmp/xframework-compose-${{ github.run_id }}-${{ github.run_attempt }}-user-actor-token
@@ -205,6 +206,7 @@ jobs:
           python3 -B -m py_compile scripts/verify-bolt-phase0-diagnostic-sinks.py
 
           install -m 600 /dev/null "$BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH"
+          install -m 600 /dev/null "$BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH"
           install -m 600 /dev/null "$BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH"
           install -m 600 /dev/null "$BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH"
           install -m 600 /dev/null "$BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH"
@@ -303,6 +305,7 @@ jobs:
           token_dir="$REMOTE_RUN_DIR/synthetic-tokens"
           install -d -m 700 "$token_dir"
           install -m 600 /dev/null "$token_dir/communications-transport-token"
+          install -m 600 /dev/null "$token_dir/communications-identity-service-token"
           install -m 600 /dev/null "$token_dir/portal-transport-token"
           install -m 600 /dev/null "$token_dir/portal-identity-service-token"
           install -m 600 /dev/null "$token_dir/user-actor-token"
@@ -365,6 +368,7 @@ jobs:
               "BOLT_SYNTHETIC_IDENTITYSERVER_BASE_URL": identity_url,
               "BOLT_SYNTHETIC_TARGET": hub_websocket_url,
               "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH": f"{token_dir}/communications-transport-token",
+              "BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH": f"{token_dir}/communications-identity-service-token",
               "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH": f"{token_dir}/portal-transport-token",
               "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH": f"{token_dir}/portal-identity-service-token",
               "BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH": f"{token_dir}/user-actor-token",
@@ -893,6 +897,7 @@ jobs:
               --evidence "$REMOTE_RUN_DIR/diagnostic-sinks.json"
           rm -f \
             "$REMOTE_RUN_DIR/synthetic-tokens/communications-transport-token" \
+            "$REMOTE_RUN_DIR/synthetic-tokens/communications-identity-service-token" \
             "$REMOTE_RUN_DIR/synthetic-tokens/portal-transport-token" \
             "$REMOTE_RUN_DIR/synthetic-tokens/portal-identity-service-token" \
             "$REMOTE_RUN_DIR/synthetic-tokens/user-actor-token" \
@@ -947,13 +952,16 @@ jobs:
             "REMOTE_RELEASES_DIR='$REMOTE_RELEASES_DIR' REMOTE_RUN_DIR='$REMOTE_RUN_DIR' REMOTE_COMPOSE_FILE='$REMOTE_COMPOSE_FILE' REMOTE_ACTIVE_ENV='$REMOTE_ACTIVE_ENV' REMOTE_CANDIDATE_COMPOSE='$REMOTE_CANDIDATE_COMPOSE' REMOTE_CANDIDATE_ENV='$REMOTE_CANDIDATE_ENV' IMAGE_TAG='$IMAGE_TAG' bash -s" <<'REMOTE_SCRIPT'
           set -euo pipefail
           umask 077
-          install -m 600 "$REMOTE_CANDIDATE_COMPOSE" "$REMOTE_COMPOSE_FILE"
+          compose_tmp="${REMOTE_COMPOSE_FILE}.tmp.$$"
+          install -m 600 "$REMOTE_CANDIDATE_COMPOSE" "$compose_tmp"
+          mv -f "$compose_tmp" "$REMOTE_COMPOSE_FILE"
           active_env_tmp="${REMOTE_ACTIVE_ENV}.tmp.$$"
           install -m 600 "$REMOTE_CANDIDATE_ENV" "$active_env_tmp"
           mv -f "$active_env_tmp" "$REMOTE_ACTIVE_ENV"
           token_dir="$REMOTE_RUN_DIR/synthetic-tokens"
           install -d -m 700 "$token_dir"
           install -m 600 /dev/null "$token_dir/communications-transport-token"
+          install -m 600 /dev/null "$token_dir/communications-identity-service-token"
           install -m 600 /dev/null "$token_dir/portal-transport-token"
           install -m 600 /dev/null "$token_dir/portal-identity-service-token"
           install -m 600 /dev/null "$token_dir/user-actor-token"
@@ -981,6 +989,7 @@ jobs:
           cleanup_synthetic_tokens() {
             rm -f \
               "$REMOTE_RUN_DIR/synthetic-tokens/communications-transport-token" \
+              "$REMOTE_RUN_DIR/synthetic-tokens/communications-identity-service-token" \
               "$REMOTE_RUN_DIR/synthetic-tokens/portal-transport-token" \
               "$REMOTE_RUN_DIR/synthetic-tokens/portal-identity-service-token" \
               "$REMOTE_RUN_DIR/synthetic-tokens/user-actor-token" \
@@ -1003,7 +1012,7 @@ jobs:
             /usr/bin/timeout --foreground --kill-after=10s 60s docker stop xframework-bolt-hub >/dev/null 2>&1 || \
               /usr/bin/timeout --foreground --kill-after=10s 30s docker kill xframework-bolt-hub >/dev/null 2>&1 || true
           }
-          trap 'stop_hub' ERR
+          trap 'stop_hub; exit 1' ERR
 
           test -f "$REMOTE_RUN_DIR/previous-release"
           test -f "$REMOTE_RUN_DIR/previous-release-kind"
@@ -1061,7 +1070,11 @@ jobs:
             done
             test "$ready" -eq 1
           done
-          install -m 600 "$release/docker-compose.yml" "$REMOTE_COMPOSE_FILE"
+          if [ "$kind" = normal ]; then
+            compose_tmp="${REMOTE_COMPOSE_FILE}.tmp.$$"
+            install -m 600 "$release/docker-compose.yml" "$compose_tmp"
+            mv -f "$compose_tmp" "$REMOTE_COMPOSE_FILE"
+          fi
           rm -f "$REMOTE_RUN_DIR/complete"
           if [ "$kind" = normal ]; then
             active_env_tmp="${REMOTE_ACTIVE_ENV}.tmp.$$"
@@ -1103,6 +1116,7 @@ jobs:
         run: |
           rm -f \
             "$BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH" \
+            "$BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH" \
             "$BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH" \
             "$BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH" \
             "$BOLT_SYNTHETIC_USER_ACTOR_TOKEN_PATH" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -675,6 +675,7 @@ services:
       BOLT_SYNTHETIC_CREDENTIAL_ID: ${BOLT_SYNTHETIC_CREDENTIAL_ID:?Set BOLT_SYNTHETIC_CREDENTIAL_ID in the protected deployment env}
       BOLT_SYNTHETIC_DEVICE_ID: ${BOLT_SYNTHETIC_DEVICE_ID:-phase0-deployment-gate}
       BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_FILE: /run/secrets/bolt-synthetic-communications-transport-token
+      BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_FILE: /run/secrets/bolt-synthetic-communications-identity-service-token
       BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_FILE: /run/secrets/bolt-synthetic-portal-transport-token
       BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_FILE: /run/secrets/bolt-synthetic-portal-identity-service-token
       BOLT_SYNTHETIC_USER_ACTOR_TOKEN_FILE: /run/secrets/bolt-synthetic-user-actor-token
@@ -682,6 +683,9 @@ services:
     secrets:
       - source: bolt-synthetic-communications-transport-token
         target: /run/secrets/bolt-synthetic-communications-transport-token
+        mode: 0400
+      - source: bolt-synthetic-communications-identity-service-token
+        target: /run/secrets/bolt-synthetic-communications-identity-service-token
         mode: 0400
       - source: bolt-synthetic-portal-transport-token
         target: /run/secrets/bolt-synthetic-portal-transport-token
@@ -729,6 +733,8 @@ services:
 secrets:
   bolt-synthetic-communications-transport-token:
     file: ${BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH:?Set BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH in the protected deployment env}
+  bolt-synthetic-communications-identity-service-token:
+    file: ${BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH:?Set BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH in the protected deployment env}
   bolt-synthetic-portal-transport-token:
     file: ${BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH:?Set BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH in the protected deployment env}
   bolt-synthetic-portal-identity-service-token:

--- a/scripts/refresh-bolt-phase0-synthetic-tokens-test.py
+++ b/scripts/refresh-bolt-phase0-synthetic-tokens-test.py
@@ -119,7 +119,12 @@ def service_claims(
     return claims
 
 
-def identity_service_claims(now: int, jti: str, **overrides: Any) -> dict[str, Any]:
+def identity_service_claims(
+    now: int,
+    jti: str,
+    client_id: str = "XFramework.Portal",
+    **overrides: Any,
+) -> dict[str, Any]:
     claims = {
         "iss": "XFramework.IdentityServer",
         "aud": "XFramework.IdentityServer",
@@ -128,8 +133,8 @@ def identity_service_claims(now: int, jti: str, **overrides: Any) -> dict[str, A
         "iat": now - 1,
         "jti": jti,
         "client_credential_generation": GENERATION,
-        "client_id": "XFramework.Portal",
-        "sub": "XFramework.Portal",
+        "client_id": client_id,
+        "sub": client_id,
         "scope": "bolt.service",
     }
     claims.update(overrides)
@@ -236,6 +241,7 @@ class Workspace:
         self.private = private_directory(root / "private")
         self.env = self.private / "protected.env"
         self.communications_transport = self.private / "communications-transport.jwt"
+        self.communications_identity_service = self.private / "communications-identity-service.jwt"
         self.portal_transport = self.private / "portal-transport.jwt"
         self.portal_identity_service = self.private / "portal-identity-service.jwt"
         self.user_actor = self.private / "user-actor.jwt"
@@ -259,6 +265,9 @@ class Workspace:
             "BOLT_SYNTHETIC_MIN_TOKEN_LIFETIME_SECONDS": "60",
             "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH": str(
                 self.communications_transport
+            ),
+            "BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH": str(
+                self.communications_identity_service
             ),
             "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH": str(self.portal_transport),
             "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH": str(
@@ -341,6 +350,16 @@ class RefreshTokenHookTests(unittest.TestCase):
 
             self.assertEqual(config.base_url, BASE_URL)
             self.assertEqual(config.actor_issuer, "xframework")
+
+    def test_communications_identity_service_token_path_is_required(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Workspace(Path(temporary))
+            values = workspace.values()
+            del values["BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH"]
+            workspace.write_env(values)
+
+            with self.assertRaisesRegex(refresh.RefreshError, "CONFIGURATION"):
+                refresh.load_config(refresh.parse_protected_env(str(workspace.env)))
 
     def test_direct_https_uses_system_trust_hostname_validation_and_ignores_proxy_environment(self) -> None:
         now = int(time.time())
@@ -574,13 +593,66 @@ class RefreshTokenHookTests(unittest.TestCase):
                             "expiresAtUtc": refresh._format_expiration(claims["exp"]),
                         },
                         config,
+                        expected_client_id="XFramework.Portal",
+                        expected_scopes=("bolt.service",),
                         now=now,
                     )
 
             mismatched_expiration = identity_service_response(claims)
             mismatched_expiration["expiresAtUtc"] = refresh._format_expiration(now + 121)
             with self.assertRaisesRegex(refresh.RefreshError, "RESPONSE_SCHEMA"):
-                refresh._parse_service_token(mismatched_expiration, config, now=now)
+                refresh._parse_service_token(
+                    mismatched_expiration,
+                    config,
+                    expected_client_id="XFramework.Portal",
+                    expected_scopes=("bolt.service",),
+                    now=now,
+                )
+
+    def test_communications_identity_service_token_requires_exact_claims_and_lifetime(self) -> None:
+        now = int(time.time())
+        with tempfile.TemporaryDirectory() as temporary:
+            config = Workspace(Path(temporary)).config()
+            claims = identity_service_claims(
+                now,
+                uuid.uuid4().hex,
+                client_id="XFramework.Communications",
+            )
+            cases = {
+                "algorithm": identity_service_jwt(claims, algorithm="HS512"),
+                "type": identity_service_jwt(claims, token_type="bolt+jwt"),
+                "key": identity_service_jwt(claims, key_id=""),
+                "issuer": identity_service_jwt({**claims, "iss": "wrong"}),
+                "audience": identity_service_jwt({**claims, "aud": "XFramework.Bolt.Hub"}),
+                "client": identity_service_jwt({**claims, "client_id": "XFramework.Portal"}),
+                "subject": identity_service_jwt({**claims, "sub": "XFramework.Portal"}),
+                "generation": identity_service_jwt(
+                    {**claims, "client_credential_generation": "wrong-generation"}
+                ),
+                "missing-scope": identity_service_jwt({**claims, "scope": ""}),
+                "extra-scope": identity_service_jwt(
+                    {**claims, "scope": "bolt.service identity.admin"}
+                ),
+                "duplicate-scope": identity_service_jwt(
+                    {**claims, "scope": "bolt.service bolt.service"}
+                ),
+                "expired": identity_service_jwt({**claims, "exp": now - 1}),
+                "short-lifetime": identity_service_jwt({**claims, "exp": now + 59}),
+                "future-nbf": identity_service_jwt({**claims, "nbf": now + 120}),
+            }
+            for name, token in cases.items():
+                with self.subTest(name=name), self.assertRaises(refresh.RefreshError):
+                    refresh._parse_service_token(
+                        {
+                            "accessToken": token,
+                            "tokenType": "Bearer",
+                            "expiresAtUtc": refresh._format_expiration(claims["exp"]),
+                        },
+                        config,
+                        expected_client_id="XFramework.Communications",
+                        expected_scopes=("bolt.service",),
+                        now=now,
+                    )
 
     def test_actor_token_is_validated_as_hs512_application_jwt_only(self) -> None:
         now = int(time.time())
@@ -663,6 +735,11 @@ class RefreshTokenHookTests(unittest.TestCase):
             client_id="XFramework.Portal",
         )
         portal_identity_claims = identity_service_claims(now, uuid.uuid4().hex)
+        communications_identity_claims = identity_service_claims(
+            now,
+            uuid.uuid4().hex,
+            client_id="XFramework.Communications",
+        )
         expiry_claims = service_claims(now, uuid.uuid4().hex, exp=now + 90)
         current_user_claims = user_claims(now, str(uuid.uuid4()))
         with tempfile.TemporaryDirectory() as temporary:
@@ -673,6 +750,7 @@ class RefreshTokenHookTests(unittest.TestCase):
                     FakeResponse(service_response(communications_claims)),
                     FakeResponse(service_response(portal_claims)),
                     FakeResponse(identity_service_response(portal_identity_claims)),
+                    FakeResponse(identity_service_response(communications_identity_claims)),
                     FakeResponse(service_response(expiry_claims)),
                     FakeResponse(user_response(current_user_claims)),
                 ]
@@ -704,6 +782,10 @@ class RefreshTokenHookTests(unittest.TestCase):
                 identity_service_jwt(portal_identity_claims),
             )
             self.assertEqual(
+                workspace.communications_identity_service.read_text().strip(),
+                identity_service_jwt(communications_identity_claims),
+            )
+            self.assertEqual(
                 workspace.expiry_transport.read_text().strip(),
                 transport_jwt(expiry_claims),
             )
@@ -727,7 +809,7 @@ class RefreshTokenHookTests(unittest.TestCase):
                     "tokenExpirationsUtc",
                 },
             )
-            self.assertEqual(receipt["schemaVersion"], "bolt-phase0-token-refresh/v3")
+            self.assertEqual(receipt["schemaVersion"], "bolt-phase0-token-refresh/v4")
             self.assertEqual(receipt["transportIssuer"], "XFramework.IdentityServer")
             self.assertEqual(receipt["transportAudience"], "XFramework.Bolt.Hub")
             self.assertEqual(receipt["serviceIssuer"], "XFramework.IdentityServer")
@@ -737,6 +819,7 @@ class RefreshTokenHookTests(unittest.TestCase):
                 set(receipt["tokenExpirationsUtc"]),
                 {
                     "communicationsTransport",
+                    "communicationsIdentityService",
                     "portalTransport",
                     "portalIdentityService",
                     "expiryTransport",
@@ -749,6 +832,7 @@ class RefreshTokenHookTests(unittest.TestCase):
                 PORTAL_CLIENT_SECRET,
                 PASSWORD,
                 transport_jwt(communications_claims),
+                identity_service_jwt(communications_identity_claims),
                 transport_jwt(portal_claims),
                 identity_service_jwt(portal_identity_claims),
                 transport_jwt(expiry_claims),
@@ -757,6 +841,7 @@ class RefreshTokenHookTests(unittest.TestCase):
                 self.assertNotIn(secret, receipt_text)
             for path in (
                 workspace.communications_transport,
+                workspace.communications_identity_service,
                 workspace.portal_transport,
                 workspace.portal_identity_service,
                 workspace.user_actor,
@@ -768,13 +853,15 @@ class RefreshTokenHookTests(unittest.TestCase):
                 "/api/service-identity/bolt-transport-token",
                 "/api/service-identity/bolt-transport-token",
                 "/api/service-identity/token",
+                "/api/service-identity/token",
                 "/api/service-identity/bolt-transport-token",
                 "/api/auth/authenticate",
             ])
             first_body = json.loads(factory.requests[0][5])
             portal_body = json.loads(factory.requests[1][5])
             portal_identity_body = json.loads(factory.requests[2][5])
-            user_body = json.loads(factory.requests[4][5])
+            communications_identity_body = json.loads(factory.requests[3][5])
+            user_body = json.loads(factory.requests[5][5])
             self.assertEqual(first_body, {"clientId": "XFramework.Communications", "clientSecret": CLIENT_SECRET})
             self.assertEqual(
                 portal_body,
@@ -789,12 +876,73 @@ class RefreshTokenHookTests(unittest.TestCase):
                     "scopes": ["bolt.service"],
                 },
             )
+            self.assertEqual(
+                communications_identity_body,
+                {
+                    "clientId": "XFramework.Communications",
+                    "clientSecret": CLIENT_SECRET,
+                    "audience": "XFramework.IdentityServer",
+                    "scopes": ["bolt.service"],
+                },
+            )
             self.assertEqual(user_body["password"], PASSWORD)
             self.assertEqual(user_body["metadata"]["tenantId"], TENANT_ID)
             self.assertEqual(user_body["metadata"]["credentialId"], CREDENTIAL_ID)
             self.assertEqual(user_body["metadata"]["name"], "bolt-phase0-synthetic")
             self.assertEqual(user_body["metadata"]["deviceName"], "bolt-phase0-synthetic")
             self.assertEqual(user_body["metadata"]["deviceAgent"], "bolt-phase0-synthetic")
+
+    def test_communications_identity_service_token_participates_in_distinctness(self) -> None:
+        now = int(time.time())
+        duplicate_jti = uuid.uuid4().hex
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Workspace(Path(temporary))
+            workspace.write_env()
+            factory = ConnectionFactory(
+                [
+                    FakeResponse(service_response(service_claims(now, uuid.uuid4().hex))),
+                    FakeResponse(
+                        service_response(
+                            service_claims(
+                                now,
+                                uuid.uuid4().hex,
+                                client_id="XFramework.Portal",
+                            )
+                        )
+                    ),
+                    FakeResponse(
+                        identity_service_response(identity_service_claims(now, duplicate_jti))
+                    ),
+                    FakeResponse(
+                        identity_service_response(
+                            identity_service_claims(
+                                now,
+                                duplicate_jti,
+                                client_id="XFramework.Communications",
+                            )
+                        )
+                    ),
+                    FakeResponse(
+                        service_response(
+                            service_claims(now, uuid.uuid4().hex, exp=now + 90)
+                        )
+                    ),
+                    FakeResponse(user_response(user_claims(now, str(uuid.uuid4())))),
+                ]
+            )
+
+            with self.assertRaisesRegex(refresh.RefreshError, "TOKEN_DISTINCTNESS"):
+                refresh.execute(
+                    str(workspace.env),
+                    str(workspace.receipt),
+                    True,
+                    connection_factory=factory,
+                    context_factory=lambda: FakeContext(),
+                    now_provider=lambda: now,
+                )
+
+            self.assertFalse(workspace.communications_identity_service.exists())
+            self.assertFalse(workspace.receipt.exists())
 
     def test_disabled_expiry_writes_private_empty_placeholder_and_omits_receipt_entry(self) -> None:
         now = int(time.time())
@@ -818,6 +966,15 @@ class RefreshTokenHookTests(unittest.TestCase):
                             identity_service_claims(now, uuid.uuid4().hex)
                         )
                     ),
+                    FakeResponse(
+                        identity_service_response(
+                            identity_service_claims(
+                                now,
+                                uuid.uuid4().hex,
+                                client_id="XFramework.Communications",
+                            )
+                        )
+                    ),
                     FakeResponse(service_response(service_claims(now, uuid.uuid4().hex, exp=now + 90))),
                     FakeResponse(user_response(user_claims(now, str(uuid.uuid4())))),
                 ]
@@ -835,6 +992,7 @@ class RefreshTokenHookTests(unittest.TestCase):
                 set(json.loads(workspace.receipt.read_text())["tokenExpirationsUtc"]),
                 {
                     "communicationsTransport",
+                    "communicationsIdentityService",
                     "portalTransport",
                     "portalIdentityService",
                     "userActor",

--- a/scripts/refresh-bolt-phase0-synthetic-tokens.py
+++ b/scripts/refresh-bolt-phase0-synthetic-tokens.py
@@ -36,9 +36,10 @@ SERVICE_AUDIENCE = "XFramework.IdentityServer"
 SERVICE_ALGORITHM = "RS256"
 SERVICE_TOKEN_TYPE = "JWT"
 PORTAL_SERVICE_SCOPES = ("bolt.service",)
+COMMUNICATIONS_SERVICE_SCOPES = ("bolt.service",)
 ACTOR_ALGORITHM = "HS512"
 ACTOR_TOKEN_TYPE = "JWT"
-RECEIPT_SCHEMA = "bolt-phase0-token-refresh/v3"
+RECEIPT_SCHEMA = "bolt-phase0-token-refresh/v4"
 PRINCIPAL_REFERENCE = "bolt-phase0-synthetic"
 GENERATION_CLAIM = "credential_generation"
 MAX_EXPIRY_REMAINING_SECONDS = 570
@@ -90,6 +91,7 @@ class Config:
     authorization_type: int
     minimum_lifetime_seconds: int
     communications_transport_path: str
+    communications_identity_service_path: str
     portal_transport_path: str
     portal_identity_service_path: str
     user_actor_path: str
@@ -297,6 +299,9 @@ def load_config(values: dict[str, str]) -> Config:
         ),
         communications_transport_path=_required(
             values, "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_PATH"
+        ),
+        communications_identity_service_path=_required(
+            values, "BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH"
         ),
         portal_transport_path=_required(values, "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_PATH"),
         portal_identity_service_path=_required(
@@ -532,6 +537,8 @@ def _validate_service_jwt(
     token: Any,
     config: Config,
     *,
+    expected_client_id: str,
+    expected_scopes: tuple[str, ...],
     now: int,
 ) -> TokenEvidence:
     value, header, claims = _read_jwt(token)
@@ -559,11 +566,11 @@ def _validate_service_jwt(
         _raise("TOKEN_IDENTITY")
     normalized_scopes = scopes.split()
     if (
-        claims.get("client_id") != PORTAL_CLIENT_ID
-        or claims.get("sub") != PORTAL_CLIENT_ID
+        claims.get("client_id") != expected_client_id
+        or claims.get("sub") != expected_client_id
         or claims.get("client_credential_generation") != config.credential_generation
-        or len(normalized_scopes) != len(PORTAL_SERVICE_SCOPES)
-        or set(normalized_scopes) != set(PORTAL_SERVICE_SCOPES)
+        or len(normalized_scopes) != len(expected_scopes)
+        or set(normalized_scopes) != set(expected_scopes)
     ):
         _raise("TOKEN_IDENTITY")
     return evidence
@@ -631,12 +638,20 @@ def _parse_service_token(
     document: dict[str, Any],
     config: Config,
     *,
+    expected_client_id: str,
+    expected_scopes: tuple[str, ...],
     now: int,
 ) -> TokenEvidence:
     data = _response_data(document, SERVICE_DATA_KEYS)
     if data.get("tokenType") != "Bearer" or not isinstance(data.get("expiresAtUtc"), str):
         _raise("RESPONSE_SCHEMA")
-    evidence = _validate_service_jwt(data.get("accessToken"), config, now=now)
+    evidence = _validate_service_jwt(
+        data.get("accessToken"),
+        config,
+        expected_client_id=expected_client_id,
+        expected_scopes=expected_scopes,
+        now=now,
+    )
     try:
         response_expiration = dt.datetime.fromisoformat(
             data["expiresAtUtc"].replace("Z", "+00:00")
@@ -818,6 +833,7 @@ def execute(
     validate_destinations(
         [
             config.communications_transport_path,
+            config.communications_identity_service_path,
             config.portal_transport_path,
             config.portal_identity_service_path,
             config.user_actor_path,
@@ -870,6 +886,26 @@ def execute(
             context_factory=context_factory,
         ),
         config,
+        expected_client_id=PORTAL_CLIENT_ID,
+        expected_scopes=PORTAL_SERVICE_SCOPES,
+        now=now,
+    )
+    communications_identity_service = _parse_service_token(
+        _post_json(
+            config,
+            "/api/service-identity/token",
+            {
+                "clientId": COMMUNICATIONS_CLIENT_ID,
+                "clientSecret": config.communications_secret,
+                "audience": SERVICE_AUDIENCE,
+                "scopes": list(COMMUNICATIONS_SERVICE_SCOPES),
+            },
+            connection_factory=connection_factory,
+            context_factory=context_factory,
+        ),
+        config,
+        expected_client_id=COMMUNICATIONS_CLIENT_ID,
+        expected_scopes=COMMUNICATIONS_SERVICE_SCOPES,
         now=now,
     )
     expiry_transport = _parse_transport_token(
@@ -917,6 +953,7 @@ def execute(
         communications_transport,
         portal_transport,
         portal_identity_service,
+        communications_identity_service,
         expiry_transport,
         user_actor,
     ]
@@ -928,6 +965,7 @@ def execute(
         communications_transport.expiration < final_validation_time + config.minimum_lifetime_seconds
         or portal_transport.expiration < final_validation_time + config.minimum_lifetime_seconds
         or portal_identity_service.expiration < final_validation_time + config.minimum_lifetime_seconds
+        or communications_identity_service.expiration < final_validation_time + config.minimum_lifetime_seconds
         or user_actor.expiration < final_validation_time + config.minimum_lifetime_seconds
     ):
         _raise("TOKEN_LIFETIME")
@@ -949,6 +987,10 @@ def execute(
         config.portal_identity_service_path,
         portal_identity_service.value.encode("ascii") + b"\n",
     )
+    atomic_replace(
+        config.communications_identity_service_path,
+        communications_identity_service.value.encode("ascii") + b"\n",
+    )
     atomic_replace(config.user_actor_path, user_actor.value.encode("ascii") + b"\n")
     atomic_replace(
         config.expiry_transport_path,
@@ -959,6 +1001,9 @@ def execute(
         "communicationsTransport": _format_expiration(communications_transport.expiration),
         "portalTransport": _format_expiration(portal_transport.expiration),
         "portalIdentityService": _format_expiration(portal_identity_service.expiration),
+        "communicationsIdentityService": _format_expiration(
+            communications_identity_service.expiration
+        ),
         "userActor": _format_expiration(user_actor.expiration),
     }
     if expiry_enabled:

--- a/src/Tests/Bolt.Phase0Synthetics.Tests/IdentityHealthCheckProbeIntegrationTests.cs
+++ b/src/Tests/Bolt.Phase0Synthetics.Tests/IdentityHealthCheckProbeIntegrationTests.cs
@@ -76,6 +76,7 @@ public sealed class IdentityHealthCheckProbeIntegrationTests
             await IdentityHealthCheckProbe.InvokeAndValidateAsync(
                 caller,
                 options,
+                options.PortalIdentityServiceToken,
                 CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
 
             IdentityHealthCheckProbe.CommandName.Should().Be(nameof(HealthCheckRequest));
@@ -109,6 +110,7 @@ public sealed class IdentityHealthCheckProbeIntegrationTests
             Guid.NewGuid(),
             "integration-test",
             new SecretToken("communications-transport-test-token"),
+            new SecretToken("communications-identity-service-test-token"),
             new SecretToken("portal-transport-test-token"),
             new SecretToken("portal-identity-service-test-token"),
             new SecretToken("user-actor-test-token"),

--- a/src/Tests/Bolt.Phase0Synthetics.Tests/SyntheticOptionsParserTests.cs
+++ b/src/Tests/Bolt.Phase0Synthetics.Tests/SyntheticOptionsParserTests.cs
@@ -20,6 +20,7 @@ public sealed class SyntheticOptionsParserTests
         options.CredentialId.Should().Be(CredentialId);
         options.DeviceId.Should().Be("phase0_device");
         options.CommunicationsTransportToken.ToString().Should().Be("[REDACTED]");
+        options.CommunicationsIdentityServiceToken.ToString().Should().Be("[REDACTED]");
         options.PortalTransportToken.ToString().Should().Be("[REDACTED]");
         options.PortalIdentityServiceToken.ToString().Should().Be("[REDACTED]");
         options.UserActorToken.ToString().Should().Be("[REDACTED]");
@@ -102,6 +103,8 @@ public sealed class SyntheticOptionsParserTests
         var environment = CreateValidEnvironment();
         environment[SyntheticOptionsParser.CommunicationsTransportTokenFileEnvironmentVariable] =
             "/run/secrets/communications-transport";
+        environment[SyntheticOptionsParser.CommunicationsIdentityServiceTokenFileEnvironmentVariable] =
+            "/run/secrets/communications-identity-service";
         environment[SyntheticOptionsParser.PortalTransportTokenFileEnvironmentVariable] =
             "/run/secrets/portal-transport";
         environment[SyntheticOptionsParser.PortalIdentityServiceTokenFileEnvironmentVariable] =
@@ -122,6 +125,7 @@ public sealed class SyntheticOptionsParserTests
 
         reads.Should().Equal(
             "/run/secrets/communications-transport",
+            "/run/secrets/communications-identity-service",
             "/run/secrets/portal-transport",
             "/run/secrets/portal-identity-service",
             "/run/secrets/user-actor",
@@ -130,6 +134,8 @@ public sealed class SyntheticOptionsParserTests
         options.UserActorToken.Sha256Prefix.Should().Be(new SecretToken("file-token-user-actor").Sha256Prefix);
         options.CommunicationsTransportToken.Sha256Prefix.Should()
             .Be(new SecretToken("file-token-communications-transport").Sha256Prefix);
+        options.CommunicationsIdentityServiceToken.Sha256Prefix.Should()
+            .Be(new SecretToken("file-token-communications-identity-service").Sha256Prefix);
         options.PortalTransportToken.Sha256Prefix.Should()
             .Be(new SecretToken("file-token-portal-transport").Sha256Prefix);
         options.PortalIdentityServiceToken.Sha256Prefix.Should()
@@ -213,6 +219,8 @@ public sealed class SyntheticOptionsParserTests
             [SyntheticOptionsParser.DeviceEnvironmentVariable] = "phase0_device",
             [SyntheticOptionsParser.DefaultCommunicationsTransportTokenEnvironmentVariable] =
                 "communications-transport-secret-token",
+            [SyntheticOptionsParser.DefaultCommunicationsIdentityServiceTokenEnvironmentVariable] =
+                "communications-identity-service-secret-token",
             [SyntheticOptionsParser.DefaultPortalTransportTokenEnvironmentVariable] =
                 "portal-transport-secret-token",
             [SyntheticOptionsParser.DefaultPortalIdentityServiceTokenEnvironmentVariable] =

--- a/src/Tests/Bolt.Phase0Synthetics.Tests/SyntheticReportValidatorTests.cs
+++ b/src/Tests/Bolt.Phase0Synthetics.Tests/SyntheticReportValidatorTests.cs
@@ -38,6 +38,7 @@ public sealed class SyntheticReportValidatorTests
             TokenSha256Prefixes = new Dictionary<string, string>
             {
                 ["communications_transport"] = "0123456789ab",
+                ["communications_identity_service"] = "56789abcdef0",
                 ["portal_transport"] = "123456789abc",
                 ["portal_identity_service"] = "456789abcdef",
                 ["user_actor"] = "23456789abcd",
@@ -94,6 +95,7 @@ public sealed class SyntheticReportValidatorTests
             new Dictionary<string, string>
             {
                 ["communications_transport"] = "0123456789ab",
+                ["communications_identity_service"] = "56789abcdef0",
                 ["portal_transport"] = "123456789abc",
                 ["portal_identity_service"] = "456789abcdef",
                 ["user_actor"] = "23456789abcd"

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -208,6 +208,9 @@ public sealed class ServiceIdentityComposeContractTests
         envExample.Should().Contain(
             "BOLT_SYNTHETIC_TARGET=wss://xeon-dev.tailed40e.ts.net:7000/bolt/ws");
         envExample.Should().Contain(
+            "BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_PATH=" +
+            "./.secrets/bolt-phase0/communications-identity-service-token");
+        envExample.Should().Contain(
             "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_PATH=" +
             "./.secrets/bolt-phase0/portal-identity-service-token");
         envExample.Should().NotContain("BOLT_SYNTHETIC_PROXY_");
@@ -222,6 +225,9 @@ public sealed class ServiceIdentityComposeContractTests
         synthetics.Should().Contain(
             "BOLT_SYNTHETIC_TARGET: ${BOLT_SYNTHETIC_TARGET:" +
             "?Set the external Tailscale Serve WSS endpoint}");
+        synthetics.Should().Contain(
+            "BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_FILE: " +
+            "/run/secrets/bolt-synthetic-communications-identity-service-token");
         synthetics.Should().Contain(
             "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_FILE: " +
             "/run/secrets/bolt-synthetic-portal-identity-service-token");
@@ -303,6 +309,10 @@ public sealed class ServiceIdentityComposeContractTests
         workflow.Should().Contain("\"--profile\", \"phase0-verification\", \"--env-file\", env_file");
         workflow.Should().Contain("os.replace(temporary, path)");
         workflow.Should().Contain("$REMOTE_RUN_DIR/legacy-previous.env");
+        workflow.Should().Contain("compose_tmp=\"${REMOTE_COMPOSE_FILE}.tmp.$$\"");
+        workflow.Should().Contain("trap 'stop_hub; exit 1' ERR");
+        workflow.Should().NotContain(
+            "install -m 600 \"$release/docker-compose.yml\" \"$REMOTE_COMPOSE_FILE\"");
         workflow.Should().NotContain("xframework-bolt-phase0-root ensure-watchdog");
         workflow.Should().NotContain("xframework-bolt-phase0-root verify-bootstrap");
         workflow.Should().Contain("systemctl is-active xframework-bolt-phase0-watchdog.service");

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/BoltPhase0SyntheticRunner.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/BoltPhase0SyntheticRunner.cs
@@ -135,7 +135,11 @@ public sealed class BoltPhase0SyntheticRunner
                 "identity_health_check",
                 async operationCt =>
                 {
-                    await IdentityHealthCheckProbe.InvokeAndValidateAsync(userClient, options, operationCt);
+                    await IdentityHealthCheckProbe.InvokeAndValidateAsync(
+                        userClient,
+                        options,
+                        options.PortalIdentityServiceToken,
+                        operationCt);
                     return Results(("query_response_validated", true));
                 },
                 ct);
@@ -196,6 +200,7 @@ public sealed class BoltPhase0SyntheticRunner
                     await IdentityHealthCheckProbe.InvokeAndValidateAsync(
                         communicationsClient,
                         options,
+                        options.CommunicationsIdentityServiceToken,
                         operationCt);
                     return Results(("published_while_offline", true), ("batch_ordered", true));
                 },
@@ -230,7 +235,11 @@ public sealed class BoltPhase0SyntheticRunner
                     await lastReplayMessage.AckAsync(operationCt);
                     await firstReplayMessage.AckAsync(operationCt);
                     await lastReplayMessage.AckAsync(operationCt);
-                    await IdentityHealthCheckProbe.InvokeAndValidateAsync(userClient, options, operationCt);
+                    await IdentityHealthCheckProbe.InvokeAndValidateAsync(
+                        userClient,
+                        options,
+                        options.PortalIdentityServiceToken,
+                        operationCt);
                     return Results(
                         ("cumulative_acknowledged", true),
                         ("duplicate_ack_idempotent", true),
@@ -260,7 +269,11 @@ public sealed class BoltPhase0SyntheticRunner
                         subscriberId,
                         options.UserActorToken.Reveal(),
                         operationCt);
-                    await IdentityHealthCheckProbe.InvokeAndValidateAsync(userClient, options, operationCt);
+                    await IdentityHealthCheckProbe.InvokeAndValidateAsync(
+                        userClient,
+                        options,
+                        options.PortalIdentityServiceToken,
+                        operationCt);
                     await DisposeClientQuietlyAsync(userClient, options.OperationTimeout);
                     userClient = null;
 
@@ -273,6 +286,7 @@ public sealed class BoltPhase0SyntheticRunner
                     await IdentityHealthCheckProbe.InvokeAndValidateAsync(
                         communicationsClient,
                         options,
+                        options.CommunicationsIdentityServiceToken,
                         operationCt);
 
                     userClient = CreatePortalClient(options);
@@ -284,7 +298,11 @@ public sealed class BoltPhase0SyntheticRunner
                         subscriberId,
                         options.UserActorToken.Reveal(),
                         operationCt);
-                    await IdentityHealthCheckProbe.InvokeAndValidateAsync(userClient, options, operationCt);
+                    await IdentityHealthCheckProbe.InvokeAndValidateAsync(
+                        userClient,
+                        options,
+                        options.PortalIdentityServiceToken,
+                        operationCt);
                     durableUnregistered = true;
                     return Results(("permanently_unregistered", true), ("post_unregister_not_queued", true));
                 },
@@ -325,7 +343,11 @@ public sealed class BoltPhase0SyntheticRunner
                                 subscriberId,
                                 options.UserActorToken.Reveal(),
                                 operationCt);
-                            await IdentityHealthCheckProbe.InvokeAndValidateAsync(userClient, options, operationCt);
+                            await IdentityHealthCheckProbe.InvokeAndValidateAsync(
+                                userClient,
+                                options,
+                                options.PortalIdentityServiceToken,
+                                operationCt);
                             return Results(("cleanup_permanently_unregistered", true));
                         },
                         CancellationToken.None,
@@ -494,7 +516,11 @@ public sealed class BoltPhase0SyntheticRunner
         try
         {
             moveNext = enumerator.MoveNextAsync().AsTask();
-            await IdentityHealthCheckProbe.InvokeAndValidateAsync(client, options, ct);
+            await IdentityHealthCheckProbe.InvokeAndValidateAsync(
+                client,
+                options,
+                options.PortalIdentityServiceToken,
+                ct);
             if (moveNext.IsCompleted && await moveNext)
                 throw new SyntheticCheckException("unexpected_durable_message_before_offline_publish");
         }
@@ -572,7 +598,11 @@ public sealed class BoltPhase0SyntheticRunner
         try
         {
             moveNext = enumerator.MoveNextAsync().AsTask();
-            await IdentityHealthCheckProbe.InvokeAndValidateAsync(client, options, ct);
+            await IdentityHealthCheckProbe.InvokeAndValidateAsync(
+                client,
+                options,
+                options.PortalIdentityServiceToken,
+                ct);
             var observation = Task.Delay(NoRedeliveryObservationWindow(options.OperationTimeout), ct);
             var completed = await Task.WhenAny(moveNext, observation);
             if (completed == moveNext)
@@ -707,6 +737,7 @@ public sealed class BoltPhase0SyntheticRunner
         var evidence = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["communications_transport"] = options.CommunicationsTransportToken.Sha256Prefix,
+            ["communications_identity_service"] = options.CommunicationsIdentityServiceToken.Sha256Prefix,
             ["portal_transport"] = options.PortalTransportToken.Sha256Prefix,
             ["portal_identity_service"] = options.PortalIdentityServiceToken.Sha256Prefix,
             ["user_actor"] = options.UserActorToken.Sha256Prefix

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/IdentityHealthCheckProbe.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/IdentityHealthCheckProbe.cs
@@ -18,6 +18,7 @@ public static class IdentityHealthCheckProbe
     public static async Task InvokeAndValidateAsync(
         BoltClient client,
         SyntheticOptions options,
+        SecretToken serviceAccessToken,
         CancellationToken ct)
     {
         var request = new HealthCheckRequest
@@ -31,7 +32,7 @@ public static class IdentityHealthCheckProbe
                 DeviceName = options.DeviceId,
                 DeviceAgent = "XFramework.Bolt.Phase0Synthetics",
                 ActorAccessToken = options.UserActorToken.Reveal(),
-                ServiceAccessToken = options.PortalIdentityServiceToken.Reveal()
+                ServiceAccessToken = serviceAccessToken.Reveal()
             }
         };
         var payload = MemoryPackSerializer.Serialize(request);

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/README.md
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/README.md
@@ -15,9 +15,10 @@ Required non-secret inputs can be supplied through environment variables or matc
 | `BOLT_SYNTHETIC_CREDENTIAL_ID` | `--credential-id` |
 | `BOLT_SYNTHETIC_DEVICE_ID` | `--device-id` |
 
-The synthetic consumes five role-specific credentials:
+The synthetic consumes six role-specific credentials:
 
 - `BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_FILE`: an RS256 `typ=bolt+jwt` token for `XFramework.Communications`.
+- `BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_FILE`: an IdentityServer-issued service token for caller `XFramework.Communications` and audience `XFramework.IdentityServer`. Communications-side ordering probes send it as `ServiceAccessToken`.
 - `BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_FILE`: an RS256 `typ=bolt+jwt` token for `XFramework.Portal`. Every user-side Bolt connection registers with this service identity.
 - `BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_FILE`: an IdentityServer-issued service token for caller `XFramework.Portal` and audience `XFramework.IdentityServer`. The health RPC sends it as `ServiceAccessToken`, independently of the user actor token.
 - `BOLT_SYNTHETIC_USER_ACTOR_TOKEN_FILE`: the ordinary HS512 user application JWT. It is never used for WebSocket transport authentication; it is supplied as `ActorAccessToken` on user-authorized RPC metadata and pub/sub subscribe, detach, acknowledgement, and permanent-unregister frames.
@@ -25,13 +26,13 @@ The synthetic consumes five role-specific credentials:
 
 Token files must be absolute, regular, non-linked files no larger than 16 KiB. On Unix they must be owner-readable with no group, other, or execute permissions. On Windows, readable access is limited to the current identity, Local System, and Administrators. Token values and file paths are never written to the report.
 
-For local compatibility only, the tool can read `BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN`, `BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN`, `BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN`, `BOLT_SYNTHETIC_USER_ACTOR_TOKEN`, and `BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN`. The matching `--*-token-env` options select alternative environment variable names; they never accept token values directly.
+For local compatibility only, the tool can read `BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN`, `BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN`, `BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN`, `BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN`, `BOLT_SYNTHETIC_USER_ACTOR_TOKEN`, and `BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN`. Transport, actor, and expiry `--*-token-env` options can select alternative environment variable names; no option accepts a token value directly.
 
 Set `BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_FILE` to enable the optional expiration-disconnect check. The token must identify `XFramework.Communications` and expire within the bounded wait configured by `BOLT_SYNTHETIC_EXPIRY_MAX_WAIT_SECONDS`; grace is configured by `BOLT_SYNTHETIC_EXPIRY_GRACE_SECONDS`.
 
 Set `BOLT_SYNTHETIC_REJECTED_COMMUNICATIONS_TRANSPORT_TOKEN_FILE` or `BOLT_SYNTHETIC_REJECTED_PORTAL_TRANSPORT_TOKEN_FILE` to verify that retired transport JWTs receive an explicit registration rejection. A timeout or unrelated transport failure does not pass this check.
 
-The deployment workflow refreshes all five credentials directly from IdentityServer over its Tailscale HTTPS endpoint immediately before invoking this tool. The refresh helper uses platform trust only. It validates transport tokens as RS256, `typ=bolt+jwt`, issuer `XFramework.IdentityServer`, audience `XFramework.Bolt.Hub`, scope `bolt.service`, and the requested service plus credential generation. It separately validates the Portal service token's caller and `XFramework.IdentityServer` audience, and validates the actor JWT as the configured HS512 application token. Bolt does not manage certificates, private CAs, root watchdogs, deployment leases, or certificate-rotation evidence.
+The deployment workflow refreshes all six credentials directly from IdentityServer over its Tailscale HTTPS endpoint immediately before invoking this tool. The refresh helper uses platform trust only. It validates transport tokens as RS256, `typ=bolt+jwt`, issuer `XFramework.IdentityServer`, audience `XFramework.Bolt.Hub`, scope `bolt.service`, and the requested service plus credential generation. It separately validates each destination service token's caller and `XFramework.IdentityServer` audience, and validates the actor JWT as the configured HS512 application token. Bolt does not manage certificates, private CAs, root watchdogs, deployment leases, or certificate-rotation evidence.
 
 ```powershell
 dotnet run --project src/Tools/XFramework.Bolt.Phase0Synthetics -- `

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticOptions.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticOptions.cs
@@ -6,6 +6,7 @@ public sealed record SyntheticOptions(
     Guid CredentialId,
     string DeviceId,
     SecretToken CommunicationsTransportToken,
+    SecretToken CommunicationsIdentityServiceToken,
     SecretToken PortalTransportToken,
     SecretToken PortalIdentityServiceToken,
     SecretToken UserActorToken,

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticOptionsParser.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticOptionsParser.cs
@@ -17,6 +17,8 @@ public sealed class SyntheticOptionsParser(
     public const string ExpiryTransportTokenEnvironmentNameVariable = "BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN_ENV";
     public const string DefaultCommunicationsTransportTokenEnvironmentVariable =
         "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN";
+    public const string DefaultCommunicationsIdentityServiceTokenEnvironmentVariable =
+        "BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN";
     public const string DefaultPortalTransportTokenEnvironmentVariable = "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN";
     public const string DefaultPortalIdentityServiceTokenEnvironmentVariable =
         "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN";
@@ -24,6 +26,8 @@ public sealed class SyntheticOptionsParser(
     public const string DefaultExpiryTransportTokenEnvironmentVariable = "BOLT_SYNTHETIC_EXPIRY_TRANSPORT_TOKEN";
     public const string CommunicationsTransportTokenFileEnvironmentVariable =
         "BOLT_SYNTHETIC_COMMUNICATIONS_TRANSPORT_TOKEN_FILE";
+    public const string CommunicationsIdentityServiceTokenFileEnvironmentVariable =
+        "BOLT_SYNTHETIC_COMMUNICATIONS_IDENTITY_SERVICE_TOKEN_FILE";
     public const string PortalTransportTokenFileEnvironmentVariable = "BOLT_SYNTHETIC_PORTAL_TRANSPORT_TOKEN_FILE";
     public const string PortalIdentityServiceTokenFileEnvironmentVariable =
         "BOLT_SYNTHETIC_PORTAL_IDENTITY_SERVICE_TOKEN_FILE";
@@ -79,6 +83,10 @@ public sealed class SyntheticOptionsParser(
                 CommunicationsTransportTokenEnvironmentNameVariable,
                 DefaultCommunicationsTransportTokenEnvironmentVariable),
             "missing_communications_transport_token");
+        var communicationsIdentityServiceToken = ReadToken(
+            CommunicationsIdentityServiceTokenFileEnvironmentVariable,
+            DefaultCommunicationsIdentityServiceTokenEnvironmentVariable,
+            "missing_communications_identity_service_token");
         var portalTransportToken = ReadToken(
             PortalTransportTokenFileEnvironmentVariable,
             TokenEnvironmentName(
@@ -121,6 +129,7 @@ public sealed class SyntheticOptionsParser(
             credentialId,
             deviceId,
             communicationsTransportToken,
+            communicationsIdentityServiceToken,
             portalTransportToken,
             portalIdentityServiceToken,
             userActorToken,

--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticReportValidator.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/SyntheticReportValidator.cs
@@ -51,6 +51,7 @@ public static partial class SyntheticReportValidator
         var allowedNames = new HashSet<string>(StringComparer.Ordinal)
         {
             "communications_transport",
+            "communications_identity_service",
             "portal_transport",
             "portal_identity_service",
             "user_actor",
@@ -93,6 +94,7 @@ public static partial class SyntheticReportValidator
             if (report.Target is null || report.Operations.Any(static operation => operation.Status != "passed") ||
                 !RequiredPassedOperations.IsSubsetOf(names) ||
                 !report.TokenSha256Prefixes.ContainsKey("communications_transport") ||
+                !report.TokenSha256Prefixes.ContainsKey("communications_identity_service") ||
                 !report.TokenSha256Prefixes.ContainsKey("portal_transport") ||
                 !report.TokenSha256Prefixes.ContainsKey("portal_identity_service") ||
                 !report.TokenSha256Prefixes.ContainsKey("user_actor"))


### PR DESCRIPTION
## Summary
- issue a separate least-privileged Communications-to-IdentityServer service token
- select the destination token that matches each authenticated Bolt sender during synthetic ordering probes
- wire and document the sixth synthetic credential with strict refresh validation and evidence
- replace the runtime compose file atomically and prevent rollback errors from being masked

## Verification
- python scripts/refresh-bolt-phase0-synthetic-tokens-test.py (24 passed)
- dotnet test src/Tests/Bolt.Phase0Synthetics.Tests/Bolt.Phase0Synthetics.Tests.csproj -c Release --no-restore -m:1 /nr:false (41 passed, 1 platform skip)
- dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj -c Release --no-restore --filter FullyQualifiedName~ServiceIdentityComposeContractTests -m:1 /nr:false (4 passed)