### PR TITLE
Fix service signing key discovery bootstrap

### DIFF
--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/GetSigningKeys/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/GetSigningKeys/Endpoint.cs
@@ -22,7 +22,10 @@ public static class GetServiceSigningKeysEndpoint
     [MapPost("/api/service-identity/signing-keys/query", Tags = ["Service Identity"],
         Summary = "Get service signing public keys",
         Description = "Returns public service signing keys for internal JWT validation.",
-        ExcludeFromOpenApi = false)]
+        ExcludeFromOpenApi = false,
+        ActorRequirement = ActorRequirement.None,
+        TenantAccessMode = TenantAccessMode.Tenantless,
+        AllowAnonymous = true)]
     public static async Task<Result<ServiceSigningKeysResponse>> HandleHttp(
         GetServiceSigningKeysRequest request,
         IServiceIdentityService serviceIdentityService,

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/ServiceSigningKeyDiscoveryContractTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/ServiceSigningKeyDiscoveryContractTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using IdentityServer.Api.Features.ServiceIdentity.GetSigningKeys;
+using NUnit.Framework;
+using XFramework.Integration.Attributes;
+using XFramework.Integration.Security;
+
+namespace IdentityServer.IntegrationTests;
+
+[TestFixture]
+[Category("Kind:Integration")]
+[Category("Module:IdentityServer")]
+[Category("Area:ServiceIdentity")]
+public sealed class ServiceSigningKeyDiscoveryContractTests
+{
+    [Test]
+    public void HttpSigningKeyDiscovery_IsExplicitlyAnonymousAndTenantless()
+    {
+        var endpoint = typeof(GetServiceSigningKeysEndpoint)
+            .GetMethod(nameof(GetServiceSigningKeysEndpoint.HandleHttp))!;
+        var attribute = endpoint.GetCustomAttributes(typeof(MapPostAttribute), inherit: false)
+            .Cast<MapPostAttribute>()
+            .Single();
+
+        attribute.AllowAnonymous.Should().BeTrue();
+        attribute.ActorRequirement.Should().Be(ActorRequirement.None);
+        attribute.TenantAccessMode.Should().Be(TenantAccessMode.Tenantless);
+        attribute.RequiredServiceScopes.Should().BeNull();
+        attribute.AllowedServiceCallers.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- make the read-only service signing-key discovery endpoint explicitly anonymous and tenantless
- break the circular dependency where service-token validation required authenticated access to its own public signing keys
- add an IdentityServer contract test for the discovery policy

## Verification
- targeted IdentityServer integration fixture test passes against PostgreSQL via xeon-dev Testcontainers
- failed deployment run restored the previous healthy IdentityServer and Bolt Hub release