### PR TITLE
Expose Bolt synthetic health response status

### DIFF
--- a/src/Tools/XFramework.Bolt.Phase0Synthetics/IdentityHealthCheckProbe.cs
+++ b/src/Tools/XFramework.Bolt.Phase0Synthetics/IdentityHealthCheckProbe.cs
@@ -41,8 +41,10 @@ public static class IdentityHealthCheckProbe
             CommandName,
             payload,
             ct);
-        if (!IsSuccess(statusCode) || data.IsEmpty)
-            throw new SyntheticCheckException("health_transport_response_invalid");
+        if (!IsSuccess(statusCode))
+            throw new SyntheticCheckException($"health_transport_status_{(int)statusCode}");
+        if (data.IsEmpty)
+            throw new SyntheticCheckException("health_transport_response_empty");
 
         QueryResponse<HealthCheckResponse>? response;
         try


### PR DESCRIPTION
## Summary
- preserve the HTTP status code when an authenticated synthetic health RPC is rejected
- distinguish transport rejection from an empty successful response

## Verification
- dotnet test src/Tests/Bolt.Phase0Synthetics.Tests/Bolt.Phase0Synthetics.Tests.csproj -c Release --no-restore -m:1 /nr:false (41 passed, 1 platform skip)