### PR TITLE
Scan saturated Seq diagnostic windows

### DIFF
--- a/scripts/verify-bolt-phase0-diagnostic-sinks-test.py
+++ b/scripts/verify-bolt-phase0-diagnostic-sinks-test.py
@@ -61,7 +61,7 @@ class SinkState:
     def __init__(self, role: str):
         self.role = role
         self.requests: list[tuple[str, dict[str, str]]] = []
-        self.seq = Response([])
+        self.seq: Response | Callable[[dict[str, list[str]]], Response] = Response([])
         self.services = Response({"data": ["bolt-hub", "identityserver"], "total": 2})
         self.traces: dict[str, Response | Callable[[dict[str, list[str]]], Response]] = {
             "bolt-hub": Response({"data": [], "total": 0}),
@@ -87,7 +87,8 @@ class SinkHandler(BaseHTTPRequestHandler):
         self.server.state.requests.append((self.path, headers))
         state: SinkState = self.server.state
         if state.role == "seq" and parsed.path == "/api/events":
-            response = state.seq
+            query = urllib.parse.parse_qs(parsed.query)
+            response = state.seq(query) if callable(state.seq) else state.seq
         elif state.role == "jaeger" and parsed.path == "/api/services":
             response = state.services
         elif state.role == "jaeger" and parsed.path == "/api/traces":
@@ -288,6 +289,31 @@ class DiagnosticSinkVerifierTests(unittest.TestCase):
         result, output = self._run()
 
         self._assert_failed_without_secrets(result, output)
+
+    def test_saturated_seq_window_is_subdivided_and_fully_scanned(self) -> None:
+        start = _utc_microseconds(self.window_start)
+        end = _utc_microseconds(self.window_end)
+        timestamps = [start + ((end - start) * index // 1499) for index in range(1500)]
+
+        def events(query: dict[str, list[str]]) -> Response:
+            window_start = _utc_microseconds(query["fromDateUtc"][0])
+            window_end = _utc_microseconds(query["toDateUtc"][0])
+            limit = int(query["count"][0])
+            count = sum(window_start <= timestamp <= window_end for timestamp in timestamps)
+            return Response([{}] * min(count, limit))
+
+        self.seq_server.state.seq = events
+
+        result, output = self._run()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        evidence = json.loads(output.read_text(encoding="ascii"))
+        self.assertEqual(1500, evidence["counts"]["seqEvents"])
+        seq_requests = [
+            path for path, _ in self.seq_server.state.requests
+            if urllib.parse.urlsplit(path).path == "/api/events"
+        ]
+        self.assertEqual(3, len(seq_requests))
 
     def test_jaeger_trace_token_leak_fails(self) -> None:
         self.jaeger_server.state.traces["bolt-hub"] = Response(

--- a/scripts/verify-bolt-phase0-diagnostic-sinks.py
+++ b/scripts/verify-bolt-phase0-diagnostic-sinks.py
@@ -203,23 +203,41 @@ def scan_jaeger_service(jaeger_url: str, service: str, start: dt.datetime, end: 
     return traces
 
 
+def scan_seq(seq_url: str, start: dt.datetime, end: dt.datetime,
+             needles: Sequence[bytes], api_key: str,
+             budget: dict[str, float | int]) -> int:
+    pending = [(start, end)]
+    events = 0
+    headers = {"X-Seq-ApiKey": api_key} if api_key else {}
+    while pending:
+        window_start, window_end = pending.pop()
+        query = urllib.parse.urlencode({"count": MAX_EVENTS + 1, "render": "true",
+                                        "fromDateUtc": format_utc(window_start),
+                                        "toDateUtc": format_utc(window_end)})
+        document = request_json(f"{seq_url}/api/events?{query}", headers, needles, budget)
+        found = document if isinstance(document, list) else result_list(
+            document, ("Events", "events"), "SEQ_RESPONSE"
+        )
+        if len(found) <= MAX_EVENTS:
+            events += len(found)
+            continue
+
+        midpoint = window_start + (window_end - window_start) / 2
+        later_start = midpoint + dt.timedelta(microseconds=1)
+        if midpoint <= window_start or later_start > window_end:
+            fail("SEQ_LIMIT")
+        pending.extend(((later_start, window_end), (window_start, midpoint)))
+    return events
+
+
 def scan_sinks(seq_url: str, jaeger_url: str, start: dt.datetime, end: dt.datetime,
                needles: Sequence[bytes], api_key: str) -> tuple[int, int, int, int]:
     budget: dict[str, float | int] = {"started": time.monotonic(), "requests": 0}
-    query = urllib.parse.urlencode({"count": MAX_EVENTS + 1, "render": "true",
-                                    "fromDateUtc": format_utc(start),
-                                    "toDateUtc": format_utc(end)})
     if api_key and (
         not 16 <= len(api_key) <= 512 or not api_key.isascii() or any(c.isspace() for c in api_key)
     ):
         fail("SEQ_API_KEY")
-    seq_document = request_json(f"{seq_url}/api/events?{query}",
-                                {"X-Seq-ApiKey": api_key} if api_key else {}, needles, budget)
-    events = seq_document if isinstance(seq_document, list) else result_list(
-        seq_document, ("Events", "events"), "SEQ_RESPONSE"
-    )
-    if len(events) > MAX_EVENTS:
-        fail("SEQ_LIMIT")
+    events = scan_seq(seq_url, start, end, needles, api_key, budget)
 
     services = result_list(request_json(f"{jaeger_url}/api/services", {}, needles, budget),
                            ("data",), "JAEGER_RESPONSE")
@@ -232,7 +250,7 @@ def scan_sinks(seq_url: str, jaeger_url: str, start: dt.datetime, end: dt.dateti
     traces = 0
     for service in services:
         traces += scan_jaeger_service(jaeger_url, service, start, end, needles, budget)
-    return len(events), len(services), traces, int(budget["requests"])
+    return events, len(services), traces, int(budget["requests"])
 
 def write_evidence(path: str, counts: dict[str, int]) -> None:
     payload = json.dumps({"status": "passed", "counts": counts}, sort_keys=True,


### PR DESCRIPTION
## Summary
- recursively split saturated Seq time windows so every deployment-window event is inspected
- preserve bounded request, time, and response-size budgets and fail-closed behavior
- add regression coverage for a 1,500-event deployment window

## Why
The post-deployment diagnostic gate previously requested at most 1,001 Seq events and failed when a healthy authenticated smoke generated more than 1,000 events. This change does not bypass the security check: it scans smaller non-overlapping windows until all events are inspected, and still rejects unsplittable or over-budget scans.

## Tests
- \python scripts/verify-bolt-phase0-diagnostic-sinks-test.py\ (13 passed)