### PR TITLE
Allow IdentityServer internal HTTP in Docker environment

### DIFF
--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityConfiguration.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Services/ServiceIdentityConfiguration.cs
@@ -75,10 +75,11 @@ public sealed class ServiceIdentityConfiguration
         var allowInsecureHttp = configuration.GetValue<bool>("ServiceIdentity:AllowInsecureHttp");
         if (allowInsecureHttp
             && !string.Equals(environmentName, Environments.Development, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(environmentName, "Test", StringComparison.OrdinalIgnoreCase))
+            && !string.Equals(environmentName, "Test", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(environmentName, "Docker", StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException(
-                "ServiceIdentity:AllowInsecureHttp is permitted only in Development or Test environments.");
+                "ServiceIdentity:AllowInsecureHttp is permitted only in Development, Test, or Docker environments.");
         }
 
         var boltTransportTokenIssuerEnabled = configuration.GetValue<bool>(

--- a/src/Tests/IdentityServer.UnitTests/BoltTransportTokenIssuerTests.cs
+++ b/src/Tests/IdentityServer.UnitTests/BoltTransportTokenIssuerTests.cs
@@ -84,7 +84,7 @@ public sealed class BoltTransportTokenIssuerTests
     }
 
     [Test]
-    public void Configuration_AllowInsecureHttp_IsLimitedToDevelopmentAndTest()
+    public void Configuration_AllowInsecureHttp_IsLimitedToDevelopmentTestAndDocker()
     {
         var now = DateTimeOffset.Parse("2026-07-13T01:00:00Z");
         var secureByDefault = ServiceIdentityConfiguration.FromConfiguration(
@@ -98,6 +98,14 @@ public sealed class BoltTransportTokenIssuerTests
                 includeSigningKeyPath: false),
             now,
             "Development");
+        var explicitlyInsecureDocker = ServiceIdentityConfiguration.FromConfiguration(
+            CreateConfiguration(
+                now,
+                enabled: false,
+                allowInsecureHttp: true,
+                includeSigningKeyPath: false),
+            now,
+            "Docker");
 
         var productionParse = () => ServiceIdentityConfiguration.FromConfiguration(
             CreateConfiguration(
@@ -110,8 +118,9 @@ public sealed class BoltTransportTokenIssuerTests
 
         secureByDefault.AllowInsecureHttp.Should().BeFalse();
         explicitlyInsecure.AllowInsecureHttp.Should().BeTrue();
+        explicitlyInsecureDocker.AllowInsecureHttp.Should().BeTrue();
         productionParse.Should().Throw<InvalidOperationException>()
-            .WithMessage("*only in Development or Test environments*");
+            .WithMessage("*only in Development, Test, or Docker environments*");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- recognize the repository's Docker development environment for explicitly enabled internal service-identity HTTP
- keep Production and other environments secure by default
- cover Docker allow and Production rejection in the startup configuration test

## Verification
- targeted IdentityServer unit test passes
- local production-composition integration test was attempted but blocked by the Windows Testcontainers Docker endpoint; GitHub integration will run it