### PR TITLE
Separate public signing key discovery policy

### DIFF
--- a/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/GetSigningKeys/Endpoint.cs
+++ b/src/Modules/XFramework.IdentityServer/IdentityServer.Api/Features/ServiceIdentity/GetSigningKeys/Endpoint.cs
@@ -18,7 +18,10 @@ public static class GetServiceSigningKeysEndpoint
     {
         return await serviceIdentityService.GetSigningKeysAsync(request, ct);
     }
+}
 
+public static class GetServiceSigningKeysHttpEndpoint
+{
     [MapPost("/api/service-identity/signing-keys/query", Tags = ["Service Identity"],
         Summary = "Get service signing public keys",
         Description = "Returns public service signing keys for internal JWT validation.",

--- a/src/Tests/IdentityServer.IntegrationTests/Tests/ServiceSigningKeyDiscoveryContractTests.cs
+++ b/src/Tests/IdentityServer.IntegrationTests/Tests/ServiceSigningKeyDiscoveryContractTests.cs
@@ -1,6 +1,9 @@
 using FluentAssertions;
 using IdentityServer.Api.Features.ServiceIdentity.GetSigningKeys;
 using NUnit.Framework;
+using System.Net;
+using System.Net.Http.Json;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 using XFramework.Integration.Security;
 
@@ -15,8 +18,8 @@ public sealed class ServiceSigningKeyDiscoveryContractTests
     [Test]
     public void HttpSigningKeyDiscovery_IsExplicitlyAnonymousAndTenantless()
     {
-        var endpoint = typeof(GetServiceSigningKeysEndpoint)
-            .GetMethod(nameof(GetServiceSigningKeysEndpoint.HandleHttp))!;
+        var endpoint = typeof(GetServiceSigningKeysHttpEndpoint)
+            .GetMethod(nameof(GetServiceSigningKeysHttpEndpoint.HandleHttp))!;
         var attribute = endpoint.GetCustomAttributes(typeof(MapPostAttribute), inherit: false)
             .Cast<MapPostAttribute>()
             .Single();
@@ -26,5 +29,17 @@ public sealed class ServiceSigningKeyDiscoveryContractTests
         attribute.TenantAccessMode.Should().Be(TenantAccessMode.Tenantless);
         attribute.RequiredServiceScopes.Should().BeNull();
         attribute.AllowedServiceCallers.Should().BeNull();
+    }
+
+    [Test]
+    public async Task HttpSigningKeyDiscovery_WithoutAuthorization_ReturnsPublicKeys()
+    {
+        using var client = new HttpClient { BaseAddress = new Uri(IntegrationTestFixture.IdentityServerUrl) };
+
+        using var response = await client.PostAsJsonAsync(
+            "/api/service-identity/signing-keys/query",
+            new GetServiceSigningKeysRequest());
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
     }
 }


### PR DESCRIPTION
## Summary
- separate anonymous HTTP signing-key discovery from the protected Bolt handler so generated authorization policies cannot bleed across transports
- preserve identity.admin protection on the Bolt wrapper path
- add a real unauthenticated HTTP integration test that requires the bootstrap endpoint to return 200

## Verification
- dotnet test src/Tests/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj --filter FullyQualifiedName~ServiceSigningKeyDiscoveryContractTests -m:1 /nr:false --no-restore (2 passed)

## Deployment context
This fixes the exact 500 observed in xeon-dev after PR #392: Anonymous access cannot be combined with service or actor authorization requirements. Deployment remains GitHub Actions-only.