### PR TITLE
Align Bolt smoke with trusted request metadata

### DIFF
--- a/scripts/refresh-bolt-phase0-synthetic-tokens-test.py
+++ b/scripts/refresh-bolt-phase0-synthetic-tokens-test.py
@@ -953,11 +953,23 @@ class RefreshTokenHookTests(unittest.TestCase):
                 },
             )
             self.assertEqual(user_body["password"], PASSWORD)
-            self.assertEqual(user_body["metadata"]["tenantId"], TENANT_ID)
-            self.assertEqual(user_body["metadata"]["credentialId"], CREDENTIAL_ID)
-            self.assertEqual(user_body["metadata"]["name"], "bolt-phase0-synthetic")
+            self.assertEqual(
+                set(user_body["metadata"]),
+                {
+                    "requestedTenantId",
+                    "operationName",
+                    "deviceName",
+                    "userAgent",
+                    "requestId",
+                },
+            )
+            self.assertEqual(user_body["metadata"]["requestedTenantId"], TENANT_ID)
+            self.assertEqual(
+                user_body["metadata"]["operationName"],
+                "Authenticate Bolt Phase 0 synthetic user",
+            )
             self.assertEqual(user_body["metadata"]["deviceName"], "bolt-phase0-synthetic")
-            self.assertEqual(user_body["metadata"]["deviceAgent"], "bolt-phase0-synthetic")
+            self.assertEqual(user_body["metadata"]["userAgent"], "bolt-phase0-synthetic")
 
     def test_communications_identity_service_token_participates_in_distinctness(self) -> None:
         now = int(time.time())

--- a/scripts/refresh-bolt-phase0-synthetic-tokens.py
+++ b/scripts/refresh-bolt-phase0-synthetic-tokens.py
@@ -948,11 +948,10 @@ def execute(
         "generateToken": True,
         "rememberMe": False,
         "metadata": {
-            "tenantId": config.tenant_id,
-            "credentialId": config.credential_id,
-            "name": PRINCIPAL_REFERENCE,
+            "requestedTenantId": config.tenant_id,
+            "operationName": "Authenticate Bolt Phase 0 synthetic user",
             "deviceName": PRINCIPAL_REFERENCE,
-            "deviceAgent": PRINCIPAL_REFERENCE,
+            "userAgent": PRINCIPAL_REFERENCE,
             "requestId": str(uuid.uuid4()),
         },
     }


### PR DESCRIPTION
## Summary
- update the Phase 0 synthetic authentication request to use the new trusted metadata contract
- send equestedTenantId, operationName, deviceName, userAgent, and equestId only
- remove legacy client-trusted 	enantId, credentialId, 
ame, and deviceAgent fields
- lock the exact metadata key set in the helper tests

## Root cause
The deployed IdentityServer correctly ignored the removed legacy fields. Public tenant lookup therefore received no RequestedTenantId and returned HTTP 400 during synthetic user authentication.

## Verification
- python scripts/refresh-bolt-phase0-synthetic-tokens-test.py (27 passed)

Deployment remains GitHub Actions-only.