### PR TITLE
fix(ci): bound xeon-dev image build concurrency

### DIFF
--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -266,7 +266,7 @@ jobs:
             notifications storage attendance smsgateway wallets inventario pos
             portal operations-dashboard bolt-phase0-synthetics
           )
-          timeout --foreground --kill-after=30s 45m \
+          COMPOSE_PARALLEL_LIMIT=2 timeout --foreground --kill-after=30s 45m \
             docker compose -f "$COMPOSE_FILE_PATH" build "${services[@]}"
 
       - name: Push images


### PR DESCRIPTION
## Summary
- limit the all-services Compose build to two concurrent services
- prevent xeon-dev resource starvation from dropping the self-hosted runner and SSH control plane

## Validation
- git diff --check`n- prior deployment failure reproduced the unbounded build starvation on the 6-core/16 GB xeon-dev host