### PR TITLE
Fix service credential generation contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,10 @@ IDENTITY_USER_JWT_PUBLIC_KEY_PATH=./.secrets/identityserver/user-jwt-public-key.
 BOLT_SIGNATURE=change-me-legacy-rollback-bolt-signature-with-at-least-64-characters
 JWT_ISSUER=xframework
 JWT_AUDIENCE=xframework
-CREDENTIAL_GENERATION_ID=local-development-g1
-CREDENTIAL_SECONDARY_GENERATION_ID=
-CREDENTIAL_SECONDARY_VALID_UNTIL_UTC=
+# Service-client credential rotation. This is independent from user JWT signing generations.
+SERVICE_CREDENTIAL_GENERATION_ID=local-development-g1
+SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID=
+SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC=
 BOLT_SIGNATURE_SECONDARY=
 
 # -- Service transport -----------------------------------------

--- a/.github/workflows/deploy-xeon-dev.yml
+++ b/.github/workflows/deploy-xeon-dev.yml
@@ -73,7 +73,7 @@ jobs:
       DB_PASSWORD: compose-validation-placeholder
       USER_JWT_GENERATION_ID: compose-validation-user-jwt-g1
       BOLT_SIGNATURE: compose-validation-placeholder
-      CREDENTIAL_GENERATION_ID: compose-validation-placeholder
+      SERVICE_CREDENTIAL_GENERATION_ID: compose-validation-placeholder
       IDENTITYSERVER_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
       BOLT_HUB_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
       COMMUNICATIONS_SERVICE_IDENTITY_SECRET: compose-validation-placeholder
@@ -350,8 +350,12 @@ jobs:
               values[name] = value
               order.append(name)
 
-          generation_id = values.get("USER_JWT_GENERATION_ID", "")
-          if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", generation_id):
+          service_generation_id = values.get("SERVICE_CREDENTIAL_GENERATION_ID", "")
+          if not re.fullmatch(r"[A-Za-z0-9_.:-]{1,96}", service_generation_id):
+              raise SystemExit("SERVICE_CREDENTIAL_GENERATION_ID is missing or invalid")
+
+          user_generation_id = values.get("USER_JWT_GENERATION_ID", "")
+          if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", user_generation_id):
               raise SystemExit("USER_JWT_GENERATION_ID is missing or invalid")
 
           key_paths = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ x-common-env: &common-env
   ServiceIdentity__Issuer: XFramework.IdentityServer
   ServiceIdentity__Authority: http://identityserver:8080
   ServiceIdentity__AllowInsecureHttp: true
-  ServiceIdentity__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-  CREDENTIAL_GENERATION_ID: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
+  ServiceIdentity__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+  SERVICE_CREDENTIAL_GENERATION_ID: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
   Seq__ApiKey: ${SEQ_API_KEY:-}
   OpenTelemetry__Sampling__Probability: ${OTEL_SAMPLING_PROBABILITY:-1.0}
   OpenTelemetry__Exporters__OTLP__Enabled: ${OTEL_OTLP_ENABLED:-true}
