### PR TITLE
Fall back to sealed xeon-dev rollback release

### DIFF
--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -480,18 +480,26 @@ jobs:
             postgres redis minio seq jaeger identityserver bolt-hub communications notifications storage attendance
             smsgateway wallets inventario pos portal operations-dashboard
           )
+          runtime_snapshot_ready=false
+          image_arguments=()
           if [ -f "$REMOTE_ACTIVE_ENV" ] && [ ! -L "$REMOTE_ACTIVE_ENV" ] && \
              [ -f "$REMOTE_COMPOSE_FILE" ] && [ ! -L "$REMOTE_COMPOSE_FILE" ]; then
+            runtime_snapshot_ready=true
+            for service in "${runtime_services[@]}"; do
+              if ! image_id="$(docker inspect --format '{{.Image}}' "xframework-${service}" 2>/dev/null)" ||
+                 [[ ! "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+                 ! docker image inspect "$image_id" >/dev/null 2>&1; then
+                runtime_snapshot_ready=false
+                image_arguments=()
+                break
+              fi
+              image_arguments+=("$service" "$image_id")
+            done
+          fi
+          if [ "$runtime_snapshot_ready" = true ]; then
             install -d -m 700 "$runtime_snapshot"
             install -m 600 "$REMOTE_COMPOSE_FILE" "$runtime_snapshot/docker-compose.yml"
             install -m 600 "$REMOTE_ACTIVE_ENV" "$runtime_snapshot/candidate.env"
-            image_arguments=()
-            for service in "${runtime_services[@]}"; do
-              image_id="$(docker inspect --format '{{.Image}}' "xframework-${service}")"
-              [[ "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]]
-              docker image inspect "$image_id" >/dev/null
-              image_arguments+=("$service" "$image_id")
-            done
             python3 - "$runtime_snapshot/images.override.json" "${image_arguments[@]}" <<'PY'
           import json
           import pathlib

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -365,6 +365,10 @@ public sealed class ServiceIdentityComposeContractTests
             "docker compose -f \"$COMPOSE_FILE_PATH\" build \"${services[@]}\"");
         workflow.Should().Contain("REMOTE_ACTIVE_ENV:");
         workflow.Should().Contain("runtime_snapshot=\"$REMOTE_RUN_DIR/pre-deployment\"");
+        workflow.Should().Contain("runtime_snapshot_ready=false");
+        workflow.Should().Contain("if ! image_id=\"$(docker inspect --format '{{.Image}}'");
+        workflow.Should().Contain("! docker image inspect \"$image_id\" >/dev/null 2>&1; then");
+        workflow.Should().Contain("if [ \"$runtime_snapshot_ready\" = true ]; then");
         workflow.Should().Contain("postgres redis minio seq jaeger identityserver bolt-hub");
         workflow.Should().Contain("docker inspect --format '{{.Image}}'");
         workflow.Should().Contain("docker image inspect \"$value\"");


### PR DESCRIPTION
## Summary
- use a live runtime snapshot only when every required container image is available
- fall back to the sealed last-known-good release when a restarted host has an incomplete live container set
- retain the requirement for a complete rollback target before deployment mutation

## Verification
- targeted Portal deployment workflow contract test passes
- git diff --check passes