### PR TITLE
Harden POS production invariants

### DIFF
--- a/docs/solutions/README.md
+++ b/docs/solutions/README.md
@@ -53,6 +53,7 @@ status: current
 - [IdentityServer schema ownership exceptions](architecture-patterns/identityserver-schema-ownership-exceptions.md) - documents the legacy `Application`, `Audit`, and `GeoLocation` tables that remain owned by IdentityServer.
 - [IdentityServer backend audit and remediation](workflow-issues/identityserver-backend-audit-2026-07-31.md) - records the post-Bolt BackendGuidelines audit, implemented fixes, independent re-audit, and verification evidence.
 - [Inventario backend audit after trusted invocation remediation](workflow-issues/inventario-backend-audit-2026-08-04.md) - records the current post-IdentityServer findings, resolved tenant/Bolt issues, and verification evidence.
+- [POS backend post-IdentityServer revalidation](workflow-issues/pos-backend-audit-2026-08-04.md) - records current POS production-readiness findings after centralized trusted invocation and separate IdentityServer token quotas.
 - [Portal service wrapper and integration test contract](developer-experience/portal-service-wrapper-and-integration-test-contract.md) - wrapper-first Portal business operations, direct `IDataContext` mutation rules, and standard/extended integration-test tiers.
 - [UI guidelines](../../rules/UiGuidelines.md) - primary Portal and Blazor UI rules, with links to BlazorBlueprint component details.
 - [Bolt protocol, Hub, and Media audit](workflow-issues/bolt-protocol-hub-media-audit-2026-07-12.md) - active correctness, security, performance, scalability, and Media finding inventory.

--- a/docs/solutions/workflow-issues/pos-backend-audit-2026-08-04.md
+++ b/docs/solutions/workflow-issues/pos-backend-audit-2026-08-04.md
@@ -1,0 +1,137 @@
+---
+title: "POS Backend Post-IdentityServer Revalidation"
+date: 2026-08-05
+category: workflow-issues
+module: POS
+problem_type: security_and_backend_compliance
+component: pos
+severity: medium
+status: partially_resolved
+tags: [pos, bolt, identityserver, ef-core, inventario, wallets, testing]
+---
+
+# POS Backend Post-IdentityServer Revalidation
+
+## Audit Scope
+
+- Baseline: `origin/develop` at `c0e0a47e79c141fe6b40b24a79f353bd200b2629` (PR #398).
+- Implementation worktree: `codex/pos-audit-post-identityserver`; the shared dirty checkout was not modified.
+- Authority: `CLAUDE.md`, `rules/BackendGuidelines.md`, and the canonical VSA, EF Core, Bolt, caching, and wrapper-boundary documents they require.
+- Method: fresh `xframework-audit-module` review followed by authorized remediation and revalidation.
+- Overall score after remediation: **B**. No verified Critical or High finding remains. Three Medium risks and one Low maintainability issue remain.
+
+## Summary
+
+The current IdentityServer/Bolt foundation remains valid: trusted invocation context is the tenant authority, service and actor identities are separate, generated Bolt handlers authorize before service resolution, and service/transport tokens use independent singleton caches with collapsed concurrent acquisition.
+
+The remediation closes the previous duplicate-capture, over-refund, total-reconciliation, capability, terminal-reservation, register-boundary, and cart-idempotency findings. POS now has deterministic payment posting, server-derived refund allocations, captured-payment caps, operation capabilities on HTTP and Bolt, replay-safe Inventario terminal operations, generated remote register reads, transaction line limits, and real PostgreSQL/Bolt integration fixtures.
+
+POS still needs Docker-executed cross-module checkout/return workflow coverage before the production-readiness claim is complete. Current integration fixtures prove migration/constraint behavior and generated Bolt authorization, but not the full Inventario reservation plus Wallets posting workflow.
+
+## Critical Findings
+
+No current Critical findings.
+
+## High Findings
+
+No current High findings.
+
+## Medium Findings
+
+### M1. Runtime integration coverage does not yet execute checkout and return across all three modules
+
+- Evidence: the new PostgreSQL fixture applies migrations and verifies the active payment constraint and cart request hash at `src/Tests/POS.IntegrationTests/PosPersistenceIntegrationTests.cs:55`.
+- Evidence: the new hosted Bolt fixture calls `GetPosRegister` through the generated wrapper and verifies actor-capability denial at `src/Tests/POS.IntegrationTests/PosBoltRuntimeIntegrationTests.cs:108`.
+- Evidence: both fixtures are intentionally skipped when no Testcontainers-compatible Docker endpoint exists at `src/Tests/POS.IntegrationTests/PosPersistenceIntegrationTests.cs:33` and `src/Tests/POS.IntegrationTests/PosBoltRuntimeIntegrationTests.cs:64`.
+- Impact: local green tests do not yet prove reservation, wallet capture/refund, compensation, and recovery behavior through running POS, Inventario, Wallets, Bolt, and PostgreSQL services.
+- Missing coverage: concurrent checkout replay with one observed Wallets posting; payment-success/fulfillment-failure recovery; concurrent partial returns with one bounded refund; tenant/feature denial; and token-acquisition counts under POS load.
+
+### M2. A concurrent different-key partial return can surface a database retry as an internal error
+
+- Evidence: return allocation runs in a serializable transaction, preserving the financial invariant, but the save catch only converts a conflict when it can reload the same idempotency key at `src/Modules/XFramework.POS/POS.Api/Services/PosReturnsService.cs:124-144`.
+- Evidence: a serialization failure from a competing return with a different key has no same-key replay row and is rethrown at `src/Modules/XFramework.POS/POS.Api/Services/PosReturnsService.cs:138-139`.
+- Impact: PostgreSQL prevents over-return, but one legitimate concurrent cashier request can receive a 500 instead of a deterministic retryable conflict.
+- Missing coverage: PostgreSQL test with two different idempotency keys returning the same remaining quantity, asserting one success and one explicit 409/retry response.
+
+### M3. Inventario enrichment and product validation remain sequential within the new request limits
+
+- Evidence: catalog stock enrichment still performs sequential `GetStockBalances` calls at `src/Modules/XFramework.POS/POS.Api/Services/PosCatalogService.cs:85`.
+- Evidence: cart and sale line construction still perform sequential product lookups at `src/Modules/XFramework.POS/POS.Api/Services/PosCartService.cs:419` and `src/Modules/XFramework.POS/POS.Api/Services/PosSalesService.cs:363`.
+- Evidence: cart, sale, and return requests are now capped at 100 lines at `src/Modules/XFramework.POS/POS.Api/Features/PosValidators.cs:74-75`, `:170-171`, and `:231-232`.
+- Impact: work is bounded, but high-line transactions and 100-item catalog pages can still have avoidable cumulative Bolt latency.
+- Missing coverage: latency/load tests at the supported maximum and a batched or bounded-concurrency Inventario read contract.
+
+## Low Findings
+
+### L1. POS endpoint and validator files remain flattened rather than feature-centric VSA
+
+- Evidence: all POS endpoint handlers remain in `src/Modules/XFramework.POS/POS.Api/Features/PosEndpoints.cs:10-309`, and validators remain in `src/Modules/XFramework.POS/POS.Api/Features/PosValidators.cs:11-267`.
+- Impact: feature ownership and navigation become harder as the module grows; runtime behavior is unaffected.
+- Required direction: split touched slices into `Features/<Area>/<Action>` incrementally, without a broad structure-only rewrite.
+
+## Resolved Findings
+
+### Resolved: C1 concurrent duplicate payment capture
+
+- Payment references are now deterministic from the sale at `src/Modules/XFramework.POS/POS.Api/Services/PosServiceHelpers.cs:34-35`.
+- V1 one-tender semantics are database-enforced by `UX_POS_Payment_Tenant_Sale_Active` at `src/Modules/XFramework.POS/POS.Domain.Shared/Configurations/PosEntityConfigurations.cs:190-194`.
+- Sale/payment uniqueness conflicts reload and resume the persisted sale at `src/Modules/XFramework.POS/POS.Api/Services/PosSalesService.cs:103-119` and `:160-174`.
+- The generated EF migration creates the constraint at `src/Kernel/XFramework.Domain/Migrations/20260805152712_HardenPosPaymentAndCartIdempotency.cs:26-32`.
+
+### Resolved: C2 over-return and over-refund
+
+- Duplicate return lines and caller-authored tax are rejected at `src/Modules/XFramework.POS/POS.Api/Features/PosValidators.cs:233-241` and rechecked by the service.
+- Refund subtotal/tax are allocated from immutable sale values at `src/Modules/XFramework.POS/POS.Api/Services/PosServiceHelpers.cs:123-177`.
+- Cumulative refunds are capped to captured payments at `src/Modules/XFramework.POS/POS.Api/Services/PosReturnsService.cs:108-121`.
+- Existing return allocations are grouped once and final partial returns receive the exact rounding remainder at `src/Modules/XFramework.POS/POS.Api/Services/PosReturnsService.cs:289-342`.
+
+### Resolved: H1 monetary totals did not reconcile
+
+- Sale totals now sum line totals, including line discounts/tax, then proportionally account for header adjustments at `src/Modules/XFramework.POS/POS.Api/Services/PosSalesService.cs:91-101` and `src/Modules/XFramework.POS/POS.Api/Services/PosServiceHelpers.cs:123-151`.
+- Cart totals now use `Sum(LineTotal) - header discount + header tax` at `src/Modules/XFramework.POS/POS.Api/Services/PosCartService.cs:654-660`.
+- Pure financial invariant tests cover header/line reconciliation and partial-return rounding.
+
+### Resolved: H2 missing operation-level actor capabilities
+
+- Stable POS capability names are defined in `src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/PosAuthorizationCapabilities.cs:3-20`.
+- Every endpoint now declares full actor capabilities for generated Bolt authorization and standard `Capability` metadata for HTTP feature authorization; representative declarations are at `src/Modules/XFramework.POS/POS.Api/Features/PosEndpoints.cs:13-18`, `:168-173`, and `:254-259`.
+
+### Resolved: H3 terminal Inventario reservation replay
+
+- Releasing an already released reservation and fulfilling an already fulfilled reservation return success without new stock posting at `src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs:127-139` and `:161-173`.
+- Regression tests verify no duplicate movements and no second save.
+
+### Resolved: M1 foreign-schema register reads and wallet ownership
+
+- Register validation uses generated IdentityServer, Wallets, and Inventario read wrappers at `src/Modules/XFramework.POS/POS.Api/Services/PosRegisterService.cs:184-225`.
+- Cash drawer ownership must match the merchant credential at `src/Modules/XFramework.POS/POS.Api/Services/PosRegisterService.cs:207-208`.
+
+### Resolved: M3 cart idempotency
+
+- `PosCart.RequestHash` is persisted and mapped; same-key/different-payload requests conflict.
+- Concurrent same-key inserts reload and replay the winner at `src/Modules/XFramework.POS/POS.Api/Services/PosCartService.cs:33-44` and `:97-117`.
+
+## IdentityServer And Trusted Invocation Revalidation
+
+The prior post-IdentityServer conclusions remain resolved and applicable:
+
+- Raw request metadata is not a tenant authority; POS uses the trusted effective tenant and rejects metadata mismatch.
+- Generated Bolt handlers establish authorization and trusted tenant context before resolving POS services.
+- Normal POS calls require separate destination-service and actor identities.
+- Sender binding, IdentityServer-backed actor/session validation, exact feature gates, and remote `IDataContext` scope checks remain centralized.
+- Service access tokens and Bolt transport tokens remain independently cached singleton providers with per-key in-flight acquisition collapse; POS introduces no per-request token provider.
+
+## Verification
+
+- `dotnet test src/Tests/POS.Api.Tests/POS.Api.Tests.csproj -m:1 /nr:false` - passed 24/24.
+- `dotnet test src/Tests/Inventario.Api.Tests/Inventario.Api.Tests.csproj -m:1 /nr:false` - passed 39/39.
+- `dotnet test src/Tests/POS.IntegrationTests/POS.IntegrationTests.csproj -m:1 /nr:false` - passed 12, skipped 2 Docker-required runtime tests.
+- `dotnet test src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj -m:1 /nr:false` - passed 338/338.
+- `dotnet ef migrations has-pending-model-changes ... --no-build` - no pending model changes after rebuilding the migration runner.
+- `git diff --check` - passed.
+
+## Deployment Preconditions
+
+- Run the two Docker-backed POS integration tests in CI or another Testcontainers-capable environment before merge.
+- Check deployed POS data for more than one active payment row per `(TenantId, SaleId)` before applying the new unique index; the EF-generated migration intentionally does not delete or rewrite financial records.
+- Ensure cashier, supervisor, returns, and register-administrator roles receive the new POS capabilities before rollout.

--- a/src/Kernel/XFramework.Domain/Migrations/20260805152712_HardenPosPaymentAndCartIdempotency.Designer.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260805152712_HardenPosPaymentAndCartIdempotency.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XFramework.Domain.Contexts;
@@ -11,9 +12,11 @@ using XFramework.Domain.Contexts;
 namespace XFramework.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805152712_HardenPosPaymentAndCartIdempotency")]
+    partial class HardenPosPaymentAndCartIdempotency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Kernel/XFramework.Domain/Migrations/20260805152712_HardenPosPaymentAndCartIdempotency.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260805152712_HardenPosPaymentAndCartIdempotency.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XFramework.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class HardenPosPaymentAndCartIdempotency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_POS_Payment_Tenant_Sale",
+                schema: "POS",
+                table: "PosPayment");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RequestHash",
+                schema: "POS",
+                table: "PosCart",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_POS_Payment_Tenant_Sale_Active",
+                schema: "POS",
+                table: "PosPayment",
+                columns: new[] { "TenantId", "SaleId" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_POS_Payment_Tenant_Sale_Active",
+                schema: "POS",
+                table: "PosPayment");
+
+            migrationBuilder.DropColumn(
+                name: "RequestHash",
+                schema: "POS",
+                table: "PosCart");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_POS_Payment_Tenant_Sale",
+                schema: "POS",
+                table: "PosPayment",
+                columns: new[] { "TenantId", "SaleId" });
+        }
+    }
+}

