### PR TITLE
Serialize xeon-dev image builds

### DIFF
--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -266,8 +266,10 @@ jobs:
             notifications storage attendance smsgateway wallets inventario pos
             portal operations-dashboard bolt-phase0-synthetics
           )
-          COMPOSE_PARALLEL_LIMIT=2 timeout --foreground --kill-after=30s 45m \
-            docker compose -f "$COMPOSE_FILE_PATH" build "${services[@]}"
+          for service in "${services[@]}"; do
+            timeout --foreground --kill-after=30s 15m \
+              docker compose -f "$COMPOSE_FILE_PATH" build "$service"
+          done
 
       - name: Push images
         shell: bash

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -359,6 +359,10 @@ public sealed class ServiceIdentityComposeContractTests
         workflow.Should().Contain("src/Tools/**");
         workflow.Should().Contain("src/Modules/**");
         workflow.Should().Contain("src/Presentation/**");
+        workflow.Should().Contain("for service in \"${services[@]}\"; do");
+        workflow.Should().Contain("docker compose -f \"$COMPOSE_FILE_PATH\" build \"$service\"");
+        workflow.Should().NotContain(
+            "docker compose -f \"$COMPOSE_FILE_PATH\" build \"${services[@]}\"");
         workflow.Should().Contain("REMOTE_ACTIVE_ENV:");
         workflow.Should().Contain("runtime_snapshot=\"$REMOTE_RUN_DIR/pre-deployment\"");
         workflow.Should().Contain("postgres redis minio seq jaeger identityserver bolt-hub");


### PR DESCRIPTION
## Summary
- build xeon-dev service images one at a time under Docker Compose v5/Bake
- prevent the unbounded multi-service Bake invocation from returning

## Verification
- targeted Portal deployment workflow contract test passes
- git diff --check passes