### PR TITLE
Register SmsGateway trusted feature gate

### DIFF
--- a/src/Modules/XFramework.SmsGateway/SmsGateway.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.SmsGateway/SmsGateway.Api/Installers/ServicesInstaller.cs
@@ -1,4 +1,5 @@
 using SmsGateway.Api.Services;
+using XFramework.Core.Extensions;
 using XFramework.Domain.Shared.Interfaces;
 
 namespace SmsGateway.Api.Installers;
@@ -7,6 +8,8 @@ public sealed class ServicesInstaller : IInstaller
 {
     public void InstallServices<TApp>(IServiceCollection services, IConfiguration configuration, IHostEnvironment hostEnvironment)
     {
+        services.AddTenantModuleFeatures();
+
         // Register SMS service (VSA migration - replaced MediatR)
         services.AddScoped<ISmsService, SmsService>();
     }

--- a/src/Tests/XFramework.Core.Tests/Security/LegacyTrustPathGuardTests.cs
+++ b/src/Tests/XFramework.Core.Tests/Security/LegacyTrustPathGuardTests.cs
@@ -267,6 +267,24 @@ public sealed class LegacyTrustPathGuardTests
         }
     }
 
+    [Test]
+    public void SmsGateway_RegistersFeatureGateRequiredByGeneratedEndpoints()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var installerPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Modules",
+            "XFramework.SmsGateway",
+            "SmsGateway.Api",
+            "Installers",
+            "ServicesInstaller.cs");
+
+        File.ReadAllText(installerPath).Should().Contain(
+            "AddTenantModuleFeatures()",
+            "generated secured SmsGateway endpoints resolve ITrustedInvocationFeatureGate at startup");
+    }
+
     private static DirectoryInfo FindRepositoryRoot()
     {
         var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);


### PR DESCRIPTION
## Summary
- register the existing tenant-module feature composition in SmsGateway
- guard the registration because generated secured endpoints require ITrustedInvocationFeatureGate

## Root cause
The post-Bolt SmsGateway image authenticated and connected to Bolt, then crashed while ASP.NET constructed generated endpoints. trustedInvocationFeatureGate was an unknown endpoint parameter because SmsGateway was the only deployed secured module not calling AddTenantModuleFeatures().

## Verification
- SmsGateway.Api build succeeded with zero warnings or errors
- focused SmsGateway registration contract test passed