--- a/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
+++ b/src/Modules/XFramework.Inventario/Inventario.Api/Services/ReservationService.cs
@@ -122,11 +122,17 @@ public sealed class ReservationService(
         ReleaseReservationRequest request,
         CancellationToken ct = default)
     {
-        var reservationResult = await GetActiveReservation(request, request.ReservationId, ct);
+        var reservationResult = await GetReservation(request, request.ReservationId, ct);
         if (!reservationResult.IsSuccess)
             return reservationResult;
 
         var reservation = reservationResult.Data!;
+        if (reservation.Status == ReservationStatus.Released)
+            return Result<Reservation>.Success(reservation, "Reservation release replayed.");
+
+        if (reservation.Status != ReservationStatus.Active)
+            return Result<Reservation>.Conflict($"A {reservation.Status} reservation cannot be released.");
+
         var releaseResult = await allocationService.ReleaseAsync(
             reservation,
             request,
@@ -150,11 +156,17 @@ public sealed class ReservationService(
         FulfillReservationRequest request,
         CancellationToken ct = default)
     {
-        var reservationResult = await GetActiveReservation(request, request.ReservationId, ct);
+        var reservationResult = await GetReservation(request, request.ReservationId, ct);
         if (!reservationResult.IsSuccess)
             return reservationResult;
 
         var reservation = reservationResult.Data!;
+        if (reservation.Status == ReservationStatus.Fulfilled)
+            return Result<Reservation>.Success(reservation, "Reservation fulfillment replayed.");
+
+        if (reservation.Status != ReservationStatus.Active)
+            return Result<Reservation>.Conflict($"A {reservation.Status} reservation cannot be fulfilled.");
+
         var fulfillmentResult = await allocationService.FulfillAsync(
             reservation,
             request,
@@ -178,11 +190,14 @@ public sealed class ReservationService(
         CancelReservationRequest request,
         CancellationToken ct = default)
     {
-        var reservationResult = await GetActiveReservation(request, request.ReservationId, ct);
+        var reservationResult = await GetReservation(request, request.ReservationId, ct);
         if (!reservationResult.IsSuccess)
             return reservationResult;
 
         var reservation = reservationResult.Data!;
+        if (reservation.Status != ReservationStatus.Active)
+            return Result<Reservation>.Conflict($"A {reservation.Status} reservation cannot be cancelled.");
+
         var releaseResult = await allocationService.ReleaseAsync(
             reservation,
             request,
@@ -248,7 +263,7 @@ public sealed class ReservationService(
         return Result<int>.Success(reservations.Count, $"{reservations.Count} reservation(s) expired.");
     }
 
-    private async Task<Result<Reservation>> GetActiveReservation(
+    private async Task<Result<Reservation>> GetReservation(
         RequestBase request,
         Guid reservationId,
         CancellationToken ct)
@@ -261,12 +276,11 @@ public sealed class ReservationService(
             .Where(x =>
                 x.TenantId == tenantResult.Data &&
                 x.Id == reservationId &&
-                x.Status == ReservationStatus.Active &&
                 !x.IsDeleted)
             .FirstOrDefaultAsync(ct);
 
         return reservation is null
-            ? Result<Reservation>.NotFound("Active reservation not found.")
+            ? Result<Reservation>.NotFound("Reservation not found.")
             : Result<Reservation>.Success(reservation);
     }
 

--- a/src/Modules/XFramework.POS/POS.Api/Features/PosEndpoints.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Features/PosEndpoints.cs
@@ -1,4 +1,6 @@
 using POS.Api.Services;
+using IdentityServer.Domain.Shared.Contracts;
+using POS.Domain.Shared.Contracts;
 using POS.Domain.Shared.Contracts.Requests;
 using POS.Domain.Shared.Contracts.Responses;
 using XFramework.Core.Patterns;
@@ -8,10 +10,12 @@ namespace POS.Api.Features;
 
 public static class SearchPosCatalogEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesView])]
     [MapGet("/api/pos/catalog", Tags = ["POS Catalog"],
         Summary = "Search POS catalog",
-        Description = "Delegates to Inventario sellable product search for POS line selection.")]
+        Description = "Delegates to Inventario sellable product search for POS line selection.",
+        Capability = IdentityAuthorizationConstants.View,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesView])]
     public static Task<Result<List<PosCatalogItemResponse>>> Handle(
         SearchPosCatalogRequest request,
         PosCatalogService service,
@@ -21,9 +25,11 @@ public static class SearchPosCatalogEndpoint
 
 public static class GetPosRegisterEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.RegistersView])]
     [MapGet("/api/pos/registers/{id:guid}", Tags = ["POS Registers"],
-        Summary = "Get POS register")]
+        Summary = "Get POS register",
+        Capability = IdentityAuthorizationConstants.View,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.RegistersView])]
     public static Task<Result<PosRegisterResponse>> Handle(
         GetPosRegisterRequest request,
         PosRegisterService service,
@@ -33,9 +39,11 @@ public static class GetPosRegisterEndpoint
 
 public static class CreatePosRegisterEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.RegistersCreate])]
     [MapPost("/api/pos/registers", Tags = ["POS Registers"],
-        Summary = "Create POS register")]
+        Summary = "Create POS register",
+        Capability = IdentityAuthorizationConstants.Create,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.RegistersCreate])]
     public static Task<Result<PosRegisterResponse>> Handle(
         CreatePosRegisterRequest request,
         PosRegisterService service,
@@ -45,9 +53,11 @@ public static class CreatePosRegisterEndpoint
 
 public static class UpdatePosRegisterEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.RegistersUpdate])]
     [MapPut("/api/pos/registers/{id:guid}", Tags = ["POS Registers"],
-        Summary = "Update POS register")]
+        Summary = "Update POS register",
+        Capability = IdentityAuthorizationConstants.Update,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.RegistersUpdate])]
     public static Task<Result<PosRegisterResponse>> Handle(
         UpdatePosRegisterRequest request,
         PosRegisterService service,
@@ -57,9 +67,11 @@ public static class UpdatePosRegisterEndpoint
 
 public static class CreatePosCartEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsCreate])]
     [MapPost("/api/pos/carts", Tags = ["POS Carts"],
-        Summary = "Create POS cart")]
+        Summary = "Create POS cart",
+        Capability = IdentityAuthorizationConstants.Create,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsCreate])]
     public static Task<Result<PosCartResponse>> Handle(
         CreatePosCartRequest request,
         PosCartService service,
@@ -69,9 +81,11 @@ public static class CreatePosCartEndpoint
 
 public static class UpdatePosCartEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsUpdate])]
     [MapPut("/api/pos/carts/{id:guid}", Tags = ["POS Carts"],
-        Summary = "Update POS cart")]
+        Summary = "Update POS cart",
+        Capability = IdentityAuthorizationConstants.Update,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsUpdate])]
     public static Task<Result<PosCartResponse>> Handle(
         UpdatePosCartRequest request,
         PosCartService service,
@@ -81,9 +95,11 @@ public static class UpdatePosCartEndpoint
 
 public static class GetPosCartEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsView])]
     [MapGet("/api/pos/carts/{id:guid}", Tags = ["POS Carts"],
-        Summary = "Get POS cart")]
+        Summary = "Get POS cart",
+        Capability = IdentityAuthorizationConstants.View,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsView])]
     public static Task<Result<PosCartResponse>> Handle(
         GetPosCartRequest request,
         PosCartService service,
@@ -93,9 +109,11 @@ public static class GetPosCartEndpoint
 
 public static class SearchPosCartsEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsView])]
     [MapGet("/api/pos/carts", Tags = ["POS Carts"],
-        Summary = "Search POS carts")]
+        Summary = "Search POS carts",
+        Capability = IdentityAuthorizationConstants.View,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsView])]
     public static Task<Result<List<PosCartSummaryResponse>>> Handle(
         SearchPosCartsRequest request,
         PosCartService service,
@@ -105,9 +123,11 @@ public static class SearchPosCartsEndpoint
 
 public static class SuspendPosCartEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsUpdate])]
     [MapPost("/api/pos/carts/{cartId:guid}/suspend", Tags = ["POS Carts"],
-        Summary = "Suspend POS cart")]
+        Summary = "Suspend POS cart",
+        Capability = IdentityAuthorizationConstants.Update,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsUpdate])]
     public static Task<Result<PosCartResponse>> Handle(
         SuspendPosCartRequest request,
         PosCartService service,
@@ -117,9 +137,11 @@ public static class SuspendPosCartEndpoint
 
 public static class ResumePosCartEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsUpdate])]
     [MapPost("/api/pos/carts/{cartId:guid}/resume", Tags = ["POS Carts"],
-        Summary = "Resume POS cart")]
+        Summary = "Resume POS cart",
+        Capability = IdentityAuthorizationConstants.Update,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsUpdate])]
     public static Task<Result<PosCartResponse>> Handle(
         ResumePosCartRequest request,
         PosCartService service,
@@ -129,9 +151,11 @@ public static class ResumePosCartEndpoint
 
 public static class CancelPosCartEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsDelete])]
     [MapPost("/api/pos/carts/{cartId:guid}/cancel", Tags = ["POS Carts"],
-        Summary = "Cancel POS cart")]
+        Summary = "Cancel POS cart",
+        Capability = IdentityAuthorizationConstants.Delete,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsDelete])]
     public static Task<Result<PosCartResponse>> Handle(
         CancelPosCartRequest request,
         PosCartService service,
@@ -141,10 +165,12 @@ public static class CancelPosCartEndpoint
 
 public static class CheckoutPosCartEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsUpdate, PosAuthorizationCapabilities.SalesCreate])]
     [MapPost("/api/pos/carts/{cartId:guid}/checkout", Tags = ["POS Carts"],
         Summary = "Checkout POS cart",
-        Description = "Converts a persisted POS cart into a sale through the existing checkout orchestration.")]
+        Description = "Converts a persisted POS cart into a sale through the existing checkout orchestration.",
+        Capability = IdentityAuthorizationConstants.Update,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.CartsUpdate, PosAuthorizationCapabilities.SalesCreate])]
     public static Task<Result<PosSaleReceiptResponse>> Handle(
         CheckoutPosCartRequest request,
         PosCartService service,
@@ -154,10 +180,12 @@ public static class CheckoutPosCartEndpoint
 
 public static class CheckoutPosSaleEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesCreate])]
     [MapPost("/api/pos/sales/checkout", Tags = ["POS Sales"],
         Summary = "Checkout POS sale",
-        Description = "Creates a sale, reserves Inventario stock, captures Wallets payment, and fulfills reservations.")]
+        Description = "Creates a sale, reserves Inventario stock, captures Wallets payment, and fulfills reservations.",
+        Capability = IdentityAuthorizationConstants.Create,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesCreate])]
     public static Task<Result<PosSaleReceiptResponse>> Handle(
         CheckoutPosSaleRequest request,
         PosSalesService service,
@@ -167,9 +195,11 @@ public static class CheckoutPosSaleEndpoint
 
 public static class GetPosSaleEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesView])]
     [MapGet("/api/pos/sales/{id:guid}", Tags = ["POS Sales"],
-        Summary = "Get POS sale")]
+        Summary = "Get POS sale",
+        Capability = IdentityAuthorizationConstants.View,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesView])]
     public static Task<Result<PosSaleReceiptResponse>> Handle(
         GetPosSaleRequest request,
         PosSalesService service,
@@ -179,9 +209,11 @@ public static class GetPosSaleEndpoint
 
 public static class SearchPosSalesEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesView])]
     [MapGet("/api/pos/sales", Tags = ["POS Sales"],
-        Summary = "Search POS sales")]
+        Summary = "Search POS sales",
+        Capability = IdentityAuthorizationConstants.View,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesView])]
     public static Task<Result<List<PosSaleSummaryResponse>>> Handle(
         SearchPosSalesRequest request,
         PosSalesService service,
@@ -191,9 +223,11 @@ public static class SearchPosSalesEndpoint
 
 public static class CancelPosSaleEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesDelete])]
     [MapPost("/api/pos/sales/{saleId:guid}/cancel", Tags = ["POS Sales"],
-        Summary = "Cancel POS sale")]
+        Summary = "Cancel POS sale",
+        Capability = IdentityAuthorizationConstants.Delete,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesDelete])]
     public static Task<Result<PosSaleReceiptResponse>> Handle(
         CancelPosSaleRequest request,
         PosSalesService service,
@@ -203,9 +237,11 @@ public static class CancelPosSaleEndpoint
 
 public static class RetryPosSaleFulfillmentEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesUpdate])]
     [MapPost("/api/pos/sales/{saleId:guid}/retry-fulfillment", Tags = ["POS Sales"],
-        Summary = "Retry POS sale fulfillment")]
+        Summary = "Retry POS sale fulfillment",
+        Capability = IdentityAuthorizationConstants.Update,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.SalesUpdate])]
     public static Task<Result<PosSaleReceiptResponse>> Handle(
         RetryPosSaleFulfillmentRequest request,
         PosSalesService service,
@@ -215,10 +251,12 @@ public static class RetryPosSaleFulfillmentEndpoint
 
 public static class CreatePosReturnEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.ReturnsCreate])]
     [MapPost("/api/pos/returns", Tags = ["POS Returns"],
         Summary = "Create POS return",
-        Description = "Posts returned stock through Inventario and refunds through Wallets.")]
+        Description = "Posts returned stock through Inventario and refunds through Wallets.",
+        Capability = IdentityAuthorizationConstants.Create,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.ReturnsCreate])]
     public static Task<Result<PosReturnResponse>> Handle(
         CreatePosReturnRequest request,
         PosReturnsService service,
@@ -228,9 +266,11 @@ public static class CreatePosReturnEndpoint
 
 public static class GetPosReturnEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.ReturnsView])]
     [MapGet("/api/pos/returns/{id:guid}", Tags = ["POS Returns"],
-        Summary = "Get POS return")]
+        Summary = "Get POS return",
+        Capability = IdentityAuthorizationConstants.View,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.ReturnsView])]
     public static Task<Result<PosReturnResponse>> Handle(
         GetPosReturnRequest request,
         PosReturnsService service,
@@ -240,9 +280,11 @@ public static class GetPosReturnEndpoint
 
 public static class SearchPosReturnsEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.ReturnsView])]
     [MapGet("/api/pos/returns", Tags = ["POS Returns"],
-        Summary = "Search POS returns")]
+        Summary = "Search POS returns",
+        Capability = IdentityAuthorizationConstants.View,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.ReturnsView])]
     public static Task<Result<List<PosReturnSummaryResponse>>> Handle(
         SearchPosReturnsRequest request,
         PosReturnsService service,
@@ -252,10 +294,12 @@ public static class SearchPosReturnsEndpoint
 
 public static class RetryPosReturnEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(RequiredActorCapabilities = [PosAuthorizationCapabilities.ReturnsUpdate])]
     [MapPost("/api/pos/returns/{returnId:guid}/retry", Tags = ["POS Returns"],
         Summary = "Retry POS return",
-        Description = "Retries recoverable inventory posting or refund failures for a POS return.")]
+        Description = "Retries recoverable inventory posting or refund failures for a POS return.",
+        Capability = IdentityAuthorizationConstants.Update,
+        RequiredActorCapabilities = [PosAuthorizationCapabilities.ReturnsUpdate])]
     public static Task<Result<PosReturnResponse>> Handle(
         RetryPosReturnRequest request,
         PosReturnsService service,

--- a/src/Modules/XFramework.POS/POS.Api/Features/PosValidators.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Features/PosValidators.cs
@@ -3,6 +3,11 @@ using POS.Domain.Shared.Contracts.Requests;
 
 namespace POS.Api.Features;
 
+internal static class PosValidationLimits
+{
+    public const int MaxTransactionLines = 100;
+}
+
 public sealed class SearchPosCatalogValidator : AbstractValidator<SearchPosCatalogRequest>
 {
     public SearchPosCatalogValidator()
@@ -66,6 +71,8 @@ public sealed class CreatePosCartValidator : AbstractValidator<CreatePosCartRequ
         RuleFor(x => x.TaxAmount).GreaterThanOrEqualTo(0);
         RuleFor(x => x.IdempotencyKey).MaximumLength(160).When(x => !string.IsNullOrWhiteSpace(x.IdempotencyKey));
         RuleFor(x => x.Lines).NotEmpty();
+        RuleFor(x => x.Lines).Must(lines => lines is not null && lines.Count <= PosValidationLimits.MaxTransactionLines)
+            .WithMessage($"A POS cart cannot contain more than {PosValidationLimits.MaxTransactionLines} lines");
         RuleForEach(x => x.Lines).SetValidator(new PosCartLineValidator());
     }
 }
