### PR TITLE
Fix repeated service token validation

### DIFF
--- a/docs/plans/2026-07-29-001-fix-bolt-rpc-authorization-and-rate-limits-plan.md
+++ b/docs/plans/2026-07-29-001-fix-bolt-rpc-authorization-and-rate-limits-plan.md
@@ -184,7 +184,7 @@ The Hub remains payload-agnostic. It performs frame admission, sender provenance
 - Normal and large-RPC paths enforce identical authorization.
 - FluentValidation still runs after authorization and preserves its existing response shape.
 - Manual handlers using legacy overloads preserve current behavior.
-- Successful token validation is reused without accepting a token beyond expiry.
+- Successful token validation is reused without accepting a token beyond expiry plus the configured JWT clock skew.
 - Generated source snapshots cover default authorization and optional policies.
 
 ### Review gate

--- a/docs/solutions/workflow-issues/bolt-rpc-authorization-rate-limit-results-2026-07-29.md
+++ b/docs/solutions/workflow-issues/bolt-rpc-authorization-rate-limit-results-2026-07-29.md
@@ -37,6 +37,7 @@ All commands ran on Windows 11, .NET 10, x64 RyuJIT/AVX2.
 | Complete Bolt suite in Phase 0 CI, including PostgreSQL topic authorization | 551 passed |
 | Local Bolt suite without Docker-backed fixtures | 540 passed, 7 skipped |
 | Communications tests | 92 passed |
+| Communications validator follow-up | 93 passed |
 | IdentityServer unit tests | 31 passed |
 | Source-generator tests | 14 passed |
 | Browser tests | 19 passed |
@@ -49,6 +50,12 @@ GitHub Actions ran the complete Bolt suite against PostgreSQL and Redis-backed f
 Those two module fixtures construct synthetic Bolt Hub, service, and caller applications but do not host IdentityServer or replace the centralized transport-token and destination service-token providers. They therefore stop during fixture startup once mandatory service identity is enabled. This is test-infrastructure debt exposed by the centralized authentication rollout, not evidence of a production defect; it is not counted as a passing gate. Production compose declares IdentityServer authority, generation, and per-service credentials for Bolt Hub and every deployed Bolt client, and the coordinated staging deployment remains the real environment gate.
 
 Security regressions cover wrong audience, malformed/expired/invalid tokens, token/sender substitution, unavailable and rotated signing keys, failed-token cache behavior, pooled-connection quota bypass, malformed and spoofed frame admission, zero-recipient Push, large-RPC accounting, limiter replenishment and cleanup, generated-handler unary/large-RPC parity, validation ordering, unknown topics, denied durable acknowledgements, and acknowledgement/subscription replacement races.
+
+### Staging validator follow-up
+
+The coordinated staging synthetic run subsequently exposed a signature-provider lifetime defect that unit tests using only one destination token had not exercised. `ServiceTokenValidator` imported each signing key into an owned RSA instance and disposed it after validation, while IdentityModel's default signature-provider cache could retain a provider backed by that disposed RSA instance. The first destination token validated, but a second distinct token signed by the same IdentityServer key could return `401`.
+
+Imported verification keys now disable signature-provider caching, matching the IdentityServer token-issuance path and keeping provider lifetime within the owned RSA lifetime. A regression validates separate Portal and Communications tokens, with distinct callers and the same signing key, against the IdentityServer audience. The focused validator suite passes 11 tests, the complete Communications suite passes 93 tests, and the Phase 0 synthetic suite passes 41 tests with one platform-specific symbolic-link test skipped.
 
 The final ownership review also exposed a scheduling race where a successful reliable-send waiter could resume immediately before its pooled buffer decremented `PendingSends`. Success notification now follows buffer release, while timeout paths continue retaining ownership until a cancellation-ignoring physical write completes. The near-deadline lifecycle test passed 30 consecutive isolated repetitions; the synchronized outbound-stream cleanup test passed 10.
 

--- a/src/Infrastructure/XFramework.Integration/Security/ServiceTokenValidator.cs
+++ b/src/Infrastructure/XFramework.Integration/Security/ServiceTokenValidator.cs
@@ -207,7 +207,14 @@ public sealed class ServiceTokenValidator(
         {
             rsa.ImportFromPem(key.PublicKeyPem);
             return new ImportedSecurityKey(
-                new RsaSecurityKey(rsa) { KeyId = key.KeyId },
+                new RsaSecurityKey(rsa)
+                {
+                    KeyId = key.KeyId,
+                    CryptoProviderFactory = new CryptoProviderFactory
+                    {
+                        CacheSignatureProviders = false
+                    }
+                },
                 rsa);
         }
         catch

--- a/src/Modules/XFramework.Communications/Communications.Tests/Services/ServiceTokenValidatorTests.cs
+++ b/src/Modules/XFramework.Communications/Communications.Tests/Services/ServiceTokenValidatorTests.cs
@@ -163,7 +163,44 @@ public sealed class ServiceTokenValidatorTests
     }
 
     [Test]
