### PR TITLE
Harden Inventario backend invariants

### DIFF
--- a/docs/solutions/README.md
+++ b/docs/solutions/README.md
@@ -52,6 +52,7 @@ status: current
 - [Decentralized remote data context](architecture-patterns/decentralized-remote-data-context.md) - remote `IDataContext` architecture over generated service wrappers.
 - [IdentityServer schema ownership exceptions](architecture-patterns/identityserver-schema-ownership-exceptions.md) - documents the legacy `Application`, `Audit`, and `GeoLocation` tables that remain owned by IdentityServer.
 - [IdentityServer backend audit and remediation](workflow-issues/identityserver-backend-audit-2026-07-31.md) - records the post-Bolt BackendGuidelines audit, implemented fixes, independent re-audit, and verification evidence.
+- [Inventario backend audit after trusted invocation remediation](workflow-issues/inventario-backend-audit-2026-08-04.md) - records the current post-IdentityServer findings, resolved tenant/Bolt issues, and verification evidence.
 - [Portal service wrapper and integration test contract](developer-experience/portal-service-wrapper-and-integration-test-contract.md) - wrapper-first Portal business operations, direct `IDataContext` mutation rules, and standard/extended integration-test tiers.
 - [UI guidelines](../../rules/UiGuidelines.md) - primary Portal and Blazor UI rules, with links to BlazorBlueprint component details.
 - [Bolt protocol, Hub, and Media audit](workflow-issues/bolt-protocol-hub-media-audit-2026-07-12.md) - active correctness, security, performance, scalability, and Media finding inventory.