@@ -80,6 +87,8 @@ public sealed class UpdatePosCartValidator : AbstractValidator<UpdatePosCartRequ
         RuleFor(x => x.DiscountAmount).GreaterThanOrEqualTo(0);
         RuleFor(x => x.TaxAmount).GreaterThanOrEqualTo(0);
         RuleFor(x => x.Lines).NotEmpty();
+        RuleFor(x => x.Lines).Must(lines => lines is not null && lines.Count <= PosValidationLimits.MaxTransactionLines)
+            .WithMessage($"A POS cart cannot contain more than {PosValidationLimits.MaxTransactionLines} lines");
         RuleForEach(x => x.Lines).SetValidator(new PosCartLineValidator());
     }
 }
@@ -158,6 +167,8 @@ public sealed class CheckoutPosSaleValidator : AbstractValidator<CheckoutPosSale
         RuleFor(x => x.TaxAmount).GreaterThanOrEqualTo(0);
         RuleFor(x => x.IdempotencyKey).NotEmpty().MaximumLength(160);
         RuleFor(x => x.Lines).NotEmpty();
+        RuleFor(x => x.Lines).Must(lines => lines is not null && lines.Count <= PosValidationLimits.MaxTransactionLines)
+            .WithMessage($"A POS sale cannot contain more than {PosValidationLimits.MaxTransactionLines} lines");
         RuleFor(x => x.Payment).NotNull();
         RuleFor(x => x.Payment.Amount).GreaterThanOrEqualTo(0);
         RuleFor(x => x.Payment.Method).IsInEnum();