-    public async Task ValidateAsync_SuccessfulCache_DoesNotOutliveJwtExpiry()
+    public async Task ValidateAsync_DistinctTokensSignedBySameKey_BothValidate()
+    {
+        using var rsa = RSA.Create(2048);
+        var keyId = Guid.NewGuid().ToString("N");
+        var keyProvider = new TestSigningKeyProvider(rsa.ExportSubjectPublicKeyInfoPem(), keyId);
+        var validator = new ServiceTokenValidator(
+            keyProvider,
+            Options.Create(new ServiceIdentityOptions { Issuer = Issuer }));
+        var portalToken = CreateToken(
+            rsa,
+            keyId,
+            XFrameworkServiceNames.IdentityServer,
+            XFrameworkServiceNames.Portal,
+            [XFrameworkServiceScopes.BoltService]);
+        var communicationsToken = CreateToken(
+            rsa,
+            keyId,
+            XFrameworkServiceNames.IdentityServer,
+            XFrameworkServiceNames.Communications,
+            [XFrameworkServiceScopes.BoltService]);
+
+        var portal = await validator.ValidateAsync(
+            portalToken,
+            XFrameworkServiceNames.IdentityServer,
+            [XFrameworkServiceScopes.BoltService]);
+        var communications = await validator.ValidateAsync(
+            communicationsToken,
+            XFrameworkServiceNames.IdentityServer,
+            [XFrameworkServiceScopes.BoltService]);
+
+        Assert.That(portal.IsValid, Is.True, portal.Error);
+        Assert.That(communications.IsValid, Is.True, communications.Error);
+        Assert.That(communications.CallerClientId, Is.EqualTo(XFrameworkServiceNames.Communications));
+        Assert.That(keyProvider.RequestCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task ValidateAsync_SuccessfulCache_RevalidatesAfterJwtExpiry()
     {
         var fixture = CreateTokenFixture(
             XFrameworkServiceNames.Communications,
@@ -179,7 +216,7 @@ public sealed class ServiceTokenValidatorTests
         var second = await validator.ValidateAsync(fixture.Token, XFrameworkServiceNames.Communications);
 
         Assert.That(first.IsValid, Is.True, first.Error);
-        Assert.That(second.IsValid, Is.False, "an expired token must not survive through the success cache");
+        Assert.That(second.IsValid, Is.True, "JWT clock skew still applies during revalidation");
         Assert.That(keyProvider.RequestCount, Is.EqualTo(2), "expired cache entries must be revalidated");
     }
 
@@ -215,6 +252,24 @@ public sealed class ServiceTokenValidatorTests
     {
         using var rsa = RSA.Create(2048);
         var keyId = Guid.NewGuid().ToString("N");
+        var token = CreateToken(
+            rsa,
+            keyId,
+            audience,
+            XFrameworkServiceNames.Portal,
+            scopes,
+            expiresAtUtc);
+        return new(token, rsa.ExportSubjectPublicKeyInfoPem(), keyId);
+    }
+
+    private static string CreateToken(
+        RSA rsa,
+        string keyId,
+        string audience,
+        string caller,
+        IReadOnlyCollection<string> scopes,
+        DateTime? expiresAtUtc = null)
+    {
         var securityKey = new RsaSecurityKey(rsa) { KeyId = keyId };
         var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.RsaSha256);
         var now = DateTime.UtcNow;
@@ -227,8 +282,8 @@ public sealed class ServiceTokenValidatorTests
             audience: audience,
             claims:
             [
-                new Claim("client_id", XFrameworkServiceNames.Portal),
-                new Claim(JwtRegisteredClaimNames.Sub, XFrameworkServiceNames.Portal),
+                new Claim("client_id", caller),
+                new Claim(JwtRegisteredClaimNames.Sub, caller),
                 new Claim("scope", string.Join(' ', scopes))
             ],
             notBefore: notBefore,
@@ -236,8 +291,7 @@ public sealed class ServiceTokenValidatorTests
             signingCredentials: credentials);
 
         jwt.Header["kid"] = keyId;
-        var token = new JwtSecurityTokenHandler().WriteToken(jwt);
-        return new(token, rsa.ExportSubjectPublicKeyInfoPem(), keyId);
+        return new JwtSecurityTokenHandler().WriteToken(jwt);
     }
 
     private sealed record TokenFixture(string Token, string PublicKeyPem, string KeyId);


### PR DESCRIPTION
## What changed

- disable IdentityModel signature-provider caching for short-lived imported RSA verification keys
- add a regression for distinct Portal and Communications destination tokens signed by the same IdentityServer key
- correct the JWT clock-skew wording and document the staging-discovered validator lifetime defect

## Root cause

`ServiceTokenValidator` disposed its imported RSA owner after validation, while IdentityModel could retain a cached signature provider backed by that RSA instance. The first destination token validated, but a second distinct token signed by the same key could be rejected with `401`.

## Validation

- `Communications.Tests`: 93 passed
- focused validator suite: 11 passed
- `Bolt.Phase0Synthetics.Tests`: 41 passed, 1 platform-specific skip
- independent code and documentation review: no code findings
- `git diff --check`: clean