--- a/docs/solutions/workflow-issues/inventario-backend-audit-2026-08-04.md
+++ b/docs/solutions/workflow-issues/inventario-backend-audit-2026-08-04.md
@@ -1,0 +1,134 @@
+---
+title: "Inventario Backend Audit After Trusted Invocation Remediation"
+date: 2026-08-05
+category: workflow-issues
+module: Inventario
+problem_type: security_and_backend_compliance
+component: inventario
+severity: medium
+status: remediated_with_deferred_item
+applies_when:
+  - "Changing Inventario services, wrappers, EF models, caching, or authorization"
+  - "Validating Inventario after IdentityServer or Bolt security changes"
+tags: [inventario, identityserver, security, bolt, ef-core, caching, testing]
+---
+
+# Inventario Backend Audit After Trusted Invocation Remediation
+
+## Audit Scope
+
+- Baseline: `origin/develop` at `c0e0a47e79c141fe6b40b24a79f353bd200b2629` (PR #398).
+- Authority: `CLAUDE.md`, `rules/BackendGuidelines.md`, and the canonical VSA, EF Core, caching, remote data-context, wrapper, and Bolt documents they reference.
+- Method: a fresh module audit using the `xframework-audit-module` workflow after the IdentityServer trusted-invocation, service-token, and Bolt-transport-token changes.
+- Implementation: all accepted Critical, High, Medium, and Low remediation items were implemented and verified. Finding 5 remains documented and intentionally deferred by user decision.
+
+## Current Result
+
+**Grade: B+ - no Critical or High findings remain. One Medium least-privilege item is deferred.**
+
+Inventario now consumes the centralized fail-closed trusted invocation context for HTTP and Bolt calls, uses dimensioned stock writes as inventory authority, protects receiving and reorder-rule concurrency at the database boundary, prevents Product remote-mutation bypass, degrades safely when product caching fails, and keeps broad report/planning predicates in PostgreSQL. The complete Inventario integration suite is green.
+
+## Deferred Finding
+
+### 5. Bolt handlers rely on broad defaults instead of operation-specific service policy
+
+**Disposition:** noted and deferred by user decision on 2026-08-05. No remediation for this finding is included in the current Inventario change.
+
+Inventario handlers use the secure generated defaults, which require a service identity, actor, actor tenant, feature gate, and capability authorization. They do not yet partition POS catalog, reservation, purchasing, stock, and administration calls with operation-specific `RequiredServiceScopes`, `AllowedServiceCallers`, or `RequiredActorCapabilities`.
+
+**Residual impact:** service identity is authenticated, but caller authorization is not yet least-privilege partitioned between Inventario operation families. Revisit this if Inventario introduces distinct service trust zones or explicit POS caller allowlists.
+
+## Remediated Findings
+
+### Product stock is no longer a competing lossy authority
+
+- `Product.StockQuantity` and `ProductResponse.StockQuantity` now use decimal precision.
+- EF maps the snapshot as `numeric(18,4)`.
+- Product creation rejects nonzero initial stock and instructs callers to use a warehouse/location-aware stock movement.
+- Stock posting updates the compatibility product snapshot without integer rounding.
+- The migration converts existing integer values without losing existing whole quantities.
+
+Coverage proves product creation cannot create dimensionless opening stock and fractional postings preserve the product snapshot.
+
+### Receiving now participates in optimistic concurrency
+
+- Purchase-order and purchase-order-line mutations are attached before changes and rotate `ConcurrencyStamp` in receiving and status transitions.
+- Stock, receipt, PO-line quantity, and PO status remain part of the same save boundary.
+
+Coverage proves the service rotates both stamps and PostgreSQL rejects a stale concurrent PO-line update.
+
+### Product writes are service-wrapper-only
+
+- `Product` no longer has `[AllowRemoteDataContextMutation]`.
+- Product create/update remain available through Inventario service wrappers.
+- Remote Product create/update/delete integration contracts now assert rejection and no database mutation.
+
+### Product cache failures are non-authoritative
+
+- Cache get, set, remove, and prefix invalidation are best effort.
+- Cache failures emit warnings but do not turn an already committed database write into a false `500` result.
+- Cache keys use the `inventario:tenant:{tenantId}:...` namespace.
+
+Coverage proves create and delete return their committed business result when cache operations throw.
+
+### Product deletion protects operational dependencies
+
+Deletion now returns conflict while the product has nonzero/reserved balances, active reservation allocations, lots, variants, active reorder rules, or open purchase-order lines.
+
+### Invalid same-dimension transfers are rejected
+
+The request validator and stock service both reject a transfer whose destination warehouse/location equals its source. Coverage proves no movement or save occurs.
+
+### Reporting and planning filter in PostgreSQL
+
+- Stock, movement, allocation, and expiry report predicates are applied to `IQueryable` before materialization.
+- Report result sets and planning candidate sets have explicit caps.
+- Lookup queries load only identifiers referenced by candidate rows.
+- Planning filters rules and balances before materialization.
+
+### Reorder-rule uniqueness is database-enforced
+
+The active reorder-rule dimension index is unique, treats nullable dimensions as equal, and excludes soft-deleted rows. The migration deterministically soft-deletes pre-existing duplicates before creating the constraint. PostgreSQL integration coverage proves duplicate active dimensions fail.
+
+### Routine query-filter bypass was removed
+
+Inventario production API services contain no `IgnoreQueryFilters()` calls. Tenant and soft-delete behavior now uses the centralized fail-closed EF filters plus explicit business predicates where useful.
+
+### Validation and metadata cleanup is complete
+
+- `ReleaseReservationValidator` now validates the reservation id and optional reason length.
+- Inventario no longer directly references `Microsoft.Extensions.Logging.Abstractions`.
+- Swagger metadata identifies Inventario rather than IdentityServer.
+
+### Integration authorization seed is current
+
+The integration fixture seeds the configured trusted actor's `IdentityInformation`, `IdentityCredential`, and `IdentityRole`, allowing the centralized capability resolver to authorize normal wrapper commands. Separate denial tests remain responsible for unauthorized scenarios.
+
+### POS catalog query projection is database-safe
+
+Catalog search applies name, SKU, brand, variant-name, and variation-type predicates before projection. Private EF projection rows support SQL ordering and pagination; transport DTOs are created after materialization. This fixed the previously untranslated positional-record filter/order expressions.
+
+## IdentityServer And Shared Security Findings Resolved Upstream
+
+1. Request metadata no longer selects the effective tenant. `TrustedInvocationResolver` validates service identity, actor identity, tenant targeting, and capabilities before establishing `EffectiveTenantId`.
+2. HTTP and Bolt authorizers both establish trusted invocation context and run generated feature gates.
+3. EF tenant filters and writes fail closed through the trusted effective-tenant accessor.
+4. Service access tokens and Bolt transport tokens use independent expiry-aware, single-flight caches, so Inventario does not create avoidable IdentityServer quota bursts.
+
+## Verification Evidence
+
+Runtime integration tests used a loopback-only SSH tunnel to Docker context `xeon-dev`; no deployed service was rebuilt or restarted.
+
+- Inventario API build: passed, 0 warnings, 0 errors.
+- Inventario integration project build: passed, 0 errors; generated change-tracker nullability warnings remain in generated code.
+- Inventario API unit tests: **37/37 passed**.
+- Inventario full integration suite: **62/62 passed**.
+- EF pending-model check: no changes since migration `InventarioBackendRemediation20260805`.
+- Production Inventario API `IgnoreQueryFilters()` count: **0**.
+- Product remote-mutation attributes: **0**.
+
+## Remaining Follow-Up
+
+1. Revisit deferred finding 5 only when operation-specific service policy is approved.
+2. Address generated integration change-tracker nullability warnings in the source generator rather than suppressing them in Inventario.
+3. Keep this audit updated when Inventario backend behavior, authorization, wrappers, or persistence rules change.

--- a/src/Kernel/XFramework.Domain/Migrations/20260805081229_InventarioBackendRemediation20260805.Designer.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260805081229_InventarioBackendRemediation20260805.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XFramework.Domain.Contexts;
@@ -11,9 +12,11 @@ using XFramework.Domain.Contexts;
 namespace XFramework.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805081229_InventarioBackendRemediation20260805")]
+    partial class InventarioBackendRemediation20260805
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kernel/XFramework.Domain/Migrations/20260805081229_InventarioBackendRemediation20260805.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260805081229_InventarioBackendRemediation20260805.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class InventarioBackendRemediation20260805 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InventoryReorderRule_TenantId_ProductId_ProductVariationId_~",
+                schema: "Inventario",
+                table: "InventoryReorderRule");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "StockQuantity",
+                schema: "Inventario",
+                table: "Product",
+                type: "numeric(18,4)",
+                precision: 18,
+                scale: 4,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldDefaultValue: 0);
+
+            migrationBuilder.Sql(
+                """
+                WITH ranked_rules AS (
+                    SELECT "ID",
+                           ROW_NUMBER() OVER (
+                               PARTITION BY "TenantId", "ProductId", "ProductVariationId", "WarehouseId", "LocationId"
+                               ORDER BY "CreatedAt", "ID") AS duplicate_rank
+                    FROM "Inventario"."InventoryReorderRule"
+                    WHERE "IsDeleted" = false
+                )
+                UPDATE "Inventario"."InventoryReorderRule" AS rule
+                SET "IsDeleted" = true,
+                    "DeletedAt" = NOW(),
+                    "ModifiedAt" = NOW()
+                FROM ranked_rules
+                WHERE rule."ID" = ranked_rules."ID"
+                  AND ranked_rules.duplicate_rank > 1;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_TenantId_ProductId_ProductVariationId_~",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                columns: new[] { "TenantId", "ProductId", "ProductVariationId", "WarehouseId", "LocationId" },
+                unique: true,
+                filter: "\"IsDeleted\" = false")
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InventoryReorderRule_TenantId_ProductId_ProductVariationId_~",
+                schema: "Inventario",
+                table: "InventoryReorderRule");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "StockQuantity",
+                schema: "Inventario",
+                table: "Product",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(18,4)",
+                oldPrecision: 18,
+                oldScale: 4,
+                oldDefaultValue: 0m);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InventoryReorderRule_TenantId_ProductId_ProductVariationId_~",
+                schema: "Inventario",
+                table: "InventoryReorderRule",
+                columns: new[] { "TenantId", "ProductId", "ProductVariationId", "WarehouseId", "LocationId" });
+        }
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Create/CreateProductValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/Create/CreateProductValidator.cs
@@ -18,7 +18,7 @@ public class CreateProductValidator : AbstractValidator<CreateProductRequest>
             .GreaterThan(0).WithMessage("Price must be greater than 0");
 
         RuleFor(x => x.StockQuantity)
-            .GreaterThanOrEqualTo(0).WithMessage("Stock quantity cannot be negative");
+            .Equal(0).WithMessage("Initial stock must be posted through a stock movement with warehouse and location dimensions");
 
         RuleFor(x => x.CategoryId)
             .NotEmpty().WithMessage("Category is required");

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/ProductResponse.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Products/ProductResponse.cs
@@ -11,7 +11,7 @@ public class ProductResponse
     public string Name { get; set; } = string.Empty;
     public string? Description { get; set; }
     public decimal Price { get; set; }
-    public int StockQuantity { get; set; }
+    public decimal StockQuantity { get; set; }
     public Guid CategoryId { get; set; }
     public string? CategoryName { get; set; }
     public string? SKU { get; set; }

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/Post/PostStockMovementValidator.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Features/Stock/Post/PostStockMovementValidator.cs
@@ -27,6 +27,12 @@ public sealed class PostStockMovementValidator : AbstractValidator<PostStockMove
             .NotEmpty()
             .When(x => x.MovementType == InventoryMovementType.Transfer)
             .WithMessage("Transfer destination location is required.");
+        RuleFor(x => x)
+            .Must(x =>
+                x.MovementType != InventoryMovementType.Transfer ||
+                x.DestinationWarehouseId != x.WarehouseId ||
+                x.DestinationLocationId != x.LocationId)
+            .WithMessage("Transfer destination must differ from the source warehouse and location.");
         RuleFor(x => x.UnitOfMeasure).MaximumLength(25).When(x => !string.IsNullOrWhiteSpace(x.UnitOfMeasure));
         RuleFor(x => x.ReferenceType).MaximumLength(100).When(x => !string.IsNullOrWhiteSpace(x.ReferenceType));
         RuleFor(x => x.Reason).MaximumLength(1000).When(x => !string.IsNullOrWhiteSpace(x.Reason));

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Inventario.Api.csproj
@@ -27,7 +27,6 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryAllocationService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryAllocationService.cs
@@ -26,7 +26,6 @@ public sealed class InventoryAllocationService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<ReservationAllocation>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ReservationId is { } reservationId)
@@ -218,7 +217,6 @@ public sealed class InventoryAllocationService(
         CancellationToken ct)
     {
         var balances = await dataContext.Query<StockBalance>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == request.ProductId &&
@@ -244,7 +242,6 @@ public sealed class InventoryAllocationService(
         var lots = lotIds.Count == 0
             ? []
             : await dataContext.Query<InventoryLot>()
-                .IgnoreQueryFilters()
                 .Where(x => x.TenantId == tenantId && lotIds.Contains(x.Id) && !x.IsDeleted)
                 .ToListAsync(ct);
 
@@ -284,7 +281,6 @@ public sealed class InventoryAllocationService(
         CancellationToken ct)
     {
         var allocations = await dataContext.Query<ReservationAllocation>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == reservation.TenantId &&
                 x.ReservationId == reservation.Id &&
@@ -300,7 +296,6 @@ public sealed class InventoryAllocationService(
             return Result<List<ReservationAllocation>>.Failure("Reservation does not have stock allocation details.", 409);
 
         var balance = await dataContext.Query<StockBalance>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == reservation.TenantId && x.Id == stockBalanceId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryLotService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryLotService.cs
@@ -30,7 +30,6 @@ public sealed class InventoryLotService(
             return Result<List<InventoryLot>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var query = dataContext.Query<InventoryLot>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
 
         if (request.ProductId is { } productId)
@@ -68,7 +67,6 @@ public sealed class InventoryLotService(
             return Result<InventoryLot>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var lot = await dataContext.Query<InventoryLot>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && x.Id == request.Id && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
 
@@ -95,7 +93,6 @@ public sealed class InventoryLotService(
             return Result<InventoryLot>.Failure("Lot number is required.", 400);
 
         var productExists = await dataContext.Query<Product>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == request.ProductId && !x.IsDeleted, ct);
         if (!productExists)
             return Result<InventoryLot>.NotFound("Product not found.");
@@ -109,7 +106,6 @@ public sealed class InventoryLotService(
             return Result<InventoryLot>.Failure(variationResult.Message!, variationResult.StatusCode);
 
         var duplicate = await dataContext.Query<InventoryLot>()
-            .IgnoreQueryFilters()
             .AnyAsync(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == request.ProductId &&

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryPlanningService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryPlanningService.cs
@@ -33,7 +33,6 @@ public sealed class InventoryPlanningService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<InventoryReorderRule>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ProductId is { } productId)
@@ -73,7 +72,6 @@ public sealed class InventoryPlanningService(
 
         var tenantId = tenantResult.Data;
         var productExists = await dataContext.Query<Product>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == request.ProductId && !x.IsDeleted, ct);
         if (!productExists)
             return Result<InventoryReorderRule>.NotFound("Product not found.");
@@ -89,7 +87,6 @@ public sealed class InventoryPlanningService(
         if (request.WarehouseId is { } warehouseId)
         {
             var warehouseExists = await dataContext.Query<Warehouse>()
-                .IgnoreQueryFilters()
                 .AnyAsync(x => x.TenantId == tenantId && x.Id == warehouseId && !x.IsDeleted, ct);
             if (!warehouseExists)
                 return Result<InventoryReorderRule>.NotFound("Warehouse not found.");
@@ -98,7 +95,6 @@ public sealed class InventoryPlanningService(
         if (request.LocationId is { } locationId)
         {
             var locationExists = await dataContext.Query<InventoryLocation>()
-                .IgnoreQueryFilters()
                 .AnyAsync(x =>
                     x.TenantId == tenantId &&
                     x.Id == locationId &&
@@ -109,7 +105,6 @@ public sealed class InventoryPlanningService(
         }
 
         var duplicate = await dataContext.Query<InventoryReorderRule>()
-            .IgnoreQueryFilters()
             .AnyAsync(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == request.ProductId &&
@@ -238,22 +233,32 @@ public sealed class InventoryPlanningService(
         if (rules.Count == 0)
             return [];
 
+        var productIds = rules.Select(x => x.ProductId).Distinct().ToList();
+        var variationIds = rules.Select(x => x.ProductVariationId).OfType<Guid>().Distinct().ToList();
+        var warehouseIds = rules.Select(x => x.WarehouseId).OfType<Guid>().Distinct().ToList();
+        var locationIds = rules.Select(x => x.LocationId).OfType<Guid>().Distinct().ToList();
+
         var products = await dataContext.Query<Product>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && productIds.Contains(x.Id))
             .ToListAsync(ct);
-        var variationLookups = await LoadVariationLookups(tenantId, ct);
+        var variationLookups = await LoadVariationLookups(tenantId, variationIds, ct);
         var warehouses = await dataContext.Query<Warehouse>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && warehouseIds.Contains(x.Id))
             .ToListAsync(ct);
         var locations = await dataContext.Query<InventoryLocation>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && locationIds.Contains(x.Id))
             .ToListAsync(ct);
-        var balances = await dataContext.Query<StockBalance>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+        var balanceQuery = dataContext.Query<StockBalance>()
+            .Where(x => x.TenantId == tenantId && productIds.Contains(x.ProductId));
+        if (productVariationId is not null)
+            balanceQuery = balanceQuery.Where(x => x.ProductVariationId == productVariationId);
+        if (warehouseId is not null)
+            balanceQuery = balanceQuery.Where(x => x.WarehouseId == warehouseId);
+        if (locationId is not null)
+            balanceQuery = balanceQuery.Where(x => x.LocationId == locationId);
+
+        var balances = await balanceQuery
+            .Take(5000)
             .ToListAsync(ct);
 
         var productNames = products.ToDictionary(x => x.Id, x => x.Name ?? x.Id.ToString()[..8]);
@@ -308,28 +313,34 @@ public sealed class InventoryPlanningService(
         Guid? locationId,
         CancellationToken ct)
     {
-        var rules = await dataContext.Query<InventoryReorderRule>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && x.IsActive && !x.IsDeleted)
-            .ToListAsync(ct);
+        var rulesQuery = dataContext.Query<InventoryReorderRule>()
+            .Where(x => x.TenantId == tenantId && x.IsActive);
 
         if (productId is not null)
-            rules = rules.Where(x => x.ProductId == productId).ToList();
+            rulesQuery = rulesQuery.Where(x => x.ProductId == productId);
         if (productVariationId is not null)
-            rules = rules.Where(x => x.ProductVariationId == productVariationId).ToList();
+            rulesQuery = rulesQuery.Where(x => x.ProductVariationId == productVariationId);
         if (warehouseId is not null)
-            rules = rules.Where(x => x.WarehouseId == null || x.WarehouseId == warehouseId).ToList();
+            rulesQuery = rulesQuery.Where(x => x.WarehouseId == null || x.WarehouseId == warehouseId);
         if (locationId is not null)
-            rules = rules.Where(x => x.LocationId == null || x.LocationId == locationId).ToList();
+            rulesQuery = rulesQuery.Where(x => x.LocationId == null || x.LocationId == locationId);
 
-        return rules;
+        return await rulesQuery
+            .OrderBy(x => x.ProductId)
+            .Take(1000)
+            .ToListAsync(ct);
     }
 
-    private async Task<VariationLookups> LoadVariationLookups(Guid tenantId, CancellationToken ct)
+    private async Task<VariationLookups> LoadVariationLookups(
+        Guid tenantId,
+        IReadOnlyCollection<Guid> variationIds,
+        CancellationToken ct)
     {
+        if (variationIds.Count == 0)
+            return new VariationLookups([], []);
+
         var variations = await dataContext.Query<ProductVariation>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && variationIds.Contains(x.Id))
             .ToListAsync(ct);
         var typeIds = variations
             .Where(x => x.ProductVariationTypeId is not null)
@@ -339,8 +350,7 @@ public sealed class InventoryPlanningService(
         var types = typeIds.Count == 0
             ? []
             : await dataContext.Query<ProductVariationType>()
-                .IgnoreQueryFilters()
-                .Where(x => x.TenantId == tenantId && typeIds.Contains(x.Id) && !x.IsDeleted)
+                .Where(x => x.TenantId == tenantId && typeIds.Contains(x.Id))
                 .ToListAsync(ct);
         var typeNames = types.ToDictionary<ProductVariationType, Guid, string?>(
             x => x.Id,

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryReportingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/InventoryReportingService.cs
@@ -60,8 +60,14 @@ public sealed class InventoryReportingService(
 
         var now = DateTime.UtcNow;
         var cutoff = now.AddDays(Math.Clamp(request.DaysAhead, 1, 365));
-        var rows = await BuildExpiryRows(tenantResult.Data, request.ProductId, request.ProductVariationId, lot =>
-            lot.ExpiresAt is not null && lot.ExpiresAt > now && lot.ExpiresAt <= cutoff, ct);
+        var rows = await BuildExpiryRows(
+            tenantResult.Data,
+            request.ProductId,
+            request.ProductVariationId,
+            expiresAfter: now,
+            expiresOnOrBefore: cutoff,
+            includeExpiredStatus: false,
+            ct);
 
         return Result<List<NearExpiryStockReportRow>>.Success(rows);
     }
@@ -83,8 +89,14 @@ public sealed class InventoryReportingService(
             return Result<List<NearExpiryStockReportRow>>.Failure(traceabilityResult.Message!, traceabilityResult.StatusCode);
 
         var now = DateTime.UtcNow;
-        var rows = await BuildExpiryRows(tenantResult.Data, request.ProductId, request.ProductVariationId, lot =>
-            lot.Status == InventoryLotStatus.Expired || lot.ExpiresAt is not null && lot.ExpiresAt <= now, ct);
+        var rows = await BuildExpiryRows(
+            tenantResult.Data,
+            request.ProductId,
+            request.ProductVariationId,
+            expiresAfter: null,
+            expiresOnOrBefore: now,
+            includeExpiredStatus: true,
+            ct);
 
         return Result<List<NearExpiryStockReportRow>>.Success(rows);
     }
@@ -102,23 +114,28 @@ public sealed class InventoryReportingService(
             return Result<List<StockPositionReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
-        var balances = await dataContext.Query<StockBalance>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .ToListAsync(ct);
+        var balancesQuery = dataContext.Query<StockBalance>()
+            .Where(x => x.TenantId == tenantId);
 
         if (request.ProductId is { } productId)
-            balances = balances.Where(x => x.ProductId == productId).ToList();
+            balancesQuery = balancesQuery.Where(x => x.ProductId == productId);
         if (request.ProductVariationId is { } productVariationId)
-            balances = balances.Where(x => x.ProductVariationId == productVariationId).ToList();
+            balancesQuery = balancesQuery.Where(x => x.ProductVariationId == productVariationId);
         if (request.WarehouseId is { } warehouseId)
-            balances = balances.Where(x => x.WarehouseId == warehouseId).ToList();
+            balancesQuery = balancesQuery.Where(x => x.WarehouseId == warehouseId);
         if (request.LocationId is { } locationId)
-            balances = balances.Where(x => x.LocationId == locationId).ToList();
+            balancesQuery = balancesQuery.Where(x => x.LocationId == locationId);
         if (request.LotId is { } lotId)
-            balances = balances.Where(x => x.LotId == lotId).ToList();
+            balancesQuery = balancesQuery.Where(x => x.LotId == lotId);
 
-        var lookups = await LoadLookups(tenantId, ct);
+        var balances = await balancesQuery
+            .OrderBy(x => x.ProductId)
+            .ThenBy(x => x.WarehouseId)
+            .ThenBy(x => x.LocationId)
+            .Take(1000)
+            .ToListAsync(ct);
+
+        var lookups = await LoadLookups(tenantId, balances, ct);
         var rows = balances.Select(balance => new StockPositionReportRow(
                 balance.Id,
                 balance.ProductId,
@@ -160,34 +177,35 @@ public sealed class InventoryReportingService(
             return Result<List<MovementLedgerReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
-        var movements = await dataContext.Query<InventoryMovement>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .ToListAsync(ct);
+        var movementsQuery = dataContext.Query<InventoryMovement>()
+            .Where(x => x.TenantId == tenantId);
 
         if (request.ProductId is { } productId)
-            movements = movements.Where(x => x.ProductId == productId).ToList();
+            movementsQuery = movementsQuery.Where(x => x.ProductId == productId);
         if (request.ProductVariationId is { } productVariationId)
-            movements = movements.Where(x => x.ProductVariationId == productVariationId).ToList();
+            movementsQuery = movementsQuery.Where(x => x.ProductVariationId == productVariationId);
         if (request.WarehouseId is { } warehouseId)
-            movements = movements.Where(x => x.WarehouseId == warehouseId).ToList();
+            movementsQuery = movementsQuery.Where(x => x.WarehouseId == warehouseId);
         if (request.LocationId is { } locationId)
-            movements = movements.Where(x => x.LocationId == locationId).ToList();
+            movementsQuery = movementsQuery.Where(x => x.LocationId == locationId);
         if (request.LotId is { } lotId)
-            movements = movements.Where(x => x.LotId == lotId).ToList();
+            movementsQuery = movementsQuery.Where(x => x.LotId == lotId);
         if (!string.IsNullOrWhiteSpace(request.ReferenceType))
-            movements = movements.Where(x => x.ReferenceType == request.ReferenceType).ToList();
+            movementsQuery = movementsQuery.Where(x => x.ReferenceType == request.ReferenceType);
         if (request.ReferenceId is { } referenceId)
-            movements = movements.Where(x => x.ReferenceId == referenceId).ToList();
+            movementsQuery = movementsQuery.Where(x => x.ReferenceId == referenceId);
         if (request.From is { } from)
-            movements = movements.Where(x => x.MovementDate >= from).ToList();
+            movementsQuery = movementsQuery.Where(x => x.MovementDate >= from);
         if (request.To is { } to)
-            movements = movements.Where(x => x.MovementDate <= to).ToList();
+            movementsQuery = movementsQuery.Where(x => x.MovementDate <= to);
 
-        var lookups = await LoadLookups(tenantId, ct);
-        var rows = movements
+        var movements = await movementsQuery
             .OrderByDescending(x => x.MovementDate)
             .Take(1000)
+            .ToListAsync(ct);
+
+        var lookups = await LoadLookups(tenantId, movements, ct);
+        var rows = movements
             .Select(movement => new MovementLedgerReportRow(
                 movement.Id,
                 movement.ProductId,
@@ -232,24 +250,25 @@ public sealed class InventoryReportingService(
             return Result<List<ReservationAllocationStatusReportRow>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var tenantId = tenantResult.Data;
-        var allocations = await dataContext.Query<ReservationAllocation>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .ToListAsync(ct);
+        var allocationsQuery = dataContext.Query<ReservationAllocation>()
+            .Where(x => x.TenantId == tenantId);
 
         if (request.ProductId is { } productId)
-            allocations = allocations.Where(x => x.ProductId == productId).ToList();
+            allocationsQuery = allocationsQuery.Where(x => x.ProductId == productId);
         if (request.ProductVariationId is { } productVariationId)
-            allocations = allocations.Where(x => x.ProductVariationId == productVariationId).ToList();
+            allocationsQuery = allocationsQuery.Where(x => x.ProductVariationId == productVariationId);
         if (request.LotId is { } lotId)
-            allocations = allocations.Where(x => x.LotId == lotId).ToList();
+            allocationsQuery = allocationsQuery.Where(x => x.LotId == lotId);
         if (request.Status is { } status)
-            allocations = allocations.Where(x => x.Status == status).ToList();
+            allocationsQuery = allocationsQuery.Where(x => x.Status == status);
 
-        var lookups = await LoadLookups(tenantId, ct);
-        var rows = allocations
+        var allocations = await allocationsQuery
             .OrderByDescending(x => x.ReservedAt)
             .Take(1000)
+            .ToListAsync(ct);
+
+        var lookups = await LoadLookups(tenantId, allocations, ct);
+        var rows = allocations
             .Select(allocation => new ReservationAllocationStatusReportRow(
                 allocation.Id,
                 allocation.ReservationId,
@@ -278,31 +297,41 @@ public sealed class InventoryReportingService(
         Guid tenantId,
         Guid? productId,
         Guid? productVariationId,
-        Func<InventoryLot, bool> lotFilter,
+        DateTime? expiresAfter,
+        DateTime expiresOnOrBefore,
+        bool includeExpiredStatus,
         CancellationToken ct)
     {
-        var lots = await dataContext.Query<InventoryLot>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .ToListAsync(ct);
+        var lotsQuery = dataContext.Query<InventoryLot>()
+            .Where(x => x.TenantId == tenantId);
         if (productId is { } id)
-            lots = lots.Where(x => x.ProductId == id).ToList();
+            lotsQuery = lotsQuery.Where(x => x.ProductId == id);
         if (productVariationId is { } variantId)
-            lots = lots.Where(x => x.ProductVariationId == variantId).ToList();
+            lotsQuery = lotsQuery.Where(x => x.ProductVariationId == variantId);
 
-        lots = lots.Where(lotFilter).ToList();
+        lotsQuery = includeExpiredStatus
+            ? lotsQuery.Where(x => x.Status == InventoryLotStatus.Expired || x.ExpiresAt != null && x.ExpiresAt <= expiresOnOrBefore)
+            : lotsQuery.Where(x => x.ExpiresAt != null && x.ExpiresAt > expiresAfter && x.ExpiresAt <= expiresOnOrBefore);
+
+        var lots = await lotsQuery
+            .OrderBy(x => x.ExpiresAt)
+            .Take(1000)
+            .ToListAsync(ct);
         if (lots.Count == 0)
             return [];
 
-        var lotIds = lots.Select(x => x.Id).ToHashSet();
+        var lotIds = lots.Select(x => x.Id).ToList();
         var balances = await dataContext.Query<StockBalance>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && x.LotId != null && !x.IsDeleted)
+            .Where(x =>
+                x.TenantId == tenantId &&
+                x.LotId != null &&
+                lotIds.Contains(x.LotId.Value) &&
+                x.OnHandQuantity > 0)
+            .Take(1000)
             .ToListAsync(ct);
-        balances = balances.Where(x => x.LotId is { } lotId && lotIds.Contains(lotId) && x.OnHandQuantity > 0).ToList();
 
         var lotMap = lots.ToDictionary(x => x.Id);
-        var lookups = await LoadLookups(tenantId, ct);
+        var lookups = await LoadLookups(tenantId, balances, ct);
 
         return balances.Select(balance =>
             {
@@ -333,27 +362,65 @@ public sealed class InventoryReportingService(
             .ToList();
     }
 
-    private async Task<LookupMaps> LoadLookups(Guid tenantId, CancellationToken ct)
+    private Task<LookupMaps> LoadLookups(Guid tenantId, IReadOnlyCollection<StockBalance> rows, CancellationToken ct) =>
+        LoadLookups(
+            tenantId,
+            rows.Select(x => x.ProductId),
+            rows.Select(x => x.ProductVariationId),
+            rows.Select(x => (Guid?)x.WarehouseId),
+            rows.Select(x => (Guid?)x.LocationId),
+            rows.Select(x => x.LotId),
+            ct);
+
+    private Task<LookupMaps> LoadLookups(Guid tenantId, IReadOnlyCollection<InventoryMovement> rows, CancellationToken ct) =>
+        LoadLookups(
+            tenantId,
+            rows.Select(x => x.ProductId),
+            rows.Select(x => x.ProductVariationId),
+            rows.Select(x => x.WarehouseId),
+            rows.Select(x => x.LocationId),
+            rows.Select(x => x.LotId),
+            ct);
+
+    private Task<LookupMaps> LoadLookups(Guid tenantId, IReadOnlyCollection<ReservationAllocation> rows, CancellationToken ct) =>
+        LoadLookups(
+            tenantId,
+            rows.Select(x => x.ProductId),
+            rows.Select(x => x.ProductVariationId),
+            [],
+            [],
+            rows.Select(x => x.LotId),
+            ct);
+
+    private async Task<LookupMaps> LoadLookups(
+        Guid tenantId,
+        IEnumerable<Guid> productIds,
+        IEnumerable<Guid?> variationIds,
+        IEnumerable<Guid?> warehouseIds,
+        IEnumerable<Guid?> locationIds,
+        IEnumerable<Guid?> lotIds,
+        CancellationToken ct)
     {
+        var productIdList = productIds.Distinct().ToList();
+        var variationIdList = variationIds.OfType<Guid>().Distinct().ToList();
+        var warehouseIdList = warehouseIds.OfType<Guid>().Distinct().ToList();
+        var locationIdList = locationIds.OfType<Guid>().Distinct().ToList();
+        var lotIdList = lotIds.OfType<Guid>().Distinct().ToList();
+
         var products = await dataContext.Query<Product>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && productIdList.Contains(x.Id))
             .ToListAsync(ct);
         var warehouses = await dataContext.Query<Warehouse>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && warehouseIdList.Contains(x.Id))
             .ToListAsync(ct);
         var locations = await dataContext.Query<InventoryLocation>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && locationIdList.Contains(x.Id))
             .ToListAsync(ct);
         var lots = await dataContext.Query<InventoryLot>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && lotIdList.Contains(x.Id))
             .ToListAsync(ct);
         var variations = await dataContext.Query<ProductVariation>()
-            .IgnoreQueryFilters()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
+            .Where(x => x.TenantId == tenantId && variationIdList.Contains(x.Id))
             .ToListAsync(ct);
         var typeIds = variations
             .Where(x => x.ProductVariationTypeId is not null)
@@ -363,8 +430,7 @@ public sealed class InventoryReportingService(
         var variationTypes = typeIds.Count == 0
             ? []
             : await dataContext.Query<ProductVariationType>()
-                .IgnoreQueryFilters()
-                .Where(x => x.TenantId == tenantId && typeIds.Contains(x.Id) && !x.IsDeleted)
+                .Where(x => x.TenantId == tenantId && typeIds.Contains(x.Id))
                 .ToListAsync(ct);
         var variationTypeNames = variationTypes.ToDictionary<ProductVariationType, Guid, string?>(
             x => x.Id,

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductService.cs
@@ -65,6 +65,13 @@ public class ProductService
 
         var tenantId = tenantResult.Data;
 
+        if (request.StockQuantity != 0)
+        {
+            return Result<Product>.Failure(
+                "Initial stock must be posted through a stock movement with warehouse and location dimensions.",
+                400);
+        }
+
         using var activity = ActivitySources.Product.StartActivity("Product.Create");
         activity?.SetTag("product.name", request.Name);
         activity?.SetTag("product.price", request.Price);
@@ -107,7 +114,7 @@ public class ProductService
                 Name = request.Name,
                 Description = request.Description,
                 Price = request.Price,
-                StockQuantity = request.StockQuantity,
+                StockQuantity = 0,
                 CategoryId = request.CategoryId,
                 SKU = normalizedSku,
                 Brand = request.Brand,
@@ -118,34 +125,11 @@ public class ProductService
 
             _dataContext.Add(product);
 
-            if (request.StockQuantity > 0)
-            {
-                _dataContext.Add(new InventoryMovement
-                {
-                    Id = Guid.NewGuid(),
-                    TenantId = tenantId,
-                    IsEnabled = true,
-                    ProductId = productId,
-                    MovementType = InventoryMovementType.OpeningBalance,
-                    QuantityDelta = request.StockQuantity,
-                    QuantityBefore = 0,
-                    QuantityAfter = request.StockQuantity,
-                    MovementDate = DateTime.UtcNow,
-                    ReferenceType = nameof(Product),
-                    ReferenceId = productId,
-                    Reason = "Initial product stock"
-                });
-            }
-
             var saveResult = await _dataContext.SaveChangesAsync(ct);
             if (!saveResult.IsSuccess)
                 return Result<Product>.Failure(saveResult.Message ?? "Product save failed", saveResult.StatusCode);
 
-            // Cache the newly created product
-            var cacheKey = BuildProductCacheKey(tenantId, product.Id);
-            await _cacheService.SetAsync(cacheKey, product,
-                absoluteExpiration: TimeSpan.FromMinutes(10),
-                cancellationToken: ct);
+            await TrySetProductCacheAsync(tenantId, product, ct);
 
             stopwatch.Stop();
 
@@ -192,13 +176,11 @@ public class ProductService
         try
         {
             var cacheKey = BuildProductCacheKey(tenantId, id);
-
-            // Try cache first
-            var cached = await _cacheService.GetAsync<Product>(cacheKey, ct);
-            if (cached.IsSuccess && cached.Data != null)
+            var cached = await TryGetProductCacheAsync(cacheKey, ct);
+            if (cached is not null)
             {
                 _logger.CacheHit(cacheKey);
-                return Result<Product>.Success(cached.Data);
+                return Result<Product>.Success(cached);
             }
 
             _logger.CacheMiss(cacheKey);
@@ -214,11 +196,7 @@ public class ProductService
                 return Result<Product>.NotFound($"Product with ID {id} not found");
             }
 
-            // Cache the result
-            await _cacheService.SetAsync(cacheKey, product,
-                absoluteExpiration: TimeSpan.FromMinutes(10),
-                cancellationToken: ct);
-            _logger.CacheSetting(cacheKey, 10);
+            await TrySetProductCacheAsync(tenantId, product, ct);
 
             _logger.EntityRetrieved("Product", id);
             return Result<Product>.Success(product);
@@ -321,32 +299,22 @@ public class ProductService
             var page = request.Page <= 0 ? 1 : request.Page;
             var pageSize = request.PageSize <= 0 ? 20 : Math.Min(request.PageSize, 100);
             var productQuery = BuildSellableProductQuery(tenantId, request.CategoryId, request.IsAvailable);
-            IQueryable<SellableProductCatalogItem>? rows = null;
+            var search = NormalizeSearch(request.Search);
+            IQueryable<SellableProductCatalogRow>? rows = null;
 
             if (request.IncludeBaseProducts)
-                rows = BuildBaseCatalogRows(productQuery);
+                rows = BuildBaseCatalogRows(productQuery, search);
 
             if (request.IncludeVariants)
             {
-                var variantRows = BuildVariantCatalogRows(productQuery, tenantId);
+                var variantRows = BuildVariantCatalogRows(productQuery, tenantId, search);
                 rows = rows is null ? variantRows : rows.Concat(variantRows);
             }
 
             if (rows is null)
                 return Result<List<SellableProductCatalogItem>>.Success([]);
 
-            var search = NormalizeSearch(request.Search);
-            if (search is not null)
-            {
-                rows = rows.Where(x =>
-                    x.ProductName.ToLower().Contains(search) ||
-                    (x.SKU != null && x.SKU.ToLower().Contains(search)) ||
-                    (x.Brand != null && x.Brand.ToLower().Contains(search)) ||
-                    (x.VariantName != null && x.VariantName.ToLower().Contains(search)) ||
-                    (x.VariantTypeName != null && x.VariantTypeName.ToLower().Contains(search)));
-            }
-
-            var items = await rows
+            var pageRows = await rows
                 .OrderBy(x => x.ProductName)
                 .ThenBy(x => x.ProductVariationId.HasValue)
                 .ThenBy(x => x.VariantTypeName)
@@ -354,6 +322,7 @@ public class ProductService
                 .Skip((page - 1) * pageSize)
                 .Take(pageSize)
                 .ToListAsync(ct);
+            var items = pageRows.Select(ToCatalogItem).ToList();
 
             _logger.EntityQueryCompleted(items.Count, "SellableProductCatalog");
             return Result<List<SellableProductCatalogItem>>.Success(items);
@@ -402,10 +371,11 @@ public class ProductService
                 return Result<SellableProductDetail>.NotFound("Product not found");
             }
 
-            var variations = await BuildSellableVariationItemsQuery(tenantId, request.ProductId)
+            var variationRows = await BuildSellableVariationRowsQuery(tenantId, request.ProductId)
                 .OrderBy(x => x.VariantTypeName)
                 .ThenBy(x => x.VariantName)
                 .ToListAsync(ct);
+            var variations = variationRows.Select(ToVariationItem).ToList();
 
             return Result<SellableProductDetail>.Success(new SellableProductDetail(
                 product.Id,
@@ -449,10 +419,11 @@ public class ProductService
                 return Result<List<SellableProductVariationItem>>.NotFound("Product not found");
             }
 
-            var variations = await BuildSellableVariationItemsQuery(tenantId, request.ProductId)
+            var variationRows = await BuildSellableVariationRowsQuery(tenantId, request.ProductId)
                 .OrderBy(x => x.VariantTypeName)
                 .ThenBy(x => x.VariantName)
                 .ToListAsync(ct);
+            var variations = variationRows.Select(ToVariationItem).ToList();
 
             return Result<List<SellableProductVariationItem>>.Success(variations);
         }
@@ -531,12 +502,7 @@ public class ProductService
             if (!saveResult.IsSuccess)
                 return Result<Product>.Failure(saveResult.Message ?? "Product update failed", saveResult.StatusCode);
 
-            // Invalidate cache
-            var cacheKey = BuildProductCacheKey(tenantId, id);
-            await _cacheService.RemoveAsync(cacheKey, ct);
-            _logger.CacheInvalidated(cacheKey);
-            await _cacheService.RemoveByPrefixAsync(BuildProductListCachePrefix(tenantId), ct);
-            _logger.CacheCleared($"products:list:{tenantId}:*");
+            await TryInvalidateProductCacheAsync(tenantId, id, ct);
 
             _logger.EntityUpdated("Product", id);
             return Result<Product>.Success(product, "Product updated successfully");
@@ -573,18 +539,17 @@ public class ProductService
                 return Result.NotFound($"Product with ID {id} not found");
             }
 
+            var dependency = await FindDeleteDependencyAsync(tenantId, id, ct);
+            if (dependency is not null)
+                return Result.Conflict($"Product cannot be deleted while {dependency} exists.");
+
             // Soft delete (XDbContext handles IsDeleted flag and DeletedAt timestamp)
             _dataContext.Remove(product);
             var saveResult = await _dataContext.SaveChangesAsync(ct);
             if (!saveResult.IsSuccess)
                 return Result.Failure(saveResult.Message ?? "Product delete failed", saveResult.StatusCode);
 
-            // Invalidate cache
-            var cacheKey = BuildProductCacheKey(tenantId, id);
-            await _cacheService.RemoveAsync(cacheKey, ct);
-            _logger.CacheInvalidated(cacheKey);
-            await _cacheService.RemoveByPrefixAsync(BuildProductListCachePrefix(tenantId), ct);
-            _logger.CacheCleared($"products:list:{tenantId}:*");
+            await TryInvalidateProductCacheAsync(tenantId, id, ct);
 
             _logger.EntityDeleted("Product", id);
             return Result.Success("Product deleted successfully");
@@ -605,10 +570,124 @@ public class ProductService
     }
 
     private static string BuildProductCacheKey(Guid tenantId, Guid productId) =>
-        $"products:{tenantId}:{productId}";
+        $"inventario:tenant:{tenantId}:product:{productId}";
 
     private static string BuildProductListCachePrefix(Guid tenantId) =>
-        $"products:list:{tenantId}:";
+        $"inventario:tenant:{tenantId}:products:";
+
+    private async Task<Product?> TryGetProductCacheAsync(string cacheKey, CancellationToken ct)
+    {
+        try
+        {
+            var cached = await _cacheService.GetAsync<Product>(cacheKey, ct);
+            if (!cached.IsSuccess)
+                _logger.LogWarning("Product cache read failed for {CacheKey}: {Message}", cacheKey, cached.Message);
+            return cached.IsSuccess ? cached.Data : null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Product cache read failed for {CacheKey}", cacheKey);
+            return null;
+        }
+    }
+
+    private async Task TrySetProductCacheAsync(Guid tenantId, Product product, CancellationToken ct)
+    {
+        var cacheKey = BuildProductCacheKey(tenantId, product.Id);
+        try
+        {
+            var cached = await _cacheService.SetAsync(
+                cacheKey,
+                product,
+                absoluteExpiration: TimeSpan.FromMinutes(10),
+                cancellationToken: ct);
+            if (!cached.IsSuccess)
+            {
+                _logger.LogWarning("Product cache write failed for {CacheKey}: {Message}", cacheKey, cached.Message);
+                return;
+            }
+
+            _logger.CacheSetting(cacheKey, 10);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Product cache write failed for {CacheKey}", cacheKey);
+        }
+    }
+
+    private async Task TryInvalidateProductCacheAsync(Guid tenantId, Guid productId, CancellationToken ct)
+    {
+        var cacheKey = BuildProductCacheKey(tenantId, productId);
+        var listPrefix = BuildProductListCachePrefix(tenantId);
+        try
+        {
+            var removed = await _cacheService.RemoveAsync(cacheKey, ct);
+            if (!removed.IsSuccess)
+                _logger.LogWarning("Product cache removal failed for {CacheKey}: {Message}", cacheKey, removed.Message);
+            else
+                _logger.CacheInvalidated(cacheKey);
+
+            var prefixRemoved = await _cacheService.RemoveByPrefixAsync(listPrefix, ct);
+            if (!prefixRemoved.IsSuccess)
+                _logger.LogWarning("Product cache prefix removal failed for {CachePrefix}: {Message}", listPrefix, prefixRemoved.Message);
+            else
+                _logger.CacheCleared($"{listPrefix}*");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Product cache invalidation failed for product {ProductId}", productId);
+        }
+    }
+
+    private async Task<string?> FindDeleteDependencyAsync(Guid tenantId, Guid productId, CancellationToken ct)
+    {
+        if (await _dataContext.Query<StockBalance>().AnyAsync(x =>
+                x.TenantId == tenantId &&
+                x.ProductId == productId &&
+                (x.OnHandQuantity != 0 || x.ReservedQuantity != 0), ct))
+        {
+            return "stock remains on hand or reserved";
+        }
+
+        if (await _dataContext.Query<ReservationAllocation>().AnyAsync(x =>
+                x.TenantId == tenantId &&
+                x.ProductId == productId &&
+                x.Status == ReservationAllocationStatus.Reserved, ct))
+        {
+            return "active reservation allocations";
+        }
+
+        if (await _dataContext.Query<InventoryLot>().AnyAsync(x =>
+                x.TenantId == tenantId && x.ProductId == productId, ct))
+        {
+            return "inventory lots";
+        }
+
+        if (await _dataContext.Query<ProductVariation>().AnyAsync(x =>
+                x.TenantId == tenantId && x.ProductId == productId, ct))
+        {
+            return "product variants";
+        }
+
+        if (await _dataContext.Query<InventoryReorderRule>().AnyAsync(x =>
+                x.TenantId == tenantId && x.ProductId == productId && x.IsActive, ct))
+        {
+            return "active reorder rules";
+        }
+
+        if (await _dataContext.Query<PurchaseOrderLine>().AnyAsync(x =>
+                x.TenantId == tenantId &&
+                x.ProductId == productId &&
+                x.ReceivedQuantity < x.OrderedQuantity &&
+                x.PurchaseOrder != null &&
+                x.PurchaseOrder.Status != PurchaseOrderStatus.Cancelled &&
+                x.PurchaseOrder.Status != PurchaseOrderStatus.Received, ct))
+        {
+            return "open purchase-order lines";
+        }
+
+        return null;
+    }
 
     private IQueryable<Product> BuildSellableProductQuery(
         Guid tenantId,
@@ -617,7 +696,6 @@ public class ProductService
     {
         var query = CatalogDb.Set<Product>()
             .AsNoTracking()
-            .IgnoreQueryFilters()
             .Where(p => p.TenantId == tenantId && !p.IsDeleted && p.IsEnabled);
 
         if (categoryId.HasValue)
@@ -629,61 +707,122 @@ public class ProductService
         return query;
     }
 
-    private static IQueryable<SellableProductCatalogItem> BuildBaseCatalogRows(
-        IQueryable<Product> products) =>
-        products.Select(product => new SellableProductCatalogItem(
-            product.Id,
-            null,
-            product.Name ?? string.Empty,
-            product.Name ?? string.Empty,
-            null,
-            null,
-            null,
-            product.SKU,
-            product.Brand,
-            product.Image,
-            product.CategoryId,
-            product.Category != null ? product.Category.Name : null,
-            product.IsAvailable,
-            product.Price));
-
-    private IQueryable<SellableProductCatalogItem> BuildVariantCatalogRows(
+    private static IQueryable<SellableProductCatalogRow> BuildBaseCatalogRows(
         IQueryable<Product> products,
-        Guid tenantId)
+        string? search)
+    {
+        if (search is not null)
+        {
+            products = products.Where(product =>
+                (product.Name != null && product.Name.ToLower().Contains(search)) ||
+                (product.SKU != null && product.SKU.ToLower().Contains(search)) ||
+                (product.Brand != null && product.Brand.ToLower().Contains(search)));
+        }
+
+        return products.Select(product => new SellableProductCatalogRow
+        {
+            ProductId = product.Id,
+            ProductVariationId = null,
+            DisplayName = product.Name ?? string.Empty,
+            ProductName = product.Name ?? string.Empty,
+            VariantName = null,
+            ProductVariationTypeId = null,
+            VariantTypeName = null,
+            SKU = product.SKU,
+            Brand = product.Brand,
+            Image = product.Image,
+            CategoryId = product.CategoryId,
+            CategoryName = product.Category != null ? product.Category.Name : null,
+            IsAvailable = product.IsAvailable,
+            Price = product.Price
+        });
+    }
+
+    private IQueryable<SellableProductCatalogRow> BuildVariantCatalogRows(
+        IQueryable<Product> products,
+        Guid tenantId,
+        string? search)
     {
         var variations = CatalogDb.Set<ProductVariation>()
             .AsNoTracking()
-            .IgnoreQueryFilters()
             .Where(v => v.TenantId == tenantId && !v.IsDeleted && v.IsEnabled);
         var variationTypes = CatalogDb.Set<ProductVariationType>()
             .AsNoTracking()
-            .IgnoreQueryFilters()
             .Where(t => t.TenantId == tenantId && !t.IsDeleted);
 
-        return
+        var rows =
             from product in products
             join variation in variations on product.Id equals variation.ProductId
             join variationType in variationTypes
                 on variation.ProductVariationTypeId equals (Guid?)variationType.Id into variationTypeJoin
             from variationType in variationTypeJoin.DefaultIfEmpty()
-            select new SellableProductCatalogItem(
-                product.Id,
-                variation.Id,
-                (product.Name ?? string.Empty) + " - " + (variation.Name ?? string.Empty),
-                product.Name ?? string.Empty,
-                variation.Name,
-                variation.ProductVariationTypeId,
-                variationType != null ? variationType.Name : variation.VariationType,
-                product.SKU,
-                product.Brand,
-                product.Image,
-                product.CategoryId,
-                product.Category != null ? product.Category.Name : null,
-                product.IsAvailable,
-                variation.Price);
+            select new { product, variation, variationType };
+
+        if (search is not null)
+        {
+            rows = rows.Where(row =>
+                (row.product.Name != null && row.product.Name.ToLower().Contains(search)) ||
+                (row.product.SKU != null && row.product.SKU.ToLower().Contains(search)) ||
+                (row.product.Brand != null && row.product.Brand.ToLower().Contains(search)) ||
+                (row.variation.Name != null && row.variation.Name.ToLower().Contains(search)) ||
+                (row.variationType != null && row.variationType.Name != null && row.variationType.Name.ToLower().Contains(search)) ||
+                (row.variation.VariationType != null && row.variation.VariationType.ToLower().Contains(search)));
+        }
+
+        return rows.Select(row => new SellableProductCatalogRow
+        {
+            ProductId = row.product.Id,
+            ProductVariationId = row.variation.Id,
+            DisplayName = (row.product.Name ?? string.Empty) + " - " + (row.variation.Name ?? string.Empty),
+            ProductName = row.product.Name ?? string.Empty,
+            VariantName = row.variation.Name,
+            ProductVariationTypeId = row.variation.ProductVariationTypeId,
+            VariantTypeName = row.variationType != null ? row.variationType.Name : row.variation.VariationType,
+            SKU = row.product.SKU,
+            Brand = row.product.Brand,
+            Image = row.product.Image,
+            CategoryId = row.product.CategoryId,
+            CategoryName = row.product.Category != null ? row.product.Category.Name : null,
+            IsAvailable = row.product.IsAvailable,
+            Price = row.variation.Price
+        });
     }
 
-    private IQueryable<SellableProductVariationItem> BuildSellableVariationItemsQuery(
+    private static SellableProductCatalogItem ToCatalogItem(SellableProductCatalogRow row) => new(
+        row.ProductId,
+        row.ProductVariationId,
+        row.DisplayName,
+        row.ProductName,
+        row.VariantName,
+        row.ProductVariationTypeId,
+        row.VariantTypeName,
+        row.SKU,
+        row.Brand,
+        row.Image,
+        row.CategoryId,
+        row.CategoryName,
+        row.IsAvailable,
+        row.Price);
+
+    private sealed class SellableProductCatalogRow
+    {
+        public Guid ProductId { get; init; }
+        public Guid? ProductVariationId { get; init; }
+        public string DisplayName { get; init; } = string.Empty;
+        public string ProductName { get; init; } = string.Empty;
+        public string? VariantName { get; init; }
+        public Guid? ProductVariationTypeId { get; init; }
+        public string? VariantTypeName { get; init; }
+        public string? SKU { get; init; }
+        public string? Brand { get; init; }
+        public string? Image { get; init; }
+        public Guid CategoryId { get; init; }
+        public string? CategoryName { get; init; }
+        public bool IsAvailable { get; init; }
+        public decimal Price { get; init; }
+    }
+
+    private IQueryable<SellableProductVariationRow> BuildSellableVariationRowsQuery(
         Guid tenantId,
         Guid productId)
     {
@@ -691,11 +830,9 @@ public class ProductService
             .Where(p => p.Id == productId);
         var variations = CatalogDb.Set<ProductVariation>()
             .AsNoTracking()
-            .IgnoreQueryFilters()
             .Where(v => v.TenantId == tenantId && !v.IsDeleted && v.IsEnabled);
         var variationTypes = CatalogDb.Set<ProductVariationType>()
             .AsNoTracking()
-            .IgnoreQueryFilters()
             .Where(t => t.TenantId == tenantId && !t.IsDeleted);
 
         return
@@ -704,15 +841,39 @@ public class ProductService
             join variationType in variationTypes
                 on variation.ProductVariationTypeId equals (Guid?)variationType.Id into variationTypeJoin
             from variationType in variationTypeJoin.DefaultIfEmpty()
-            select new SellableProductVariationItem(
-                variation.Id,
-                product.Id,
-                variation.ProductVariationTypeId,
-                variationType != null ? variationType.Name : variation.VariationType,
-                variation.Name ?? string.Empty,
-                variation.Price,
-                product.Price,
-                variation.Price - product.Price);
+            select new SellableProductVariationRow
+            {
+                ProductVariationId = variation.Id,
+                ProductId = product.Id,
+                ProductVariationTypeId = variation.ProductVariationTypeId,
+                VariantTypeName = variationType != null ? variationType.Name : variation.VariationType,
+                VariantName = variation.Name ?? string.Empty,
+                Price = variation.Price,
+                BaseProductPrice = product.Price,
+                PriceDelta = variation.Price - product.Price
+            };
+    }
+
+    private static SellableProductVariationItem ToVariationItem(SellableProductVariationRow row) => new(
+        row.ProductVariationId,
+        row.ProductId,
+        row.ProductVariationTypeId,
+        row.VariantTypeName,
+        row.VariantName,
+        row.Price,
+        row.BaseProductPrice,
+        row.PriceDelta);
+
+    private sealed class SellableProductVariationRow
+    {
+        public Guid ProductVariationId { get; init; }
+        public Guid ProductId { get; init; }
+        public Guid? ProductVariationTypeId { get; init; }
+        public string? VariantTypeName { get; init; }
+        public string VariantName { get; init; } = string.Empty;
+        public decimal Price { get; init; }
+        public decimal BaseProductPrice { get; init; }
+        public decimal PriceDelta { get; init; }
     }
 
     private static string? NormalizeSku(string? sku) =>

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductVariationService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ProductVariationService.cs
@@ -30,7 +30,6 @@ public sealed class ProductVariationService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<ProductVariationType>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ProductId is { } productId)
@@ -81,7 +80,6 @@ public sealed class ProductVariationService(
 
         var normalizedName = NormalizeKey(name);
         var duplicate = await dataContext.Query<ProductVariationType>()
-            .IgnoreQueryFilters()
             .AnyAsync(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == request.ProductId &&
@@ -138,7 +136,6 @@ public sealed class ProductVariationService(
             return Result<ProductVariation>.Failure("Variant name is required.", 400);
 
         var duplicate = await dataContext.Query<ProductVariation>()
-            .IgnoreQueryFilters()
             .AnyAsync(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == request.ProductId &&
@@ -186,7 +183,6 @@ public sealed class ProductVariationService(
 
         var tenantId = tenantResult.Data;
         var variation = await dataContext.Query<ProductVariation>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.Id == request.ProductVariationId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
         if (variation is null)
@@ -205,7 +201,6 @@ public sealed class ProductVariationService(
             return Result<ProductVariation>.Failure("Variant name is required.", 400);
 
         var duplicate = await dataContext.Query<ProductVariation>()
-            .IgnoreQueryFilters()
             .AnyAsync(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == variation.ProductId &&
@@ -243,7 +238,6 @@ public sealed class ProductVariationService(
             return Result<ProductVariation?>.Success(null);
 
         var variation = await dataContext.Query<ProductVariation>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantId &&
                 x.Id == productVariationId.Value &&
@@ -270,7 +264,6 @@ public sealed class ProductVariationService(
         CancellationToken ct)
     {
         var type = await dataContext.Query<ProductVariationType>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantId &&
                 x.Id == productVariationTypeId &&
@@ -288,13 +281,11 @@ public sealed class ProductVariationService(
 
     private async Task<Product?> LoadProductAsync(Guid tenantId, Guid productId, CancellationToken ct) =>
         await dataContext.Query<Product>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.Id == productId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
 
     private async Task<bool> ProductExistsAsync(Guid tenantId, Guid productId, CancellationToken ct) =>
         await dataContext.Query<Product>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == productId && !x.IsDeleted, ct);
 
     private Result<Guid> GetCurrentTenantId(RequestBase? request)

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/PurchasingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/PurchasingService.cs
@@ -38,7 +38,6 @@ public sealed class PurchasingService(
             return Result<List<Supplier>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var query = dataContext.Query<Supplier>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
 
         if (!request.IncludeInactive)
@@ -71,7 +70,6 @@ public sealed class PurchasingService(
             return Result<Supplier>.Failure("Supplier code and name are required.", 400);
 
         var duplicate = await dataContext.Query<Supplier>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Code == code && !x.IsDeleted, ct);
         if (duplicate)
             return Result<Supplier>.Conflict("A supplier with the same code already exists.");
@@ -112,7 +110,6 @@ public sealed class PurchasingService(
             return Result<List<PurchaseOrder>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var query = dataContext.Query<PurchaseOrder>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
 
         if (request.Status is { } status)
@@ -168,7 +165,6 @@ public sealed class PurchasingService(
         if (request.SupplierId is { } supplierId)
         {
             var supplierExists = await dataContext.Query<Supplier>()
-                .IgnoreQueryFilters()
                 .AnyAsync(x => x.TenantId == tenantId && x.Id == supplierId && !x.IsDeleted && x.IsActive, ct);
             if (!supplierExists)
                 return Result<PurchaseOrder>.NotFound("Supplier not found.");
@@ -180,7 +176,6 @@ public sealed class PurchasingService(
                 return Result<PurchaseOrder>.Failure("Purchase order line quantities must be greater than zero.", 400);
 
             var productExists = await dataContext.Query<Product>()
-                .IgnoreQueryFilters()
                 .AnyAsync(x => x.TenantId == tenantId && x.Id == line.ProductId && !x.IsDeleted, ct);
             if (!productExists)
                 return Result<PurchaseOrder>.NotFound("Product not found.");
@@ -196,7 +191,6 @@ public sealed class PurchasingService(
 
         var orderNumber = NormalizeOptional(request.OrderNumber) ?? GenerateDocumentNumber("PO");
         var duplicate = await dataContext.Query<PurchaseOrder>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.OrderNumber == orderNumber && !x.IsDeleted, ct);
         if (duplicate)
             return Result<PurchaseOrder>.Conflict("A purchase order with the same number already exists.");
@@ -269,9 +263,10 @@ public sealed class PurchasingService(
         if (request.Status is PurchaseOrderStatus.PartiallyReceived or PurchaseOrderStatus.Received)
             return Result<PurchaseOrder>.Failure("Receiving controls received purchase order statuses.", 400);
 
+        dataContext.Update(order);
         order.Status = request.Status;
         order.ModifiedAt = DateTime.UtcNow;
-        dataContext.Update(order);
+        order.ConcurrencyStamp = Guid.NewGuid();
 
         var saveResult = await dataContext.SaveChangesAsync(ct);
         if (!saveResult.IsSuccess)
@@ -293,7 +288,6 @@ public sealed class PurchasingService(
             return Result<List<ReceivingDocument>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var query = dataContext.Query<ReceivingDocument>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
 
         if (request.PurchaseOrderId is { } purchaseOrderId)
@@ -332,13 +326,11 @@ public sealed class PurchasingService(
             return replay;
 
         var warehouseExists = await dataContext.Query<Warehouse>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == request.WarehouseId && !x.IsDeleted, ct);
         if (!warehouseExists)
             return Result<ReceivingDocument>.NotFound("Warehouse not found.");
 
         var locationExists = await dataContext.Query<InventoryLocation>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == request.LocationId && x.WarehouseId == request.WarehouseId && !x.IsDeleted, ct);
         if (!locationExists)
             return Result<ReceivingDocument>.NotFound("Location not found.");
@@ -359,7 +351,6 @@ public sealed class PurchasingService(
         if (request.SupplierId is { } supplierId)
         {
             var supplierExists = await dataContext.Query<Supplier>()
-                .IgnoreQueryFilters()
                 .AnyAsync(x => x.TenantId == tenantId && x.Id == supplierId && !x.IsDeleted && x.IsActive, ct);
             if (!supplierExists)
                 return Result<ReceivingDocument>.NotFound("Supplier not found.");
@@ -367,7 +358,6 @@ public sealed class PurchasingService(
 
         var receiptNumber = NormalizeOptional(request.ReceiptNumber) ?? GenerateDocumentNumber("RCV");
         var duplicateReceipt = await dataContext.Query<ReceivingDocument>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.ReceiptNumber == receiptNumber && !x.IsDeleted, ct);
         if (duplicateReceipt)
             return Result<ReceivingDocument>.Conflict("A receiving document with the same receipt number already exists.");
@@ -413,9 +403,10 @@ public sealed class PurchasingService(
 
         if (purchaseOrder is not null)
         {
+            dataContext.Update(purchaseOrder);
             ApplyPurchaseOrderStatus(purchaseOrder, purchaseOrderLines);
             purchaseOrder.ModifiedAt = now;
-            dataContext.Update(purchaseOrder);
+            purchaseOrder.ConcurrencyStamp = Guid.NewGuid();
         }
 
         var saveResult = await dataContext.SaveChangesAsync(ct);
@@ -438,7 +429,6 @@ public sealed class PurchasingService(
             return Result<ReceivingLine>.Failure("Receiving quantity must be greater than zero.", 400);
 
         var product = await dataContext.Query<Product>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.Id == lineRequest.ProductId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
         if (product is null)
@@ -500,9 +490,10 @@ public sealed class PurchasingService(
 
         if (purchaseOrderLine is not null)
         {
+            dataContext.Update(purchaseOrderLine);
             purchaseOrderLine.ReceivedQuantity += lineRequest.Quantity;
             purchaseOrderLine.ModifiedAt = DateTime.UtcNow;
-            dataContext.Update(purchaseOrderLine);
+            purchaseOrderLine.ConcurrencyStamp = Guid.NewGuid();
         }
 
         var line = new ReceivingLine
@@ -536,7 +527,6 @@ public sealed class PurchasingService(
         if (lineRequest.LotId is { } lotId)
         {
             var existing = await dataContext.Query<InventoryLot>()
-                .IgnoreQueryFilters()
                 .Where(x => x.TenantId == tenantId && x.Id == lotId && !x.IsDeleted)
                 .FirstOrDefaultAsync(ct);
             if (existing is null)
@@ -554,7 +544,6 @@ public sealed class PurchasingService(
             return Result<InventoryLot?>.Success(null);
 
         var existingLot = await dataContext.Query<InventoryLot>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == lineRequest.ProductId &&
@@ -605,7 +594,6 @@ public sealed class PurchasingService(
             return null;
 
         var existing = await dataContext.Query<ReceivingDocument>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.IdempotencyKey == idempotencyKey && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
         if (existing is null)
@@ -615,7 +603,6 @@ public sealed class PurchasingService(
             return Result<ReceivingDocument>.Conflict("Idempotency key was already used with a different receiving request.");
 
         existing.Lines = await dataContext.Query<ReceivingLine>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.ReceivingDocumentId == existing.Id && !x.IsDeleted)
             .ToListAsync(ct);
         return Result<ReceivingDocument>.Success(existing, "Receiving document already processed.");
@@ -624,14 +611,12 @@ public sealed class PurchasingService(
     private async Task<PurchaseOrder?> LoadPurchaseOrder(Guid tenantId, Guid purchaseOrderId, CancellationToken ct)
     {
         var order = await dataContext.Query<PurchaseOrder>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.Id == purchaseOrderId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
         if (order is null)
             return null;
 
         order.Lines = await dataContext.Query<PurchaseOrderLine>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.PurchaseOrderId == purchaseOrderId && !x.IsDeleted)
             .OrderBy(x => x.CreatedAt)
             .ToListAsync(ct);

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
@@ -25,7 +25,6 @@ public sealed class ReservationService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<Reservation>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ProductId is { } productId)
@@ -66,7 +65,6 @@ public sealed class ReservationService(
         if (idempotencyKey is not null)
         {
             var existingReservation = await dataContext.Query<Reservation>()
-                .IgnoreQueryFilters()
                 .Include(x => x.Allocations)
                 .Where(x =>
                     x.TenantId == tenantResult.Data &&
@@ -215,7 +213,6 @@ public sealed class ReservationService(
         var cutoff = request.ExpiresBefore ?? DateTime.UtcNow;
         var maxCount = Math.Clamp(request.MaxCount, 1, 500);
         var reservations = await dataContext.Query<Reservation>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantResult.Data &&
                 x.Status == ReservationStatus.Active &&
@@ -261,7 +258,6 @@ public sealed class ReservationService(
             return Result<Reservation>.Failure(tenantResult.Message!, tenantResult.StatusCode);
 
         var reservation = await dataContext.Query<Reservation>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantResult.Data &&
                 x.Id == reservationId &&

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/StockPostingService.cs
@@ -156,7 +156,6 @@ public sealed class StockPostingService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<StockBalance>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ProductId is { } id)
@@ -192,7 +191,6 @@ public sealed class StockPostingService(
 
         var tenantId = tenantResult.Data;
         var query = dataContext.Query<InventoryMovement>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && !x.IsDeleted);
 
         if (request.ProductId is { } id)
@@ -233,6 +231,13 @@ public sealed class StockPostingService(
             request.DestinationLocationId is not { } destinationLocationId)
         {
             return Result<StockPostingResponse>.Failure("Transfers require destination warehouse and location.", 400);
+        }
+
+        if (destinationWarehouseId == request.WarehouseId && destinationLocationId == request.LocationId)
+        {
+            return Result<StockPostingResponse>.Failure(
+                "Transfer destination must differ from the source warehouse and location.",
+                400);
         }
 
         var product = await GetProduct(tenantId, request.ProductId, ct);
@@ -345,7 +350,6 @@ public sealed class StockPostingService(
             return tracked;
 
         return await dataContext.Query<Product>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.Id == productId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
     }
@@ -374,7 +378,6 @@ public sealed class StockPostingService(
         }
 
         var lot = await dataContext.Query<InventoryLot>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantId &&
                 x.Id == lotId.Value &&
@@ -414,19 +417,16 @@ public sealed class StockPostingService(
             return Result<StockBalanceLookup>.Success(new StockBalanceLookup(trackedBalance, IsNew: false));
 
         var warehouseExists = await dataContext.Query<Warehouse>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == warehouseId && !x.IsDeleted, ct);
         if (!warehouseExists)
             return Result<StockBalanceLookup>.NotFound("Warehouse not found.");
 
         var locationExists = await dataContext.Query<InventoryLocation>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == locationId && x.WarehouseId == warehouseId && !x.IsDeleted, ct);
         if (!locationExists)
             return Result<StockBalanceLookup>.NotFound("Location not found.");
 
         var balance = await dataContext.Query<StockBalance>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantId &&
                 x.ProductId == productId &&
@@ -559,7 +559,7 @@ public sealed class StockPostingService(
         CancellationToken ct)
     {
         await Task.CompletedTask;
-        product.StockQuantity += (int)Math.Round(currentDelta, MidpointRounding.AwayFromZero);
+        product.StockQuantity += currentDelta;
         product.ModifiedAt = DateTime.UtcNow;
         dataContext.Update(product);
     }
@@ -583,7 +583,6 @@ public sealed class StockPostingService(
             return null;
 
         var existing = await dataContext.Query<InventoryMovement>()
-            .IgnoreQueryFilters()
             .Where(x =>
                 x.TenantId == tenantId &&
                 !x.IsDeleted &&
@@ -604,7 +603,6 @@ public sealed class StockPostingService(
             return Result<StockPostingResponse>.Conflict("Processed stock movement is missing a stock balance.");
 
         var balance = await dataContext.Query<StockBalance>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantId && x.Id == stockBalanceId && !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
 

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/WarehouseService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/WarehouseService.cs
@@ -31,7 +31,6 @@ public sealed class WarehouseService(
             return Result<List<Warehouse>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var warehouses = await dataContext.Query<Warehouse>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted)
             .OrderBy(x => x.Code)
             .Take(200)
@@ -57,7 +56,6 @@ public sealed class WarehouseService(
             return Result<Warehouse>.Failure("Warehouse code and name are required.", 400);
 
         var duplicate = await dataContext.Query<Warehouse>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Code == code && !x.IsDeleted, ct);
         if (duplicate)
             return Result<Warehouse>.Failure("A warehouse with the same code already exists.", 409);
@@ -101,7 +99,6 @@ public sealed class WarehouseService(
             return Result<List<InventoryLocation>>.Failure(featureResult.Message!, featureResult.StatusCode);
 
         var query = dataContext.Query<InventoryLocation>()
-            .IgnoreQueryFilters()
             .Where(x => x.TenantId == tenantResult.Data && !x.IsDeleted);
 
         if (request.WarehouseId is { } id)
@@ -132,13 +129,11 @@ public sealed class WarehouseService(
             return Result<InventoryLocation>.Failure("Location code and name are required.", 400);
 
         var warehouseExists = await dataContext.Query<Warehouse>()
-            .IgnoreQueryFilters()
             .AnyAsync(x => x.TenantId == tenantId && x.Id == request.WarehouseId && !x.IsDeleted, ct);
         if (!warehouseExists)
             return Result<InventoryLocation>.NotFound("Warehouse not found.");
 
         var duplicate = await dataContext.Query<InventoryLocation>()
-            .IgnoreQueryFilters()
             .AnyAsync(x =>
                 x.TenantId == tenantId &&
                 x.WarehouseId == request.WarehouseId &&

--- a/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.json
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/appsettings.json
@@ -1,9 +1,9 @@
 {
   "SwaggerOptions": {
     "JsonRoute" : "swagger/{documentName}/swagger.json",
-    "Description": "Identity Server API",
+    "Description": "Inventario API",
     "UIEndpoint": "/swagger.json",
-    "Title" : "Identity Server Api",
+    "Title" : "Inventario API",
     "Version": 1
   },
   "OpenTelemetry": {

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryReorderRuleConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/InventoryReorderRuleConfiguration.cs
@@ -18,7 +18,10 @@ public class InventoryReorderRuleConfiguration : IEntityTypeConfiguration<Invent
         entity.Property(e => e.PreferredSupplier).HasMaxLength(200);
         entity.Property(e => e.IsActive).HasDefaultValue(true);
 
-        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.ProductVariationId, e.WarehouseId, e.LocationId });
+        entity.HasIndex(e => new { e.TenantId, e.ProductId, e.ProductVariationId, e.WarehouseId, e.LocationId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false")
+            .HasAnnotation("Npgsql:NullsDistinct", false);
         entity.HasIndex(e => new { e.TenantId, e.IsActive });
 
         entity.HasOne(e => e.Product)

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductConfiguration.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Configurations/ProductConfiguration.cs
@@ -14,7 +14,7 @@ public class ProductConfiguration : IEntityTypeConfiguration<Product>
         entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
         entity.Property(e => e.Description).HasMaxLength(1000);
         entity.Property(e => e.Price).HasPrecision(18, 2);
-        entity.Property(e => e.StockQuantity).HasDefaultValue(0);
+        entity.Property(e => e.StockQuantity).HasPrecision(18, 4).HasDefaultValue(0m);
         entity.Property(e => e.SKU).HasMaxLength(50);
         entity.Property(e => e.Brand).HasMaxLength(100);
         entity.Property(e => e.Weight).HasPrecision(18, 3);

--- a/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Product.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Domain.Shared/Contracts/Product.cs
@@ -3,7 +3,6 @@ using XFramework.Domain.Shared.Attributes;
 namespace XFramework.Inventario.Domain.Shared.Contracts;
 
 [MemoryPackable(GenerateType.CircularReference)]
-[AllowRemoteDataContextMutation]
 [GenerateEndpoints(
     Type = EndpointType.Rest,
     Actions = EndpointActions.None,
@@ -21,7 +20,7 @@ public partial class Product : BaseModel, IProduct
     [MemoryPackOrder(2)]
     public decimal Price { get; set; }
     [MemoryPackOrder(3)]
-    public int StockQuantity { get; set; }
+    public decimal StockQuantity { get; set; }
     [MemoryPackOrder(4)]
     public Guid CategoryId { get; set; }
     [MemoryPackOrder(5)]

--- a/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ProductServiceTests.cs
@@ -14,7 +14,6 @@ using XFramework.Domain.Shared.DataContext;
 using XFramework.Inventario.Api.Services;
 using XFramework.Inventario.Domain.Shared.Contracts;
 using XFramework.Inventario.Domain.Shared.Contracts.Requests.Products;
-using XFramework.Inventario.Domain.Shared.Enums;
 
 namespace Inventario.Api.Tests;
 
@@ -22,7 +21,7 @@ namespace Inventario.Api.Tests;
 public sealed class ProductServiceTests
 {
     [Test]
-    public async Task CreateAsync_AuthenticatedTenant_AssignsTenantAndCreatesOpeningMovement()
+    public async Task CreateAsync_AuthenticatedTenant_AssignsTenantWithoutCreatingStock()
     {
         var tenantId = Guid.NewGuid();
         var categoryId = Guid.NewGuid();
@@ -42,7 +41,7 @@ public sealed class ProductServiceTests
             Name = "Widget",
             Description = "Tenant-owned product",
             Price = 12.50m,
-            StockQuantity = 7,
+            StockQuantity = 0,
             CategoryId = categoryId,
             SKU = "W-001"
         });
@@ -50,17 +49,31 @@ public sealed class ProductServiceTests
         result.IsSuccess.Should().BeTrue(result.Message);
         result.StatusCode.Should().Be(201);
         result.Data!.TenantId.Should().Be(tenantId);
-        result.Data.StockQuantity.Should().Be(7);
+        result.Data.StockQuantity.Should().Be(0);
+        dataContext.Added.OfType<InventoryMovement>().Should().BeEmpty();
 
-        var movement = dataContext.Added.OfType<InventoryMovement>().Single();
-        movement.TenantId.Should().Be(tenantId);
-        movement.ProductId.Should().Be(result.Data.Id);
-        movement.MovementType.Should().Be(InventoryMovementType.OpeningBalance);
-        movement.QuantityDelta.Should().Be(7);
-        movement.QuantityBefore.Should().Be(0);
-        movement.QuantityAfter.Should().Be(7);
+        cache.SetKeys.Should().Contain($"inventario:tenant:{tenantId}:product:{result.Data.Id}");
+    }
 
-        cache.SetKeys.Should().Contain($"products:{tenantId}:{result.Data.Id}");
+    [Test]
+    public async Task CreateAsync_WithInitialStock_RequiresDimensionedStockMovement()
+    {
+        var tenantId = Guid.NewGuid();
+        var dataContext = new FakeDataContext();
+        var service = CreateService(dataContext, new FakeCacheService(), tenantId);
+
+        var result = await service.CreateAsync(new CreateProductRequest
+        {
+            Name = "Widget",
+            Price = 12.50m,
+            StockQuantity = 7,
+            CategoryId = Guid.NewGuid()
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(400);
+        dataContext.Added.Should().BeEmpty();
+        dataContext.SaveCount.Should().Be(0);
     }
 
     [Test]
@@ -164,6 +177,87 @@ public sealed class ProductServiceTests
         result.IsSuccess.Should().BeFalse();
         result.StatusCode.Should().Be(409);
         dataContext.Added.OfType<Product>().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task CreateAsync_CacheWriteThrows_ReturnsCommittedProduct()
+    {
+        var tenantId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var dataContext = new FakeDataContext();
+        dataContext.Set<ProductCategory>().Add(new ProductCategory
+        {
+            Id = categoryId,
+            TenantId = tenantId,
+            Name = "Parts"
+        });
+        var cache = new FakeCacheService { ThrowOnSet = true };
+        var service = CreateService(dataContext, cache, tenantId);
+
+        var result = await service.CreateAsync(new CreateProductRequest
+        {
+            Name = "Widget",
+            Price = 12.50m,
+            CategoryId = categoryId
+        });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        dataContext.SaveCount.Should().Be(1);
+        dataContext.Added.OfType<Product>().Should().ContainSingle();
+    }
+
+    [Test]
+    public async Task DeleteAsync_ProductWithStock_ReturnsConflictWithoutDeleting()
+    {
+        var tenantId = Guid.NewGuid();
+        var product = new Product
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Name = "Stocked product"
+        };
+        var dataContext = new FakeDataContext();
+        dataContext.Set<Product>().Add(product);
+        dataContext.Set<StockBalance>().Add(new StockBalance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = product.Id,
+            WarehouseId = Guid.NewGuid(),
+            LocationId = Guid.NewGuid(),
+            OnHandQuantity = 1,
+            AvailableQuantity = 1
+        });
+        var service = CreateService(dataContext, new FakeCacheService(), tenantId);
+
+        var result = await service.DeleteAsync(product.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        dataContext.Removed.Should().BeEmpty();
+        dataContext.SaveCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task DeleteAsync_CacheInvalidationThrows_ReturnsCommittedSuccess()
+    {
+        var tenantId = Guid.NewGuid();
+        var product = new Product
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Name = "Disposable product"
+        };
+        var dataContext = new FakeDataContext();
+        dataContext.Set<Product>().Add(product);
+        var cache = new FakeCacheService { ThrowOnRemove = true };
+        var service = CreateService(dataContext, cache, tenantId);
+
+        var result = await service.DeleteAsync(product.Id);
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        dataContext.Removed.Should().ContainSingle(x => ReferenceEquals(x, product));
+        dataContext.SaveCount.Should().Be(1);
     }
 
     [Test]
@@ -472,6 +566,8 @@ public sealed class ProductServiceTests
     private sealed class FakeCacheService : ICacheService
     {
         public List<string> SetKeys { get; } = [];
+        public bool ThrowOnSet { get; init; }
+        public bool ThrowOnRemove { get; init; }
 
         public Task<Result<T?>> GetAsync<T>(string key, CancellationToken cancellationToken = default) =>
             Task.FromResult(Result<T?>.Success(default));
@@ -483,12 +579,20 @@ public sealed class ProductServiceTests
             TimeSpan? slidingExpiration = null,
             CancellationToken cancellationToken = default)
         {
+            if (ThrowOnSet)
+                throw new InvalidOperationException("Cache unavailable");
+
             SetKeys.Add(key);
             return Task.FromResult(Result.Success());
         }
 
-        public Task<Result> RemoveAsync(string key, CancellationToken cancellationToken = default) =>
-            Task.FromResult(Result.Success());
+        public Task<Result> RemoveAsync(string key, CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnRemove)
+                throw new InvalidOperationException("Cache unavailable");
+
+            return Task.FromResult(Result.Success());
+        }
 
         public Task<Result<bool>> ExistsAsync(string key, CancellationToken cancellationToken = default) =>
             Task.FromResult(Result<bool>.Success(false));
@@ -501,8 +605,13 @@ public sealed class ProductServiceTests
             CancellationToken cancellationToken = default) =>
             factory(cancellationToken).ContinueWith(t => Result<T>.Success(t.Result), cancellationToken);
 
-        public Task<Result<int>> RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default) =>
-            Task.FromResult(Result<int>.Success(0));
+        public Task<Result<int>> RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnRemove)
+                throw new InvalidOperationException("Cache unavailable");
+
+            return Task.FromResult(Result<int>.Success(0));
+        }
 
         public Result<CacheStatistics> GetStatistics() =>
             Result<CacheStatistics>.Success(new CacheStatistics());

--- a/src/Tests/Inventario.Api.Tests/PurchasingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/PurchasingServiceTests.cs
@@ -24,6 +24,8 @@ public sealed class PurchasingServiceTests
         var tenantId = Guid.NewGuid();
         var ids = TestIds.Create();
         var dataContext = SeedPurchasingData(tenantId, ids, orderedQuantity: 10);
+        var originalOrderStamp = dataContext.Set<PurchaseOrder>().Single().ConcurrencyStamp;
+        var originalLineStamp = dataContext.Set<PurchaseOrderLine>().Single().ConcurrencyStamp;
         var service = CreateService(dataContext, tenantId);
 
         var result = await service.ReceiveAsync(new ReceiveInventoryRequest
@@ -51,6 +53,10 @@ public sealed class PurchasingServiceTests
 
         dataContext.Set<PurchaseOrder>().Single().Status.Should().Be(PurchaseOrderStatus.PartiallyReceived);
         dataContext.Set<PurchaseOrderLine>().Single().ReceivedQuantity.Should().Be(4);
+        dataContext.Set<PurchaseOrder>().Single().ConcurrencyStamp.Should().NotBe(originalOrderStamp);
+        dataContext.Set<PurchaseOrderLine>().Single().ConcurrencyStamp.Should().NotBe(originalLineStamp);
+        dataContext.Updated.Should().Contain(x => x is PurchaseOrder);
+        dataContext.Updated.Should().Contain(x => x is PurchaseOrderLine);
         dataContext.Set<InventoryLot>().Should().ContainSingle(x => x.LotNumber == "LOT-RCV-1");
         dataContext.Set<StockBalance>().Should().ContainSingle(x => x.LotId != null && x.OnHandQuantity == 4 && x.AvailableQuantity == 4);
         dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle(x =>

--- a/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/StockPostingServiceTests.cs
@@ -56,6 +56,66 @@ public sealed class StockPostingServiceTests
     }
 
     [Test]
+    public async Task PostAsync_FractionalOpeningBalance_PreservesProductSnapshotPrecision()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            MovementType = InventoryMovementType.OpeningBalance,
+            Quantity = 1.25m
+        });
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        dataContext.Set<Product>().Single().StockQuantity.Should().Be(1.25m);
+    }
+
+    [Test]
+    public async Task PostAsync_TransferToSameDimensions_ReturnsBadRequestWithoutSaving()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var warehouseId = Guid.NewGuid();
+        var locationId = Guid.NewGuid();
+        var dataContext = SeedStockData(tenantId, productId, warehouseId, locationId);
+        dataContext.Set<StockBalance>().Add(new StockBalance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            OnHandQuantity = 10,
+            AvailableQuantity = 10
+        });
+        var service = CreateService(dataContext, tenantId);
+
+        var result = await service.PostAsync(new PostStockMovementRequest
+        {
+            ProductId = productId,
+            WarehouseId = warehouseId,
+            LocationId = locationId,
+            DestinationWarehouseId = warehouseId,
+            DestinationLocationId = locationId,
+            MovementType = InventoryMovementType.Transfer,
+            Quantity = 2
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(400);
+        dataContext.SaveCount.Should().Be(0);
+        dataContext.Added.OfType<InventoryMovement>().Should().BeEmpty();
+    }
+
+    [Test]
     public async Task PostAsync_ShipmentBeyondAvailableStock_ReturnsConflictWithoutSaving()
     {
         var tenantId = Guid.NewGuid();

--- a/src/Tests/Inventario.IntegrationTests/Infrastructure/InventarioIntegrationTestFixture.cs
+++ b/src/Tests/Inventario.IntegrationTests/Infrastructure/InventarioIntegrationTestFixture.cs
@@ -337,7 +337,55 @@ public sealed class InventarioIntegrationTestFixture
             new TestEffectiveTenantContextAccessor(TestTenantId));
         await db.Database.MigrateAsync();
         await TestSeedData.SeedAll(db);
+        await SeedInvocationActor(db);
         await EnableInventarioFeatures(db);
+    }
+
+    private static async Task SeedInvocationActor(AppDbContext db)
+    {
+        if (await db.Set<IdentityServer.Domain.Shared.Contracts.IdentityCredential>()
+                .IgnoreQueryFilters()
+                .AnyAsync(x => x.Id == InvocationIdentity.CredentialId))
+        {
+            return;
+        }
+
+        db.Set<IdentityServer.Domain.Shared.Contracts.IdentityInformation>().Add(new()
+        {
+            Id = InvocationIdentity.IdentityId,
+            TenantId = InvocationIdentity.TenantId,
+            FirstName = "Inventario",
+            LastName = "Integration Actor",
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        });
+
+        db.Set<IdentityServer.Domain.Shared.Contracts.IdentityCredential>().Add(new()
+        {
+            Id = InvocationIdentity.CredentialId,
+            TenantId = InvocationIdentity.TenantId,
+            IdentityInfoId = InvocationIdentity.IdentityId,
+            UserName = "inventario-integration-actor",
+            PasswordByte = [0],
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        });
+
+        db.Set<IdentityServer.Domain.Shared.Contracts.IdentityRole>().Add(new()
+        {
+            Id = Guid.NewGuid(),
+            TenantId = InvocationIdentity.TenantId,
+            CredentialId = InvocationIdentity.CredentialId,
+            TypeId = TestConstants.RoleTypeId,
+            RoleExpiration = DateTime.UtcNow.AddYears(1),
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        });
+
+        await db.SaveChangesAsync();
     }
 
     private static async Task EnableInventarioFeatures(AppDbContext db)

--- a/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/CatalogTests.cs
@@ -85,7 +85,7 @@ public sealed class CatalogTests : InventarioTestBase
     }
 
     [Test]
-    public async Task SaveChangesAsync_RemoteProductCreate_PersistsWithCategory()
+    public async Task SaveChangesAsync_RemoteProductCreate_IsRejected()
     {
         await using var db = CreateDbContext();
         var category = await TestInventarioSeed.SeedCategory(db);
@@ -106,17 +106,16 @@ public sealed class CatalogTests : InventarioTestBase
         ctx.Add(product);
         var save = await ctx.SaveChangesAsync();
 
-        save.IsSuccess.Should().BeTrue(save.Message);
+        save.IsSuccess.Should().BeFalse();
         var persisted = await db.Set<Product>()
             .IgnoreQueryFilters()
             .FirstOrDefaultAsync(x => x.Id == product.Id);
-        persisted.Should().NotBeNull();
-        persisted!.CategoryId.Should().Be(category.Id);
+        persisted.Should().BeNull();
     }
 
     [Test]
     [Category(TestCategories.ExtendedIntegration)]
-    public async Task SaveChangesAsync_RemoteProductUpdate_PersistsThroughInventarioDataContext()
+    public async Task SaveChangesAsync_RemoteProductUpdate_IsRejected()
     {
         await using var db = CreateDbContext();
         var product = await TestInventarioSeed.SeedProduct(db);
@@ -131,19 +130,19 @@ public sealed class CatalogTests : InventarioTestBase
         ctx.Update(remoteProduct);
         var save = await ctx.SaveChangesAsync();
 
-        save.IsSuccess.Should().BeTrue(save.Message);
+        save.IsSuccess.Should().BeFalse();
         await using var verifyDb = CreateDbContext();
         var persisted = await verifyDb.Set<Product>()
             .IgnoreQueryFilters()
             .AsNoTracking()
             .FirstAsync(x => x.Id == product.Id);
-        persisted.Name.Should().Be(remoteProduct.Name);
-        persisted.Price.Should().Be(42m);
+        persisted.Name.Should().Be(product.Name);
+        persisted.Price.Should().Be(product.Price);
     }
 
     [Test]
     [Category(TestCategories.ExtendedIntegration)]
-    public async Task SaveChangesAsync_RemoteProductRemove_SoftDeletesThroughInventarioDataContext()
+    public async Task SaveChangesAsync_RemoteProductRemove_IsRejected()
     {
         await using var db = CreateDbContext();
         var product = await TestInventarioSeed.SeedProduct(db);
@@ -152,14 +151,14 @@ public sealed class CatalogTests : InventarioTestBase
         ctx.Remove(product);
         var save = await ctx.SaveChangesAsync();
 
-        save.IsSuccess.Should().BeTrue(save.Message);
+        save.IsSuccess.Should().BeFalse();
         await using var verifyDb = CreateDbContext();
         var persisted = await verifyDb.Set<Product>()
             .IgnoreQueryFilters()
             .AsNoTracking()
             .FirstAsync(x => x.Id == product.Id);
-        persisted.IsDeleted.Should().BeTrue();
-        persisted.DeletedAt.Should().NotBeNull();
+        persisted.IsDeleted.Should().BeFalse();
+        persisted.DeletedAt.Should().BeNull();
     }
 
     [Test]

--- a/src/Tests/Inventario.IntegrationTests/Tests/PlanningPurchasingReportingTests.cs
+++ b/src/Tests/Inventario.IntegrationTests/Tests/PlanningPurchasingReportingTests.cs
@@ -57,6 +57,21 @@ public sealed class PlanningPurchasingReportingTests : InventarioTestBase
 
     [Test]
     [Category(TestCategories.Planning)]
+    public async Task InventoryReorderRule_DuplicateActiveDimensions_IsRejectedByDatabase()
+    {
+        var seed = await SeedInventoryScope();
+        await using var db = CreateDbContext();
+        db.Set<InventoryReorderRule>().AddRange(
+            CreateReorderRule(seed),
+            CreateReorderRule(seed));
+
+        var act = async () => await db.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Test]
+    [Category(TestCategories.Planning)]
     [Category(TestCategories.Reporting)]
     public async Task GetReorderSuggestions_LowStockProduct_ReturnsSuggestedQuantity()
     {
@@ -365,6 +380,53 @@ public sealed class PlanningPurchasingReportingTests : InventarioTestBase
         documentCount.Should().Be(1);
     }
 
+    [Test]
+    [Category(TestCategories.Purchasing)]
+    public async Task PurchaseOrderLine_StaleConcurrentReceiptUpdate_ThrowsConcurrencyException()
+    {
+        var seed = await SeedInventoryScope();
+        var orderId = Guid.NewGuid();
+        var lineId = Guid.NewGuid();
+        await using (var setupDb = CreateDbContext())
+        {
+            setupDb.Set<PurchaseOrder>().Add(new PurchaseOrder
+            {
+                Id = orderId,
+                TenantId = InventarioIntegrationTestFixture.TestTenantId,
+                OrderNumber = UniqueCode("PO-CONC"),
+                Status = PurchaseOrderStatus.Open,
+                OrderDate = DateTime.UtcNow,
+                IsEnabled = true
+            });
+            setupDb.Set<PurchaseOrderLine>().Add(new PurchaseOrderLine
+            {
+                Id = lineId,
+                TenantId = InventarioIntegrationTestFixture.TestTenantId,
+                PurchaseOrderId = orderId,
+                ProductId = seed.Product.Id,
+                OrderedQuantity = 10,
+                ReceivedQuantity = 0,
+                IsEnabled = true
+            });
+            await setupDb.SaveChangesAsync();
+        }
+
+        await using var firstDb = CreateDbContext();
+        await using var secondDb = CreateDbContext();
+        var firstLine = await firstDb.Set<PurchaseOrderLine>().SingleAsync(x => x.Id == lineId);
+        var staleLine = await secondDb.Set<PurchaseOrderLine>().SingleAsync(x => x.Id == lineId);
+
+        firstLine.ReceivedQuantity = 6;
+        firstLine.ConcurrencyStamp = Guid.NewGuid();
+        await firstDb.SaveChangesAsync();
+
+        staleLine.ReceivedQuantity = 6;
+        staleLine.ConcurrencyStamp = Guid.NewGuid();
+        var act = async () => await secondDb.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+
     private async Task<InventoryScope> SeedInventoryScope(
         bool withLot = false,
         DateTime? expiresAt = null)
@@ -379,6 +441,21 @@ public sealed class PlanningPurchasingReportingTests : InventarioTestBase
             : null;
         return new InventoryScope(product, warehouse, location, lot);
     }
+
+    private static InventoryReorderRule CreateReorderRule(InventoryScope seed) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = InventarioIntegrationTestFixture.TestTenantId,
+        ProductId = seed.Product.Id,
+        WarehouseId = seed.Warehouse.Id,
+        LocationId = seed.Location.Id,
+        MinimumQuantity = 1,
+        MaximumQuantity = 10,
+        ReorderPoint = 2,
+        ReorderQuantity = 5,
+        IsActive = true,
+        IsEnabled = true
+    };
 
     private static async Task PostOpeningBalance(
         Guid productId,


### PR DESCRIPTION
﻿## Summary

- make dimensioned stock movements authoritative and preserve fractional product stock snapshots
- enforce receiving concurrency, active reorder-rule uniqueness, product dependency deletion guards, and same-dimension transfer validation
- remove Product remote mutation and routine Inventario query-filter bypasses
- make product caching best-effort after committed writes
- move planning/report filtering and lookup narrowing into PostgreSQL
- repair the trusted actor integration fixture and document the remediated backend audit
- fix POS sellable-catalog EF projections so search, ordering, and pagination execute in SQL

## Migration

Adds `InventarioBackendRemediation20260805` to:

- convert `Product.StockQuantity` to `numeric(18,4)`
- retire duplicate active reorder rules deterministically
- create a filtered unique index with null dimensions treated as equal

## Validation

- Inventario API build: passed, 0 warnings/errors
- Inventario API unit tests: 37/37 passed
- Inventario integration tests: 62/62 passed through xeon-dev Testcontainers
- EF pending-model check: no pending changes
- production Inventario API `IgnoreQueryFilters()` count: 0
- Product remote-mutation attributes: 0
- `git diff --check`: clean

## Deferred

Audit finding #5, operation-specific Bolt service policy, remains documented and intentionally deferred by user decision.