@@ -217,11 +228,17 @@ public sealed class CreatePosReturnValidator : AbstractValidator<CreatePosReturn
         RuleFor(x => x.Reason).MaximumLength(500).When(x => !string.IsNullOrWhiteSpace(x.Reason));
         RuleFor(x => x.IdempotencyKey).NotEmpty().MaximumLength(160);
         RuleFor(x => x.Lines).NotEmpty();
+        RuleFor(x => x.Lines).Must(lines => lines is not null && lines.Count <= PosValidationLimits.MaxTransactionLines)
+            .WithMessage($"A POS return cannot contain more than {PosValidationLimits.MaxTransactionLines} lines");
+        RuleFor(x => x.Lines).Must(lines =>
+                lines is not null && lines.Select(line => line.SaleLineId).Distinct().Count() == lines.Count)
+            .WithMessage("A sale line can appear only once in a POS return");
         RuleForEach(x => x.Lines).ChildRules(line =>
         {
             line.RuleFor(x => x.SaleLineId).NotEmpty();
             line.RuleFor(x => x.Quantity).GreaterThan(0);
-            line.RuleFor(x => x.TaxAmount).GreaterThanOrEqualTo(0);
+            line.RuleFor(x => x.TaxAmount).Equal(0)
+                .WithMessage("Return tax is calculated from the original sale and must not be supplied by the client");
         });
     }
 }

