### PR TITLE
Fix Portal service-token rate-limit failures

### DIFF
--- a/src/Kernel/XFramework.Core/RateLimiting/StrictSecurityRateLimitPolicyMap.cs
+++ b/src/Kernel/XFramework.Core/RateLimiting/StrictSecurityRateLimitPolicyMap.cs
@@ -18,8 +18,11 @@ public static class StrictSecurityRateLimitPolicyMap
     public static readonly StrictSecurityRateLimitPolicy Refresh =
         new("refresh", 10, TimeSpan.FromMinutes(1));
 
-    private static readonly StrictSecurityRateLimitPolicy ServiceIdentity =
-        new("service-identity", 5, TimeSpan.FromMinutes(1));
+    private static readonly StrictSecurityRateLimitPolicy ServiceToken =
+        new("service-token", 60, TimeSpan.FromMinutes(1));
+
+    private static readonly StrictSecurityRateLimitPolicy BoltTransportToken =
+        new("bolt-transport-token", 30, TimeSpan.FromMinutes(1));
 
     public static readonly StrictSecurityRateLimitPolicy PasswordReset =
         new("password-reset", 3, TimeSpan.FromMinutes(15));
@@ -30,10 +33,16 @@ public static class StrictSecurityRateLimitPolicyMap
     public static bool TryResolve(HttpRequest request, out StrictSecurityRateLimitPolicy policy)
     {
         if (HttpMethods.IsPost(request.Method)
-            && (request.Path.Equals("/api/service-identity/token", StringComparison.OrdinalIgnoreCase)
-                || request.Path.Equals("/api/service-identity/bolt-transport-token", StringComparison.OrdinalIgnoreCase)))
+            && request.Path.Equals("/api/service-identity/token", StringComparison.OrdinalIgnoreCase))
         {
-            policy = ServiceIdentity;
+            policy = ServiceToken;
+            return true;
+        }
+
+        if (HttpMethods.IsPost(request.Method)
+            && request.Path.Equals("/api/service-identity/bolt-transport-token", StringComparison.OrdinalIgnoreCase))
+        {
+            policy = BoltTransportToken;
             return true;
         }
 

--- a/src/Presentation/XFramework.Portal/Components/Pages/Dashboard.razor
+++ b/src/Presentation/XFramework.Portal/Components/Pages/Dashboard.razor
@@ -19,7 +19,7 @@ else
     @if (_error is not null)
     {
         <BbAlert Variant="AlertVariant.Danger">
-            <BbAlertTitle>Database Error</BbAlertTitle>
+            <BbAlertTitle>Dashboard unavailable</BbAlertTitle>
             <BbAlertDescription>@_error</BbAlertDescription>
         </BbAlert>
     }
@@ -138,7 +138,7 @@ else
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to load dashboard stats");
-            _error = $"Failed to load stats: {ex.Message}";
+            _error = "Dashboard statistics are temporarily unavailable. Please try again.";
         }
         finally
         {

--- a/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/IdentityServerPortalContractTests.cs
@@ -9,6 +9,24 @@ namespace Portal.E2ETests;
 public sealed class IdentityServerPortalContractTests
 {
     [Test]
+    public void Dashboard_DoesNotExposeIdentityServerTokenFailures()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Presentation",
+            "XFramework.Portal",
+            "Components",
+            "Pages",
+            "Dashboard.razor"));
+
+        source.Should().Contain("Dashboard statistics are temporarily unavailable. Please try again.");
+        source.Should().NotContain("ex.Message");
+        source.Should().NotContain("IdentityServer token request failed");
+    }
+
+    [Test]
     public void IdentityServerEntityRelationshipDialogs_UseSharedEntityPickerAdvancedSearch()
     {
         var repositoryRoot = FindRepositoryRoot();

--- a/src/Tests/XFramework.Core.Tests/RateLimiting/DistributedSecurityRateLimitingTests.cs
+++ b/src/Tests/XFramework.Core.Tests/RateLimiting/DistributedSecurityRateLimitingTests.cs
@@ -22,8 +22,8 @@ namespace XFramework.Core.Tests.RateLimiting;
 [TestFixture]
 public sealed class DistributedSecurityRateLimitingTests
 {
-    [TestCase("POST", "/api/service-identity/token", "service-identity", 5, 60)]
-    [TestCase("POST", "/api/service-identity/bolt-transport-token", "service-identity", 5, 60)]
+    [TestCase("POST", "/api/service-identity/token", "service-token", 60, 60)]
+    [TestCase("POST", "/api/service-identity/bolt-transport-token", "bolt-transport-token", 30, 60)]
     [TestCase("PATCH", "/api/verifications/34ed62ad-e830-4cf9-a428-29a03e7ef917/token", "verification", 5, 900)]
     public void PolicyMap_MapsStrictIdentityServerRoutes(
         string method,
@@ -40,6 +40,20 @@ public sealed class DistributedSecurityRateLimitingTests
         policy.Name.Should().Be(expectedName);
         policy.PermitLimit.Should().Be(expectedLimit);
         policy.Window.Should().Be(TimeSpan.FromSeconds(expectedWindowSeconds));
+    }
+
+    [Test]
+    public void PolicyMap_UsesIndependentQuotasForServiceAndBoltTransportTokens()
+    {
+        var serviceContext = CreateContext("POST", "/api/service-identity/token");
+        var transportContext = CreateContext("POST", "/api/service-identity/bolt-transport-token");
+
+        StrictSecurityRateLimitPolicyMap.TryResolve(serviceContext.Request, out var servicePolicy)
+            .Should().BeTrue();
+        StrictSecurityRateLimitPolicyMap.TryResolve(transportContext.Request, out var transportPolicy)
+            .Should().BeTrue();
+
+        servicePolicy.Name.Should().NotBe(transportPolicy.Name);
     }
 
     [TestCase("GET", "/api/auth/authenticate")]


### PR DESCRIPTION
## Summary
- separate service access-token and Bolt transport-token rate-limit buckets
- right-size authenticated token endpoint quotas while retaining the global IP limiter
- replace raw IdentityServer errors on the Portal dashboard with a safe message
- add focused rate-limit and Portal contract regressions

## Verification
- dotnet test src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj --filter FullyQualifiedName~DistributedSecurityRateLimitingTests -m:1 /nr:false
- dotnet test src/Tests/Portal.E2ETests/Portal.E2ETests.csproj --filter FullyQualifiedName~IdentityServerPortalContractTests.Dashboard_DoesNotExposeIdentityServerTokenFailures -m:1 /nr:false
- dotnet build src/Presentation/XFramework.Portal/XFramework.Portal.csproj -m:1 /nr:false