@@ -119,9 +119,9 @@ services:
       Kestrel__Endpoints__Http__Url: http://0.0.0.0:8080
       ServiceIdentity__ClientSecret: ${BOLT_HUB_SERVICE_IDENTITY_SECRET:?Set BOLT_HUB_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${BOLT_HUB_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       BoltConfiguration__Durable__RedisConnectionString: ${BOLT_REDIS_CONNECTION:-redis:6379}
       BoltConfiguration__MediaEnabled: false
       BoltConfiguration__QueueDepth: 256
@@ -185,9 +185,9 @@ services:
       ServiceIdentity__DefaultScopes__1: storage.read
       ServiceIdentity__DefaultScopes__2: storage.write
       DistributedSecurityRateLimiting__RedisConnectionString: ${IDENTITYSERVER_RATE_LIMIT_REDIS_CONNECTION:-redis:6379}
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${IDENTITYSERVER_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__BoltTransportTokenIssuer__Enabled: true
       ServiceIdentity__BoltTransportTokenIssuer__LifetimeSeconds: 120
       ServiceIdentity__BoltTransportTokenIssuer__SigningKeyPath: /var/lib/xframework/identity/bolt-transport-signing-key.pem
@@ -195,98 +195,98 @@ services:
       JwtOptions__SigningPrivateKeyPath: /run/secrets/identity-user-jwt-private-key.pem
       ServiceIdentity__Clients__0__ClientId: XFramework.IdentityServer
       ServiceIdentity__Clients__0__ClientSecret: ${IDENTITYSERVER_SERVICE_IDENTITY_SECRET:?Set IDENTITYSERVER_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__0__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__0__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__0__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__0__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__0__ValidationFallback__ClientSecret: ${IDENTITYSERVER_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__0__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__0__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__0__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__0__AllowedScopes: bolt.service,storage.read,storage.write
       ServiceIdentity__Clients__1__ClientId: XFramework.Portal
       ServiceIdentity__Clients__1__ClientSecret: ${PORTAL_SERVICE_IDENTITY_SECRET:?Set PORTAL_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__1__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__1__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__1__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__1__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__1__ValidationFallback__ClientSecret: ${PORTAL_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__1__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__1__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__1__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__1__AllowedScopes: bolt.service,datacontext.query,datacontext.query.all-tenants,datacontext.mutate,identity.admin,identity.session.validate
       ServiceIdentity__Clients__2__ClientId: XFramework.Bolt.Hub
       ServiceIdentity__Clients__2__ClientSecret: ${BOLT_HUB_SERVICE_IDENTITY_SECRET:?Set BOLT_HUB_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__2__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__2__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__2__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__2__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__2__ValidationFallback__ClientSecret: ${BOLT_HUB_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__2__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__2__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__2__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__2__AllowedScopes: bolt.service
       ServiceIdentity__Clients__3__ClientId: XFramework.Communications
       ServiceIdentity__Clients__3__ClientSecret: ${COMMUNICATIONS_SERVICE_IDENTITY_SECRET:?Set COMMUNICATIONS_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__3__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__3__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__3__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__3__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__3__ValidationFallback__ClientSecret: ${COMMUNICATIONS_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__3__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__3__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__3__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__3__AllowedScopes: bolt.service,identity.session.validate
       ServiceIdentity__Clients__4__ClientId: XFramework.Notifications
       ServiceIdentity__Clients__4__ClientSecret: ${NOTIFICATIONS_SERVICE_IDENTITY_SECRET:?Set NOTIFICATIONS_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__4__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__4__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__4__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__4__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__4__ValidationFallback__ClientSecret: ${NOTIFICATIONS_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__4__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__4__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__4__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__4__AllowedScopes: bolt.service,identity.session.validate
       ServiceIdentity__Clients__5__ClientId: XFramework.Storage
       ServiceIdentity__Clients__5__ClientSecret: ${STORAGE_SERVICE_IDENTITY_SECRET:?Set STORAGE_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__5__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__5__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__5__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__5__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__5__ValidationFallback__ClientSecret: ${STORAGE_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__5__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__5__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__5__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__5__AllowedScopes: bolt.service,identity.session.validate
       ServiceIdentity__Clients__6__ClientId: XFramework.Attendance
       ServiceIdentity__Clients__6__ClientSecret: ${ATTENDANCE_SERVICE_IDENTITY_SECRET:?Set ATTENDANCE_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__6__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__6__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__6__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__6__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__6__ValidationFallback__ClientSecret: ${ATTENDANCE_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__6__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__6__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__6__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__6__AllowedScopes: bolt.service,identity.session.validate
       ServiceIdentity__Clients__7__ClientId: XFramework.SmsGateway
       ServiceIdentity__Clients__7__ClientSecret: ${SMSGATEWAY_SERVICE_IDENTITY_SECRET:?Set SMSGATEWAY_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__7__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__7__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__7__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__7__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__7__ValidationFallback__ClientSecret: ${SMSGATEWAY_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__7__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__7__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__7__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__7__AllowedScopes: bolt.service
       ServiceIdentity__Clients__8__ClientId: XFramework.Wallets
       ServiceIdentity__Clients__8__ClientSecret: ${WALLETS_SERVICE_IDENTITY_SECRET:?Set WALLETS_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__8__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__8__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__8__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__8__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__8__ValidationFallback__ClientSecret: ${WALLETS_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__8__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__8__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__8__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__8__AllowedScopes: bolt.service,identity.session.validate
       ServiceIdentity__Clients__9__ClientId: XFramework.Inventario
       ServiceIdentity__Clients__9__ClientSecret: ${INVENTARIO_SERVICE_IDENTITY_SECRET:?Set INVENTARIO_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__9__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__9__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__9__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__9__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__9__ValidationFallback__ClientSecret: ${INVENTARIO_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__9__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__9__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__9__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__9__AllowedScopes: bolt.service,identity.session.validate
       ServiceIdentity__Clients__10__ClientId: XFramework.POS
       ServiceIdentity__Clients__10__ClientSecret: ${POS_SERVICE_IDENTITY_SECRET:?Set POS_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__10__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__10__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__10__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__10__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__10__ValidationFallback__ClientSecret: ${POS_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__10__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__10__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__10__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__10__AllowedScopes: bolt.service,identity.session.validate
       ServiceIdentity__Clients__11__ClientId: XFramework.Operations.Dashboard
       ServiceIdentity__Clients__11__ClientSecret: ${OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET:?Set OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET in .env}
-      ServiceIdentity__Clients__11__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      ServiceIdentity__Clients__11__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__Clients__11__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__Clients__11__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__Clients__11__ValidationFallback__ClientSecret: ${OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__Clients__11__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__Clients__11__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__11__AllowedAudiences: *service-identity-audiences
       ServiceIdentity__Clients__11__AllowedScopes: bolt.service
       TrustedProxyForwarding__KnownProxies__0: host.docker.internal
@@ -331,9 +331,9 @@ services:
       ServiceIdentity__ClientSecret: ${COMMUNICATIONS_SERVICE_IDENTITY_SECRET:?Set COMMUNICATIONS_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
       ServiceIdentity__DefaultScopes__1: identity.session.validate
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${COMMUNICATIONS_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
     secrets: *identity-user-jwt-public-key-secret
     ports:
       - "${COMMUNICATIONS_EXPOSE_PORT:-5148}:8080"
@@ -363,9 +363,9 @@ services:
       ServiceIdentity__ClientSecret: ${NOTIFICATIONS_SERVICE_IDENTITY_SECRET:?Set NOTIFICATIONS_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
       ServiceIdentity__DefaultScopes__1: identity.session.validate
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${NOTIFICATIONS_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
     secrets: *identity-user-jwt-public-key-secret
     ports:
       - "${NOTIFICATIONS_EXPOSE_PORT:-5166}:8080"
@@ -394,9 +394,9 @@ services:
       ServiceIdentity__ClientSecret: ${STORAGE_SERVICE_IDENTITY_SECRET:?Set STORAGE_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
       ServiceIdentity__DefaultScopes__1: identity.session.validate
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${STORAGE_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       BoltConfiguration__ClientName: XFramework.Storage
       Storage__DefaultProvider: ${STORAGE_DEFAULT_PROVIDER:-S3Compatible}
       Storage__ProviderProfileName: ${STORAGE_PROVIDER_PROFILE_NAME:-default}
@@ -441,9 +441,9 @@ services:
       ServiceIdentity__ClientSecret: ${ATTENDANCE_SERVICE_IDENTITY_SECRET:?Set ATTENDANCE_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
       ServiceIdentity__DefaultScopes__1: identity.session.validate
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${ATTENDANCE_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
     secrets: *identity-user-jwt-public-key-secret
     ports:
       - "${ATTENDANCE_EXPOSE_PORT:-5182}:8080"
@@ -472,9 +472,9 @@ services:
       <<: *common-env
       ServiceIdentity__ClientSecret: ${SMSGATEWAY_SERVICE_IDENTITY_SECRET:?Set SMSGATEWAY_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${SMSGATEWAY_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
     secrets: *identity-user-jwt-public-key-secret
     ports:
       - "${SMSGATEWAY_EXPOSE_PORT:-5274}:8080"
@@ -504,9 +504,9 @@ services:
       ServiceIdentity__ClientSecret: ${WALLETS_SERVICE_IDENTITY_SECRET:?Set WALLETS_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
       ServiceIdentity__DefaultScopes__1: identity.session.validate
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${WALLETS_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
     secrets: *identity-user-jwt-public-key-secret
     ports:
       - "${WALLETS_EXPOSE_PORT:-9696}:8080"
@@ -536,9 +536,9 @@ services:
       ServiceIdentity__ClientSecret: ${INVENTARIO_SERVICE_IDENTITY_SECRET:?Set INVENTARIO_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
       ServiceIdentity__DefaultScopes__1: identity.session.validate
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${INVENTARIO_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
     secrets: *identity-user-jwt-public-key-secret
     ports:
       - "${INVENTARIO_EXPOSE_PORT:-8105}:8080"
@@ -568,9 +568,9 @@ services:
       ServiceIdentity__ClientSecret: ${POS_SERVICE_IDENTITY_SECRET:?Set POS_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
       ServiceIdentity__DefaultScopes__1: identity.session.validate
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${POS_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
     secrets: *identity-user-jwt-public-key-secret
     ports:
       - "${POS_EXPOSE_PORT:-8115}:8080"
@@ -606,9 +606,9 @@ services:
       ServiceIdentity__DefaultScopes__0: bolt.service
       ServiceIdentity__DefaultScopes__1: identity.admin
       ServiceIdentity__DefaultScopes__2: identity.session.validate
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${PORTAL_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
     secrets: *identity-user-jwt-public-key-secret
     ports:
       - "${PORTAL_EXPOSE_PORT:-5000}:8080"
@@ -661,13 +661,13 @@ services:
       ServiceIdentity__Issuer: XFramework.IdentityServer
       ServiceIdentity__Authority: http://identityserver:8080
       ServiceIdentity__AllowInsecureHttp: true
-      ServiceIdentity__GenerationId: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
-      CREDENTIAL_GENERATION_ID: ${CREDENTIAL_GENERATION_ID:?Set CREDENTIAL_GENERATION_ID in the protected deployment env}
+      ServiceIdentity__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
+      SERVICE_CREDENTIAL_GENERATION_ID: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}
       ServiceIdentity__ClientSecret: ${OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET:?Set OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__DefaultScopes__0: bolt.service
-      ServiceIdentity__ValidationFallback__GenerationId: ${CREDENTIAL_SECONDARY_GENERATION_ID:-}
+      ServiceIdentity__ValidationFallback__GenerationId: ${SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID:-}
       ServiceIdentity__ValidationFallback__ClientSecret: ${OPERATIONS_DASHBOARD_SERVICE_IDENTITY_SECRET_SECONDARY:-}
-      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
+      ServiceIdentity__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       Seq__Url: http://seq:80
       Seq__ApiKey: ${SEQ_API_KEY:-}
       Jaeger__QueryUrl: http://jaeger:16686

--- a/scripts/refresh-bolt-phase0-synthetic-tokens-test.py
+++ b/scripts/refresh-bolt-phase0-synthetic-tokens-test.py
@@ -32,7 +32,8 @@ SPEC.loader.exec_module(refresh)
 TENANT_ID = "11111111-1111-4111-8111-111111111111"
 CREDENTIAL_ID = "22222222-2222-4222-8222-222222222222"
 ROLE_ID = "33333333-3333-4333-8333-333333333333"
-GENERATION = "phase0-g2"
+SERVICE_GENERATION = "phase0-service-g2"
+USER_JWT_GENERATION = "phase0-user-g7"
 BASE_URL = "https://identity.test:8443"
 ISSUER = "xframework"
 AUDIENCE = "xframework-phase0"
@@ -60,8 +61,13 @@ def b64url(value: bytes) -> str:
     return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
 
 
-def actor_jwt(claims: dict[str, Any], *, generation: str = GENERATION) -> str:
-    header = {"alg": "HS512", "kid": generation, "typ": "JWT"}
+def actor_jwt(
+    claims: dict[str, Any],
+    *,
+    algorithm: str = "RS512",
+    generation: str = USER_JWT_GENERATION,
+) -> str:
+    header = {"alg": algorithm, "kid": generation, "typ": "JWT"}
     encoded_header = b64url(json.dumps(header, separators=(",", ":"), sort_keys=True).encode())
     encoded_claims = b64url(json.dumps(claims, separators=(",", ":"), sort_keys=True).encode())
     signature = b64url(("signature-" + str(claims.get("jti", "missing"))).encode())
@@ -109,7 +115,7 @@ def service_claims(
         "nbf": now - 1,
         "iat": now - 1,
         "jti": jti,
-        "client_credential_generation": GENERATION,
+        "client_credential_generation": SERVICE_GENERATION,
         "client_id": client_id,
         "service": client_id,
         "sub": client_id,
@@ -132,7 +138,7 @@ def identity_service_claims(
         "nbf": now - 1,
         "iat": now - 1,
         "jti": jti,
-        "client_credential_generation": GENERATION,
+        "client_credential_generation": SERVICE_GENERATION,
         "client_id": client_id,
         "sub": client_id,
         "scope": "bolt.service",
@@ -148,7 +154,7 @@ def user_claims(now: int, jti: str, **overrides: Any) -> dict[str, Any]:
         "exp": now + 900,
         "nbf": now - 1,
         "jti": jti,
-        "credential_generation": GENERATION,
+        "credential_generation": USER_JWT_GENERATION,
         "credential_id": CREDENTIAL_ID,
         "tenant_id": TENANT_ID,
         "tenantId": TENANT_ID,
@@ -253,7 +259,8 @@ class Workspace:
             "BOLT_SYNTHETIC_IDENTITYSERVER_BASE_URL": BASE_URL,
             "JWT_ISSUER": ISSUER,
             "JWT_AUDIENCE": AUDIENCE,
-            "CREDENTIAL_GENERATION_ID": GENERATION,
+            "SERVICE_CREDENTIAL_GENERATION_ID": SERVICE_GENERATION,
+            "USER_JWT_GENERATION_ID": USER_JWT_GENERATION,
             "COMMUNICATIONS_SERVICE_IDENTITY_SECRET": CLIENT_SECRET,
             "PORTAL_SERVICE_IDENTITY_SECRET": PORTAL_CLIENT_SECRET,
             "BOLT_SYNTHETIC_TENANT_ID": TENANT_ID,
@@ -288,6 +295,17 @@ class Workspace:
 
 
 class RefreshTokenHookTests(unittest.TestCase):
+    def test_config_keeps_service_and_user_generations_distinct(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            config = Workspace(Path(temporary)).config()
+
+            self.assertEqual(config.service_credential_generation, SERVICE_GENERATION)
+            self.assertEqual(config.user_jwt_generation, USER_JWT_GENERATION)
+            self.assertNotEqual(
+                config.service_credential_generation,
+                config.user_jwt_generation,
+            )
+
     def test_env_parser_accepts_crlf_and_full_line_comments_without_evaluation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             workspace = Workspace(Path(temporary))
@@ -654,16 +672,23 @@ class RefreshTokenHookTests(unittest.TestCase):
                         now=now,
                     )
 
-    def test_actor_token_is_validated_as_hs512_application_jwt_only(self) -> None:
+    def test_actor_token_requires_rs512_and_user_jwt_generation(self) -> None:
         now = int(time.time())
         with tempfile.TemporaryDirectory() as temporary:
             config = Workspace(Path(temporary)).config()
             claims = user_claims(now, str(uuid.uuid4()))
-            response = user_response(claims)
-            response["accessToken"] = transport_jwt(claims)
-
-            with self.assertRaisesRegex(refresh.RefreshError, "TOKEN_HEADER"):
-                refresh._parse_user_token(response, config, now=now)
+            for name, token in {
+                "algorithm": actor_jwt(claims, algorithm="HS512"),
+                "service-generation": actor_jwt(
+                    claims,
+                    generation=SERVICE_GENERATION,
+                ),
+            }.items():
+                with self.subTest(name=name):
+                    response = user_response(claims)
+                    response["accessToken"] = token
+                    with self.assertRaisesRegex(refresh.RefreshError, "TOKEN_HEADER"):
+                        refresh._parse_user_token(response, config, now=now)
 
     def test_user_token_must_bind_expected_tenant_and_credential(self) -> None:
         now = int(time.time())

--- a/scripts/refresh-bolt-phase0-synthetic-tokens.py
+++ b/scripts/refresh-bolt-phase0-synthetic-tokens.py
@@ -37,7 +37,7 @@ SERVICE_ALGORITHM = "RS256"
 SERVICE_TOKEN_TYPE = "JWT"
 PORTAL_SERVICE_SCOPES = ("bolt.service",)
 COMMUNICATIONS_SERVICE_SCOPES = ("bolt.service",)
-ACTOR_ALGORITHM = "HS512"
+ACTOR_ALGORITHM = "RS512"
 ACTOR_TOKEN_TYPE = "JWT"
 RECEIPT_SCHEMA = "bolt-phase0-token-refresh/v4"
 PRINCIPAL_REFERENCE = "bolt-phase0-synthetic"
@@ -80,7 +80,8 @@ class Config:
     port: int
     actor_issuer: str
     actor_audience: str
-    credential_generation: str
+    service_credential_generation: str
+    user_jwt_generation: str
     communications_secret: str
     portal_secret: str
     tenant_id: str
@@ -264,8 +265,11 @@ def load_config(values: dict[str, str]) -> Config:
     audience = _required(values, "JWT_AUDIENCE")
     if len(audience) > 512 or audience != audience.strip() or any(ord(c) < 33 for c in audience):
         _raise("CONFIGURATION")
-    generation = _required(values, "CREDENTIAL_GENERATION_ID")
-    if not re.fullmatch(r"[A-Za-z0-9_.:-]{1,96}", generation):
+    service_generation = _required(values, "SERVICE_CREDENTIAL_GENERATION_ID")
+    if not re.fullmatch(r"[A-Za-z0-9_.:-]{1,96}", service_generation):
+        _raise("CONFIGURATION")
+    user_generation = _required(values, "USER_JWT_GENERATION_ID")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", user_generation):
         _raise("CONFIGURATION")
 
     username = _required(values, "BOLT_SYNTHETIC_USER_USERNAME")
@@ -279,7 +283,8 @@ def load_config(values: dict[str, str]) -> Config:
         port=port,
         actor_issuer=raw_issuer,
         actor_audience=audience,
-        credential_generation=generation,
+        service_credential_generation=service_generation,
+        user_jwt_generation=user_generation,
         communications_secret=_validate_secret(
             _required(values, "COMMUNICATIONS_SERVICE_IDENTITY_SECRET"), minimum=32
         ),
@@ -527,7 +532,7 @@ def _validate_transport_jwt(
         or claims.get("service") != expected_client_id
         or claims.get("sub") != expected_client_id
         or claims.get("scope") != TRANSPORT_SCOPE
-        or claims.get("client_credential_generation") != config.credential_generation
+        or claims.get("client_credential_generation") != config.service_credential_generation
     ):
         _raise("TOKEN_IDENTITY")
     return evidence, claims
@@ -568,7 +573,7 @@ def _validate_service_jwt(
     if (
         claims.get("client_id") != expected_client_id
         or claims.get("sub") != expected_client_id
-        or claims.get("client_credential_generation") != config.credential_generation
+        or claims.get("client_credential_generation") != config.service_credential_generation
         or len(normalized_scopes) != len(expected_scopes)
         or set(normalized_scopes) != set(expected_scopes)
     ):
@@ -586,11 +591,11 @@ def _validate_actor_jwt(
     value, header, claims = _read_jwt(token)
     if set(header) != {"alg", "kid", "typ"} or header != {
         "alg": ACTOR_ALGORITHM,
-        "kid": config.credential_generation,
+        "kid": config.user_jwt_generation,
         "typ": ACTOR_TOKEN_TYPE,
     }:
         _raise("TOKEN_HEADER")
-    if claims.get(GENERATION_CLAIM) != config.credential_generation:
+    if claims.get(GENERATION_CLAIM) != config.user_jwt_generation:
         _raise("TOKEN_CLAIMS")
     evidence = _validate_temporal_claims(
         value,

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -302,6 +302,16 @@ public sealed class ServiceIdentityComposeContractTests
         }
 
         envExample.Should().Contain("USER_JWT_GENERATION_ID=");
+        envExample.Should().Contain("SERVICE_CREDENTIAL_GENERATION_ID=");
+        envExample.Should().Contain("SERVICE_CREDENTIAL_SECONDARY_GENERATION_ID=");
+        envExample.Should().Contain("SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC=");
+        envExample.Should().NotContain("\nCREDENTIAL_GENERATION_ID=");
+        envExample.Should().NotContain("\nCREDENTIAL_SECONDARY_GENERATION_ID=");
+        envExample.Should().NotContain("\nCREDENTIAL_SECONDARY_VALID_UNTIL_UTC=");
+        compose.Should().NotContain("${CREDENTIAL_GENERATION_ID");
+        compose.Should().NotContain("${CREDENTIAL_SECONDARY_GENERATION_ID");
+        compose.Should().NotContain("${CREDENTIAL_SECONDARY_VALID_UNTIL_UTC");
+        workflow.Should().Contain("SERVICE_CREDENTIAL_GENERATION_ID is missing or invalid");
         envExample.Should().Contain("IDENTITY_USER_JWT_PUBLIC_KEY_PATH=");
         envExample.Should().Contain("IDENTITY_USER_JWT_PRIVATE_KEY_PATH=");
         workflow.Should().Contain("Identity user JWT public and private keys do not match");


### PR DESCRIPTION
## Summary
- rename the service credential generation environment contract to SERVICE_CREDENTIAL_*
- validate user actor JWTs against the independent USER_JWT_GENERATION_ID and RS512 algorithm
- add focused smoke-hook and deployment contract regression coverage

## Validation
- python scripts/refresh-bolt-phase0-synthetic-tokens-test.py
- dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --filter FullyQualifiedName~ServiceIdentityComposeContractTests --logger console;verbosity=minimal -m:1 /nr:false
- git diff --check