--- a/src/Modules/XFramework.POS/POS.Api/Properties/AssemblyInfo.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("POS.Api.Tests")]

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosCartService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosCartService.cs
@@ -31,11 +31,17 @@ public sealed class PosCartService(
         var tenantId = contextResult.Data!.TenantId;
 
         var idempotencyKey = PosServiceHelpers.NormalizeOptional(request.IdempotencyKey) ?? string.Empty;
+        var requestHash = PosServiceHelpers.BuildCartRequestHash(request);
         if (!string.IsNullOrWhiteSpace(idempotencyKey))
         {
             var replay = await LoadCartByIdempotencyAsync(tenantId, idempotencyKey, ct);
             if (replay is not null)
+            {
+                if (!string.Equals(replay.RequestHash, requestHash, StringComparison.Ordinal))
+                    return Result<PosCartResponse>.Conflict("Cart idempotency key was reused with a different payload");
+
                 return Result<PosCartResponse>.Success(PosServiceHelpers.ToCartResponse(replay), "POS cart replayed");
+            }
         }
 
         var register = await LoadRegisterAsync(tenantId, request.RegisterId, ct);
@@ -61,6 +67,7 @@ public sealed class PosCartService(
             DiscountAmount = request.DiscountAmount,
             TaxAmount = request.TaxAmount,
             IdempotencyKey = idempotencyKey,
+            RequestHash = requestHash,
             SuspendedAt = request.Suspend ? now : null,
             ExpiresAt = now.Add(CartTtl),
             CreatedAt = now,
@@ -88,7 +95,22 @@ public sealed class PosCartService(
             return Result<PosCartResponse>.Failure(totalsResult.Message!, totalsResult.StatusCode);
 
         db.Set<PosCart>().Add(cart);
-        await db.SaveChangesAsync(ct);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException) when (!string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            db.ChangeTracker.Clear();
+            var concurrentReplay = await LoadCartByIdempotencyAsync(tenantId, idempotencyKey, ct);
+            if (concurrentReplay is null)
+                throw;
+
+            if (!string.Equals(concurrentReplay.RequestHash, requestHash, StringComparison.Ordinal))
+                return Result<PosCartResponse>.Conflict("Cart idempotency key was reused with a different payload");
+
+            return Result<PosCartResponse>.Success(PosServiceHelpers.ToCartResponse(concurrentReplay), "POS cart replayed");
+        }
 
         return Result<PosCartResponse>.Success(
             PosServiceHelpers.ToCartResponse(cart),
@@ -632,7 +654,7 @@ public sealed class PosCartService(
     private static Result ApplyTotals(PosCart cart)
     {
         cart.SubtotalAmount = cart.Lines.Sum(line => line.Quantity * line.UnitPrice);
-        cart.TotalAmount = cart.SubtotalAmount - cart.DiscountAmount + cart.TaxAmount;
+        cart.TotalAmount = cart.Lines.Sum(line => line.LineTotal) - cart.DiscountAmount + cart.TaxAmount;
 
         return cart.TotalAmount < 0
             ? Result.Failure("Cart total cannot be negative", 400)

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosRegisterService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosRegisterService.cs
@@ -2,15 +2,20 @@ using Microsoft.EntityFrameworkCore;
 using POS.Domain.Shared.Contracts;
 using POS.Domain.Shared.Contracts.Requests;
 using POS.Domain.Shared.Contracts.Responses;
-using IdentityServer.Domain.Shared.Contracts;
-using Wallets.Domain.Shared.Contracts;
+using IdentityServer.Integration.Drivers;
+using Inventario.Integration.Drivers;
+using Wallets.Integration.Drivers;
 using XFramework.Core.Patterns;
 using XFramework.Domain.Contexts;
-using XFramework.Inventario.Domain.Shared.Contracts;
 
 namespace POS.Api.Services;
 
-public sealed class PosRegisterService(AppDbContext db, IPosRequestContextResolver contextResolver)
+public sealed class PosRegisterService(
+    AppDbContext db,
+    IPosRequestContextResolver contextResolver,
+    IIdentityServerServiceWrapper identityServer,
+    IWalletsServiceWrapper wallets,
+    IInventarioServiceWrapper inventario)
 {
     public async Task<Result<PosRegisterResponse>> GetAsync(
         GetPosRegisterRequest request,
@@ -176,52 +181,50 @@ public sealed class PosRegisterService(AppDbContext db, IPosRequestContextResolv
         Guid locationId,
         CancellationToken ct)
     {
-        var merchantExists = await db.Set<IdentityCredential>()
-            .AsNoTracking()
-            .AnyAsync(item => item.TenantId == tenantId && item.Id == merchantCredentialId && !item.IsDeleted, ct);
-        if (!merchantExists)
+        var merchantResponse = await identityServer.IdentityCredential.Get(merchantCredentialId, tenantId);
+        var merchant = merchantResponse.Response;
+        if (!merchantResponse.IsSuccess || merchant is null || merchant.IsDeleted || merchant.TenantId != tenantId)
             return Result.NotFound("Merchant credential was not found for this tenant");
 
-        var walletType = await db.Set<WalletType>()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == walletTypeId && !item.IsDeleted, ct);
-        if (walletType is null)
+        var walletTypeResponse = await wallets.WalletType.Get(walletTypeId, tenantId);
+        var walletType = walletTypeResponse.Response;
+        if (!walletTypeResponse.IsSuccess || walletType is null || walletType.IsDeleted || walletType.TenantId != tenantId)
             return Result.NotFound("Wallet type was not found for this tenant");
 
         if (walletType.CurrencyTypeId.HasValue && walletType.CurrencyTypeId.Value != currencyId)
             return Result.Conflict("Wallet type currency does not match the POS register currency");
 
-        var currencyExists = await db.Set<CurrencyType>()
-            .AsNoTracking()
-            .AnyAsync(item => item.TenantId == tenantId && item.Id == currencyId && !item.IsDeleted, ct);
-        if (!currencyExists)
+        var currencyResponse = await wallets.CurrencyType.Get(currencyId, tenantId);
+        var currency = currencyResponse.Response;
+        if (!currencyResponse.IsSuccess || currency is null || currency.IsDeleted || currency.TenantId != tenantId)
             return Result.NotFound("Currency was not found for this tenant");
 
-        var cashDrawerWallet = await db.Set<Wallet>()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == cashDrawerWalletId && !item.IsDeleted, ct);
-        if (cashDrawerWallet is null)
+        var cashDrawerWalletResponse = await wallets.Wallet.Get(cashDrawerWalletId, tenantId);
+        var cashDrawerWallet = cashDrawerWalletResponse.Response;
+        if (!cashDrawerWalletResponse.IsSuccess || cashDrawerWallet is null || cashDrawerWallet.IsDeleted || cashDrawerWallet.TenantId != tenantId)
             return Result.NotFound("Cash drawer wallet was not found for this tenant");
+
+        if (cashDrawerWallet.CredentialId != merchantCredentialId)
+            return Result.Conflict("Cash drawer wallet does not belong to the merchant credential");
 
         if (cashDrawerWallet.WalletTypeId.HasValue && cashDrawerWallet.WalletTypeId.Value != walletTypeId)
             return Result.Conflict("Cash drawer wallet type does not match the POS register wallet type");
 
-        var warehouseExists = await db.Set<Warehouse>()
-            .AsNoTracking()
-            .AnyAsync(item => item.TenantId == tenantId && item.Id == warehouseId && !item.IsDeleted, ct);
-        if (!warehouseExists)
+        var warehouseResponse = await inventario.Warehouse.Get(warehouseId, tenantId);
+        var warehouse = warehouseResponse.Response;
+        if (!warehouseResponse.IsSuccess || warehouse is null || warehouse.IsDeleted || warehouse.TenantId != tenantId)
             return Result.NotFound("Warehouse was not found for this tenant");
 
-        var locationExists = await db.Set<InventoryLocation>()
-            .AsNoTracking()
-            .AnyAsync(item =>
-                item.TenantId == tenantId &&
-                item.Id == locationId &&
-                item.WarehouseId == warehouseId &&
-                !item.IsDeleted,
-                ct);
-        if (!locationExists)
+        var locationResponse = await inventario.InventoryLocation.Get(locationId, tenantId);
+        var location = locationResponse.Response;
+        if (!locationResponse.IsSuccess ||
+            location is null ||
+            location.IsDeleted ||
+            location.TenantId != tenantId ||
+            location.WarehouseId != warehouseId)
+        {
             return Result.NotFound("Location was not found in the selected warehouse for this tenant");
+        }
 
         return Result.Success();
     }

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosReturnsService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosReturnsService.cs
@@ -48,11 +48,18 @@ public sealed class PosReturnsService(
         if (request.Lines.Count == 0)
             return Result<PosReturnResponse>.Failure("At least one return line is required", 400);
 
+        if (request.Lines.Select(line => line.SaleLineId).Distinct().Count() != request.Lines.Count)
+            return Result<PosReturnResponse>.Failure("A sale line can appear only once in a POS return", 400);
+
+        if (request.Lines.Any(line => line.TaxAmount != 0))
+            return Result<PosReturnResponse>.Failure("Return tax is calculated from the original sale", 400);
+
         await using var transaction = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct);
         var sale = await db.Set<PosSale>()
             .AsTracking()
             .Include(item => item.Register)
             .Include(item => item.Lines)
+            .Include(item => item.Payments)
             .FirstOrDefaultAsync(item =>
                 item.TenantId == context.TenantId &&
                 item.Id == request.SaleId &&
@@ -89,18 +96,53 @@ public sealed class PosReturnsService(
             Register = sale.Register
         };
         posReturn.ReturnNumber = PosServiceHelpers.NewReturnNumber(now, posReturn.Id);
-        posReturn.Lines = await BuildReturnLinesAsync(posReturn, sale, request, context.TenantId, ct);
+        var lineResult = await BuildReturnLinesAsync(posReturn, sale, request, context.TenantId, ct);
+        if (!lineResult.IsSuccess)
+            return Result<PosReturnResponse>.Failure(lineResult.Message!, lineResult.StatusCode);
 
-        if (posReturn.Lines.Count != request.Lines.Count)
-            return Result<PosReturnResponse>.Failure("One or more return lines are invalid", 400);
-
-        posReturn.SubtotalAmount = posReturn.Lines.Sum(line => line.Quantity * line.UnitPrice);
+        posReturn.Lines = lineResult.Data!;
         posReturn.TaxAmount = posReturn.Lines.Sum(line => line.TaxAmount);
-        posReturn.TotalRefundAmount = posReturn.SubtotalAmount + posReturn.TaxAmount;
+        posReturn.TotalRefundAmount = posReturn.Lines.Sum(line => line.RefundAmount);
+        posReturn.SubtotalAmount = posReturn.TotalRefundAmount - posReturn.TaxAmount;
+
+        var capturedAmount = sale.Payments
+            .Where(payment => payment.Status == PosPaymentStatus.Captured)
+            .Sum(payment => payment.Amount);
+        var saleLineIds = sale.Lines.Select(line => line.Id).ToList();
+        var previouslyAllocatedRefund = await db.Set<PosReturnLine>()
+            .AsNoTracking()
+            .Where(line =>
+                line.TenantId == context.TenantId &&
+                saleLineIds.Contains(line.SaleLineId) &&
+                !line.IsDeleted)
+            .SumAsync(line => line.RefundAmount, ct);
+
+        if (previouslyAllocatedRefund + posReturn.TotalRefundAmount > capturedAmount)
+            return Result<PosReturnResponse>.Conflict("Return total exceeds the captured payment amount");
 
         db.Set<PosReturn>().Add(posReturn);
-        await db.SaveChangesAsync(ct);
-        await transaction.CommitAsync(ct);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+            await transaction.CommitAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            await transaction.RollbackAsync(ct);
+            db.ChangeTracker.Clear();
+            var concurrentReplay = await LoadReturnByIdempotencyAsync(
+                context.TenantId,
+                idempotencyKey,
+                tracking: true,
+                ct);
+            if (concurrentReplay is null)
+                throw;
+
+            if (!string.Equals(concurrentReplay.RequestHash, requestHash, StringComparison.Ordinal))
+                return Result<PosReturnResponse>.Conflict("Return idempotency key was reused with a different payload");
+
+            return await ExecuteReturnWorkflowAsync(concurrentReplay, context.Metadata, ct, replayed: true);
+        }
 
         return await ExecuteReturnWorkflowAsync(posReturn, context.Metadata, ct, replayed: false);
     }
@@ -238,7 +280,7 @@ public sealed class PosReturnsService(
             : Result<PosReturnResponse>.Success(response, 201, "POS return completed");
     }
 
-    private async Task<List<PosReturnLine>> BuildReturnLinesAsync(
+    private async Task<Result<List<PosReturnLine>>> BuildReturnLinesAsync(
         PosReturn posReturn,
         PosSale sale,
         CreatePosReturnRequest request,
@@ -246,25 +288,55 @@ public sealed class PosReturnsService(
         CancellationToken ct)
     {
         var lines = new List<PosReturnLine>();
+        var saleLineIds = sale.Lines.Select(line => line.Id).ToList();
+        var previousReturns = await db.Set<PosReturnLine>()
+            .AsNoTracking()
+            .Where(line =>
+                line.TenantId == tenantId &&
+                saleLineIds.Contains(line.SaleLineId) &&
+                !line.IsDeleted)
+            .GroupBy(line => line.SaleLineId)
+            .Select(group => new
+            {
+                SaleLineId = group.Key,
+                Quantity = group.Sum(line => line.Quantity),
+                TaxAmount = group.Sum(line => line.TaxAmount),
+                RefundAmount = group.Sum(line => line.RefundAmount)
+            })
+            .ToDictionaryAsync(item => item.SaleLineId, ct);
+        var allocations = PosServiceHelpers.BuildSaleRefundAllocations(sale);
 
         foreach (var requestLine in request.Lines)
         {
             var saleLine = sale.Lines.FirstOrDefault(item => item.Id == requestLine.SaleLineId);
-            if (saleLine is null || requestLine.Quantity <= 0)
-                continue;
+            if (saleLine is null)
+                return Result<List<PosReturnLine>>.NotFound("POS sale line was not found");
 
-            var returnedQuantity = await db.Set<PosReturnLine>()
-                .AsNoTracking()
-                .Where(item =>
-                    item.TenantId == tenantId &&
-                    item.SaleLineId == saleLine.Id &&
-                    !item.IsDeleted)
-                .SumAsync(item => item.Quantity, ct);
+            if (requestLine.Quantity <= 0)
+                return Result<List<PosReturnLine>>.Failure("Return quantity must be greater than zero", 400);
 
-            if (returnedQuantity + requestLine.Quantity > saleLine.Quantity)
-                continue;
+            previousReturns.TryGetValue(saleLine.Id, out var previous);
+            var returnedQuantity = previous?.Quantity ?? 0;
+            var remainingQuantity = saleLine.Quantity - returnedQuantity;
+            if (requestLine.Quantity > remainingQuantity)
+                return Result<List<PosReturnLine>>.Conflict("Return quantity exceeds the remaining sale line quantity");
 
-            var refundAmount = requestLine.Quantity * saleLine.UnitPrice + requestLine.TaxAmount;
+            var allocation = allocations[saleLine.Id];
+            var remainingRefund = allocation.RefundAmount - (previous?.RefundAmount ?? 0);
+            var remainingTax = allocation.TaxAmount - (previous?.TaxAmount ?? 0);
+            var partialAllocation = PosServiceHelpers.BuildPartialReturnAllocation(
+                allocation,
+                saleLine.Quantity,
+                returnedQuantity,
+                previous?.TaxAmount ?? 0,
+                previous?.RefundAmount ?? 0,
+                requestLine.Quantity);
+            var refundAmount = partialAllocation.RefundAmount;
+            var taxAmount = partialAllocation.TaxAmount;
+
+            if (refundAmount < 0 || refundAmount > remainingRefund || taxAmount > remainingTax)
+                return Result<List<PosReturnLine>>.Conflict("Return amount exceeds the remaining refundable amount");
+
             lines.Add(new PosReturnLine
             {
                 Id = Guid.NewGuid(),
@@ -277,7 +349,7 @@ public sealed class PosReturnsService(
                 VariantName = saleLine.VariantName,
                 Quantity = requestLine.Quantity,
                 UnitPrice = saleLine.UnitPrice,
-                TaxAmount = requestLine.TaxAmount,
+                TaxAmount = taxAmount,
                 RefundAmount = refundAmount,
                 WarehouseId = saleLine.WarehouseId,
                 LocationId = saleLine.LocationId,
@@ -288,7 +360,7 @@ public sealed class PosReturnsService(
             });
         }
 
-        return lines;
+        return Result<List<PosReturnLine>>.Success(lines);
     }
 
     private async Task<Result> PostReturnInventoryAsync(

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosSalesService.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosSalesService.cs
@@ -91,16 +91,32 @@ public sealed class PosSalesService(
 
         sale.Lines = lineBuildResult.Data!;
         sale.SubtotalAmount = sale.Lines.Sum(line => line.Quantity * line.UnitPrice);
-        sale.TotalAmount = sale.SubtotalAmount - sale.DiscountAmount + sale.TaxAmount;
+        var allocations = PosServiceHelpers.BuildSaleRefundAllocations(sale);
+        sale.TotalAmount = allocations.Values.Sum(allocation => allocation.RefundAmount);
 
-        if (sale.TotalAmount < 0)
-            return Result<PosSaleReceiptResponse>.Failure("Sale total cannot be negative", 400);
+        if (allocations.Values.Any(allocation => allocation.RefundAmount < 0))
+            return Result<PosSaleReceiptResponse>.Failure("Sale discounts cannot make a line total negative", 400);
 
         if (request.Payment.Amount != sale.TotalAmount)
             return Result<PosSaleReceiptResponse>.Conflict("Payment amount does not match sale total");
 
         db.Set<PosSale>().Add(sale);
-        await db.SaveChangesAsync(ct);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            db.ChangeTracker.Clear();
+            var concurrentReplay = await LoadSaleByIdempotencyAsync(tenantId, idempotencyKey, tracking: true, ct);
+            if (concurrentReplay is null)
+                throw;
+
+            if (!string.Equals(concurrentReplay.RequestHash, requestHash, StringComparison.Ordinal))
+                return Result<PosSaleReceiptResponse>.Conflict("Checkout idempotency key was reused with a different payload");
+
+            return await ContinueCheckoutAsync(concurrentReplay, register, request, context.Metadata, ct, replayed: true);
+        }
 
         return await ContinueCheckoutAsync(sale, register, request, context.Metadata, ct, replayed: false);
     }
@@ -143,7 +159,19 @@ public sealed class PosSalesService(
                 payment = CreatePayment(sale, register, request);
                 db.Set<PosPayment>().Add(payment);
                 sale.Payments.Add(payment);
-                await db.SaveChangesAsync(ct);
+                try
+                {
+                    await db.SaveChangesAsync(ct);
+                }
+                catch (DbUpdateException)
+                {
+                    db.ChangeTracker.Clear();
+                    var concurrentSale = await LoadSaleAsync(sale.TenantId, sale.Id, true, ct);
+                    if (concurrentSale?.Payments.Count != 1)
+                        throw;
+
+                    return await ContinueCheckoutAsync(concurrentSale, register, request, metadata, ct, replayed: true);
+                }
             }
 
             if (payment.Status == PosPaymentStatus.Failed)
@@ -478,7 +506,7 @@ public sealed class PosSalesService(
             IsEnabled = true
         };
 
-        payment.ReferenceNumber = PosServiceHelpers.SalePaymentReference(sale, payment);
+        payment.ReferenceNumber = PosServiceHelpers.SalePaymentReference(sale);
         payment.IdempotencyKey = payment.ReferenceNumber;
         return payment;
     }

--- a/src/Modules/XFramework.POS/POS.Api/Services/PosServiceHelpers.cs
+++ b/src/Modules/XFramework.POS/POS.Api/Services/PosServiceHelpers.cs
@@ -31,8 +31,8 @@ internal static class PosServiceHelpers
     public static string NewCartNumber(DateTime now, Guid cartId) =>
         $"CART-{now:yyyyMMddHHmmss}-{cartId:N}"[..32];
 
-    public static string SalePaymentReference(PosSale sale, PosPayment payment) =>
-        $"POS-SALE-{sale.Id:N}-{payment.Id:N}"[..80];
+    public static string SalePaymentReference(PosSale sale) =>
+        $"POS-SALE-{sale.Id:N}-PAYMENT";
 
     public static string SaleLineReservationReference(PosSaleLine line) =>
         $"POS-LINE-{line.Id:N}"[..80];
@@ -89,6 +89,92 @@ internal static class PosServiceHelpers
                 line.TaxAmount
             }).ToArray()
         });
+
+    public static string BuildCartRequestHash(CreatePosCartRequest request) =>
+        Hash(new
+        {
+            request.RegisterId,
+            request.CashierCredentialId,
+            request.CustomerCredentialId,
+            request.CustomerLabel,
+            request.Notes,
+            request.WarehouseId,
+            request.LocationId,
+            request.CurrencyId,
+            request.WalletTypeId,
+            request.DiscountAmount,
+            request.TaxAmount,
+            request.Suspend,
+            Lines = request.Lines.Select((line, index) => new
+            {
+                index,
+                line.ProductId,
+                line.ProductVariationId,
+                line.Quantity,
+                line.ExpectedUnitPrice,
+                line.DiscountAmount,
+                line.TaxAmount,
+                line.WarehouseId,
+                line.LocationId,
+                line.LotId
+            }).ToArray()
+        });
+
+    public static IReadOnlyDictionary<Guid, PosSaleLineRefundAllocation> BuildSaleRefundAllocations(PosSale sale)
+    {
+        var orderedLines = sale.Lines.OrderBy(line => line.LineNumber).ToList();
+        var grossSubtotal = orderedLines.Sum(line => line.Quantity * line.UnitPrice);
+        var remainingHeaderDiscount = sale.DiscountAmount;
+        var remainingHeaderTax = sale.TaxAmount;
+        var allocations = new Dictionary<Guid, PosSaleLineRefundAllocation>(orderedLines.Count);
+
+        for (var index = 0; index < orderedLines.Count; index++)
+        {
+            var line = orderedLines[index];
+            var isLast = index == orderedLines.Count - 1;
+            var grossLineAmount = line.Quantity * line.UnitPrice;
+            var headerDiscount = isLast
+                ? remainingHeaderDiscount
+                : AllocateProportion(sale.DiscountAmount, grossLineAmount, grossSubtotal);
+            var headerTax = isLast
+                ? remainingHeaderTax
+                : AllocateProportion(sale.TaxAmount, grossLineAmount, grossSubtotal);
+
+            remainingHeaderDiscount -= headerDiscount;
+            remainingHeaderTax -= headerTax;
+            allocations[line.Id] = new PosSaleLineRefundAllocation(
+                line.TaxAmount + headerTax,
+                line.LineTotal - headerDiscount + headerTax);
+        }
+
+        return allocations;
+    }
+
+    public static PosSaleLineRefundAllocation BuildPartialReturnAllocation(
+        PosSaleLineRefundAllocation original,
+        decimal originalQuantity,
+        decimal previouslyReturnedQuantity,
+        decimal previouslyReturnedTax,
+        decimal previouslyReturnedRefund,
+        decimal requestedQuantity)
+    {
+        var remainingQuantity = originalQuantity - previouslyReturnedQuantity;
+        if (requestedQuantity == remainingQuantity)
+        {
+            return new PosSaleLineRefundAllocation(
+                original.TaxAmount - previouslyReturnedTax,
+                original.RefundAmount - previouslyReturnedRefund);
+        }
+
+        return new PosSaleLineRefundAllocation(
+            decimal.Round(original.TaxAmount * requestedQuantity / originalQuantity, 2, MidpointRounding.AwayFromZero),
+            decimal.Round(original.RefundAmount * requestedQuantity / originalQuantity, 2, MidpointRounding.AwayFromZero));
+    }
+
+    private static decimal AllocateProportion(decimal amount, decimal lineAmount, decimal totalAmount) =>
+        amount == 0 || totalAmount == 0
+            ? 0
+            : decimal.Round(amount * lineAmount / totalAmount, 2, MidpointRounding.AwayFromZero);
 
     private static string Hash<T>(T value)
     {
@@ -327,3 +413,5 @@ internal static class PosServiceHelpers
         FailureReason = line.FailureReason
     };
 }
+
+internal readonly record struct PosSaleLineRefundAllocation(decimal TaxAmount, decimal RefundAmount);

--- a/src/Modules/XFramework.POS/POS.Domain.Shared/Configurations/PosEntityConfigurations.cs
+++ b/src/Modules/XFramework.POS/POS.Domain.Shared/Configurations/PosEntityConfigurations.cs
@@ -77,6 +77,7 @@ public sealed class PosCartConfiguration : IEntityTypeConfiguration<PosCart>
         entity.Property(e => e.TotalAmount).HasPrecision(18, 2);
         entity.Property(e => e.IdempotencyKey).HasMaxLength(160);
         entity.Property(e => e.CancelReason).HasMaxLength(500);
+        entity.Property(e => e.RequestHash).HasMaxLength(64);
 
         entity.HasIndex(e => new { e.TenantId, e.CartNumber })
             .IsUnique()
@@ -188,7 +189,9 @@ public sealed class PosPaymentConfiguration : IEntityTypeConfiguration<PosPaymen
         entity.Property(e => e.RefundedAmount).HasPrecision(18, 2);
 
         entity.HasIndex(e => new { e.TenantId, e.SaleId })
-            .HasDatabaseName("IX_POS_Payment_Tenant_Sale");
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false")
+            .HasDatabaseName("UX_POS_Payment_Tenant_Sale_Active");
         entity.HasIndex(e => new { e.TenantId, e.IdempotencyKey })
             .IsUnique()
             .HasFilter("\"IsDeleted\" = false")

--- a/src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/PosAuthorizationCapabilities.cs
+++ b/src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/PosAuthorizationCapabilities.cs
@@ -1,0 +1,19 @@
+namespace POS.Domain.Shared.Contracts;
+
+public static class PosAuthorizationCapabilities
+{
+    public const string RegistersView = "pos.registers:view";
+    public const string RegistersCreate = "pos.registers:create";
+    public const string RegistersUpdate = "pos.registers:update";
+    public const string SalesView = "pos.sales:view";
+    public const string SalesCreate = "pos.sales:create";
+    public const string SalesUpdate = "pos.sales:update";
+    public const string SalesDelete = "pos.sales:delete";
+    public const string CartsView = "pos.carts:view";
+    public const string CartsCreate = "pos.carts:create";
+    public const string CartsUpdate = "pos.carts:update";
+    public const string CartsDelete = "pos.carts:delete";
+    public const string ReturnsView = "pos.returns:view";
+    public const string ReturnsCreate = "pos.returns:create";
+    public const string ReturnsUpdate = "pos.returns:update";
+}

--- a/src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/PosEntities.cs
+++ b/src/Modules/XFramework.POS/POS.Domain.Shared/Contracts/PosEntities.cs
@@ -125,6 +125,9 @@ public partial class PosCart : BaseModel
     [MemoryPackOrder(21)]
     public string? CancelReason { get; set; }
 
+    [MemoryPackOrder(22)]
+    public string? RequestHash { get; set; }
+
     [MemoryPackIgnore]
     public virtual PosRegister Register { get; set; } = null!;
 

--- a/src/Tests/Inventario.Api.Tests/ReservationServiceTests.cs
+++ b/src/Tests/Inventario.Api.Tests/ReservationServiceTests.cs
@@ -264,6 +264,46 @@ public sealed class ReservationServiceTests
     }
 
     [Test]
+    public async Task FulfillAsync_AlreadyFulfilledReservation_ReplaysWithoutPostingStockAgain()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var reservationId = Guid.NewGuid();
+        var dataContext = SeedReservationData(tenantId, ids, onHand: 10, reserved: 4, reservationId);
+        var service = CreateService(dataContext, tenantId);
+        var request = new FulfillReservationRequest { ReservationId = reservationId };
+
+        var first = await service.FulfillAsync(request);
+        var second = await service.FulfillAsync(request);
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        second.IsSuccess.Should().BeTrue(second.Message);
+        second.Data!.Status.Should().Be(ReservationStatus.Fulfilled);
+        dataContext.Added.OfType<InventoryMovement>().Should().HaveCount(2);
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task ReleaseAsync_AlreadyReleasedReservation_ReplaysWithoutPostingStockAgain()
+    {
+        var tenantId = Guid.NewGuid();
+        var ids = TestIds.Create();
+        var reservationId = Guid.NewGuid();
+        var dataContext = SeedReservationData(tenantId, ids, onHand: 10, reserved: 4, reservationId);
+        var service = CreateService(dataContext, tenantId);
+        var request = new ReleaseReservationRequest { ReservationId = reservationId };
+
+        var first = await service.ReleaseAsync(request);
+        var second = await service.ReleaseAsync(request);
+
+        first.IsSuccess.Should().BeTrue(first.Message);
+        second.IsSuccess.Should().BeTrue(second.Message);
+        second.Data!.Status.Should().Be(ReservationStatus.Released);
+        dataContext.Added.OfType<InventoryMovement>().Should().ContainSingle();
+        dataContext.SaveCount.Should().Be(1);
+    }
+
+    [Test]
     public async Task ExpireAsync_DueReservation_ReleasesReservedQuantity()
     {
         var tenantId = Guid.NewGuid();

--- a/src/Tests/POS.Api.Tests/PosFinancialInvariantTests.cs
+++ b/src/Tests/POS.Api.Tests/PosFinancialInvariantTests.cs
@@ -1,0 +1,67 @@
+using POS.Api.Services;
+using POS.Domain.Shared.Contracts;
+using XFramework.TestInfrastructure;
+
+namespace POS.Api.Tests;
+
+[TestFixture]
+[Category(TestCategories.POS)]
+public sealed class PosFinancialInvariantTests
+{
+    [Test]
+    public void BuildSaleRefundAllocations_ReconcilesLineAndHeaderAdjustmentsExactly()
+    {
+        var sale = new PosSale
+        {
+            DiscountAmount = 20,
+            TaxAmount = 10,
+            Lines =
+            [
+                new PosSaleLine
+                {
+                    Id = Guid.NewGuid(),
+                    LineNumber = 1,
+                    Quantity = 2,
+                    UnitPrice = 50,
+                    DiscountAmount = 10,
+                    TaxAmount = 5,
+                    LineTotal = 95
+                },
+                new PosSaleLine
+                {
+                    Id = Guid.NewGuid(),
+                    LineNumber = 2,
+                    Quantity = 1,
+                    UnitPrice = 100,
+                    LineTotal = 100
+                }
+            ]
+        };
+
+        var allocations = PosServiceHelpers.BuildSaleRefundAllocations(sale);
+
+        allocations[sale.Lines.ElementAt(0).Id].Should().Be(new PosSaleLineRefundAllocation(10, 90));
+        allocations[sale.Lines.ElementAt(1).Id].Should().Be(new PosSaleLineRefundAllocation(5, 95));
+        allocations.Values.Sum(item => item.RefundAmount).Should().Be(185);
+    }
+
+    [Test]
+    public void BuildPartialReturnAllocation_FinalReturnReceivesRoundingRemainder()
+    {
+        var original = new PosSaleLineRefundAllocation(1, 10);
+
+        var first = PosServiceHelpers.BuildPartialReturnAllocation(original, 3, 0, 0, 0, 1);
+        var final = PosServiceHelpers.BuildPartialReturnAllocation(
+            original,
+            3,
+            1,
+            first.TaxAmount,
+            first.RefundAmount,
+            2);
+
+        first.Should().Be(new PosSaleLineRefundAllocation(0.33m, 3.33m));
+        final.Should().Be(new PosSaleLineRefundAllocation(0.67m, 6.67m));
+        (first.RefundAmount + final.RefundAmount).Should().Be(10);
+        (first.TaxAmount + final.TaxAmount).Should().Be(1);
+    }
+}

--- a/src/Tests/POS.Api.Tests/PosOrchestrationContractTests.cs
+++ b/src/Tests/POS.Api.Tests/PosOrchestrationContractTests.cs
@@ -77,6 +77,32 @@ public sealed class PosOrchestrationContractTests
         source.Should().Contain("MapGeneratedEndpoints");
     }
 
+    [Test]
+    public void PosEndpoints_RequireOperationCapabilitiesForHttpAndBolt()
+    {
+        var source = ReadSource("src", "Modules", "XFramework.POS", "POS.Api", "Features", "PosEndpoints.cs");
+
+        source.Should().Contain("RequiredActorCapabilities");
+        source.Should().Contain("PosAuthorizationCapabilities.SalesCreate");
+        source.Should().Contain("PosAuthorizationCapabilities.RegistersUpdate");
+        source.Should().Contain("PosAuthorizationCapabilities.CartsDelete");
+        source.Should().Contain("PosAuthorizationCapabilities.ReturnsCreate");
+    }
+
+    [Test]
+    public void RegisterService_ValidatesReferencesThroughRemoteWrappersAndWalletOwnership()
+    {
+        var source = ReadSource("src", "Modules", "XFramework.POS", "POS.Api", "Services", "PosRegisterService.cs");
+
+        source.Should().Contain("identityServer.IdentityCredential.Get");
+        source.Should().Contain("wallets.Wallet.Get");
+        source.Should().Contain("inventario.Warehouse.Get");
+        source.Should().Contain("cashDrawerWallet.CredentialId != merchantCredentialId");
+        source.Should().NotContain("db.Set<Wallet>");
+        source.Should().NotContain("db.Set<Warehouse>");
+        source.Should().NotContain("db.Set<IdentityCredential>");
+    }
+
     private static string ReadSource(params string[] segments)
     {
         var repositoryRoot = FindRepositoryRoot();

--- a/src/Tests/POS.Api.Tests/PosValidatorTests.cs
+++ b/src/Tests/POS.Api.Tests/PosValidatorTests.cs
@@ -207,6 +207,48 @@ public sealed class PosValidatorTests
         result.Errors.Should().Contain(error => error.PropertyName == nameof(RetryPosReturnRequest.ReturnId));
     }
 
+    [Test]
+    public void CreatePosReturnValidator_DuplicateLinesOrClientTax_ReturnsValidationErrors()
+    {
+        var saleLineId = Guid.NewGuid();
+        var request = new CreatePosReturnRequest
+        {
+            SaleId = Guid.NewGuid(),
+            CashierCredentialId = Guid.NewGuid(),
+            IdempotencyKey = "return-key",
+            Lines =
+            [
+                new CreatePosReturnLineRequest { SaleLineId = saleLineId, Quantity = 1, TaxAmount = 1 },
+                new CreatePosReturnLineRequest { SaleLineId = saleLineId, Quantity = 1 }
+            ]
+        };
+
+        var result = new CreatePosReturnValidator().Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error => error.PropertyName == nameof(CreatePosReturnRequest.Lines));
+        result.Errors.Should().Contain(error => error.PropertyName == "Lines[0].TaxAmount");
+    }
+
+    [Test]
+    public void TransactionValidators_MoreThanMaximumLines_ReturnValidationErrors()
+    {
+        var sale = ValidCheckout();
+        sale.Lines = Enumerable.Range(0, 101)
+            .Select(_ => new CheckoutPosSaleLineRequest
+            {
+                ProductId = Guid.NewGuid(),
+                Quantity = 1,
+                ExpectedUnitPrice = 1
+            })
+            .ToList();
+
+        var result = new CheckoutPosSaleValidator().Validate(sale);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error => error.PropertyName == nameof(CheckoutPosSaleRequest.Lines));
+    }
+
     private static CheckoutPosSaleRequest ValidCheckout() => new()
     {
         RegisterId = Guid.NewGuid(),

--- a/src/Tests/POS.IntegrationTests/POS.IntegrationTests.csproj
+++ b/src/Tests/POS.IntegrationTests/POS.IntegrationTests.csproj
@@ -15,10 +15,13 @@
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
+        <PackageReference Include="Moq" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\Modules\XFramework.POS\POS.Domain.Shared\POS.Domain.Shared.csproj" />
+        <ProjectReference Include="..\..\Modules\XFramework.POS\POS.Api\POS.Api.csproj" />
         <ProjectReference Include="..\..\Modules\XFramework.POS\POS.Integration\POS.Integration.csproj" />
         <ProjectReference Include="..\XFramework.TestInfrastructure\XFramework.TestInfrastructure.csproj" />
     </ItemGroup>

--- a/src/Tests/POS.IntegrationTests/PosBoltRuntimeIntegrationTests.cs
+++ b/src/Tests/POS.IntegrationTests/PosBoltRuntimeIntegrationTests.cs
@@ -1,0 +1,258 @@
+using Bolt.Client;
+using Bolt.Hub.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using POS.Api.Services;
+using POS.Domain.Shared.Contracts;
+using POS.Domain.Shared.Contracts.Requests;
+using POS.Integration.Drivers;
+using Testcontainers.PostgreSql;
+using XFramework.Core.Extensions;
+using XFramework.Core.Middlewares;
+using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
+using XFramework.Domain.Contexts;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Extensions;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Extensions;
+using XFramework.Integration.Extensions;
+using XFramework.TestInfrastructure;
+
+namespace POS.IntegrationTests;
+
+[TestFixture]
+[Category(TestCategories.Integration)]
+[Category(TestCategories.POS)]
+public sealed class PosBoltRuntimeIntegrationTests
+{
+    private const string BoltUrl = "http://localhost:17500";
+    private const string PosUrl = "http://localhost:18700";
+    private const string ClientUrl = "http://localhost:18701";
+    private readonly Guid tenantId = Guid.NewGuid();
+    private readonly Guid credentialId = Guid.NewGuid();
+    private PostgreSqlContainer? postgres;
+    private TestBoltTransportAuthority transportAuthority = null!;
+    private TestInvocationIdentityOptions invocationIdentity = null!;
+    private WebApplication? boltApp;
+    private WebApplication? posApp;
+    private WebApplication? clientApp;
+    private IServiceScope? clientScope;
+    private Guid registerId;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        try
+        {
+            postgres = new PostgreSqlBuilder()
+                .WithDatabase("XFramework_POS_Bolt_Test")
+                .WithUsername("test_user")
+                .WithPassword("test_password")
+                .Build();
+            await postgres.StartAsync();
+        }
+        catch (ArgumentException exception) when (exception.Message.Contains("Docker", StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Ignore("POS Bolt integration tests require a Testcontainers-compatible Docker endpoint.");
+        }
+
+        registerId = Guid.NewGuid();
+        transportAuthority = new TestBoltTransportAuthority(BoltUrl);
+        var actorToken = TestInvocationIdentityExtensions.CreateTestActorToken(
+            tenantId,
+            credentialId,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            ["Cashier"],
+            [PosAuthorizationCapabilities.RegistersView]);
+        invocationIdentity = new TestInvocationIdentityOptions(
+            actorToken,
+            "pos-runtime-service-token",
+            XFrameworkServiceNames.Portal,
+            tenantId,
+            credentialId,
+            Guid.NewGuid(),
+            Guid.NewGuid());
+
+        await MigrateAndSeedAsync();
+        boltApp = StartBolt();
+        posApp = StartPos();
+        clientApp = StartClient();
+        clientScope = clientApp.Services.CreateScope();
+
+        await ConnectAsync(posApp.Services.GetRequiredService<BoltClient>());
+        await ConnectAsync(clientApp.Services.GetRequiredService<BoltClient>());
+        await Task.Delay(1000);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        clientScope?.Dispose();
+        if (clientApp is not null) await clientApp.StopAsync();
+        if (posApp is not null) await posApp.StopAsync();
+        if (boltApp is not null) await boltApp.StopAsync();
+        if (postgres is not null) await postgres.DisposeAsync();
+        transportAuthority?.Dispose();
+    }
+
+    [Test]
+    public async Task GetPosRegister_ThroughGeneratedBoltWrapper_EnforcesActorCapability()
+    {
+        var wrapper = clientScope!.ServiceProvider.GetRequiredService<IPOSServiceWrapper>();
+        var request = new GetPosRegisterRequest
+        {
+            Id = registerId,
+            Metadata = new RequestMetadata { RequestedTenantId = tenantId }
+        };
+
+        var allowed = await wrapper.GetPosRegister(request);
+
+        allowed.IsSuccess.Should().BeTrue(allowed.Message);
+        allowed.Response!.Id.Should().Be(registerId);
+
+        var unauthorizedToken = TestInvocationIdentityExtensions.CreateTestActorToken(
+            tenantId,
+            credentialId,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            ["Cashier"],
+            []);
+        using var tokenScope = TestInvocationActorTokenScope.Push(unauthorizedToken);
+
+        var denied = await wrapper.GetPosRegister(request);
+
+        denied.IsSuccess.Should().BeFalse();
+        ((int)denied.HttpStatusCode).Should().Be(403);
+    }
+
+    private async Task MigrateAndSeedAsync()
+    {
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(PosRegister).TypeHandle);
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(postgres!.GetConnectionString())
+            .ConfigureWarnings(warnings => warnings.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        await using var db = new AppDbContext(
+            options,
+            new HttpContextAccessor(),
+            new ConfigurationBuilder().Build(),
+            new TestEffectiveTenantContextAccessor(tenantId));
+        await db.Database.MigrateAsync();
+        db.Add(new PosRegister
+        {
+            Id = registerId,
+            TenantId = tenantId,
+            Name = "Bolt register",
+            MerchantCredentialId = Guid.NewGuid(),
+            CashDrawerWalletId = Guid.NewGuid(),
+            WalletTypeId = Guid.NewGuid(),
+            CurrencyId = Guid.NewGuid(),
+            DefaultWarehouseId = Guid.NewGuid(),
+            DefaultLocationId = Guid.NewGuid(),
+            IsEnabled = true,
+            CreatedAt = DateTime.UtcNow,
+            ConcurrencyStamp = Guid.NewGuid()
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private WebApplication StartBolt()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+        builder.WebHost.UseUrls(BoltUrl);
+        OverrideConfig(builder, "Bolt.PosRuntimeTest", BoltUrl);
+        transportAuthority.Configure(builder);
+        builder.Services.InstallServicesInAssembly<Bolt.Hub.Installers.BoltInstaller>(builder.Configuration, builder.Environment);
+        builder.Services.InstallSwagger(builder.Configuration);
+        builder.Services.InstallOData(builder.Configuration);
+        builder.Services.InstallJwt(builder.Configuration);
+        builder.Services.InstallStandardServices<Bolt.Hub.Installers.BoltInstaller>(builder.Configuration);
+        builder.Services.InstallRuntimeServices(builder.Configuration);
+        builder.Services.AddTestInvocationClient(invocationIdentity);
+
+        var app = (WebApplication)builder.Build();
+        transportAuthority.MapEndpoints(app);
+        app.UseCorrelationId();
+        app.UseAppServices();
+        app.Start();
+        return app;
+    }
+
+    private WebApplication StartPos()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+        builder.WebHost.UseUrls(PosUrl);
+        OverrideConfig(builder, XFrameworkServiceNames.Pos, PosUrl);
+        builder.Configuration["ConnectionStrings:DefaultDatabaseConnection"] = postgres!.GetConnectionString();
+        builder.Configuration["DefaultDatabaseConnection"] = postgres.GetConnectionString();
+        builder.Services.InstallStandardServices<PosRegisterService>(builder.Configuration);
+        builder.Services.AddTestInvocationServer(invocationIdentity);
+        builder.Services.AddSingleton(transportAuthority.CreateTokenProvider(XFrameworkServiceNames.Pos));
+
+        var featureGate = new Mock<ITrustedInvocationFeatureGate>();
+        featureGate
+            .Setup(gate => gate.EnsureAllowedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        builder.Services.AddSingleton(featureGate.Object);
+
+        var app = (WebApplication)builder.Build();
+        POS.Api.Generated.BoltHandlerRegistry.RegisterAll(
+            app.Services.GetRequiredService<BoltClient>(),
+            app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("POS.RuntimeTests"),
+            app.Services.GetRequiredService<IServiceScopeFactory>());
+        app.Start();
+        return app;
+    }
+
+    private WebApplication StartClient()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+        builder.WebHost.UseUrls(ClientUrl);
+        OverrideConfig(builder, XFrameworkServiceNames.Portal, ClientUrl);
+        builder.Services.InstallStandardServices<PosBoltRuntimeIntegrationTests>(builder.Configuration);
+        builder.Services.AddXFrameworkBoltClient(builder.Configuration, autoConnect: false);
+        builder.Services.AddSingleton(transportAuthority.CreateTokenProvider(XFrameworkServiceNames.Portal));
+        builder.Services.AddTestInvocationClient(invocationIdentity);
+        builder.Services.AddPOSWrapperServices();
+
+        var app = builder.Build();
+        app.Start();
+        return app;
+    }
+
+    private static async Task ConnectAsync(BoltClient client)
+    {
+        if (!client.IsConnected)
+            await client.ConnectWithRetryAsync(new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token);
+    }
+
+    private static void OverrideConfig(WebApplicationBuilder builder, string clientName, string url)
+    {
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["BoltConfiguration:ClientName"] = clientName,
+            ["BoltConfiguration:ClientGuid"] = Guid.NewGuid().ToString(),
+            ["BoltConfiguration:ServerUrls:0"] = $"{BoltUrl}/bolt/ws",
+            ["ServiceIdentity:ClientId"] = clientName,
+            ["ServiceIdentity:Authority"] = BoltUrl,
+            ["ServiceIdentity:AllowInsecureHttp"] = "true",
+            ["ServiceIdentity:GenerationId"] = "pos-runtime-tests-g1",
+            ["ServiceIdentity:ClientSecret"] = "pos-runtime-tests-secret-2026-secure",
+            ["ServiceIdentity:DefaultScopes:0"] = XFrameworkServiceScopes.BoltService,
+            ["Tenant:DefaultId"] = TestConstants.TenantId.ToString(),
+            ["Kestrel:Endpoints:Http:Url"] = url,
+            ["urls"] = url,
+            ["Logging:LogLevel:Default"] = "Warning"
+        });
+    }
+}

