### PR TITLE
Fix offline durable unregistration

### DIFF
--- a/docs/solutions/workflow-issues/bolt-rpc-authorization-rate-limit-results-2026-07-29.md
+++ b/docs/solutions/workflow-issues/bolt-rpc-authorization-rate-limit-results-2026-07-29.md
@@ -59,6 +59,8 @@ Imported verification keys now disable signature-provider caching, matching the 
 
 The staging gate also keeps the durable replay subscription active until its cumulative, stale, and duplicate acknowledgement frames pass the IdentityServer RPC processing barrier. Persistence is reported only after the next subscription observes no redelivery. Previously the runner disposed the subscription before sending those acknowledgement frames, so the Hub correctly rejected them as coming from a detached owner and the next connection replayed the unacknowledged message. This was a synthetic lifecycle defect; Hub ownership checks, durable-store behavior, and Bolt's at-least-once delivery contract are unchanged.
 
+Permanent durable unregistration now also removes an authorized offline subscription after its live session has detached, matching the public client API contract. A permanent unregister remains rejected while another live connection owns the same subscriber identity, preventing a stale session from deleting active durable state.
+
 The final ownership review also exposed a scheduling race where a successful reliable-send waiter could resume immediately before its pooled buffer decremented `PendingSends`. Success notification now follows buffer release, while timeout paths continue retaining ownership until a cancellation-ignoring physical write completes. The near-deadline lifecycle test passed 30 consecutive isolated repetitions; the synchronized outbound-stream cleanup test passed 10.
 
 ## Performance Gate

--- a/src/Libraries/Bolt/Bolt.Server/BoltServer.cs
+++ b/src/Libraries/Bolt/Bolt.Server/BoltServer.cs
@@ -2990,8 +2990,12 @@ public sealed class BoltServer : IDisposable
             await gate.WaitAsync(ct);
             try
             {
-                if (_liveDurableConnections.TryGetValue(durableKey, out var mappedConnection) &&
-                    ReferenceEquals(mappedConnection, conn))
+                if (!_liveDurableConnections.TryGetValue(durableKey, out var mappedConnection))
+                {
+                    if (permanent && _durableStore is not null)
+                        await _durableStore.UnregisterDurableSubscriberAsync(topicHash, subscriberId, ct);
+                }
+                else if (ReferenceEquals(mappedConnection, conn))
                 {
                     if (permanent && _durableStore is not null)
                         await _durableStore.UnregisterDurableSubscriberAsync(topicHash, subscriberId, ct);
@@ -3006,6 +3010,14 @@ public sealed class BoltServer : IDisposable
                     }
 
                     RemoveDurableReplayState(durableKey, conn);
+                }
+                else if (permanent)
+                {
+                    _logger.LogWarning(
+                        "Rejected permanent durable unsubscribe from non-current subscriber session. client={ClientId} topic={Topic} subscriber={Subscriber}",
+                        conn.ClientId,
+                        topic,
+                        subscriberId);
                 }
             }
             finally

--- a/src/Tests/Bolt.Tests/BoltPhase0ContainmentTests.cs
+++ b/src/Tests/Bolt.Tests/BoltPhase0ContainmentTests.cs
@@ -752,6 +752,114 @@ public sealed class BoltPhase0ContainmentTests
     }
 
     [Test]