--- a/src/Tests/POS.IntegrationTests/PosPersistenceIntegrationTests.cs
+++ b/src/Tests/POS.IntegrationTests/PosPersistenceIntegrationTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using POS.Domain.Shared.Contracts;
+using POS.Domain.Shared.Enums;
+using Testcontainers.PostgreSql;
+using XFramework.Domain.Contexts;
+using XFramework.TestInfrastructure;
+
+namespace POS.IntegrationTests;
+
+[TestFixture]
+[Category(TestCategories.POS)]
+public sealed class PosPersistenceIntegrationTests
+{
+    private PostgreSqlContainer? postgres;
+    private DbContextOptions<AppDbContext> options = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        try
+        {
+            postgres = new PostgreSqlBuilder()
+                .WithDatabase("XFramework_POS_Test")
+                .WithUsername("test_user")
+                .WithPassword("test_password")
+                .Build();
+            await postgres.StartAsync();
+        }
+        catch (ArgumentException exception) when (exception.Message.Contains("Docker", StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Ignore("POS PostgreSQL integration tests require a Testcontainers-compatible Docker endpoint.");
+        }
+
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(PosRegister).TypeHandle);
+        options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(postgres!.GetConnectionString())
+            .ConfigureWarnings(warnings => warnings.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        await using var db = CreateContext(Guid.NewGuid());
+        await db.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (postgres is not null)
+            await postgres.DisposeAsync();
+    }
+
+    [Test]
+    public async Task PosMigration_EnforcesSingleActivePaymentAndPersistsCartRequestHash()
+    {
+        var tenantId = Guid.NewGuid();
+        var register = CreateRegister(tenantId);
+        var sale = CreateSale(tenantId, register.Id);
+        var firstPayment = CreatePayment(tenantId, sale.Id, Guid.NewGuid());
+        const string requestHash = "6E7F31D96835BBAC2E3514F65B6849D1082B92C89A3BCB9E7B27E5C85A67036A";
+        var cart = CreateCart(tenantId, register.Id, requestHash);
+
+        await using (var db = CreateContext(tenantId))
+        {
+            db.AddRange(register, sale, firstPayment, cart);
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = CreateContext(tenantId))
+        {
+            db.Add(CreatePayment(tenantId, sale.Id, Guid.NewGuid()));
+            var save = () => db.SaveChangesAsync();
+            await save.Should().ThrowAsync<DbUpdateException>();
+        }
+
+        await using (var db = CreateContext(tenantId))
+        {
+            var persistedHash = await db.Set<PosCart>()
+                .Where(item => item.Id == cart.Id)
+                .Select(item => item.RequestHash)
+                .SingleAsync();
+            persistedHash.Should().Be(requestHash);
+        }
+    }
+
+    private AppDbContext CreateContext(Guid tenantId) => new(
+        options,
+        new HttpContextAccessor(),
+        new ConfigurationBuilder().Build(),
+        new TestEffectiveTenantContextAccessor(tenantId));
+
+    private static PosRegister CreateRegister(Guid tenantId) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = tenantId,
+        Name = "Integration register",
+        MerchantCredentialId = Guid.NewGuid(),
+        CashDrawerWalletId = Guid.NewGuid(),
+        WalletTypeId = Guid.NewGuid(),
+        CurrencyId = Guid.NewGuid(),
+        DefaultWarehouseId = Guid.NewGuid(),
+        DefaultLocationId = Guid.NewGuid(),
+        IsEnabled = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid()
+    };
+
+    private static PosSale CreateSale(Guid tenantId, Guid registerId) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = tenantId,
+        SaleNumber = $"TEST-{Guid.NewGuid():N}"[..30],
+        RegisterId = registerId,
+        CashierCredentialId = Guid.NewGuid(),
+        WarehouseId = Guid.NewGuid(),
+        LocationId = Guid.NewGuid(),
+        CurrencyId = Guid.NewGuid(),
+        WalletTypeId = Guid.NewGuid(),
+        IdempotencyKey = Guid.NewGuid().ToString("N"),
+        Status = PosSaleStatus.PaymentPending,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid(),
+        IsEnabled = true
+    };
+
+    private static PosPayment CreatePayment(Guid tenantId, Guid saleId, Guid id) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        SaleId = saleId,
+        Method = PosPaymentMethod.CashDrawer,
+        Status = PosPaymentStatus.Pending,
+        CurrencyId = Guid.NewGuid(),
+        WalletTypeId = Guid.NewGuid(),
+        MerchantCredentialId = Guid.NewGuid(),
+        ReferenceNumber = $"PAY-{id:N}",
+        IdempotencyKey = $"PAY-{id:N}",
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid(),
+        IsEnabled = true
+    };
+
+    private static PosCart CreateCart(Guid tenantId, Guid registerId, string requestHash) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = tenantId,
+        CartNumber = $"CART-{Guid.NewGuid():N}"[..32],
+        RegisterId = registerId,
+        CashierCredentialId = Guid.NewGuid(),
+        WarehouseId = Guid.NewGuid(),
+        LocationId = Guid.NewGuid(),
+        CurrencyId = Guid.NewGuid(),
+        WalletTypeId = Guid.NewGuid(),
+        IdempotencyKey = Guid.NewGuid().ToString("N"),
+        RequestHash = requestHash,
+        Status = PosCartStatus.Open,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid(),
+        IsEnabled = true
+    };
+}


### PR DESCRIPTION
## Summary
- harden POS payment, cart, sale, and return idempotency and financial invariants
- enforce operation-specific HTTP/Bolt capabilities and validate register references through wrappers
- make Inventario reservation terminal-state replays safe
- add the EF-generated migration, regression/integration coverage, and the refreshed POS backend audit

## Why
The post-IdentityServer audit found remaining POS production risks around concurrent payment creation, caller-controlled refund amounts, replay behavior, and overly broad operation authorization. These changes close those gaps while preserving the centralized trusted invocation context from `develop`.

## Impact
POS checkout and return operations now use deterministic replay semantics, server-derived financial values, scoped capabilities, and a database constraint preventing multiple active payment attempts for one sale. The migration adds `PosCart.RequestHash` and the active-payment unique index; deployed data must be checked for duplicate active payment rows before rollout.

## Validation
- `POS.Api.Tests`: 24 passed
- `Inventario.Api.Tests`: 39 passed
- `POS.IntegrationTests`: 12 passed, 2 skipped because local Docker/Testcontainers was unavailable
- `XFramework.Core.Tests`: 338 passed
- `XFramework.Portal` build: succeeded with 0 warnings and 0 errors
- EF Core pending-model check: no pending changes