+    public async Task DurablePermanentUnsubscribe_WhenDetached_RemovesOfflineSubscription()
+    {
+        var authorizer = new CountingAllowAuthorizer();
+        var durableOptions = Options.Create(new DurableQueueOptions());
+        var durableStore = new InMemoryDurableQueueStore(
+            durableOptions,
+            NullLogger<InMemoryDurableQueueStore>.Instance);
+        using var server = new BoltServer(
+            NullLogger<BoltServer>.Instance,
+            new BoltServerOptions(),
+            durableStore,
+            durableOptions,
+            [authorizer]);
+        await using var connection = new ChannelBoltConnection();
+        var connectionTask = server.HandleConnectionAsync(connection, CancellationToken.None);
+
+        connection.Enqueue(WriteFrame(writer => BoltCodec.WriteRegister(writer, "offline-owner", "OfflineOwner")));
+        await connection.WaitForSentFramesAsync(1);
+        const string topic = "durable.offline.unregister";
+        const string subscriberId = "offline-subscriber";
+        var topicHash = BoltCodec.Fnv1aHash(topic);
+        connection.Enqueue(WriteFrame(writer => BoltCodec.WriteSubscribe(
+            writer,
+            topic,
+            subscriberId,
+            durable: true)));
+        await WaitForDurableBindingAsync(server, topic, subscriberId, "offline-owner");
+        await durableStore.AppendAsync(topicHash, subscriberId, new byte[] { 1 });
+
+        connection.Enqueue(WriteFrame(writer => BoltCodec.WriteUnsubscribe(
+            writer,
+            topic,
+            subscriberId,
+            permanent: false)));
+        await WaitForNoDurableBindingAsync(server, topicHash, subscriberId);
+        (await durableStore.IsDurableSubscriberRegisteredAsync(topicHash, subscriberId)).Should().BeTrue();
+
+        connection.Enqueue(WriteFrame(writer => BoltCodec.WriteUnsubscribe(
+            writer,
+            topic,
+            subscriberId,
+            permanent: true)));
+        connection.Enqueue(WriteFrame(writer => BoltCodec.WritePublish(
+            writer,
+            "durable.unregister.barrier",
+            false,
+            [2])));
+        await authorizer.WaitForCallsAsync(4);
+        (await durableStore.IsDurableSubscriberRegisteredAsync(topicHash, subscriberId)).Should().BeFalse();
+        (await durableStore.GetLastAckedSequenceAsync(topicHash, subscriberId)).Should().Be(0);
+
+        connection.Complete();
+        await connectionTask.WaitAsync(TimeSpan.FromSeconds(3));
+    }
+
+    [Test]
+    public async Task DurablePermanentUnsubscribe_WhenAnotherSessionOwnsSubscription_DoesNotRemoveIt()
+    {
+        var authorizer = new CountingAllowAuthorizer();
+        var durableOptions = Options.Create(new DurableQueueOptions());
+        var durableStore = new InMemoryDurableQueueStore(
+            durableOptions,
+            NullLogger<InMemoryDurableQueueStore>.Instance);
+        using var server = new BoltServer(
+            NullLogger<BoltServer>.Instance,
+            new BoltServerOptions(),
+            durableStore,
+            durableOptions,
+            [authorizer]);
+        await using var owner = new ChannelBoltConnection();
+        await using var other = new ChannelBoltConnection();
+        var ownerTask = server.HandleConnectionAsync(owner, CancellationToken.None);
+        var otherTask = server.HandleConnectionAsync(other, CancellationToken.None);
+
+        owner.Enqueue(WriteFrame(writer => BoltCodec.WriteRegister(writer, "current-owner", "CurrentOwner")));
+        other.Enqueue(WriteFrame(writer => BoltCodec.WriteRegister(writer, "other-session", "OtherSession")));
+        await Task.WhenAll(owner.WaitForSentFramesAsync(1), other.WaitForSentFramesAsync(1));
+        const string topic = "durable.unregister.ownership";
+        const string subscriberId = "owned-subscriber";
+        var topicHash = BoltCodec.Fnv1aHash(topic);
+        owner.Enqueue(WriteFrame(writer => BoltCodec.WriteSubscribe(
+            writer,
+            topic,
+            subscriberId,
+            durable: true)));
+        await WaitForDurableBindingAsync(server, topic, subscriberId, "current-owner");
+
+        other.Enqueue(WriteFrame(writer => BoltCodec.WriteUnsubscribe(
+            writer,
+            topic,
+            subscriberId,
+            permanent: true)));
+        other.Enqueue(WriteFrame(writer => BoltCodec.WritePublish(
+            writer,
+            "durable.unregister.ownership.barrier",
+            false,
+            [2])));
+        await authorizer.WaitForCallsAsync(3);
+
+        GetDurableBinding(server, topicHash, subscriberId).ClientId.Should().Be("current-owner");
+        (await durableStore.IsDurableSubscriberRegisteredAsync(topicHash, subscriberId)).Should().BeTrue();
+
+        owner.Complete();
+        other.Complete();
+        await Task.WhenAll(ownerTask, otherTask).WaitAsync(TimeSpan.FromSeconds(3));
+    }
+
+    [Test]
     public async Task DurableReplayReplacement_ObsoleteReplayCannotDrainNewOwnerDeferredEvents()
     {
         var authorizer = new CountingAllowAuthorizer();


### PR DESCRIPTION
## What changed

- allow an authorized permanent durable unsubscribe to delete offline state after the live session has detached
- keep permanent unregister rejected when another connection currently owns the same subscriber identity
- keep all ownership and store decisions under the existing per-subscription gate
- add deterministic regressions for offline deletion and stale-session protection
- update the Bolt security/results knowledge note

## Root cause

`UnregisterDurableSubscriptionAsync` sends a permanent unsubscribe and is documented to remove durable state, including offline subscriptions. Hub only called the durable store when the requesting connection was still the current live owner. After a normal non-permanent detach, the later authorized permanent unregister became a no-op, so future durable publishes queued again.

## Validation

- focused permanent-unregister tests: 2 passed, repeated 10 times
- complete local Bolt run: 542 passed; 4 PostgreSQL fixture setup failures because local Docker/Testcontainers is unavailable; 7 Redis container tests skipped
- independent ownership/security review confirmed the three-case policy
- `git diff --check`: clean