### PR TITLE
fix(attendance): remediate backend audit findings

### DIFF
--- a/.github/workflows/attendance-integration-tests.yml
+++ b/.github/workflows/attendance-integration-tests.yml
@@ -1,0 +1,91 @@
+name: Attendance Tests
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - "src/Modules/XFramework.Attendance/**"
+      - "src/Tests/Attendance.IntegrationTests/**"
+      - "src/Kernel/XFramework.Core/DataContext/**"
+      - "src/Infrastructure/XFramework.Integration/**"
+      - "src/SourceGenerators/XFramework.SourceGenerators/**"
+      - "src/Shared/XFramework.Domain.Shared/ServiceIdentity/XFrameworkServiceScopes.cs"
+      - "src/Kernel/XFramework.Domain/Migrations/*Attendance*"
+      - "src/Presentation/XFramework.Portal/Services/AttendancePortalReadService.cs"
+      - "src/Tests/Portal.E2ETests/AttendancePortalContractTests.cs"
+      - "docker-compose.yml"
+      - ".github/workflows/attendance-integration-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  attendance-tests:
+    name: Attendance unit and integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore XFramework.slnx
+
+      - name: Run Attendance unit tests
+        run: >
+          dotnet test
+          src/Modules/XFramework.Attendance/Attendance.Tests/Attendance.Tests.csproj
+          --no-restore
+          -m:1
+          /nr:false
+
+      - name: Run Attendance PostgreSQL integration tests
+        run: >
+          dotnet test
+          src/Tests/Attendance.IntegrationTests/Attendance.IntegrationTests.csproj
+          --no-restore
+          -m:1
+          /nr:false
+
+      - name: Run Portal Attendance contract tests
+        run: >
+          dotnet test
+          src/Tests/Portal.E2ETests/Portal.E2ETests.csproj
+          --no-restore
+          --filter "FullyQualifiedName~AttendancePortalContractTests"
+          -m:1
+          /nr:false
+
+      - name: Run generated authorization and data-context security tests
+        run: >
+          dotnet test
+          src/Tests/XFramework.Core.Tests/XFramework.Core.Tests.csproj
+          --no-restore
+          --filter "FullyQualifiedName~GeneratedEntityAuthorizationPolicyRegistryTests|FullyQualifiedName~DataContextBoltHandlerTests|FullyQualifiedName~QueryExecutionServiceTests"
+          -m:1
+          /nr:false
+
+      - name: Run authorization source-generator parity tests
+        run: >
+          dotnet test
+          src/Tests/XFramework.SourceGenerators.Tests/XFramework.SourceGenerators.Tests.csproj
+          --no-restore
+          --filter "FullyQualifiedName~DataContextRegistrationGeneratorTests|FullyQualifiedName~EntityEndpointGeneratorTests|FullyQualifiedName~EntityServiceGeneratorTests|FullyQualifiedName~ServiceWrapperGeneratorTests|FullyQualifiedName~BoltHandlerGeneratorTests"
+          -m:1
+          /nr:false
+
+      - name: Run service and Bolt token cache tests
+        run: >
+          dotnet test
+          src/Tests/Bolt.Tests/Bolt.Tests.csproj
+          --no-restore
+          --filter "FullyQualifiedName~IdentityServerTokenProviderTests"
+          -m:1
+          /nr:false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,7 +227,7 @@ services:
       ServiceIdentity__Clients__1__ValidationFallback__ClientSecret: ${PORTAL_SERVICE_IDENTITY_SECRET_SECONDARY:-}
       ServiceIdentity__Clients__1__ValidationFallback__ValidUntilUtc: ${SERVICE_CREDENTIAL_SECONDARY_VALID_UNTIL_UTC:-}
       ServiceIdentity__Clients__1__AllowedAudiences: *service-identity-audiences
-      ServiceIdentity__Clients__1__AllowedScopes: bolt.service,datacontext.query,datacontext.query.all-tenants,datacontext.mutate,tenant.target,communications.admin,communications.chat,identity.admin,identity.session.validate
+      ServiceIdentity__Clients__1__AllowedScopes: bolt.service,datacontext.query,datacontext.query.all-tenants,datacontext.mutate,tenant.target,attendance.read,attendance.write,communications.admin,communications.chat,identity.admin,identity.session.validate
       ServiceIdentity__Clients__2__ClientId: XFramework.Bolt.Hub
       ServiceIdentity__Clients__2__ClientSecret: ${BOLT_HUB_SERVICE_IDENTITY_SECRET:?Set BOLT_HUB_SERVICE_IDENTITY_SECRET in .env}
       ServiceIdentity__Clients__2__GenerationId: ${SERVICE_CREDENTIAL_GENERATION_ID:?Set SERVICE_CREDENTIAL_GENERATION_ID in the protected deployment env}

--- a/docs/solutions/workflow-issues/attendance-backend-audit-2026-08-05.md
+++ b/docs/solutions/workflow-issues/attendance-backend-audit-2026-08-05.md
@@ -1,0 +1,127 @@
+# Attendance Backend Audit - Remediated 2026-08-10
+
+**Baseline:** `origin/develop` at `e3d91743a2789e5e689fa86f7bc6f5852285245b`, including PR #403 (`eef41054`, generated entity authorization parity), plus the scoped remediation on `codex/attendance-audit-core-correctness`
+
+**Scope:** `XFramework.Attendance`, its IdentityServer dependency, Portal and wrapper boundaries, PostgreSQL integration suite, generated authorization, trusted invocation, Bolt, token caching, schema ownership, deployment configuration, and CI
+
+**Overall grade:** A-
+
+## Executive Summary
+
+The complete post-IdentityServer and post-PR #403 audit was rerun against the remediated code. No Critical, High, Medium, or Low findings remain open in the scoped review.
+
+Attendance now uses explicit actor-authorized read wrappers while generic remote `IDataContext` remains fail-closed. Actor attribution comes only from trusted invocation context, participant history is date-effective, credentials are verified through IdentityServer, Bolt callers and scopes are least-privilege, event idempotency is payload-aware and concurrency-safe, session lifecycle rules are explicit, migrations own only the Attendance schema, wrappers propagate cancellation, the SQLite advisory is removed, and mandatory CI covers module plus shared authorization/token contracts.
+
+## Current Findings
+
+### Critical
+
+None.
+
+### High
+
+None.
+
+### Medium
+
+None.
+
+### Low
+
+None.
+
+## Finding Resolutions
+
+### H1 - Trusted actor attribution: Resolved
+
+- Event and adjustment operations require an authenticated trusted actor and reject mismatching compatibility actor fields at `Attendance.Api/Services/AttendanceService.cs:453-460` and `:758-763`.
+- Persisted actor IDs come from trusted invocation context at `AttendanceService.cs:537` and `:861`.
+- Unit coverage includes spoof rejection and trusted actor persistence for events and adjustments.
+
+### H2 - Approved reads after PR #403: Resolved
+
+- All seven Attendance entities intentionally keep generated CRUD disabled while declaring `AuthorizationFeature = "attendance"`; representative metadata is at `Attendance.Domain.Shared/Contracts/AttendanceContext.cs:3-10`.
+- Five explicit tenant-scoped read operations replace generic Attendance remote queries under `Attendance.Api/Features/Reads/` and `Attendance.Api/Services/AttendanceReadService.cs`.
+- Portal uses those wrappers at `XFramework.Portal/Services/AttendancePortalReadService.cs:23-65` and no longer calls `IgnoreQueryFilters()` for Attendance data.
+- The completeness guard at `Attendance.IntegrationTests/Tests/AttendanceGeneratedAuthorizationCompletenessTests.cs:16-55` asserts zero generic read policies, zero mutable entities, actor-required metadata, and no service-only exception.
+- Authorization tests cover valid Portal actor access, service-only denial, missing capability, feature-disabled, wrong caller, missing scope, and cross-tenant denial.
+
+### H3 - Participant history and reports: Resolved
+
+- Removal now deactivates and end-dates membership without deleting it at `AttendanceService.cs:221-230`.
+- Event/record/adjustment membership checks and report rosters apply `StartedAt`/`EndedAt` to the session start at `AttendanceService.cs:515-521`, `:711-720`, and `:810-816`.
+- The explicit session-detail projection applies the same date-effective roster rule in `AttendanceReadService.cs`; tests cover deactivation visibility, historical session detail, and report stability when memberships start or end after a session.
+
+### M1 - Identity credential integrity: Resolved
+
+- `AttendanceCredentialResolver` uses `IIdentityServerServiceWrapper`, maps unavailable IdentityServer responses to a controlled 503, and logs the failure at `Attendance.Api/Services/AttendanceCredentialResolver.cs:22-76`.
+- Enrollment verifies credential ID, effective tenant, enabled/deleted state, and copies authoritative alias/username labels at `AttendanceService.cs:170-190`.
+- Direct resolver and service tests cover success, missing, wrong tenant, disabled, deleted, authoritative labels, and unavailable IdentityServer.
+
+### M2 - Bolt destination least privilege: Resolved
+
+- Canonical `attendance.read` and `attendance.write` scopes are declared at `XFrameworkServiceScopes.cs:12-13`.
+- Every custom handler requires one exact operation scope and the `XFramework.Portal` caller; representative write metadata is at `Features/Contexts/Create/Endpoint.cs:10-12`.
+- Contract tests enumerate all 18 handlers and wrapper methods and verify actor/tenant policy, caller, exact scope, cancellation propagation, and service-only denial.
+- Compose grants the two scopes to Portal's issuer allowlist without adding them to default token requests.
+
+### M3 - Event idempotency: Resolved
+
+- Replay compares the complete normalized event payload and returns conflict for key reuse with different data at `AttendanceService.cs:1026-1081`.
+- Unique-key races are translated into replay/conflict after clearing failed tracked state at `AttendanceService.cs:556-578`.
+- PostgreSQL coverage runs two concurrent same-key requests and asserts one persisted event at `AttendancePostgresTests.cs:210-239`.
+
+### M4 - Session and event lifecycle: Resolved
+
+- Session creation validates UTC timestamps, real timezone IDs, chronology, and initial status at `AttendanceService.cs:294-314` and `Features/Sessions/Create/CreateAttendanceSessionValidator.cs:20-38`.
+- The transition operation implements `Scheduled -> Open`, `Open -> Closed`, cancellation from scheduled/open, and terminal closed/cancelled states at `AttendanceService.cs:405-445` and `Features/Sessions/Transition/Endpoint.cs:8-21`.
+- Events require an open session, cannot be future-dated, and must fall inside the session window at `AttendanceService.cs:502-511`; adjustment chronology and window checks are enforced at `:766-805`.
+
+### M5 - Migration schema ownership: Resolved
+
+- `AddAttendanceBaseline` now creates/drops only Attendance-owned objects and contains no Identity/Application data mutation.
+- `AttendanceMigrationOwnershipTests.cs:16-36` reflectively checks both `Up` and `Down` for cross-schema SQL.
+
+### M6 - Mandatory security integration and CI: Resolved
+
+- The PostgreSQL/Bolt integration fixture fails rather than skips in CI when Testcontainers cannot start at `AttendanceIntegrationTestFixture.cs:99-106`.
+- `.github/workflows/attendance-integration-tests.yml` runs Attendance unit/PostgreSQL tests plus targeted shared generated-authorization, data-context, source-generator parity, and token-cache suites.
+- Runtime tests exercise real PostgreSQL, Bolt envelopes, trusted invocation resolution, feature/capability gates, caller/scope checks, wrapper reads/writes, tenant denial, generic data-context denial, and concurrent idempotency.
+- The module fixture uses deterministic token/identity providers; production token acquisition, independent service/Bolt caches, and validation remain covered by the shared Bolt/Core suites invoked by the workflow.
+
+### L1 - SQLite advisory: Resolved
+
+- `Attendance.Tests.csproj:17` pins `SQLitePCLRaw.bundle_e_sqlite3` to the centrally managed patched version.
+- `dotnet list ... --vulnerable --include-transitive` reports no vulnerable packages.
+
+### L2 - Wrapper cancellation: Resolved
+
+- All 18 business/read methods accept `CancellationToken` at `AttendanceServiceWrapper.cs:20-55` and pass it through token acquisition, actor-token lookup, and Bolt invocation.
+
+## PR #403 Revalidation
+
+| Previous condition | Current status |
+|---|---|
+| Remote Attendance reads bypassed generated authorization | **Resolved by PR #403 and retained.** Generic reads fail closed; approved reads use explicit wrappers. |
+| PR #403 caused Portal Attendance reads to fail because no generated policies existed | **Resolved.** Portal no longer depends on generic Attendance policies. |
+| Generated service-only access could be broader than intended | **Resolved.** No Attendance entity has `AllowGeneratedServiceAccess`; custom reads also require an actor. |
+| Capability taxonomy/completeness was absent | **Resolved.** Explicit `attendance:view` read capability and completeness tests are present. |
+| Client-selected tenant could cross tenant boundaries | **Resolved and reverified.** Trusted effective tenant mismatch is denied before business execution. |
+| Service/Bolt token acquisition could burst independent quotas | **Resolved and reverified.** Shared singleton per-key caches remain independently single-flight; targeted tests pass. |
+
+## Verification Evidence
+
+- `Attendance.Tests`: 37 passed, 0 failed.
+- `Attendance.IntegrationTests` through the documented xeon-dev loopback Docker tunnel: 10 passed, 0 failed, including PostgreSQL migration/index checks, wrapper flow, explicit reads, tenant denial, generic `IDataContext` denial, transition, and concurrent idempotency.
+- Attendance migration and generated-authorization static guards: 2 passed independently of Docker.
+- Core generated authorization/data-context security: 64 passed.
+- Source-generator authorization parity: 64 passed.
+- Service/Bolt token provider cache tests: 13 passed.
+- Portal Attendance contract command: exit code 0; Portal build passed.
+- Attendance API and integration-test builds passed with 0 errors.
+- Attendance test package vulnerability scan: no vulnerable packages.
+- xeon-dev tunnel, remote `socat`, and Testcontainers resources were cleaned up after runtime verification.
+
+## Residual Risk
+
+The Attendance integration suite intentionally substitutes deterministic identity/token providers so it is self-contained; it does not boot a second full IdentityServer process. The production resolver contract and failure mapping are directly tested, while IdentityServer issuance/validation and both token caches are gated by the shared security suites in the same workflow. No actionable Attendance defect remains from this audit.

--- a/src/Kernel/XFramework.Domain/Migrations/20260625160142_AddAttendanceBaseline.cs
+++ b/src/Kernel/XFramework.Domain/Migrations/20260625160142_AddAttendanceBaseline.cs
@@ -14,33 +14,6 @@ namespace XFramework.Domain.Migrations
             migrationBuilder.EnsureSchema(
                 name: "Attendance");
 
-            migrationBuilder.Sql(
-                """
-                INSERT INTO "Identity"."TenantModuleFeature"
-                    ("ID", "ModuleKey", "SubFeatureKey", "DisplayName", "Description", "IsEnabled", "IsDeleted", "ConcurrencyStamp", "CreatedAt", "ModifiedAt", "TenantId")
-                SELECT
-                    uuid_generate_v4(),
-                    'attendance',
-                    '',
-                    'Attendance',
-                    'Attendance contexts, sessions, participants, time events, and reports.',
-                    true,
-                    false,
-                    uuid_generate_v4(),
-                    now(),
-                    now(),
-                    tenants."ID"
-                FROM "Application"."Application" tenants
-                WHERE tenants."IsDeleted" = false
-                  AND NOT EXISTS (
-                      SELECT 1
-                      FROM "Identity"."TenantModuleFeature" existing
-                      WHERE existing."TenantId" = tenants."ID"
-                        AND existing."ModuleKey" = 'attendance'
-                        AND existing."SubFeatureKey" = ''
-                  );
-                """);
-
             migrationBuilder.CreateTable(
                 name: "AttendancePolicy",
                 schema: "Attendance",
@@ -572,12 +545,6 @@ namespace XFramework.Domain.Migrations
                 name: "AttendancePolicy",
                 schema: "Attendance");
 
-            migrationBuilder.Sql(
-                """
-                DELETE FROM "Identity"."TenantModuleFeature"
-                WHERE "ModuleKey" = 'attendance'
-                  AND "SubFeatureKey" = '';
-                """);
         }
     }
 }

--- a/src/Modules/XFramework.Attendance/AGENTS.md
+++ b/src/Modules/XFramework.Attendance/AGENTS.md
@@ -63,7 +63,10 @@ The mental model is:
 - Cross-module and Portal business operations must go through `IAttendanceServiceWrapper`.
 - Use wrapper methods for creating or updating contexts, participants, sessions, attendance events, adjustments, and reports.
 - Do not perform direct remote `IDataContext` mutations from Portal or another module for Attendance business actions.
-- Remote `IDataContext.Query<T>()` is acceptable only for tenant-scoped read projections that are covered by integration or Portal contract tests.
+- Attendance entity `GenerateEndpoints` declarations intentionally keep `Actions=None`; generic remote `IDataContext` reads and mutations must remain fail-closed.
+- Portal and cross-module Attendance reads must use the explicit read methods on `IAttendanceServiceWrapper`.
+- Custom Attendance Bolt handlers are Portal-only and require exactly `attendance.read` or `attendance.write`. Preserve the trusted actor, actor-tenant, feature, and capability checks when adding operations.
+- Pass cancellation tokens through every wrapper method and transport call.
 - Keep `Attendance.Api/Program.cs` explicit generated Bolt registration:
   `BoltHandlerRegistry.RegisterAll(client, logger, scopeFactory)`.
 - Pass `hostEnvironment` to `AddXFrameworkBoltClient` so non-Development startup validates secure `wss://` transport configuration. Do not bypass that validation with the environment-free overload or a plaintext client URL.
@@ -76,29 +79,32 @@ The mental model is:
 - `AttendanceSession` defines the scheduled window. Actual time-in/time-out is recorded through `RecordAttendanceEventRequest`.
 - `AttendanceEvent` is append-only and idempotent by tenant plus `IdempotencyKey`.
 - Generate a unique, deterministic-enough idempotency key per UI or device action. Portal keys should stay prefixed with a Portal-specific value.
-- Duplicate idempotency-key replays should return the existing event outcome, not create another event.
+- Duplicate idempotency-key replays should return the existing event outcome only when the complete event payload matches. Reusing a key for different data is a conflict, and concurrent matching retries must converge on one event.
+- Events are accepted only for `Open` sessions and must fall inside the UTC session window. Use the session transition operation for `Scheduled -> Open`, `Open -> Closed`, and cancellation from `Scheduled` or `Open`; closed and cancelled sessions are terminal.
 - Check-in after the grace period becomes `Late`.
 - Missing checkout can become `Incomplete` when the policy requires checkout.
-- Manual adjustments must include `ActorCredentialId` and a non-empty reason.
+- Manual adjustments must include a non-empty reason. Compatibility actor fields, when supplied, must match the authenticated actor.
 - Manual check-in/check-out from operators should use `AttendanceEventSource.Manual` and the validated operator credential from `ITrustedInvocationContextAccessor`.
+- Never persist a caller-selected audit actor. Event and adjustment actor attribution comes from `ITrustedInvocationContextAccessor`.
+- Participant removal ends the membership without soft-deleting it. Rosters and reports must apply `StartedAt`/`EndedAt` to each session so later membership changes do not rewrite history.
 
 ## Portal Integration Rules
 
 - Attendance navigation and pages must be feature-gated by `TenantModuleFeatureKeys.Attendance`.
 - Portal writes must call `IAttendanceServiceWrapper`.
-- Portal read-heavy screens may use `IDataContext.Query<T>()` through `AttendancePortalReadService` when tenant-scoped and tested.
+- Portal Attendance data reads must call the explicit wrapper read operations through `AttendancePortalReadService`; do not restore generic Attendance `IDataContext` queries or `IgnoreQueryFilters()`.
 - Use `XfEntityPicker<IdentityCredential>` or an equivalent credential picker for participant selection. Never make operators type credential GUIDs.
-- Copy `DisplayName` and `ReferenceCode` from the selected credential for participant display, but treat IdentityServer as authoritative.
+- `AddParticipantAsync` validates the selected credential through IdentityServer for the effective tenant and rejects missing, disabled, deleted, or cross-tenant credentials. The API persists authoritative alias/username labels; caller-provided labels are not authoritative.
 - Session rosters should show active context participants. If a participant has no `AttendanceRecord` for the session, display `Absent` without creating a record.
 - Use BlazorBlueprint `BbDataGrid` for list, roster, and report UI. Do not introduce raw tables or custom table components for tabular Attendance UI.
 - User Detail Attendance views are read-only in V1; operational changes belong in the Attendance workspace.
 
-## Remote DataContext Footguns
+## Read Boundary Footguns
 
-- Be careful with remote `IDataContext` expression serialization.
-- Do not push `DateTime` constants into remote Attendance predicates unless a deployed-shape integration test proves that query shape works.
-- For Portal session date filters, prefer bounded tenant/context/status reads followed by normalized in-process UTC filtering, or use wrapper/report endpoints.
-- If a remote query works locally but fails on xeon-dev, add coverage in `Attendance.IntegrationTests` or `Portal.E2ETests` before shipping the fix.
+- Do not enable generated CRUD or remote-query actions merely to make a screen load. Add or extend an explicit tenant-scoped read contract instead.
+- Keep the generated-authorization completeness test asserting zero generic Attendance policies and zero mutable Attendance entities.
+- Attendance read wrappers require an actor with `attendance:view`, the Attendance feature, the Portal caller identity, and `attendance.read`; service-only reads remain denied.
+- Identity credential option/label reads still belong to IdentityServer and must follow its authorized boundary.
 
 ## EF And Schema Rules
 
@@ -120,6 +126,7 @@ The mental model is:
 
 - Add or update `Attendance.Tests` for service rules, state transitions, idempotency, policies, tenant validation, and manual adjustments.
 - Add or update `Attendance.IntegrationTests` for PostgreSQL mappings, migrations, wrapper calls, remote `IDataContext` query surfaces, and production-like Bolt registration.
+- Keep `.github/workflows/attendance-integration-tests.yml` mandatory for Attendance changes. CI must fail when PostgreSQL/Testcontainers cannot start; local runs may skip only when no configured runtime is available.
 - Add or update Portal contract tests when Attendance read/display projection behavior changes.
 - For deployment or wrapper fixes, verify both HTTP endpoint behavior and wrapper/Bolt behavior.
 - Documentation-only changes do not require a full build, but run `git diff --check` and check links/paths you reference.

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Adjustments/Create/CreateAttendanceAdjustmentValidator.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Adjustments/Create/CreateAttendanceAdjustmentValidator.cs
@@ -17,12 +17,22 @@ public sealed class CreateAttendanceAdjustmentValidator : AbstractValidator<Crea
             .Must(status => status != AttendanceRecordStatus.Unknown)
             .WithMessage("Attendance status must be explicit");
 
-        RuleFor(x => x.ActorCredentialId)
-            .NotEmpty().WithMessage("Actor credential ID is required");
-
         RuleFor(x => x.Reason)
             .NotEmpty().WithMessage("Adjustment reason is required")
             .MaximumLength(500).WithMessage("Adjustment reason must not exceed 500 characters");
+
+        RuleFor(x => x.AdjustedCheckInAt)
+            .Must(value => !value.HasValue || value.Value.Kind == DateTimeKind.Utc)
+            .WithMessage("Adjusted check-in time must be UTC");
+
+        RuleFor(x => x.AdjustedCheckOutAt)
+            .Must(value => !value.HasValue || value.Value.Kind == DateTimeKind.Utc)
+            .WithMessage("Adjusted checkout time must be UTC")
+            .Must((request, checkOut) => !checkOut.HasValue || request.AdjustedCheckInAt.HasValue)
+            .WithMessage("Adjusted checkout requires an adjusted check-in")
+            .GreaterThanOrEqualTo(x => x.AdjustedCheckInAt)
+            .When(x => x.AdjustedCheckInAt.HasValue && x.AdjustedCheckOutAt.HasValue)
+            .WithMessage("Adjusted checkout cannot be before adjusted check-in");
 
         RuleFor(x => x.Notes)
             .MaximumLength(2000).WithMessage("Notes must not exceed 2000 characters")

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Adjustments/Create/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Adjustments/Create/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Adjustments.Create;
 
 public static class CreateAttendanceAdjustmentEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceWrite],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapPost("/api/attendance/adjustments", Tags = ["Attendance"],
         Summary = "Create attendance adjustment",
         Description = "Creates an audited manual attendance correction and updates the participant session record.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Contexts/Create/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Contexts/Create/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Contexts.Create;
 
 public static class CreateAttendanceContextEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceWrite],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapPost("/api/attendance/contexts", Tags = ["Attendance"],
         Summary = "Create attendance context",
         Description = "Creates a tenant-scoped attendance context for school, HR, project, event, or gate attendance.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Contexts/GetList/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Contexts/GetList/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Contexts.GetList;
 
 public static class GetAttendanceContextsEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapGet("/api/attendance/contexts", Tags = ["Attendance"],
         Summary = "Get attendance contexts",
         Description = "Retrieves paginated tenant-scoped attendance contexts.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Contexts/Update/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Contexts/Update/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Contexts.Update;
 
 public static class UpdateAttendanceContextEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceWrite],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapPut("/api/attendance/contexts", Tags = ["Attendance"],
         Summary = "Update attendance context",
         Description = "Updates a tenant-scoped attendance context.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Events/Record/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Events/Record/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Events.Record;
 
 public static class RecordAttendanceEventEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceWrite],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapPost("/api/attendance/events", Tags = ["Attendance"],
         Summary = "Record attendance event",
         Description = "Records an idempotent check-in or check-out event and updates the session attendance record.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Events/Record/RecordAttendanceEventValidator.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Events/Record/RecordAttendanceEventValidator.cs
@@ -19,6 +19,10 @@ public sealed class RecordAttendanceEventValidator : AbstractValidator<RecordAtt
         RuleFor(x => x.Source)
             .IsInEnum().WithMessage("Attendance event source is invalid");
 
+        RuleFor(x => x.OccurredAt)
+            .Must(value => !value.HasValue || value.Value.Kind == DateTimeKind.Utc)
+            .WithMessage("Attendance event time must be UTC");
+
         RuleFor(x => x.IdempotencyKey)
             .NotEmpty().WithMessage("Idempotency key is required")
             .MaximumLength(128).WithMessage("Idempotency key must not exceed 128 characters");

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/Add/AddAttendanceParticipantValidator.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/Add/AddAttendanceParticipantValidator.cs
@@ -19,6 +19,10 @@ public sealed class AddAttendanceParticipantValidator : AbstractValidator<AddAtt
         RuleFor(x => x.ReferenceCode)
             .MaximumLength(128).WithMessage("Reference code must not exceed 128 characters")
             .When(x => !string.IsNullOrWhiteSpace(x.ReferenceCode));
+
+        RuleFor(x => x.StartedAt)
+            .Must(value => !value.HasValue || value.Value.Kind == DateTimeKind.Utc)
+            .WithMessage("Participant start time must be UTC");
     }
 }
 

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/Add/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/Add/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Participants.Add;
 
 public static class AddAttendanceParticipantEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceWrite],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapPost("/api/attendance/participants", Tags = ["Attendance"],
         Summary = "Add attendance participant",
         Description = "Adds an IdentityServer credential as a participant in an attendance context.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/GetList/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/GetList/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Participants.GetList;
 
 public static class GetAttendanceParticipantsEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapGet("/api/attendance/participants", Tags = ["Attendance"],
         Summary = "Get attendance participants",
         Description = "Retrieves paginated participants for an attendance context.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/Remove/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/Remove/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Participants.Remove;
 
 public static class RemoveAttendanceParticipantEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceWrite],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapDelete("/api/attendance/participants", Tags = ["Attendance"],
         Summary = "Remove attendance participant",
         Description = "Soft-removes a participant from an attendance context.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/Remove/RemoveAttendanceParticipantValidator.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Participants/Remove/RemoveAttendanceParticipantValidator.cs
@@ -8,6 +8,10 @@ public sealed class RemoveAttendanceParticipantValidator : AbstractValidator<Rem
     {
         RuleFor(x => x.ParticipantId)
             .NotEmpty().WithMessage("Attendance participant ID is required");
+
+        RuleFor(x => x.EndedAt)
+            .Must(value => !value.HasValue || value.Value.Kind == DateTimeKind.Utc)
+            .WithMessage("Participant end time must be UTC");
     }
 }
 

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/ContextOverview/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/ContextOverview/Endpoint.cs
@@ -1,0 +1,26 @@
+using Attendance.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Attributes;
+using XFramework.Integration.Security;
+
+namespace Attendance.Api.Features.Reads.ContextOverview;
+
+public static class GetAttendanceContextOverviewEndpoint
+{
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal],
+        ActorRequirement = ActorRequirement.Required,
+        TenantAccessMode = TenantAccessMode.ActorTenant,
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    [MapPost("/api/attendance/reads/context-overview", Tags = ["Attendance"],
+        Summary = "Get attendance context overview",
+        Capability = "view",
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    public static Task<Result<GetAttendanceContextOverviewResponse>> Handle(
+        GetAttendanceContextOverviewRequest request,
+        IAttendanceReadService readService,
+        CancellationToken ct) =>
+        readService.GetContextOverviewAsync(request, ct);
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/CredentialHistory/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/CredentialHistory/Endpoint.cs
@@ -1,0 +1,26 @@
+using Attendance.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Attributes;
+using XFramework.Integration.Security;
+
+namespace Attendance.Api.Features.Reads.CredentialHistory;
+
+public static class GetAttendanceCredentialHistoryEndpoint
+{
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal],
+        ActorRequirement = ActorRequirement.Required,
+        TenantAccessMode = TenantAccessMode.ActorTenant,
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    [MapPost("/api/attendance/reads/credential-history", Tags = ["Attendance"],
+        Summary = "Get attendance history for credentials",
+        Capability = "view",
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    public static Task<Result<AttendanceCredentialHistoryResponse>> Handle(
+        GetAttendanceCredentialHistoryRequest request,
+        IAttendanceReadService readService,
+        CancellationToken ct) =>
+        readService.GetCredentialHistoryAsync(request, ct);
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/ParticipantList/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/ParticipantList/Endpoint.cs
@@ -1,0 +1,26 @@
+using Attendance.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Attributes;
+using XFramework.Integration.Security;
+
+namespace Attendance.Api.Features.Reads.ParticipantList;
+
+public static class GetAttendanceParticipantReadListEndpoint
+{
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal],
+        ActorRequirement = ActorRequirement.Required,
+        TenantAccessMode = TenantAccessMode.ActorTenant,
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    [MapPost("/api/attendance/reads/participants", Tags = ["Attendance"],
+        Summary = "Get attendance participants for operator views",
+        Capability = "view",
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    public static Task<Result<GetAttendanceParticipantReadListResponse>> Handle(
+        GetAttendanceParticipantReadListRequest request,
+        IAttendanceReadService readService,
+        CancellationToken ct) =>
+        readService.GetParticipantsAsync(request, ct);
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/SessionDetail/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/SessionDetail/Endpoint.cs
@@ -1,0 +1,26 @@
+using Attendance.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Attributes;
+using XFramework.Integration.Security;
+
+namespace Attendance.Api.Features.Reads.SessionDetail;
+
+public static class GetAttendanceSessionDetailReadEndpoint
+{
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal],
+        ActorRequirement = ActorRequirement.Required,
+        TenantAccessMode = TenantAccessMode.ActorTenant,
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    [MapPost("/api/attendance/reads/session-detail", Tags = ["Attendance"],
+        Summary = "Get attendance session detail",
+        Capability = "view",
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    public static Task<Result<AttendanceSessionDetailReadResponse>> Handle(
+        GetAttendanceSessionDetailReadRequest request,
+        IAttendanceReadService readService,
+        CancellationToken ct) =>
+        readService.GetSessionDetailAsync(request, ct);
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/SessionList/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reads/SessionList/Endpoint.cs
@@ -1,0 +1,26 @@
+using Attendance.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Attributes;
+using XFramework.Integration.Security;
+
+namespace Attendance.Api.Features.Reads.SessionList;
+
+public static class GetAttendanceSessionReadListEndpoint
+{
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal],
+        ActorRequirement = ActorRequirement.Required,
+        TenantAccessMode = TenantAccessMode.ActorTenant,
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    [MapPost("/api/attendance/reads/sessions", Tags = ["Attendance"],
+        Summary = "Get attendance sessions for operator views",
+        Capability = "view",
+        RequiredActorCapabilities = [AttendanceAuthorizationCapabilities.View])]
+    public static Task<Result<GetAttendanceSessionReadListResponse>> Handle(
+        GetAttendanceSessionReadListRequest request,
+        IAttendanceReadService readService,
+        CancellationToken ct) =>
+        readService.GetSessionsAsync(request, ct);
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Records/Get/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Records/Get/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Records.Get;
 
 public static class GetAttendanceRecordEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapGet("/api/attendance/records", Tags = ["Attendance"],
         Summary = "Get attendance record",
         Description = "Gets the session-level attendance record for one participant.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reports/GetContextRange/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reports/GetContextRange/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Reports.GetContextRange;
 
 public static class GetAttendanceReportEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapGet("/api/attendance/reports/context-range", Tags = ["Attendance"],
         Summary = "Get attendance report",
         Description = "Gets paginated session attendance summaries for a context and UTC date range.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reports/GetContextRange/GetAttendanceReportValidator.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Reports/GetContextRange/GetAttendanceReportValidator.cs
@@ -10,9 +10,11 @@ public sealed class GetAttendanceReportValidator : AbstractValidator<GetAttendan
             .NotEmpty().WithMessage("Attendance context ID is required");
 
         RuleFor(x => x.FromUtc)
-            .NotEmpty().WithMessage("From UTC is required");
+            .NotEmpty().WithMessage("From UTC is required")
+            .Must(value => value.Kind == DateTimeKind.Utc).WithMessage("From UTC must be UTC");
 
         RuleFor(x => x.ToUtc)
+            .Must(value => value.Kind == DateTimeKind.Utc).WithMessage("To UTC must be UTC")
             .GreaterThan(x => x.FromUtc).WithMessage("To UTC must be after From UTC");
 
         RuleFor(x => x.Page)

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/Create/CreateAttendanceSessionValidator.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/Create/CreateAttendanceSessionValidator.cs
@@ -19,13 +19,42 @@ public sealed class CreateAttendanceSessionValidator : AbstractValidator<CreateA
 
         RuleFor(x => x.TimeZoneId)
             .NotEmpty().WithMessage("Time zone ID is required")
-            .MaximumLength(100).WithMessage("Time zone ID must not exceed 100 characters");
+            .MaximumLength(100).WithMessage("Time zone ID must not exceed 100 characters")
+            .Must(BeValidTimeZone).WithMessage("Time zone ID is invalid");
 
         RuleFor(x => x.Status)
-            .IsInEnum().WithMessage("Attendance session status is invalid");
+            .IsInEnum().WithMessage("Attendance session status is invalid")
+            .Must(status => status is AttendanceSessionStatus.Scheduled or AttendanceSessionStatus.Open)
+            .WithMessage("New attendance sessions must be scheduled or open");
+
+        RuleFor(x => x.StartsAt)
+            .Must(BeUtc).WithMessage("Attendance session start must be UTC");
 
         RuleFor(x => x.EndsAt)
+            .Must(BeUtc).WithMessage("Attendance session end must be UTC")
             .GreaterThan(x => x.StartsAt).WithMessage("Attendance session end must be after start");
+    }
+
+    private static bool BeUtc(DateTime value) => value.Kind == DateTimeKind.Utc;
+
+    private static bool BeValidTimeZone(string timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+            return false;
+
+        try
+        {
+            _ = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return false;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            return false;
+        }
     }
 }
 

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/Create/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/Create/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Sessions.Create;
 
 public static class CreateAttendanceSessionEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceWrite],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapPost("/api/attendance/sessions", Tags = ["Attendance"],
         Summary = "Create attendance session",
         Description = "Creates a concrete attendance window inside an attendance context.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/GetList/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/GetList/Endpoint.cs
@@ -1,12 +1,15 @@
 using Attendance.Api.Services;
 using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Attributes;
 
 namespace Attendance.Api.Features.Sessions.GetList;
 
 public static class GetAttendanceSessionsEndpoint
 {
-    [BoltHandler]
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceRead],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
     [MapGet("/api/attendance/sessions", Tags = ["Attendance"],
         Summary = "Get attendance sessions",
         Description = "Retrieves paginated attendance sessions for a context.")]

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/GetList/GetAttendanceSessionsValidator.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/GetList/GetAttendanceSessionsValidator.cs
@@ -13,6 +13,14 @@ public sealed class GetAttendanceSessionsValidator : AbstractValidator<GetAttend
             .IsInEnum().WithMessage("Attendance session status is invalid")
             .When(x => x.Status.HasValue);
 
+        RuleFor(x => x.FromUtc)
+            .Must(value => !value.HasValue || value.Value.Kind == DateTimeKind.Utc)
+            .WithMessage("From UTC must be UTC");
+
+        RuleFor(x => x.ToUtc)
+            .Must(value => !value.HasValue || value.Value.Kind == DateTimeKind.Utc)
+            .WithMessage("To UTC must be UTC");
+
         RuleFor(x => x.ToUtc)
             .GreaterThan(x => x.FromUtc!.Value).WithMessage("To UTC must be after From UTC")
             .When(x => x.FromUtc.HasValue && x.ToUtc.HasValue);

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/Transition/Endpoint.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/Transition/Endpoint.cs
@@ -1,0 +1,21 @@
+using Attendance.Api.Services;
+using XFramework.Core.Patterns;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Attributes;
+
+namespace Attendance.Api.Features.Sessions.Transition;
+
+public static class TransitionAttendanceSessionEndpoint
+{
+    [BoltHandler(
+        RequiredServiceScopes = [XFrameworkServiceScopes.AttendanceWrite],
+        AllowedServiceCallers = [XFrameworkServiceNames.Portal])]
+    [MapPost("/api/attendance/sessions/status", Tags = ["Attendance"],
+        Summary = "Transition attendance session status",
+        Description = "Opens, closes, or cancels an attendance session using the allowed lifecycle transitions.")]
+    public static Task<Result<AttendanceSessionResponse>> Handle(
+        TransitionAttendanceSessionRequest request,
+        AttendanceService attendanceService,
+        CancellationToken ct) =>
+        attendanceService.TransitionSessionAsync(request, ct);
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/Transition/TransitionAttendanceSessionValidator.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Features/Sessions/Transition/TransitionAttendanceSessionValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Attendance.Api.Features.Sessions.Transition;
+
+public sealed class TransitionAttendanceSessionValidator : AbstractValidator<TransitionAttendanceSessionRequest>
+{
+    public TransitionAttendanceSessionValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty().WithMessage("Attendance session ID is required");
+
+        RuleFor(x => x.Status)
+            .IsInEnum().WithMessage("Attendance session status is invalid")
+            .Must(status => status is AttendanceSessionStatus.Open or AttendanceSessionStatus.Closed or AttendanceSessionStatus.Cancelled)
+            .WithMessage("Attendance session target status must be open, closed, or cancelled");
+    }
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Installers/ServicesInstaller.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Installers/ServicesInstaller.cs
@@ -13,7 +13,9 @@ public sealed class ServicesInstaller : IInstaller
     {
         services.AddTenantResolver();
         services.AddTenantModuleFeatures();
+        services.AddScoped<IAttendanceCredentialResolver, AttendanceCredentialResolver>();
         services.AddScoped<AttendanceService>();
+        services.AddScoped<IAttendanceReadService, AttendanceReadService>();
     }
 }
 

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Services/AttendanceCredentialResolver.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Services/AttendanceCredentialResolver.cs
@@ -1,0 +1,79 @@
+using IdentityServer.Integration.Drivers;
+using XFramework.Core.Patterns;
+
+namespace Attendance.Api.Services;
+
+public sealed record AttendanceCredentialSnapshot(
+    Guid CredentialId,
+    Guid TenantId,
+    bool IsEnabled,
+    bool IsDeleted,
+    string? UserAlias,
+    string? UserName);
+
+public interface IAttendanceCredentialResolver
+{
+    Task<Result<AttendanceCredentialSnapshot>> ResolveAsync(
+        Guid credentialId,
+        Guid tenantId,
+        CancellationToken ct);
+}
+
+public sealed class AttendanceCredentialResolver(
+    IIdentityServerServiceWrapper identityServer,
+    ILogger<AttendanceCredentialResolver> logger)
+    : IAttendanceCredentialResolver
+{
+    public async Task<Result<AttendanceCredentialSnapshot>> ResolveAsync(
+        Guid credentialId,
+        Guid tenantId,
+        CancellationToken ct)
+    {
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+            var response = await identityServer.IdentityCredential.Get(
+                credentialId,
+                tenantId,
+                noCache: true,
+                navigationDepth: 0,
+                includeNavigations: false);
+            ct.ThrowIfCancellationRequested();
+
+            if (!response.IsSuccess)
+            {
+                var statusCode = (int)response.HttpStatusCode;
+                return statusCode == 404
+                    ? Result<AttendanceCredentialSnapshot>.NotFound("Identity credential was not found")
+                    : Result<AttendanceCredentialSnapshot>.Failure(
+                        response.Message ?? "IdentityServer credential validation failed",
+                        statusCode >= 500 ? 503 : statusCode);
+            }
+
+            var credential = response.Response;
+            if (credential is null)
+                return Result<AttendanceCredentialSnapshot>.NotFound("Identity credential was not found");
+
+            return Result<AttendanceCredentialSnapshot>.Success(new AttendanceCredentialSnapshot(
+                credential.Id,
+                credential.TenantId,
+                credential.IsEnabled,
+                credential.IsDeleted,
+                credential.UserAlias,
+                credential.UserName));
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "IdentityServer credential validation failed for credential {CredentialId} in tenant {TenantId}",
+                credentialId,
+                tenantId);
+            return Result<AttendanceCredentialSnapshot>.Failure("IdentityServer is unavailable", 503);
+        }
+    }
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Services/AttendanceReadService.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Services/AttendanceReadService.cs
@@ -1,0 +1,379 @@
+using Attendance.Domain.Shared.Contracts;
+using Attendance.Domain.Shared.Contracts.Requests;
+using Attendance.Domain.Shared.Contracts.Responses;
+using XFramework.Core.Patterns;
+using XFramework.Integration.Security;
+
+namespace Attendance.Api.Services;
+
+public interface IAttendanceReadService
+{
+    Task<Result<GetAttendanceContextOverviewResponse>> GetContextOverviewAsync(
+        GetAttendanceContextOverviewRequest request,
+        CancellationToken ct);
+
+    Task<Result<GetAttendanceSessionReadListResponse>> GetSessionsAsync(
+        GetAttendanceSessionReadListRequest request,
+        CancellationToken ct);
+
+    Task<Result<AttendanceSessionDetailReadResponse>> GetSessionDetailAsync(
+        GetAttendanceSessionDetailReadRequest request,
+        CancellationToken ct);
+
+    Task<Result<GetAttendanceParticipantReadListResponse>> GetParticipantsAsync(
+        GetAttendanceParticipantReadListRequest request,
+        CancellationToken ct);
+
+    Task<Result<AttendanceCredentialHistoryResponse>> GetCredentialHistoryAsync(
+        GetAttendanceCredentialHistoryRequest request,
+        CancellationToken ct);
+}
+
+public sealed class AttendanceReadService(
+    AppDbContext db,
+    ITrustedInvocationContextAccessor trustedInvocationContextAccessor) : IAttendanceReadService
+{
+    public async Task<Result<GetAttendanceContextOverviewResponse>> GetContextOverviewAsync(
+        GetAttendanceContextOverviewRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, out var tenantId))
+            return Result<GetAttendanceContextOverviewResponse>.Failure("Tenant ID is required", 400);
+
+        var limit = NormalizeLimit(request.Limit, 500);
+        var items = await db.Set<AttendanceContext>()
+            .AsNoTracking()
+            .Where(context => context.TenantId == tenantId)
+            .OrderBy(context => context.Name)
+            .Take(limit)
+            .Select(context => new AttendanceContextOverviewResponse
+            {
+                Id = context.Id,
+                TenantId = context.TenantId,
+                Name = context.Name,
+                Code = context.Code,
+                ContextType = context.ContextType,
+                Description = context.Description,
+                IsActive = context.IsActive,
+                ActiveParticipantCount = db.Set<AttendanceParticipant>().Count(participant =>
+                    participant.TenantId == tenantId &&
+                    participant.ContextId == context.Id &&
+                    participant.IsActive),
+                SessionCount = db.Set<AttendanceSession>().Count(session =>
+                    session.TenantId == tenantId &&
+                    session.ContextId == context.Id),
+                CreatedAt = context.CreatedAt
+            })
+            .ToListAsync(ct);
+
+        return Result<GetAttendanceContextOverviewResponse>.Success(new()
+        {
+            Items = items
+        });
+    }
+
+    public async Task<Result<GetAttendanceSessionReadListResponse>> GetSessionsAsync(
+        GetAttendanceSessionReadListRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, out var tenantId))
+            return Result<GetAttendanceSessionReadListResponse>.Failure("Tenant ID is required", 400);
+
+        var fromUtc = NormalizeUtc(request.FromUtc);
+        var toUtc = NormalizeUtc(request.ToUtc);
+        if (fromUtc > toUtc)
+            return Result<GetAttendanceSessionReadListResponse>.Failure("FromUtc must be before or equal to ToUtc", 400);
+
+        IQueryable<AttendanceSession> query = db.Set<AttendanceSession>()
+            .AsNoTracking()
+            .Where(session =>
+                session.TenantId == tenantId &&
+                session.StartsAt >= fromUtc &&
+                session.StartsAt <= toUtc);
+
+        if (request.ContextId is { } contextId && contextId != Guid.Empty)
+            query = query.Where(session => session.ContextId == contextId);
+
+        if (request.Status is { } status)
+            query = query.Where(session => session.Status == status);
+
+        var sessions = await query
+            .OrderByDescending(session => session.StartsAt)
+            .Take(NormalizeLimit(request.Limit, 500))
+            .Select(session => new AttendanceSessionResponse
+            {
+                Id = session.Id,
+                TenantId = session.TenantId,
+                ContextId = session.ContextId,
+                PolicyId = session.PolicyId,
+                Name = session.Name,
+                Code = session.Code,
+                StartsAt = session.StartsAt,
+                EndsAt = session.EndsAt,
+                TimeZoneId = session.TimeZoneId,
+                Status = session.Status
+            })
+            .ToListAsync(ct);
+
+        var contextIds = sessions.Select(session => session.ContextId).Distinct().ToList();
+        var contexts = contextIds.Count == 0
+            ? []
+            : await db.Set<AttendanceContext>()
+                .AsNoTracking()
+                .Where(context => context.TenantId == tenantId && contextIds.Contains(context.Id))
+                .Select(context => ToContextResponse(context))
+                .ToListAsync(ct);
+
+        return Result<GetAttendanceSessionReadListResponse>.Success(new()
+        {
+            Items = sessions,
+            Contexts = contexts
+        });
+    }
+
+    public async Task<Result<AttendanceSessionDetailReadResponse>> GetSessionDetailAsync(
+        GetAttendanceSessionDetailReadRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, out var tenantId))
+            return Result<AttendanceSessionDetailReadResponse>.Failure("Tenant ID is required", 400);
+
+        if (request.SessionId == Guid.Empty)
+            return Result<AttendanceSessionDetailReadResponse>.Failure("Session ID is required", 400);
+
+        var session = await db.Set<AttendanceSession>()
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.Id == request.SessionId)
+            .Select(item => new AttendanceSessionResponse
+            {
+                Id = item.Id,
+                TenantId = item.TenantId,
+                ContextId = item.ContextId,
+                PolicyId = item.PolicyId,
+                Name = item.Name,
+                Code = item.Code,
+                StartsAt = item.StartsAt,
+                EndsAt = item.EndsAt,
+                TimeZoneId = item.TimeZoneId,
+                Status = item.Status
+            })
+            .FirstOrDefaultAsync(ct);
+
+        if (session is null)
+            return Result<AttendanceSessionDetailReadResponse>.NotFound("Attendance session was not found");
+
+        var context = await db.Set<AttendanceContext>()
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.Id == session.ContextId)
+            .Select(item => ToContextResponse(item))
+            .FirstOrDefaultAsync(ct);
+
+        var participants = await db.Set<AttendanceParticipant>()
+            .AsNoTracking()
+            .Where(item =>
+                item.TenantId == tenantId &&
+                item.ContextId == session.ContextId &&
+                item.StartedAt <= session.StartsAt &&
+                (item.EndedAt == null || item.EndedAt >= session.StartsAt))
+            .OrderBy(item => item.DisplayName)
+            .Take(1000)
+            .Select(item => ToParticipantResponse(item))
+            .ToListAsync(ct);
+
+        var records = await db.Set<AttendanceRecord>()
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.SessionId == session.Id)
+            .Take(1000)
+            .Select(item => ToRecordResponse(item))
+            .ToListAsync(ct);
+
+        var events = await db.Set<AttendanceEvent>()
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.SessionId == session.Id)
+            .OrderByDescending(item => item.OccurredAt)
+            .Take(100)
+            .Select(item => ToEventResponse(item))
+            .ToListAsync(ct);
+
+        return Result<AttendanceSessionDetailReadResponse>.Success(new()
+        {
+            Session = session,
+            Context = context,
+            Participants = participants,
+            Records = records,
+            RecentEvents = events
+        });
+    }
+
+    public async Task<Result<GetAttendanceParticipantReadListResponse>> GetParticipantsAsync(
+        GetAttendanceParticipantReadListRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, out var tenantId))
+            return Result<GetAttendanceParticipantReadListResponse>.Failure("Tenant ID is required", 400);
+
+        if (request.ContextId == Guid.Empty)
+            return Result<GetAttendanceParticipantReadListResponse>.Failure("Context ID is required", 400);
+
+        var participants = await db.Set<AttendanceParticipant>()
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.ContextId == request.ContextId)
+            .OrderBy(item => item.DisplayName)
+            .Take(NormalizeLimit(request.Limit, 1000))
+            .Select(item => ToParticipantResponse(item))
+            .ToListAsync(ct);
+
+        return Result<GetAttendanceParticipantReadListResponse>.Success(new()
+        {
+            Items = participants
+        });
+    }
+
+    public async Task<Result<AttendanceCredentialHistoryResponse>> GetCredentialHistoryAsync(
+        GetAttendanceCredentialHistoryRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, out var tenantId))
+            return Result<AttendanceCredentialHistoryResponse>.Failure("Tenant ID is required", 400);
+
+        var credentialIds = request.CredentialIds
+            .Where(id => id != Guid.Empty)
+            .Distinct()
+            .Take(100)
+            .ToList();
+        if (credentialIds.Count == 0)
+            return Result<AttendanceCredentialHistoryResponse>.Success(new());
+
+        var participants = await db.Set<AttendanceParticipant>()
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId && credentialIds.Contains(item.CredentialId))
+            .OrderByDescending(item => item.StartedAt)
+            .Take(500)
+            .Select(item => ToParticipantResponse(item))
+            .ToListAsync(ct);
+
+        var records = await db.Set<AttendanceRecord>()
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId && credentialIds.Contains(item.CredentialId))
+            .OrderByDescending(item => item.CreatedAt)
+            .Take(500)
+            .Select(item => ToRecordResponse(item))
+            .ToListAsync(ct);
+
+        var sessionIds = records.Select(record => record.SessionId).Distinct().ToList();
+        var sessions = sessionIds.Count == 0
+            ? []
+            : await db.Set<AttendanceSession>()
+                .AsNoTracking()
+                .Where(item => item.TenantId == tenantId && sessionIds.Contains(item.Id))
+                .Select(item => new AttendanceSessionResponse
+                {
+                    Id = item.Id,
+                    TenantId = item.TenantId,
+                    ContextId = item.ContextId,
+                    PolicyId = item.PolicyId,
+                    Name = item.Name,
+                    Code = item.Code,
+                    StartsAt = item.StartsAt,
+                    EndsAt = item.EndsAt,
+                    TimeZoneId = item.TimeZoneId,
+                    Status = item.Status
+                })
+                .ToListAsync(ct);
+
+        var contextIds = participants.Select(item => item.ContextId)
+            .Concat(sessions.Select(item => item.ContextId))
+            .Distinct()
+            .ToList();
+        var contexts = contextIds.Count == 0
+            ? []
+            : await db.Set<AttendanceContext>()
+                .AsNoTracking()
+                .Where(item => item.TenantId == tenantId && contextIds.Contains(item.Id))
+                .Select(item => ToContextResponse(item))
+                .ToListAsync(ct);
+
+        return Result<AttendanceCredentialHistoryResponse>.Success(new()
+        {
+            Participants = participants,
+            Records = records,
+            Sessions = sessions,
+            Contexts = contexts
+        });
+    }
+
+    private bool TryResolveTenantId(Guid? requestTenantId, out Guid tenantId)
+    {
+        tenantId = trustedInvocationContextAccessor.Current?.EffectiveTenantId ?? Guid.Empty;
+        return tenantId != Guid.Empty &&
+               (requestTenantId is null || requestTenantId == Guid.Empty || requestTenantId == tenantId);
+    }
+
+    private static int NormalizeLimit(int requested, int maximum) =>
+        requested <= 0 ? Math.Min(100, maximum) : Math.Min(requested, maximum);
+
+    private static DateTime NormalizeUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+    };
+
+    private static AttendanceContextResponse ToContextResponse(AttendanceContext context) => new()
+    {
+        Id = context.Id,
+        TenantId = context.TenantId,
+        Name = context.Name,
+        Code = context.Code,
+        ContextType = context.ContextType,
+        Description = context.Description,
+        DefaultPolicyId = context.DefaultPolicyId,
+        IsActive = context.IsActive,
+        CreatedAt = context.CreatedAt
+    };
+
+    private static AttendanceParticipantResponse ToParticipantResponse(AttendanceParticipant participant) => new()
+    {
+        Id = participant.Id,
+        TenantId = participant.TenantId,
+        ContextId = participant.ContextId,
+        CredentialId = participant.CredentialId,
+        DisplayName = participant.DisplayName,
+        ReferenceCode = participant.ReferenceCode,
+        StartedAt = participant.StartedAt,
+        EndedAt = participant.EndedAt,
+        IsActive = participant.IsActive
+    };
+
+    private static AttendanceRecordResponse ToRecordResponse(AttendanceRecord record) => new()
+    {
+        Id = record.Id,
+        TenantId = record.TenantId,
+        SessionId = record.SessionId,
+        ParticipantId = record.ParticipantId,
+        CredentialId = record.CredentialId,
+        FirstCheckInAt = record.FirstCheckInAt,
+        LastCheckOutAt = record.LastCheckOutAt,
+        Status = record.Status,
+        IsManual = record.IsManual,
+        SourceEventId = record.SourceEventId,
+        Notes = record.Notes
+    };
+
+    private static AttendanceEventResponse ToEventResponse(AttendanceEvent attendanceEvent) => new()
+    {
+        Id = attendanceEvent.Id,
+        TenantId = attendanceEvent.TenantId,
+        SessionId = attendanceEvent.SessionId,
+        ParticipantId = attendanceEvent.ParticipantId,
+        CredentialId = attendanceEvent.CredentialId,
+        EventType = attendanceEvent.EventType,
+        Source = attendanceEvent.Source,
+        OccurredAt = attendanceEvent.OccurredAt,
+        RecordedByCredentialId = attendanceEvent.RecordedByCredentialId,
+        IdempotencyKey = attendanceEvent.IdempotencyKey,
+        SourceReference = attendanceEvent.SourceReference,
+        Notes = attendanceEvent.Notes,
+        MetadataJson = attendanceEvent.MetadataJson
+    };
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Api/Services/AttendanceService.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Api/Services/AttendanceService.cs
@@ -12,7 +12,8 @@ namespace Attendance.Api.Services;
 public sealed class AttendanceService(
     AppDbContext db,
     ILogger<AttendanceService> logger,
-    ITrustedInvocationContextAccessor trustedInvocationContextAccessor)
+    ITrustedInvocationContextAccessor trustedInvocationContextAccessor,
+    IAttendanceCredentialResolver credentialResolver)
 {
     private const int DefaultGracePeriodMinutes = 5;
     private const int DefaultEarlyCheckoutGraceMinutes = 0;
@@ -145,6 +146,9 @@ public sealed class AttendanceService(
         if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
             return Result<AttendanceParticipantResponse>.Failure("Tenant ID is required", 400);
 
+        if (request.StartedAt.HasValue && !IsUtc(request.StartedAt.Value))
+            return Result<AttendanceParticipantResponse>.Failure("Participant start time must be UTC", 400);
+
         var contextExists = await db.Set<AttendanceContext>()
             .AsNoTracking()
             .AnyAsync(item => item.TenantId == tenantId && item.Id == request.ContextId && item.IsActive, ct);
@@ -163,15 +167,28 @@ public sealed class AttendanceService(
         if (existing is not null)
             return Result<AttendanceParticipantResponse>.Conflict("Credential is already an attendance participant in this context");
 
+        var credentialResult = await credentialResolver.ResolveAsync(request.CredentialId, tenantId, ct);
+        if (!credentialResult.IsSuccess)
+            return Result<AttendanceParticipantResponse>.Failure(
+                credentialResult.Message ?? "Identity credential could not be validated",
+                credentialResult.StatusCode);
+
+        var credential = credentialResult.Data!;
+        if (credential.CredentialId != request.CredentialId || credential.TenantId != tenantId)
+            return Result<AttendanceParticipantResponse>.NotFound("Identity credential was not found for this tenant");
+
+        if (!credential.IsEnabled || credential.IsDeleted)
+            return Result<AttendanceParticipantResponse>.Conflict("Identity credential is not active");
+
         var participant = new AttendanceParticipant
         {
             Id = Guid.NewGuid(),
             TenantId = tenantId,
             ContextId = request.ContextId,
             CredentialId = request.CredentialId,
-            DisplayName = NormalizeOptional(request.DisplayName),
-            ReferenceCode = NormalizeOptional(request.ReferenceCode),
-            StartedAt = request.StartedAt ?? DateTime.UtcNow,
+            DisplayName = NormalizeOptional(credential.UserAlias) ?? NormalizeOptional(credential.UserName),
+            ReferenceCode = NormalizeOptional(credential.UserName),
+            StartedAt = NormalizeUtcPrecision(request.StartedAt ?? DateTime.UtcNow),
             IsActive = true,
             CreatedAt = DateTime.UtcNow,
             ConcurrencyStamp = Guid.NewGuid(),
@@ -198,10 +215,19 @@ public sealed class AttendanceService(
         if (participant is null)
             return Result.NotFound("Attendance participant was not found");
 
+        if (!participant.IsActive)
+            return Result.Conflict("Attendance participant is already inactive");
+
+        if (request.EndedAt.HasValue && !IsUtc(request.EndedAt.Value))
+            return Result.Failure("Participant end time must be UTC", 400);
+
+        var endedAt = NormalizeUtcPrecision(request.EndedAt ?? DateTime.UtcNow);
+        if (endedAt < participant.StartedAt)
+            return Result.Failure("Participant end time cannot be before the start time", 400);
+
         participant.IsActive = false;
-        participant.EndedAt = request.EndedAt ?? DateTime.UtcNow;
+        participant.EndedAt = endedAt;
         participant.ModifiedAt = DateTime.UtcNow;
-        db.Set<AttendanceParticipant>().Remove(participant);
         await db.SaveChangesAsync(ct);
 
         return Result.Success("Attendance participant removed");
@@ -270,6 +296,21 @@ public sealed class AttendanceService(
         if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
             return Result<AttendanceSessionResponse>.Failure("Tenant ID is required", 400);
 
+        if (!IsUtc(request.StartsAt) || !IsUtc(request.EndsAt))
+            return Result<AttendanceSessionResponse>.Failure("Attendance session start and end times must be UTC", 400);
+
+        var startsAt = NormalizeUtcPrecision(request.StartsAt);
+        var endsAt = NormalizeUtcPrecision(request.EndsAt);
+        if (endsAt <= startsAt)
+            return Result<AttendanceSessionResponse>.Failure("Attendance session end must be after start", 400);
+
+        var timeZoneId = NormalizeOptional(request.TimeZoneId);
+        if (timeZoneId is null || !IsValidTimeZone(timeZoneId))
+            return Result<AttendanceSessionResponse>.Failure("Attendance session time zone is invalid", 400);
+
+        if (request.Status is AttendanceSessionStatus.Closed or AttendanceSessionStatus.Cancelled)
+            return Result<AttendanceSessionResponse>.Failure("New attendance sessions must be scheduled or open", 400);
+
         var context = await db.Set<AttendanceContext>()
             .AsNoTracking()
             .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == request.ContextId && item.IsActive, ct);
@@ -295,9 +336,9 @@ public sealed class AttendanceService(
             PolicyId = request.PolicyId ?? context.DefaultPolicyId,
             Name = request.Name.Trim(),
             Code = NormalizeOptional(request.Code),
-            StartsAt = request.StartsAt,
-            EndsAt = request.EndsAt,
-            TimeZoneId = request.TimeZoneId.Trim(),
+            StartsAt = startsAt,
+            EndsAt = endsAt,
+            TimeZoneId = timeZoneId,
             Status = request.Status,
             CreatedAt = DateTime.UtcNow,
             ConcurrencyStamp = Guid.NewGuid(),
@@ -361,6 +402,45 @@ public sealed class AttendanceService(
         });
     }
 
+    public async Task<Result<AttendanceSessionResponse>> TransitionSessionAsync(
+        TransitionAttendanceSessionRequest request,
+        CancellationToken ct)
+    {
+        if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
+            return Result<AttendanceSessionResponse>.Failure("Tenant ID is required", 400);
+
+        var session = await db.Set<AttendanceSession>()
+            .AsTracking()
+            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == request.SessionId, ct);
+
+        if (session is null)
+            return Result<AttendanceSessionResponse>.NotFound("Attendance session was not found");
+
+        if (session.Status == request.Status)
+            return Result<AttendanceSessionResponse>.Success(ToSessionResponse(session), "Attendance session status unchanged");
+
+        var transitionAllowed = session.Status switch
+        {
+            AttendanceSessionStatus.Scheduled => request.Status is AttendanceSessionStatus.Open or AttendanceSessionStatus.Cancelled,
+            AttendanceSessionStatus.Open => request.Status is AttendanceSessionStatus.Closed or AttendanceSessionStatus.Cancelled,
+            _ => false
+        };
+
+        if (!transitionAllowed)
+        {
+            return Result<AttendanceSessionResponse>.Conflict(
+                $"Attendance session cannot transition from {session.Status} to {request.Status}");
+        }
+
+        session.Status = request.Status;
+        session.ModifiedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+
+        return Result<AttendanceSessionResponse>.Success(
+            ToSessionResponse(session),
+            "Attendance session status updated");
+    }
+
     public async Task<Result<AttendanceEventResponse>> RecordEventAsync(
         RecordAttendanceEventRequest request,
         CancellationToken ct)
@@ -368,17 +448,48 @@ public sealed class AttendanceService(
         if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
             return Result<AttendanceEventResponse>.Failure("Tenant ID is required", 400);
 
+        var actorCredentialId = trustedInvocationContextAccessor.Current?.Actor?.CredentialId;
+        if (!actorCredentialId.HasValue || actorCredentialId == Guid.Empty)
+            return Result<AttendanceEventResponse>.Failure("Authenticated actor credential is required", 401);
+
+        if (request.RecordedByCredentialId is { } suppliedActorCredentialId &&
+            suppliedActorCredentialId != Guid.Empty &&
+            suppliedActorCredentialId != actorCredentialId.Value)
+        {
+            return Result<AttendanceEventResponse>.Failure(
+                "Recorded-by credential must match the authenticated actor",
+                403);
+        }
+
+        var idempotencyKey = NormalizeOptional(request.IdempotencyKey);
+        if (idempotencyKey is null)
+            return Result<AttendanceEventResponse>.Failure("Idempotency key is required", 400);
+
+        if (request.OccurredAt.HasValue && !IsUtc(request.OccurredAt.Value))
+            return Result<AttendanceEventResponse>.Failure("Attendance event time must be UTC", 400);
+
+        var requestedOccurredAt = request.OccurredAt.HasValue
+            ? NormalizeUtcPrecision(request.OccurredAt.Value)
+            : (DateTime?)null;
+        var sourceReference = NormalizeOptional(request.SourceReference);
+        var notes = NormalizeOptional(request.Notes);
+        var metadataJson = SerializeMetadata(request.Data);
+
         var existingEvent = await db.Set<AttendanceEvent>()
             .AsNoTracking()
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.IdempotencyKey == request.IdempotencyKey, ct);
+            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.IdempotencyKey == idempotencyKey, ct);
 
         if (existingEvent is not null)
-        {
-            var replayRecord = await GetRecordEntityAsync(tenantId, existingEvent.SessionId, existingEvent.ParticipantId, false, ct);
-            return Result<AttendanceEventResponse>.Success(
-                ToEventResponse(existingEvent, replayRecord is null ? null : ToRecordResponse(replayRecord, replayRecord.Status)),
-                "Attendance event replayed");
-        }
+            return await ResolveEventReplayAsync(
+                tenantId,
+                existingEvent,
+                request,
+                requestedOccurredAt,
+                actorCredentialId.Value,
+                sourceReference,
+                notes,
+                metadataJson,
+                ct);
 
         var session = await db.Set<AttendanceSession>()
             .AsNoTracking()
@@ -387,8 +498,17 @@ public sealed class AttendanceService(
         if (session is null)
             return Result<AttendanceEventResponse>.NotFound("Attendance session was not found");
 
-        if (session.Status == AttendanceSessionStatus.Cancelled)
-            return Result<AttendanceEventResponse>.Conflict("Cannot record attendance against a cancelled session");
+        if (session.Status != AttendanceSessionStatus.Open)
+            return Result<AttendanceEventResponse>.Conflict("Attendance events can only be recorded for open sessions");
+
+        var occurredAt = requestedOccurredAt ?? NormalizeUtcPrecision(DateTime.UtcNow);
+        if (occurredAt > DateTime.UtcNow)
+            return Result<AttendanceEventResponse>.Failure("Attendance event time cannot be in the future", 400);
+
+        var sessionStartsAt = NormalizeUtcPrecision(session.StartsAt);
+        var sessionEndsAt = NormalizeUtcPrecision(session.EndsAt);
+        if (occurredAt < sessionStartsAt || occurredAt > sessionEndsAt)
+            return Result<AttendanceEventResponse>.Conflict("Attendance event time must be within the session window");
 
         var participant = await db.Set<AttendanceParticipant>()
             .AsNoTracking()
@@ -396,14 +516,14 @@ public sealed class AttendanceService(
                 item.TenantId == tenantId &&
                 item.Id == request.ParticipantId &&
                 item.ContextId == session.ContextId &&
-                item.IsActive,
+                item.StartedAt <= session.StartsAt &&
+                (!item.EndedAt.HasValue || item.EndedAt.Value > session.StartsAt),
                 ct);
 
         if (participant is null)
             return Result<AttendanceEventResponse>.NotFound("Attendance participant was not found for this session context");
 
         var policy = await GetEffectivePolicyAsync(tenantId, session, ct);
-        var occurredAt = request.OccurredAt ?? DateTime.UtcNow;
         var attendanceEvent = new AttendanceEvent
         {
             Id = Guid.NewGuid(),
@@ -414,11 +534,11 @@ public sealed class AttendanceService(
             EventType = request.EventType,
             Source = request.Source,
             OccurredAt = occurredAt,
-            RecordedByCredentialId = request.RecordedByCredentialId ?? trustedInvocationContextAccessor.Current?.Actor?.CredentialId,
-            IdempotencyKey = request.IdempotencyKey.Trim(),
-            SourceReference = NormalizeOptional(request.SourceReference),
-            Notes = NormalizeOptional(request.Notes),
-            MetadataJson = request.Data is null ? null : JsonSerializer.Serialize(request.Data),
+            RecordedByCredentialId = actorCredentialId.Value,
+            IdempotencyKey = idempotencyKey,
+            SourceReference = sourceReference,
+            Notes = notes,
+            MetadataJson = metadataJson,
             CreatedAt = DateTime.UtcNow,
             ConcurrencyStamp = Guid.NewGuid(),
             IsEnabled = true
@@ -429,7 +549,33 @@ public sealed class AttendanceService(
             return Result<AttendanceEventResponse>.Failure(recordResult.Message ?? "Attendance event rejected", recordResult.StatusCode);
 
         db.Set<AttendanceEvent>().Add(attendanceEvent);
-        await db.SaveChangesAsync(ct);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            db.ChangeTracker.Clear();
+            var concurrentEvent = await db.Set<AttendanceEvent>()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(
+                    item => item.TenantId == tenantId && item.IdempotencyKey == idempotencyKey,
+                    ct);
+
+            if (concurrentEvent is null)
+                throw;
+
+            return await ResolveEventReplayAsync(
+                tenantId,
+                concurrentEvent,
+                request,
+                requestedOccurredAt,
+                actorCredentialId.Value,
+                sourceReference,
+                notes,
+                metadataJson,
+                ct);
+        }
 
         logger.LogInformation(
             "Attendance event {AttendanceEventId} recorded for credential {CredentialId} in session {SessionId}",
@@ -492,6 +638,14 @@ public sealed class AttendanceService(
         if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
             return Result<AttendanceReportResponse>.Failure("Tenant ID is required", 400);
 
+        if (!IsUtc(request.FromUtc) || !IsUtc(request.ToUtc))
+            return Result<AttendanceReportResponse>.Failure("Attendance report range must be UTC", 400);
+
+        var fromUtc = NormalizeUtcPrecision(request.FromUtc);
+        var toUtc = NormalizeUtcPrecision(request.ToUtc);
+        if (toUtc <= fromUtc)
+            return Result<AttendanceReportResponse>.Failure("Attendance report end must be after start", 400);
+
         var contextExists = await db.Set<AttendanceContext>()
             .AsNoTracking()
             .AnyAsync(item => item.TenantId == tenantId && item.Id == request.ContextId, ct);
@@ -500,17 +654,31 @@ public sealed class AttendanceService(
             return Result<AttendanceReportResponse>.NotFound("Attendance context was not found");
 
         var (page, pageSize) = NormalizePage(request.Page, request.PageSize);
-        var activeParticipantCount = await db.Set<AttendanceParticipant>()
+        var participants = await db.Set<AttendanceParticipant>()
             .AsNoTracking()
-            .CountAsync(item => item.TenantId == tenantId && item.ContextId == request.ContextId && item.IsActive, ct);
+            .Where(item =>
+                item.TenantId == tenantId &&
+                item.ContextId == request.ContextId &&
+                item.StartedAt <= toUtc)
+            .Select(item => new
+            {
+                item.Id,
+                item.StartedAt,
+                item.EndedAt
+            })
+            .ToListAsync(ct);
+
+        var activeParticipantCount = participants.Count(item =>
+            item.StartedAt <= toUtc &&
+            (!item.EndedAt.HasValue || item.EndedAt.Value > toUtc));
 
         IQueryable<AttendanceSession> sessionQuery = db.Set<AttendanceSession>()
             .AsNoTracking()
             .Where(item =>
                 item.TenantId == tenantId &&
                 item.ContextId == request.ContextId &&
-                item.StartsAt >= request.FromUtc &&
-                item.StartsAt <= request.ToUtc);
+                item.StartsAt >= fromUtc &&
+                item.StartsAt <= toUtc);
 
         var totalSessions = await sessionQuery.CountAsync(ct);
         var sessions = await sessionQuery
@@ -540,7 +708,17 @@ public sealed class AttendanceService(
 
         foreach (var session in sessions)
         {
-            var sessionRecords = records.Where(item => item.SessionId == session.SessionId).ToList();
+            var sessionParticipantIds = participants
+                .Where(item =>
+                    item.StartedAt <= session.StartsAt &&
+                    (!item.EndedAt.HasValue || item.EndedAt.Value > session.StartsAt))
+                .Select(item => item.Id)
+                .ToHashSet();
+            var sessionRecords = records
+                .Where(item =>
+                    item.SessionId == session.SessionId &&
+                    sessionParticipantIds.Contains(item.ParticipantId))
+                .ToList();
             session.PresentCount = sessionRecords.Count(item => item.Status == AttendanceRecordStatus.Present);
             session.LateCount = sessionRecords.Count(item => item.Status == AttendanceRecordStatus.Late);
             session.IncompleteCount = sessionRecords.Count(item => item.Status == AttendanceRecordStatus.Incomplete);
@@ -548,7 +726,7 @@ public sealed class AttendanceService(
             session.ExcusedCount = sessionRecords.Count(item => item.Status == AttendanceRecordStatus.Excused);
             session.AbsentCount = Math.Max(
                 0,
-                activeParticipantCount -
+                sessionParticipantIds.Count -
                 sessionRecords.Select(item => item.ParticipantId).Distinct().Count() +
                 sessionRecords.Count(item => item.Status == AttendanceRecordStatus.Absent));
         }
@@ -557,8 +735,8 @@ public sealed class AttendanceService(
         {
             TenantId = tenantId,
             ContextId = request.ContextId,
-            FromUtc = request.FromUtc,
-            ToUtc = request.ToUtc,
+            FromUtc = fromUtc,
+            ToUtc = toUtc,
             ActiveParticipantCount = activeParticipantCount,
             Page = page,
             PageSize = pageSize,
@@ -575,6 +753,38 @@ public sealed class AttendanceService(
         if (!TryResolveTenantId(request.TenantId, request.Metadata, out var tenantId))
             return Result<AttendanceAdjustmentResponse>.Failure("Tenant ID is required", 400);
 
+        var actorCredentialId = trustedInvocationContextAccessor.Current?.Actor?.CredentialId;
+        if (!actorCredentialId.HasValue || actorCredentialId == Guid.Empty)
+            return Result<AttendanceAdjustmentResponse>.Failure("Authenticated actor credential is required", 401);
+
+        if (request.ActorCredentialId != Guid.Empty && request.ActorCredentialId != actorCredentialId.Value)
+        {
+            return Result<AttendanceAdjustmentResponse>.Failure(
+                "Adjustment actor credential must match the authenticated actor",
+                403);
+        }
+
+        if (request.AdjustedCheckInAt.HasValue && !IsUtc(request.AdjustedCheckInAt.Value) ||
+            request.AdjustedCheckOutAt.HasValue && !IsUtc(request.AdjustedCheckOutAt.Value))
+        {
+            return Result<AttendanceAdjustmentResponse>.Failure("Adjusted attendance times must be UTC", 400);
+        }
+
+        var adjustedCheckInAt = request.AdjustedCheckInAt.HasValue
+            ? NormalizeUtcPrecision(request.AdjustedCheckInAt.Value)
+            : (DateTime?)null;
+        var adjustedCheckOutAt = request.AdjustedCheckOutAt.HasValue
+            ? NormalizeUtcPrecision(request.AdjustedCheckOutAt.Value)
+            : (DateTime?)null;
+
+        if (adjustedCheckOutAt.HasValue && !adjustedCheckInAt.HasValue)
+            return Result<AttendanceAdjustmentResponse>.Failure("Adjusted checkout requires an adjusted check-in", 400);
+
+        if (adjustedCheckInAt.HasValue &&
+            adjustedCheckOutAt.HasValue &&
+            adjustedCheckOutAt.Value < adjustedCheckInAt.Value)
+            return Result<AttendanceAdjustmentResponse>.Failure("Adjusted checkout cannot be before adjusted check-in", 400);
+
         var session = await db.Set<AttendanceSession>()
             .AsNoTracking()
             .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == request.SessionId, ct);
@@ -582,12 +792,27 @@ public sealed class AttendanceService(
         if (session is null)
             return Result<AttendanceAdjustmentResponse>.NotFound("Attendance session was not found");
 
+        if (session.Status is AttendanceSessionStatus.Scheduled or AttendanceSessionStatus.Cancelled)
+            return Result<AttendanceAdjustmentResponse>.Conflict("Attendance adjustments require an open or closed session");
+
+        var sessionStartsAt = NormalizeUtcPrecision(session.StartsAt);
+        var sessionEndsAt = NormalizeUtcPrecision(session.EndsAt);
+        if (adjustedCheckInAt.HasValue &&
+            (adjustedCheckInAt.Value < sessionStartsAt || adjustedCheckInAt.Value > sessionEndsAt) ||
+            adjustedCheckOutAt.HasValue &&
+            (adjustedCheckOutAt.Value < sessionStartsAt || adjustedCheckOutAt.Value > sessionEndsAt))
+        {
+            return Result<AttendanceAdjustmentResponse>.Conflict("Adjusted attendance times must be within the session window");
+        }
+
         var participant = await db.Set<AttendanceParticipant>()
             .AsNoTracking()
             .FirstOrDefaultAsync(item =>
                 item.TenantId == tenantId &&
                 item.Id == request.ParticipantId &&
-                item.ContextId == session.ContextId,
+                item.ContextId == session.ContextId &&
+                item.StartedAt <= session.StartsAt &&
+                (!item.EndedAt.HasValue || item.EndedAt.Value > session.StartsAt),
                 ct);
 
         if (participant is null)
@@ -614,8 +839,8 @@ public sealed class AttendanceService(
             ? AttendanceRecordStatus.Absent
             : record.Status;
 
-        record.FirstCheckInAt = request.AdjustedCheckInAt;
-        record.LastCheckOutAt = request.AdjustedCheckOutAt;
+        record.FirstCheckInAt = adjustedCheckInAt;
+        record.LastCheckOutAt = adjustedCheckOutAt;
         record.Status = request.NewStatus;
         record.IsManual = true;
         record.Notes = NormalizeOptional(request.Notes);
@@ -631,9 +856,9 @@ public sealed class AttendanceService(
             CredentialId = participant.CredentialId,
             PreviousStatus = previousStatus,
             NewStatus = request.NewStatus,
-            AdjustedCheckInAt = request.AdjustedCheckInAt,
-            AdjustedCheckOutAt = request.AdjustedCheckOutAt,
-            ActorCredentialId = request.ActorCredentialId,
+            AdjustedCheckInAt = adjustedCheckInAt,
+            AdjustedCheckOutAt = adjustedCheckOutAt,
+            ActorCredentialId = actorCredentialId.Value,
             Reason = request.Reason.Trim(),
             Notes = NormalizeOptional(request.Notes),
             CreatedAt = DateTime.UtcNow,
@@ -683,6 +908,9 @@ public sealed class AttendanceService(
 
                 if (record.LastCheckOutAt.HasValue)
                     return Result<AttendanceRecordResponse>.Conflict("Participant is already checked out for this session");
+
+                if (attendanceEvent.OccurredAt < record.FirstCheckInAt.Value)
+                    return Result<AttendanceRecordResponse>.Conflict("Checkout cannot be before check-in");
 
                 record.LastCheckOutAt = attendanceEvent.OccurredAt;
                 record.SourceEventId = attendanceEvent.Id;
@@ -779,7 +1007,7 @@ public sealed class AttendanceService(
             return AttendanceRecordStatus.Absent;
 
         var graceMinutes = policy?.GracePeriodMinutes ?? DefaultGracePeriodMinutes;
-        if (record.FirstCheckInAt.Value > session.StartsAt.AddMinutes(graceMinutes))
+        if (record.FirstCheckInAt.Value > NormalizeUtcPrecision(session.StartsAt).AddMinutes(graceMinutes))
             return AttendanceRecordStatus.Late;
 
         var checkoutRequired = policy?.CheckoutRequired ?? true;
@@ -789,10 +1017,124 @@ public sealed class AttendanceService(
         var earlyCheckoutGrace = policy?.EarlyCheckoutGraceMinutes ?? DefaultEarlyCheckoutGraceMinutes;
         if (checkoutRequired &&
             record.LastCheckOutAt.HasValue &&
-            record.LastCheckOutAt.Value < session.EndsAt.AddMinutes(-earlyCheckoutGrace))
+            record.LastCheckOutAt.Value < NormalizeUtcPrecision(session.EndsAt).AddMinutes(-earlyCheckoutGrace))
             return AttendanceRecordStatus.Incomplete;
 
         return AttendanceRecordStatus.Present;
+    }
+
+    private async Task<Result<AttendanceEventResponse>> ResolveEventReplayAsync(
+        Guid tenantId,
+        AttendanceEvent existingEvent,
+        RecordAttendanceEventRequest request,
+        DateTime? requestedOccurredAt,
+        Guid actorCredentialId,
+        string? sourceReference,
+        string? notes,
+        string? metadataJson,
+        CancellationToken ct)
+    {
+        if (!EventPayloadMatches(
+                existingEvent,
+                request,
+                requestedOccurredAt,
+                actorCredentialId,
+                sourceReference,
+                notes,
+                metadataJson))
+        {
+            return Result<AttendanceEventResponse>.Conflict(
+                "Idempotency key is already associated with a different attendance event");
+        }
+
+        var replayRecord = await GetRecordEntityAsync(
+            tenantId,
+            existingEvent.SessionId,
+            existingEvent.ParticipantId,
+            false,
+            ct);
+        return Result<AttendanceEventResponse>.Success(
+            ToEventResponse(
+                existingEvent,
+                replayRecord is null ? null : ToRecordResponse(replayRecord, replayRecord.Status)),
+            "Attendance event replayed");
+    }
+
+    private static bool EventPayloadMatches(
+        AttendanceEvent existingEvent,
+        RecordAttendanceEventRequest request,
+        DateTime? requestedOccurredAt,
+        Guid actorCredentialId,
+        string? sourceReference,
+        string? notes,
+        string? metadataJson) =>
+        existingEvent.SessionId == request.SessionId &&
+        existingEvent.ParticipantId == request.ParticipantId &&
+        existingEvent.EventType == request.EventType &&
+        existingEvent.Source == request.Source &&
+        (!requestedOccurredAt.HasValue ||
+         NormalizeUtcPrecision(existingEvent.OccurredAt).Ticks == requestedOccurredAt.Value.Ticks) &&
+        existingEvent.RecordedByCredentialId == actorCredentialId &&
+        string.Equals(existingEvent.SourceReference, sourceReference, StringComparison.Ordinal) &&
+        string.Equals(existingEvent.Notes, notes, StringComparison.Ordinal) &&
+        MetadataMatches(existingEvent.MetadataJson, metadataJson);
+
+    private static string? SerializeMetadata(IReadOnlyDictionary<string, string>? data)
+    {
+        if (data is null)
+            return null;
+
+        var orderedData = data
+            .OrderBy(item => item.Key, StringComparer.Ordinal)
+            .ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal);
+        return JsonSerializer.Serialize(orderedData);
+    }
+
+    private static bool MetadataMatches(string? existingJson, string? requestJson)
+    {
+        if (existingJson is null || requestJson is null)
+            return existingJson is null && requestJson is null;
+
+        try
+        {
+            var existing = JsonSerializer.Deserialize<Dictionary<string, string>>(existingJson);
+            var requested = JsonSerializer.Deserialize<Dictionary<string, string>>(requestJson);
+            return existing is not null &&
+                   requested is not null &&
+                   existing.Count == requested.Count &&
+                   existing.All(item =>
+                       requested.TryGetValue(item.Key, out var value) &&
+                       string.Equals(item.Value, value, StringComparison.Ordinal));
+        }
+        catch (JsonException)
+        {
+            return string.Equals(existingJson, requestJson, StringComparison.Ordinal);
+        }
+    }
+
+    private static bool IsUtc(DateTime value) => value.Kind == DateTimeKind.Utc;
+
+    private static DateTime NormalizeUtcPrecision(DateTime value) =>
+        new(value.Ticks - value.Ticks % 10, DateTimeKind.Utc);
+
+    private static bool IsValidTimeZone(string timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+            return false;
+
+        try
+        {
+            _ = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return false;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            return false;
+        }
     }
 
     private bool TryResolveTenantId(Guid? requestTenantId, RequestMetadata metadata, out Guid tenantId)

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceAdjustment.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceAdjustment.cs
@@ -6,6 +6,7 @@ namespace Attendance.Domain.Shared.Contracts;
     Actions = EndpointActions.None,
     RoutePrefix = "api/attendance/adjustments",
     RequireAuthorization = true,
+    AuthorizationFeature = "attendance",
     CacheDurationSeconds = 0,
     CacheKeyPrefix = "attendance-adjustments"
 )]

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceAuthorizationCapabilities.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceAuthorizationCapabilities.cs
@@ -1,0 +1,6 @@
+namespace Attendance.Domain.Shared.Contracts;
+
+public static class AttendanceAuthorizationCapabilities
+{
+    public const string View = "attendance:view";
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceContext.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceContext.cs
@@ -6,6 +6,7 @@ namespace Attendance.Domain.Shared.Contracts;
     Actions = EndpointActions.None,
     RoutePrefix = "api/attendance/contexts",
     RequireAuthorization = true,
+    AuthorizationFeature = "attendance",
     CacheDurationSeconds = 300,
     CacheKeyPrefix = "attendance-contexts"
 )]

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceEvent.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceEvent.cs
@@ -6,6 +6,7 @@ namespace Attendance.Domain.Shared.Contracts;
     Actions = EndpointActions.None,
     RoutePrefix = "api/attendance/events",
     RequireAuthorization = true,
+    AuthorizationFeature = "attendance",
     CacheDurationSeconds = 0,
     CacheKeyPrefix = "attendance-events"
 )]

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceParticipant.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceParticipant.cs
@@ -6,6 +6,7 @@ namespace Attendance.Domain.Shared.Contracts;
     Actions = EndpointActions.None,
     RoutePrefix = "api/attendance/participants",
     RequireAuthorization = true,
+    AuthorizationFeature = "attendance",
     CacheDurationSeconds = 300,
     CacheKeyPrefix = "attendance-participants"
 )]

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendancePolicy.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendancePolicy.cs
@@ -6,6 +6,7 @@ namespace Attendance.Domain.Shared.Contracts;
     Actions = EndpointActions.None,
     RoutePrefix = "api/attendance/policies",
     RequireAuthorization = true,
+    AuthorizationFeature = "attendance",
     CacheDurationSeconds = 300,
     CacheKeyPrefix = "attendance-policies"
 )]

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceRecord.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceRecord.cs
@@ -6,6 +6,7 @@ namespace Attendance.Domain.Shared.Contracts;
     Actions = EndpointActions.None,
     RoutePrefix = "api/attendance/records",
     RequireAuthorization = true,
+    AuthorizationFeature = "attendance",
     CacheDurationSeconds = 60,
     CacheKeyPrefix = "attendance-records"
 )]

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceSession.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/AttendanceSession.cs
@@ -6,6 +6,7 @@ namespace Attendance.Domain.Shared.Contracts;
     Actions = EndpointActions.None,
     RoutePrefix = "api/attendance/sessions",
     RequireAuthorization = true,
+    AuthorizationFeature = "attendance",
     CacheDurationSeconds = 120,
     CacheKeyPrefix = "attendance-sessions"
 )]

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/Requests/AttendanceReadRequests.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/Requests/AttendanceReadRequests.cs
@@ -1,0 +1,51 @@
+namespace Attendance.Domain.Shared.Contracts.Requests;
+
+[MemoryPackable]
+public partial record GetAttendanceContextOverviewRequest : RequestBase,
+    IQuery<QueryResponse<GetAttendanceContextOverviewResponse>>,
+    IBoltRequest<GetAttendanceContextOverviewRequest, QueryResponse<GetAttendanceContextOverviewResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public int Limit { get; set; } = 500;
+}
+
+[MemoryPackable]
+public partial record GetAttendanceSessionReadListRequest : RequestBase,
+    IQuery<QueryResponse<GetAttendanceSessionReadListResponse>>,
+    IBoltRequest<GetAttendanceSessionReadListRequest, QueryResponse<GetAttendanceSessionReadListResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public Guid? ContextId { get; set; }
+    public DateTime FromUtc { get; set; }
+    public DateTime ToUtc { get; set; }
+    public AttendanceSessionStatus? Status { get; set; }
+    public int Limit { get; set; } = 500;
+}
+
+[MemoryPackable]
+public partial record GetAttendanceSessionDetailReadRequest : RequestBase,
+    IQuery<QueryResponse<AttendanceSessionDetailReadResponse>>,
+    IBoltRequest<GetAttendanceSessionDetailReadRequest, QueryResponse<AttendanceSessionDetailReadResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public Guid SessionId { get; set; }
+}
+
+[MemoryPackable]
+public partial record GetAttendanceParticipantReadListRequest : RequestBase,
+    IQuery<QueryResponse<GetAttendanceParticipantReadListResponse>>,
+    IBoltRequest<GetAttendanceParticipantReadListRequest, QueryResponse<GetAttendanceParticipantReadListResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public Guid ContextId { get; set; }
+    public int Limit { get; set; } = 1000;
+}
+
+[MemoryPackable]
+public partial record GetAttendanceCredentialHistoryRequest : RequestBase,
+    IQuery<QueryResponse<AttendanceCredentialHistoryResponse>>,
+    IBoltRequest<GetAttendanceCredentialHistoryRequest, QueryResponse<AttendanceCredentialHistoryResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public List<Guid> CredentialIds { get; set; } = [];
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/Requests/TransitionAttendanceSessionRequest.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/Requests/TransitionAttendanceSessionRequest.cs
@@ -1,0 +1,11 @@
+namespace Attendance.Domain.Shared.Contracts.Requests;
+
+[MemoryPackable]
+public partial record TransitionAttendanceSessionRequest : RequestBase,
+    ICommand<QueryResponse<AttendanceSessionResponse>>,
+    IBoltRequest<TransitionAttendanceSessionRequest, QueryResponse<AttendanceSessionResponse>>
+{
+    public Guid? TenantId { get; set; }
+    public Guid SessionId { get; set; }
+    public AttendanceSessionStatus Status { get; set; }
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/Responses/AttendanceReadResponses.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Domain.Shared/Contracts/Responses/AttendanceReadResponses.cs
@@ -1,0 +1,54 @@
+namespace Attendance.Domain.Shared.Contracts.Responses;
+
+[MemoryPackable]
+public partial record AttendanceContextOverviewResponse
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Code { get; set; }
+    public AttendanceContextType ContextType { get; set; }
+    public string? Description { get; set; }
+    public bool IsActive { get; set; }
+    public int ActiveParticipantCount { get; set; }
+    public int SessionCount { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+[MemoryPackable]
+public partial record GetAttendanceContextOverviewResponse
+{
+    public List<AttendanceContextOverviewResponse> Items { get; set; } = [];
+}
+
+[MemoryPackable]
+public partial record GetAttendanceSessionReadListResponse
+{
+    public List<AttendanceSessionResponse> Items { get; set; } = [];
+    public List<AttendanceContextResponse> Contexts { get; set; } = [];
+}
+
+[MemoryPackable]
+public partial record AttendanceSessionDetailReadResponse
+{
+    public AttendanceSessionResponse Session { get; set; } = new();
+    public AttendanceContextResponse? Context { get; set; }
+    public List<AttendanceParticipantResponse> Participants { get; set; } = [];
+    public List<AttendanceRecordResponse> Records { get; set; } = [];
+    public List<AttendanceEventResponse> RecentEvents { get; set; } = [];
+}
+
+[MemoryPackable]
+public partial record GetAttendanceParticipantReadListResponse
+{
+    public List<AttendanceParticipantResponse> Items { get; set; } = [];
+}
+
+[MemoryPackable]
+public partial record AttendanceCredentialHistoryResponse
+{
+    public List<AttendanceParticipantResponse> Participants { get; set; } = [];
+    public List<AttendanceRecordResponse> Records { get; set; } = [];
+    public List<AttendanceSessionResponse> Sessions { get; set; } = [];
+    public List<AttendanceContextResponse> Contexts { get; set; } = [];
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Integration/Drivers/AttendanceServiceWrapper.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Integration/Drivers/AttendanceServiceWrapper.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Attendance.Domain.Shared.Contracts.Requests;
 using Attendance.Domain.Shared.Contracts.Responses;
 using Bolt.Client;
@@ -5,6 +6,7 @@ using MemoryPack;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.Contracts.Base;
 using XFramework.Domain.Shared.DataContext;
 using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Abstractions.Wrappers;
@@ -15,18 +17,42 @@ namespace Attendance.Integration.Drivers;
 
 public interface IAttendanceServiceWrapper : IServiceWrapper, IDataContextServiceWrapper
 {
-    Task<QueryResponse<AttendanceContextResponse>> CreateAttendanceContext(CreateAttendanceContextRequest request);
-    Task<QueryResponse<AttendanceContextResponse>> UpdateAttendanceContext(UpdateAttendanceContextRequest request);
-    Task<QueryResponse<GetAttendanceContextsResponse>> GetAttendanceContexts(GetAttendanceContextsRequest request);
-    Task<QueryResponse<AttendanceParticipantResponse>> AddAttendanceParticipant(AddAttendanceParticipantRequest request);
-    Task<CmdResponse> RemoveAttendanceParticipant(RemoveAttendanceParticipantRequest request);
-    Task<QueryResponse<GetAttendanceParticipantsResponse>> GetAttendanceParticipants(GetAttendanceParticipantsRequest request);
-    Task<QueryResponse<AttendanceSessionResponse>> CreateAttendanceSession(CreateAttendanceSessionRequest request);
-    Task<QueryResponse<GetAttendanceSessionsResponse>> GetAttendanceSessions(GetAttendanceSessionsRequest request);
-    Task<QueryResponse<AttendanceEventResponse>> RecordAttendanceEvent(RecordAttendanceEventRequest request);
-    Task<QueryResponse<AttendanceRecordResponse>> GetAttendanceRecord(GetAttendanceRecordRequest request);
-    Task<QueryResponse<AttendanceReportResponse>> GetAttendanceReport(GetAttendanceReportRequest request);
-    Task<QueryResponse<AttendanceAdjustmentResponse>> CreateAttendanceAdjustment(CreateAttendanceAdjustmentRequest request);
+    Task<QueryResponse<AttendanceContextResponse>> CreateAttendanceContext(
+        CreateAttendanceContextRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceContextResponse>> UpdateAttendanceContext(
+        UpdateAttendanceContextRequest request, CancellationToken ct = default);
+    Task<QueryResponse<GetAttendanceContextsResponse>> GetAttendanceContexts(
+        GetAttendanceContextsRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceParticipantResponse>> AddAttendanceParticipant(
+        AddAttendanceParticipantRequest request, CancellationToken ct = default);
+    Task<CmdResponse> RemoveAttendanceParticipant(
+        RemoveAttendanceParticipantRequest request, CancellationToken ct = default);
+    Task<QueryResponse<GetAttendanceParticipantsResponse>> GetAttendanceParticipants(
+        GetAttendanceParticipantsRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceSessionResponse>> CreateAttendanceSession(
+        CreateAttendanceSessionRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceSessionResponse>> TransitionAttendanceSession(
+        TransitionAttendanceSessionRequest request, CancellationToken ct = default);
+    Task<QueryResponse<GetAttendanceSessionsResponse>> GetAttendanceSessions(
+        GetAttendanceSessionsRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceEventResponse>> RecordAttendanceEvent(
+        RecordAttendanceEventRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceRecordResponse>> GetAttendanceRecord(
+        GetAttendanceRecordRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceReportResponse>> GetAttendanceReport(
+        GetAttendanceReportRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceAdjustmentResponse>> CreateAttendanceAdjustment(
+        CreateAttendanceAdjustmentRequest request, CancellationToken ct = default);
+    Task<QueryResponse<GetAttendanceContextOverviewResponse>> GetAttendanceContextOverview(
+        GetAttendanceContextOverviewRequest request, CancellationToken ct = default);
+    Task<QueryResponse<GetAttendanceSessionReadListResponse>> GetAttendanceSessionReadList(
+        GetAttendanceSessionReadListRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceSessionDetailReadResponse>> GetAttendanceSessionDetailRead(
+        GetAttendanceSessionDetailReadRequest request, CancellationToken ct = default);
+    Task<QueryResponse<GetAttendanceParticipantReadListResponse>> GetAttendanceParticipantReadList(
+        GetAttendanceParticipantReadListRequest request, CancellationToken ct = default);
+    Task<QueryResponse<AttendanceCredentialHistoryResponse>> GetAttendanceCredentialHistory(
+        GetAttendanceCredentialHistoryRequest request, CancellationToken ct = default);
 }
 
 public sealed record AttendanceServiceWrapper(
@@ -39,44 +65,200 @@ public sealed record AttendanceServiceWrapper(
 {
     public override void Initialize()
     {
-        TargetClient = "XFramework.Attendance".ToSha256();
+        TargetClient = XFrameworkServiceNames.Attendance.ToSha256();
     }
 
-    public Task<QueryResponse<AttendanceContextResponse>> CreateAttendanceContext(CreateAttendanceContextRequest request) =>
-        SendAsync<CreateAttendanceContextRequest, AttendanceContextResponse>(request);
+    public Task<QueryResponse<AttendanceContextResponse>> CreateAttendanceContext(
+        CreateAttendanceContextRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<CreateAttendanceContextRequest, AttendanceContextResponse>(
+            request, XFrameworkServiceScopes.AttendanceWrite, ct);
 
-    public Task<QueryResponse<AttendanceContextResponse>> UpdateAttendanceContext(UpdateAttendanceContextRequest request) =>
-        SendAsync<UpdateAttendanceContextRequest, AttendanceContextResponse>(request);
+    public Task<QueryResponse<AttendanceContextResponse>> UpdateAttendanceContext(
+        UpdateAttendanceContextRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<UpdateAttendanceContextRequest, AttendanceContextResponse>(
+            request, XFrameworkServiceScopes.AttendanceWrite, ct);
 
-    public Task<QueryResponse<GetAttendanceContextsResponse>> GetAttendanceContexts(GetAttendanceContextsRequest request) =>
-        SendAsync<GetAttendanceContextsRequest, GetAttendanceContextsResponse>(request);
+    public Task<QueryResponse<GetAttendanceContextsResponse>> GetAttendanceContexts(
+        GetAttendanceContextsRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceContextsRequest, GetAttendanceContextsResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
 
-    public Task<QueryResponse<AttendanceParticipantResponse>> AddAttendanceParticipant(AddAttendanceParticipantRequest request) =>
-        SendAsync<AddAttendanceParticipantRequest, AttendanceParticipantResponse>(request);
+    public Task<QueryResponse<AttendanceParticipantResponse>> AddAttendanceParticipant(
+        AddAttendanceParticipantRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<AddAttendanceParticipantRequest, AttendanceParticipantResponse>(
+            request, XFrameworkServiceScopes.AttendanceWrite, ct);
 
-    public Task<CmdResponse> RemoveAttendanceParticipant(RemoveAttendanceParticipantRequest request) =>
-        SendVoidAsync(request);
+    public Task<CmdResponse> RemoveAttendanceParticipant(
+        RemoveAttendanceParticipantRequest request, CancellationToken ct = default) =>
+        SendBusinessVoidAsync(request, XFrameworkServiceScopes.AttendanceWrite, ct);
 
-    public Task<QueryResponse<GetAttendanceParticipantsResponse>> GetAttendanceParticipants(GetAttendanceParticipantsRequest request) =>
-        SendAsync<GetAttendanceParticipantsRequest, GetAttendanceParticipantsResponse>(request);
+    public Task<QueryResponse<GetAttendanceParticipantsResponse>> GetAttendanceParticipants(
+        GetAttendanceParticipantsRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceParticipantsRequest, GetAttendanceParticipantsResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
 
-    public Task<QueryResponse<AttendanceSessionResponse>> CreateAttendanceSession(CreateAttendanceSessionRequest request) =>
-        SendAsync<CreateAttendanceSessionRequest, AttendanceSessionResponse>(request);
+    public Task<QueryResponse<AttendanceSessionResponse>> CreateAttendanceSession(
+        CreateAttendanceSessionRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<CreateAttendanceSessionRequest, AttendanceSessionResponse>(
+            request, XFrameworkServiceScopes.AttendanceWrite, ct);
 
-    public Task<QueryResponse<GetAttendanceSessionsResponse>> GetAttendanceSessions(GetAttendanceSessionsRequest request) =>
-        SendAsync<GetAttendanceSessionsRequest, GetAttendanceSessionsResponse>(request);
+    public Task<QueryResponse<AttendanceSessionResponse>> TransitionAttendanceSession(
+        TransitionAttendanceSessionRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<TransitionAttendanceSessionRequest, AttendanceSessionResponse>(
+            request, XFrameworkServiceScopes.AttendanceWrite, ct);
 
-    public Task<QueryResponse<AttendanceEventResponse>> RecordAttendanceEvent(RecordAttendanceEventRequest request) =>
-        SendAsync<RecordAttendanceEventRequest, AttendanceEventResponse>(request);
+    public Task<QueryResponse<GetAttendanceSessionsResponse>> GetAttendanceSessions(
+        GetAttendanceSessionsRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceSessionsRequest, GetAttendanceSessionsResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
 
-    public Task<QueryResponse<AttendanceRecordResponse>> GetAttendanceRecord(GetAttendanceRecordRequest request) =>
-        SendAsync<GetAttendanceRecordRequest, AttendanceRecordResponse>(request);
+    public Task<QueryResponse<AttendanceEventResponse>> RecordAttendanceEvent(
+        RecordAttendanceEventRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<RecordAttendanceEventRequest, AttendanceEventResponse>(
+            request, XFrameworkServiceScopes.AttendanceWrite, ct);
 
-    public Task<QueryResponse<AttendanceReportResponse>> GetAttendanceReport(GetAttendanceReportRequest request) =>
-        SendAsync<GetAttendanceReportRequest, AttendanceReportResponse>(request);
+    public Task<QueryResponse<AttendanceRecordResponse>> GetAttendanceRecord(
+        GetAttendanceRecordRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceRecordRequest, AttendanceRecordResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
 
-    public Task<QueryResponse<AttendanceAdjustmentResponse>> CreateAttendanceAdjustment(CreateAttendanceAdjustmentRequest request) =>
-        SendAsync<CreateAttendanceAdjustmentRequest, AttendanceAdjustmentResponse>(request);
+    public Task<QueryResponse<AttendanceReportResponse>> GetAttendanceReport(
+        GetAttendanceReportRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceReportRequest, AttendanceReportResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
+
+    public Task<QueryResponse<AttendanceAdjustmentResponse>> CreateAttendanceAdjustment(
+        CreateAttendanceAdjustmentRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<CreateAttendanceAdjustmentRequest, AttendanceAdjustmentResponse>(
+            request, XFrameworkServiceScopes.AttendanceWrite, ct);
+
+    public Task<QueryResponse<GetAttendanceContextOverviewResponse>> GetAttendanceContextOverview(
+        GetAttendanceContextOverviewRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceContextOverviewRequest, GetAttendanceContextOverviewResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
+
+    public Task<QueryResponse<GetAttendanceSessionReadListResponse>> GetAttendanceSessionReadList(
+        GetAttendanceSessionReadListRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceSessionReadListRequest, GetAttendanceSessionReadListResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
+
+    public Task<QueryResponse<AttendanceSessionDetailReadResponse>> GetAttendanceSessionDetailRead(
+        GetAttendanceSessionDetailReadRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceSessionDetailReadRequest, AttendanceSessionDetailReadResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
+
+    public Task<QueryResponse<GetAttendanceParticipantReadListResponse>> GetAttendanceParticipantReadList(
+        GetAttendanceParticipantReadListRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceParticipantReadListRequest, GetAttendanceParticipantReadListResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
+
+    public Task<QueryResponse<AttendanceCredentialHistoryResponse>> GetAttendanceCredentialHistory(
+        GetAttendanceCredentialHistoryRequest request, CancellationToken ct = default) =>
+        SendBusinessAsync<GetAttendanceCredentialHistoryRequest, AttendanceCredentialHistoryResponse>(
+            request, XFrameworkServiceScopes.AttendanceRead, ct);
+
+    private async Task<QueryResponse<TResponse>> SendBusinessAsync<TRequest, TResponse>(
+        TRequest request,
+        string requiredScope,
+        CancellationToken ct)
+        where TRequest : class, IHasRequestServer
+    {
+        var targetClient = GetTargetClient();
+        PrepareRequest(request);
+        var payload = await BoltInvocationEnvelopeFactory.CreateAsync(
+            request,
+            targetClient,
+            [requiredScope],
+            serviceTokenProvider,
+            actorAccessTokenProvider,
+            ct);
+        var (status, responsePayload) = await boltClient.InvokeAsync(
+            targetClient, typeof(TRequest).Name, payload, ct);
+        return DeserializeQueryResponse<TResponse>(status, responsePayload);
+    }
+
+    private async Task<CmdResponse> SendBusinessVoidAsync<TRequest>(
+        TRequest request,
+        string requiredScope,
+        CancellationToken ct)
+        where TRequest : class, IHasRequestServer
+    {
+        var targetClient = GetTargetClient();
+        PrepareRequest(request);
+        var payload = await BoltInvocationEnvelopeFactory.CreateAsync(
+            request,
+            targetClient,
+            [requiredScope],
+            serviceTokenProvider,
+            actorAccessTokenProvider,
+            ct);
+        var (status, responsePayload) = await boltClient.InvokeAsync(
+            targetClient, typeof(TRequest).Name, payload, ct);
+        return DeserializeCmdResponse(status, responsePayload);
+    }
+
+    private string GetTargetClient()
+    {
+        if (string.IsNullOrWhiteSpace(TargetClient))
+            Initialize();
+
+        return TargetClient ?? throw new InvalidOperationException("Target client was not initialized.");
+    }
+
+    private static void PrepareRequest<TRequest>(TRequest request)
+        where TRequest : IHasRequestServer
+    {
+        request.Metadata ??= new RequestMetadata();
+        request.Metadata.OperationName ??= typeof(TRequest).Name;
+        request.Metadata.RequestId ??= Guid.NewGuid();
+    }
+
+    private static QueryResponse<TResponse> DeserializeQueryResponse<TResponse>(
+        HttpStatusCode status,
+        ReadOnlyMemory<byte> responsePayload)
+    {
+        if (responsePayload.IsEmpty)
+            return new QueryResponse<TResponse> { HttpStatusCode = status, Message = status.ToString() };
+
+        try
+        {
+            var wrapped = MemoryPackSerializer.Deserialize<QueryResponse<TResponse>>(responsePayload.Span);
+            if (wrapped is not null)
+                return wrapped;
+        }
+        catch (MemoryPackSerializationException)
+        {
+            // Legacy handlers may serialize only the response body.
+        }
+
+        return new QueryResponse<TResponse>
+        {
+            HttpStatusCode = status,
+            Message = status.ToString(),
+            Response = MemoryPackSerializer.Deserialize<TResponse>(responsePayload.Span)
+        };
+    }
+
+    private static CmdResponse DeserializeCmdResponse(
+        HttpStatusCode status,
+        ReadOnlyMemory<byte> responsePayload)
+    {
+        if (!responsePayload.IsEmpty)
+        {
+            try
+            {
+                var wrapped = MemoryPackSerializer.Deserialize<CmdResponse>(responsePayload.Span);
+                if (wrapped is not null)
+                    return wrapped;
+            }
+            catch (MemoryPackSerializationException)
+            {
+                // Legacy handlers may return no command envelope payload.
+            }
+        }
+
+        return new CmdResponse { HttpStatusCode = status, Message = status.ToString() };
+    }
 
     public async Task<byte[]> ExecuteQueryAsync(byte[] queryDescriptorBytes, CancellationToken ct = default)
     {

--- a/src/Modules/XFramework.Attendance/Attendance.Tests/Attendance.Tests.csproj
+++ b/src/Modules/XFramework.Attendance/Attendance.Tests/Attendance.Tests.csproj
@@ -13,6 +13,8 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
@@ -21,6 +23,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Attendance.Api\Attendance.Api.csproj" />
+        <ProjectReference Include="..\Attendance.Integration\Attendance.Integration.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Modules/XFramework.Attendance/Attendance.Tests/Services/AttendanceBoltContractTests.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Tests/Services/AttendanceBoltContractTests.cs
@@ -1,0 +1,125 @@
+using System.Reflection;
+using Attendance.Api.Features.Contexts.GetList;
+using Attendance.Domain.Shared.Contracts;
+using Attendance.Integration.Drivers;
+using FluentAssertions;
+using NUnit.Framework;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Attributes;
+using XFramework.Integration.Security;
+
+namespace Attendance.Tests.Services;
+
+[TestFixture]
+public sealed class AttendanceBoltContractTests
+{
+    [Test]
+    public void CustomHandlers_RequireActorTenantAndPortalReadOrWriteScope()
+    {
+        var handlers = typeof(GetAttendanceContextsEndpoint).Assembly
+            .GetTypes()
+            .Where(type => type.Namespace?.StartsWith("Attendance.Api.Features", StringComparison.Ordinal) == true)
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            .Select(method => new
+            {
+                Method = method,
+                Attribute = method.GetCustomAttribute<BoltHandlerAttribute>()
+            })
+            .Where(item => item.Attribute is not null)
+            .ToList();
+
+        handlers.Should().HaveCount(18);
+        foreach (var handler in handlers)
+        {
+            var requestType = handler.Method.GetParameters()[0].ParameterType;
+            var expectedScope = requestType.Name.StartsWith("Get", StringComparison.Ordinal)
+                ? XFrameworkServiceScopes.AttendanceRead
+                : XFrameworkServiceScopes.AttendanceWrite;
+
+            handler.Attribute!.RequiredServiceScopes.Should().Equal(expectedScope);
+            handler.Attribute.AllowedServiceCallers.Should().Equal(XFrameworkServiceNames.Portal);
+            handler.Attribute.ActorRequirement.Should().Be(ActorRequirement.Required);
+            handler.Attribute.TenantAccessMode.Should().Be(TenantAccessMode.ActorTenant);
+            handler.Attribute.AllowAnonymous.Should().BeFalse();
+
+            if (handler.Method.DeclaringType?.Namespace?.StartsWith(
+                    "Attendance.Api.Features.Reads",
+                    StringComparison.Ordinal) == true)
+            {
+                handler.Attribute.RequiredActorCapabilities.Should()
+                    .Equal(AttendanceAuthorizationCapabilities.View);
+            }
+        }
+    }
+
+    [Test]
+    public async Task BusinessWrapperMethods_RequestExactScopeAndPropagateCancellation()
+    {
+        var methods = typeof(IAttendanceServiceWrapper)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .OrderBy(method => method.Name)
+            .ToList();
+
+        methods.Should().HaveCount(18);
+        foreach (var method in methods)
+        {
+            var parameters = method.GetParameters();
+            parameters.Should().HaveCount(2);
+            parameters[1].ParameterType.Should().Be<CancellationToken>();
+            parameters[1].HasDefaultValue.Should().BeTrue();
+
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            var serviceTokenProvider = new RecordingServiceTokenProvider();
+            var actorTokenProvider = new RecordingActorAccessTokenProvider();
+            var wrapper = new AttendanceServiceWrapper(
+                null!,
+                null!,
+                null!,
+                serviceTokenProvider,
+                actorTokenProvider);
+            var request = Activator.CreateInstance(parameters[0].ParameterType)!;
+
+            var task = (Task)method.Invoke(wrapper, [request, cancellation.Token])!;
+            Func<Task> act = async () => await task;
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+            var expectedScope = method.Name.StartsWith("Get", StringComparison.Ordinal)
+                ? XFrameworkServiceScopes.AttendanceRead
+                : XFrameworkServiceScopes.AttendanceWrite;
+            serviceTokenProvider.Audience.Should().Be(XFrameworkServiceNames.Attendance);
+            serviceTokenProvider.Scopes.Should().Equal(expectedScope);
+            serviceTokenProvider.CancellationToken.Should().Be(cancellation.Token);
+            actorTokenProvider.CancellationToken.Should().Be(cancellation.Token);
+        }
+    }
+
+    private sealed class RecordingActorAccessTokenProvider : IActorAccessTokenProvider
+    {
+        public CancellationToken CancellationToken { get; private set; }
+
+        public ValueTask<string?> GetTokenAsync(CancellationToken ct = default)
+        {
+            CancellationToken = ct;
+            return ValueTask.FromResult<string?>("actor-token");
+        }
+    }
+
+    private sealed class RecordingServiceTokenProvider : IServiceTokenProvider
+    {
+        public string? Audience { get; private set; }
+        public IReadOnlyCollection<string>? Scopes { get; private set; }
+        public CancellationToken CancellationToken { get; private set; }
+
+        public ValueTask<string> GetTokenAsync(
+            string audience,
+            IReadOnlyCollection<string>? scopes = null,
+            CancellationToken ct = default)
+        {
+            Audience = audience;
+            Scopes = scopes;
+            CancellationToken = ct;
+            return ValueTask.FromException<string>(new OperationCanceledException(ct));
+        }
+    }
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Tests/Services/AttendanceCredentialResolverTests.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Tests/Services/AttendanceCredentialResolverTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using Attendance.Api.Services;
+using FluentAssertions;
+using IdentityServer.Domain.Shared.Contracts;
+using IdentityServer.Integration.Drivers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using XFramework.Domain.Shared.BusinessObjects;
+
+namespace Attendance.Tests.Services;
+
+[TestFixture]
+public sealed class AttendanceCredentialResolverTests
+{
+    [Test]
+    public async Task ResolveAsync_ActiveIdentityCredential_ReturnsAuthoritativeSnapshot()
+    {
+        var tenantId = Guid.NewGuid();
+        var credential = new IdentityCredential
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            IsEnabled = true,
+            UserAlias = "Authoritative Alias",
+            UserName = "authoritative.user"
+        };
+        var resolver = CreateResolver(new QueryResponse<IdentityCredential>
+        {
+            HttpStatusCode = HttpStatusCode.OK,
+            Response = credential
+        });
+
+        var result = await resolver.ResolveAsync(credential.Id, tenantId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data.Should().BeEquivalentTo(new AttendanceCredentialSnapshot(
+            credential.Id,
+            tenantId,
+            true,
+            false,
+            credential.UserAlias,
+            credential.UserName));
+    }
+
+    [Test]
+    public async Task ResolveAsync_IdentityServerFailure_ReturnsServiceUnavailable()
+    {
+        var resolver = CreateResolver(exception: new HttpRequestException("IdentityServer unavailable"));
+
+        var result = await resolver.ResolveAsync(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(503);
+        result.Message.Should().Contain("unavailable");
+    }
+
+    private static AttendanceCredentialResolver CreateResolver(
+        QueryResponse<IdentityCredential>? response = null,
+        Exception? exception = null)
+    {
+        var credentials = new Mock<IIdentityCredentialCrudService>();
+        var setup = credentials.Setup(service => service.Get(
+            It.IsAny<Guid>(),
+            It.IsAny<Guid?>(),
+            true,
+            0,
+            false,
+            It.IsAny<List<string>?>()));
+        if (exception is not null)
+            setup.ThrowsAsync(exception);
+        else
+            setup.ReturnsAsync(response!);
+
+        var identityServer = new Mock<IIdentityServerServiceWrapper>();
+        identityServer.SetupGet(wrapper => wrapper.IdentityCredential).Returns(credentials.Object);
+        return new AttendanceCredentialResolver(
+            identityServer.Object,
+            NullLogger<AttendanceCredentialResolver>.Instance);
+    }
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Tests/Services/AttendanceReadAuthorizationTests.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Tests/Services/AttendanceReadAuthorizationTests.cs
@@ -1,0 +1,239 @@
+using Attendance.Api.Features.Reads.ContextOverview;
+using Attendance.Domain.Shared.Contracts;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
+using XFramework.Domain.Shared.BusinessObjects;
+using XFramework.Domain.Shared.ServiceIdentity;
+using XFramework.Integration.Attributes;
+using XFramework.Integration.Security;
+
+namespace Attendance.Tests.Services;
+
+[TestFixture]
+public sealed class AttendanceReadAuthorizationTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OtherTenantId = Guid.NewGuid();
+
+    [Test]
+    public async Task ReadPolicy_ValidPortalActorForOwnTenant_IsAllowed()
+    {
+        var result = await ResolveAsync(CreateActor([AttendanceAuthorizationCapabilities.View]));
+
+        result.IsSuccess.Should().BeTrue(result.Error);
+        result.Context!.EffectiveTenantId.Should().Be(TenantId);
+    }
+
+    [Test]
+    public async Task ReadPolicy_ServiceOnlyInvocation_IsDenied()
+    {
+        var result = await ResolveAsync(actor: null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(401);
+    }
+
+    [Test]
+    public async Task ReadPolicy_ActorWithoutAttendanceView_IsDenied()
+    {
+        var result = await ResolveAsync(CreateActor([]));
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+    }
+
+    [Test]
+    public async Task ReadPolicy_DifferentRequestedTenant_IsDenied()
+    {
+        var result = await ResolveAsync(
+            CreateActor([AttendanceAuthorizationCapabilities.View]),
+            requestedTenantId: OtherTenantId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+    }
+
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    public async Task ReadPolicy_WrongCallerOrMissingScope_IsDenied(
+        bool allowedCaller,
+        bool hasReadScope)
+    {
+        var service = CreateService(
+            allowedCaller ? XFrameworkServiceNames.Portal : XFrameworkServiceNames.Wallets,
+            hasReadScope ? [XFrameworkServiceScopes.AttendanceRead] : []);
+
+        var result = await ResolveAsync(
+            CreateActor([AttendanceAuthorizationCapabilities.View]),
+            service);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+    }
+
+    [Test]
+    public async Task ReadRoute_DisabledAttendanceFeature_IsDeniedBeforeCapabilityLookup()
+    {
+        var featureService = new DenyingFeatureService();
+        var capabilityService = new RecordingCapabilityService();
+        var context = new TrustedInvocationContext(
+            CreateActor([AttendanceAuthorizationCapabilities.View]),
+            CreateService(XFrameworkServiceNames.Portal, [XFrameworkServiceScopes.AttendanceRead]),
+            TenantId,
+            TenantId,
+            Guid.NewGuid());
+        var gate = new TrustedInvocationFeatureGate(
+            new TenantModuleFeatureGateOptions().RequireFeature("attendance", "/api/attendance"),
+            featureService,
+            capabilityService,
+            new FixedContextAccessor(context),
+            NullLogger<TrustedInvocationFeatureGate>.Instance);
+        var map = typeof(GetAttendanceContextOverviewEndpoint)
+            .GetMethod(nameof(GetAttendanceContextOverviewEndpoint.Handle))!
+            .GetCustomAttributes(typeof(MapPostAttribute), false)
+            .Cast<MapPostAttribute>()
+            .Single();
+
+        var result = await gate.EnsureAllowedAsync(map.Route, "POST", map.Capability);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+        capabilityService.CallCount.Should().Be(0);
+    }
+
+    private static async Task<TrustedInvocationResult> ResolveAsync(
+        TrustedActorIdentity? actor,
+        TrustedServiceIdentity? service = null,
+        Guid? requestedTenantId = null)
+    {
+        service ??= CreateService(
+            XFrameworkServiceNames.Portal,
+            [XFrameworkServiceScopes.AttendanceRead]);
+        var resolver = new TrustedInvocationResolver(
+            new FixedActorProvider(actor),
+            new FixedServiceProvider(service));
+
+        return await resolver.ResolveAsync(
+            new InvocationCredentials(
+                ServiceAccessToken: "service-token",
+                ActorAccessToken: actor is null ? null : "actor-token"),
+            new RequestMetadata { RequestedTenantId = requestedTenantId ?? TenantId },
+            ReadPolicy(),
+            XFrameworkServiceNames.Attendance);
+    }
+
+    private static InvocationAuthorizationPolicy ReadPolicy()
+    {
+        var attribute = typeof(GetAttendanceContextOverviewEndpoint)
+            .GetMethod(nameof(GetAttendanceContextOverviewEndpoint.Handle))!
+            .GetCustomAttributes(typeof(BoltHandlerAttribute), false)
+            .Cast<BoltHandlerAttribute>()
+            .Single();
+
+        return new InvocationAuthorizationPolicy
+        {
+            ActorRequirement = attribute.ActorRequirement,
+            TenantAccessMode = attribute.TenantAccessMode,
+            RequiredServiceScopes = attribute.RequiredServiceScopes ?? [],
+            AllowedServiceCallers = attribute.AllowedServiceCallers ?? [],
+            RequiredActorCapabilities = attribute.RequiredActorCapabilities ?? [],
+            AllowAnonymous = attribute.AllowAnonymous
+        };
+    }
+
+    private static TrustedActorIdentity CreateActor(IReadOnlyCollection<string> capabilities) => new(
+        Guid.NewGuid(),
+        Guid.NewGuid(),
+        TenantId,
+        Guid.NewGuid(),
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+        capabilities.ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "attendance-tests",
+        DateTimeOffset.UtcNow.AddMinutes(5));
+
+    private static TrustedServiceIdentity CreateService(
+        string clientId,
+        IReadOnlyCollection<string> scopes) => new(
+        clientId,
+        XFrameworkServiceNames.Attendance,
+        scopes.ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "attendance-tests");
+
+    private sealed class FixedActorProvider(TrustedActorIdentity? actor) : IActorIdentityProvider
+    {
+        public Task<ActorIdentityValidationResult> ValidateAsync(
+            string token,
+            CancellationToken ct = default) =>
+            Task.FromResult(actor is null
+                ? ActorIdentityValidationResult.Failure("Actor is unavailable.")
+                : ActorIdentityValidationResult.Success(actor));
+    }
+
+    private sealed class FixedServiceProvider(TrustedServiceIdentity service) : IServiceIdentityProvider
+    {
+        public Task<ServiceIdentityValidationResult> ValidateAsync(
+            string token,
+            string expectedAudience,
+            CancellationToken ct = default) =>
+            Task.FromResult(ServiceIdentityValidationResult.Success(service));
+    }
+
+    private sealed class FixedContextAccessor(TrustedInvocationContext context)
+        : ITrustedInvocationContextAccessor
+    {
+        public TrustedInvocationContext? Current => context;
+    }
+
+    private sealed class DenyingFeatureService : ITenantModuleFeatureService
+    {
+        public Task<Result<bool>> IsEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result<bool>.Success(false));
+
+        public Task<Result> EnsureEnabledAsync(
+            Guid tenantId,
+            string moduleKey,
+            string? subFeatureKey = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(Result.Forbidden("Attendance is disabled."));
+
+        public void Invalidate(Guid tenantId, string moduleKey, string? subFeatureKey = null)
+        {
+        }
+    }
+
+    private sealed class RecordingCapabilityService : ITenantCredentialCapabilityService
+    {
+        public int CallCount { get; private set; }
+
+        public Task<Result<bool>> IsAllowedAsync(
+            Guid tenantId,
+            Guid credentialId,
+            string moduleKey,
+            string? subFeatureKey,
+            string capabilityKey,
+            CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(Result<bool>.Success(true));
+        }
+
+        public Task<Result> EnsureAllowedAsync(
+            Guid tenantId,
+            Guid credentialId,
+            string moduleKey,
+            string? subFeatureKey,
+            string capabilityKey,
+            CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(Result.Success());
+        }
+    }
+}

--- a/src/Modules/XFramework.Attendance/Attendance.Tests/Services/AttendanceServiceTests.cs
+++ b/src/Modules/XFramework.Attendance/Attendance.Tests/Services/AttendanceServiceTests.cs
@@ -8,11 +8,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
+using XFramework.Core.Patterns;
 using XFramework.Domain.Contexts;
 using XFramework.Integration.Security;
 
 namespace Attendance.Tests.Services;
 
+[NonParallelizable]
 public sealed class AttendanceServiceTests
 {
     [Test]
@@ -45,8 +47,8 @@ public sealed class AttendanceServiceTests
         checkIn.IsSuccess.Should().BeTrue();
         checkOut.IsSuccess.Should().BeTrue();
         checkOut.Data!.Record!.Status.Should().Be(AttendanceRecordStatus.Present);
-        checkOut.Data.Record.FirstCheckInAt.Should().Be(seed.Session.StartsAt);
-        checkOut.Data.Record.LastCheckOutAt.Should().Be(seed.Session.EndsAt);
+        checkOut.Data.Record.FirstCheckInAt.Should().BeCloseTo(seed.Session.StartsAt, TimeSpan.FromMicroseconds(1));
+        checkOut.Data.Record.LastCheckOutAt.Should().BeCloseTo(seed.Session.EndsAt, TimeSpan.FromMicroseconds(1));
     }
 
     [Test]
@@ -162,7 +164,7 @@ public sealed class AttendanceServiceTests
     {
         await using var database = await TestDatabase.CreateAsync();
         var seed = await SeedAttendanceAsync(database);
-        var service = CreateService(database.Context, database.TenantId);
+        var service = CreateService(database.Context, database.TenantId, database.ActorCredentialId);
 
         var result = await service.CreateAdjustmentAsync(new CreateAttendanceAdjustmentRequest
         {
@@ -170,7 +172,6 @@ public sealed class AttendanceServiceTests
             SessionId = seed.Session.Id,
             ParticipantId = seed.Participant.Id,
             NewStatus = AttendanceRecordStatus.ManualAdjusted,
-            ActorCredentialId = Guid.NewGuid(),
             Reason = "Scanner was offline",
             Notes = "Corrected from paper log"
         }, CancellationToken.None);
@@ -178,7 +179,492 @@ public sealed class AttendanceServiceTests
         result.IsSuccess.Should().BeTrue();
         result.Data!.NewStatus.Should().Be(AttendanceRecordStatus.ManualAdjusted);
         result.Data.Record!.Status.Should().Be(AttendanceRecordStatus.ManualAdjusted);
+        result.Data.ActorCredentialId.Should().Be(database.ActorCredentialId);
         result.Data.Reason.Should().Be("Scanner was offline");
+    }
+
+    [Test]
+    public async Task RecordEventAsync_SpoofedActorCredential_ReturnsForbidden()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId, database.ActorCredentialId);
+
+        var result = await service.RecordEventAsync(new RecordAttendanceEventRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            EventType = AttendanceEventType.CheckIn,
+            OccurredAt = seed.Session.StartsAt,
+            RecordedByCredentialId = Guid.NewGuid(),
+            IdempotencyKey = "spoofed-event-actor"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+        (await database.Context.Set<AttendanceEvent>().CountAsync()).Should().Be(0);
+    }
+
+    [Test]
+    public async Task RecordEventAsync_NoSuppliedActor_PersistsTrustedActor()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId, database.ActorCredentialId);
+
+        var result = await service.RecordEventAsync(new RecordAttendanceEventRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            EventType = AttendanceEventType.CheckIn,
+            OccurredAt = seed.Session.StartsAt,
+            IdempotencyKey = "trusted-event-actor"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.RecordedByCredentialId.Should().Be(database.ActorCredentialId);
+    }
+
+    [Test]
+    public async Task CreateAdjustmentAsync_SpoofedActorCredential_ReturnsForbidden()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId, database.ActorCredentialId);
+
+        var result = await service.CreateAdjustmentAsync(new CreateAttendanceAdjustmentRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            NewStatus = AttendanceRecordStatus.Excused,
+            ActorCredentialId = Guid.NewGuid(),
+            Reason = "Approved absence"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(403);
+        (await database.Context.Set<AttendanceAdjustment>().CountAsync()).Should().Be(0);
+    }
+
+    [Test]
+    public async Task RemoveParticipantAsync_Deactivation_PreservesMembershipHistory()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId);
+        var endedAt = seed.Session.StartsAt.AddMinutes(30);
+
+        var result = await service.RemoveParticipantAsync(new RemoveAttendanceParticipantRequest
+        {
+            TenantId = database.TenantId,
+            ParticipantId = seed.Participant.Id,
+            EndedAt = endedAt
+        }, CancellationToken.None);
+
+        database.Context.ChangeTracker.Clear();
+        var participant = await database.Context.Set<AttendanceParticipant>()
+            .SingleAsync(item => item.Id == seed.Participant.Id);
+        result.IsSuccess.Should().BeTrue();
+        participant.IsActive.Should().BeFalse();
+        participant.IsDeleted.Should().BeFalse();
+        participant.EndedAt.Should().Be(new DateTime(endedAt.Ticks - endedAt.Ticks % 10, DateTimeKind.Utc));
+    }
+
+    [Test]
+    public async Task GetReportAsync_MembershipChangedLater_UsesSessionEffectiveRoster()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId);
+        var endedAt = seed.Session.StartsAt.AddMinutes(30);
+
+        await service.RemoveParticipantAsync(new RemoveAttendanceParticipantRequest
+        {
+            TenantId = database.TenantId,
+            ParticipantId = seed.Participant.Id,
+            EndedAt = endedAt
+        }, CancellationToken.None);
+
+        database.Context.Set<AttendanceParticipant>().AddRange(
+            CreateParticipant(database.TenantId, seed.Context.Id, seed.Session.EndsAt.AddMinutes(1)),
+            CreateParticipant(database.TenantId, seed.Context.Id, seed.Session.EndsAt.AddMinutes(1)));
+        await database.Context.SaveChangesAsync();
+        database.Context.ChangeTracker.Clear();
+
+        var result = await service.GetReportAsync(new GetAttendanceReportRequest
+        {
+            TenantId = database.TenantId,
+            ContextId = seed.Context.Id,
+            FromUtc = seed.Session.StartsAt.AddMinutes(-1),
+            ToUtc = seed.Session.EndsAt.AddMinutes(2)
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.ActiveParticipantCount.Should().Be(2);
+        result.Data.Sessions.Should().ContainSingle();
+        result.Data.Sessions[0].AbsentCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task RecordEventAsync_SameIdempotencyKeyDifferentPayload_ReturnsConflict()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId);
+
+        var first = await service.RecordEventAsync(new RecordAttendanceEventRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            EventType = AttendanceEventType.CheckIn,
+            OccurredAt = seed.Session.StartsAt,
+            IdempotencyKey = "payload-aware-key"
+        }, CancellationToken.None);
+        var conflictingReplay = await service.RecordEventAsync(new RecordAttendanceEventRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            EventType = AttendanceEventType.CheckOut,
+            OccurredAt = seed.Session.EndsAt,
+            IdempotencyKey = "payload-aware-key"
+        }, CancellationToken.None);
+
+        first.IsSuccess.Should().BeTrue();
+        conflictingReplay.IsSuccess.Should().BeFalse();
+        conflictingReplay.StatusCode.Should().Be(409);
+        (await database.Context.Set<AttendanceEvent>().CountAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task CreateSessionAsync_InvalidTimeZone_ReturnsValidationFailure()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId);
+
+        var result = await service.CreateSessionAsync(new CreateAttendanceSessionRequest
+        {
+            TenantId = database.TenantId,
+            ContextId = seed.Context.Id,
+            Name = "Invalid time zone",
+            StartsAt = DateTime.UtcNow.AddHours(1),
+            EndsAt = DateTime.UtcNow.AddHours(2),
+            TimeZoneId = "Not/A-TimeZone",
+            Status = AttendanceSessionStatus.Scheduled
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(400);
+        result.Message.Should().Contain("time zone");
+    }
+
+    [Test]
+    public async Task RecordEventAsync_ScheduledSession_ReturnsConflict()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var scheduledSession = await database.Context.Set<AttendanceSession>()
+            .AsTracking()
+            .SingleAsync(item => item.Id == seed.Session.Id);
+        scheduledSession.Status = AttendanceSessionStatus.Scheduled;
+        await database.Context.SaveChangesAsync();
+        database.Context.ChangeTracker.Clear();
+        var service = CreateService(database.Context, database.TenantId);
+
+        var result = await service.RecordEventAsync(new RecordAttendanceEventRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            EventType = AttendanceEventType.CheckIn,
+            OccurredAt = seed.Session.StartsAt,
+            IdempotencyKey = "scheduled-session-event"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        result.Message.Should().Contain("open sessions");
+    }
+
+    [Test]
+    public async Task RecordEventAsync_CheckoutBeforeRecordedCheckIn_ReturnsConflict()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId);
+
+        await service.RecordEventAsync(new RecordAttendanceEventRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            EventType = AttendanceEventType.CheckIn,
+            OccurredAt = seed.Session.StartsAt.AddMinutes(10),
+            IdempotencyKey = "chronology-check-in"
+        }, CancellationToken.None);
+        var result = await service.RecordEventAsync(new RecordAttendanceEventRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            EventType = AttendanceEventType.CheckOut,
+            OccurredAt = seed.Session.StartsAt.AddMinutes(5),
+            IdempotencyKey = "chronology-check-out"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        result.Message.Should().Contain("before check-in");
+    }
+
+    [Test]
+    public async Task CreateAdjustmentAsync_CheckoutBeforeCheckIn_ReturnsValidationFailure()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(database.Context, database.TenantId, database.ActorCredentialId);
+
+        var result = await service.CreateAdjustmentAsync(new CreateAttendanceAdjustmentRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            ParticipantId = seed.Participant.Id,
+            NewStatus = AttendanceRecordStatus.ManualAdjusted,
+            AdjustedCheckInAt = seed.Session.StartsAt.AddMinutes(10),
+            AdjustedCheckOutAt = seed.Session.StartsAt.AddMinutes(5),
+            Reason = "Invalid chronology"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(400);
+        result.Message.Should().Contain("before adjusted check-in");
+    }
+
+    [Test]
+    public async Task TransitionSessionAsync_ScheduledToOpenToClosed_Succeeds()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var persistedSession = await database.Context.Set<AttendanceSession>()
+            .AsTracking()
+            .SingleAsync(item => item.Id == seed.Session.Id);
+        persistedSession.Status = AttendanceSessionStatus.Scheduled;
+        await database.Context.SaveChangesAsync();
+        database.Context.ChangeTracker.Clear();
+        var service = CreateService(database.Context, database.TenantId, database.ActorCredentialId);
+
+        var opened = await service.TransitionSessionAsync(new TransitionAttendanceSessionRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            Status = AttendanceSessionStatus.Open
+        }, CancellationToken.None);
+        var closed = await service.TransitionSessionAsync(new TransitionAttendanceSessionRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            Status = AttendanceSessionStatus.Closed
+        }, CancellationToken.None);
+
+        opened.IsSuccess.Should().BeTrue();
+        opened.Data!.Status.Should().Be(AttendanceSessionStatus.Open);
+        closed.IsSuccess.Should().BeTrue();
+        closed.Data!.Status.Should().Be(AttendanceSessionStatus.Closed);
+    }
+
+    [Test]
+    public async Task TransitionSessionAsync_InvalidTransition_ReturnsConflict()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var persistedSession = await database.Context.Set<AttendanceSession>()
+            .AsTracking()
+            .SingleAsync(item => item.Id == seed.Session.Id);
+        persistedSession.Status = AttendanceSessionStatus.Scheduled;
+        await database.Context.SaveChangesAsync();
+        database.Context.ChangeTracker.Clear();
+        var service = CreateService(database.Context, database.TenantId, database.ActorCredentialId);
+
+        var result = await service.TransitionSessionAsync(new TransitionAttendanceSessionRequest
+        {
+            TenantId = database.TenantId,
+            SessionId = seed.Session.Id,
+            Status = AttendanceSessionStatus.Closed
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+        result.Message.Should().Contain("Scheduled").And.Contain("Closed");
+    }
+
+    [Test]
+    public async Task AddParticipantAsync_CredentialDoesNotExist_ReturnsNotFound()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var credentialId = Guid.NewGuid();
+        var service = CreateService(
+            database.Context,
+            database.TenantId,
+            credentialResolver: new TestCredentialResolver(
+                Result<AttendanceCredentialSnapshot>.NotFound("Identity credential was not found")));
+
+        var result = await service.AddParticipantAsync(new AddAttendanceParticipantRequest
+        {
+            TenantId = database.TenantId,
+            ContextId = seed.Context.Id,
+            CredentialId = credentialId
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(404);
+    }
+
+    [Test]
+    public async Task AddParticipantAsync_IdentityServerUnavailable_ReturnsServiceUnavailable()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var service = CreateService(
+            database.Context,
+            database.TenantId,
+            credentialResolver: new TestCredentialResolver(
+                Result<AttendanceCredentialSnapshot>.Failure("IdentityServer is unavailable", 503)));
+
+        var result = await service.AddParticipantAsync(new AddAttendanceParticipantRequest
+        {
+            TenantId = database.TenantId,
+            ContextId = seed.Context.Id,
+            CredentialId = Guid.NewGuid()
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(503);
+        result.Message.Should().Contain("unavailable");
+    }
+
+    [Test]
+    public async Task AddParticipantAsync_CredentialBelongsToAnotherTenant_ReturnsNotFound()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var credentialId = Guid.NewGuid();
+        var credential = new AttendanceCredentialSnapshot(
+            credentialId,
+            Guid.NewGuid(),
+            true,
+            false,
+            "Wrong tenant",
+            "wrong-tenant");
+        var service = CreateService(
+            database.Context,
+            database.TenantId,
+            credentialResolver: new TestCredentialResolver(Result<AttendanceCredentialSnapshot>.Success(credential)));
+
+        var result = await service.AddParticipantAsync(new AddAttendanceParticipantRequest
+        {
+            TenantId = database.TenantId,
+            ContextId = seed.Context.Id,
+            CredentialId = credentialId
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(404);
+    }
+
+    [Test]
+    public async Task AddParticipantAsync_DisabledCredential_ReturnsConflict()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var credentialId = Guid.NewGuid();
+        var credential = new AttendanceCredentialSnapshot(
+            credentialId,
+            database.TenantId,
+            false,
+            false,
+            "Disabled",
+            "disabled");
+        var service = CreateService(
+            database.Context,
+            database.TenantId,
+            credentialResolver: new TestCredentialResolver(Result<AttendanceCredentialSnapshot>.Success(credential)));
+
+        var result = await service.AddParticipantAsync(new AddAttendanceParticipantRequest
+        {
+            TenantId = database.TenantId,
+            ContextId = seed.Context.Id,
+            CredentialId = credentialId
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+    }
+
+    [Test]
+    public async Task AddParticipantAsync_DeletedCredential_ReturnsConflict()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var credentialId = Guid.NewGuid();
+        var credential = new AttendanceCredentialSnapshot(
+            credentialId,
+            database.TenantId,
+            true,
+            true,
+            "Deleted",
+            "deleted");
+        var service = CreateService(
+            database.Context,
+            database.TenantId,
+            credentialResolver: new TestCredentialResolver(Result<AttendanceCredentialSnapshot>.Success(credential)));
+
+        var result = await service.AddParticipantAsync(new AddAttendanceParticipantRequest
+        {
+            TenantId = database.TenantId,
+            ContextId = seed.Context.Id,
+            CredentialId = credentialId
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(409);
+    }
+
+    [Test]
+    public async Task AddParticipantAsync_ActiveCredential_CopiesAuthoritativeLabels()
+    {
+        await using var database = await TestDatabase.CreateAsync();
+        var seed = await SeedAttendanceAsync(database);
+        var credentialId = Guid.NewGuid();
+        var credential = new AttendanceCredentialSnapshot(
+            credentialId,
+            database.TenantId,
+            true,
+            false,
+            "Authoritative alias",
+            "authoritative.user");
+        var service = CreateService(
+            database.Context,
+            database.TenantId,
+            credentialResolver: new TestCredentialResolver(Result<AttendanceCredentialSnapshot>.Success(credential)));
+
+        var result = await service.AddParticipantAsync(new AddAttendanceParticipantRequest
+        {
+            TenantId = database.TenantId,
+            ContextId = seed.Context.Id,
+            CredentialId = credentialId,
+            DisplayName = "Caller supplied name",
+            ReferenceCode = "caller-supplied-code"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.DisplayName.Should().Be("Authoritative alias");
+        result.Data.ReferenceCode.Should().Be("authoritative.user");
     }
 
     [Test]
@@ -198,14 +684,46 @@ public sealed class AttendanceServiceTests
         result.Message.Should().Contain("Tenant ID");
     }
 
-    private static AttendanceService CreateService(AppDbContext db, Guid? tenantId) =>
-        new(db, NullLogger<AttendanceService>.Instance, new TestInvocationContextAccessor(tenantId));
+    private static AttendanceService CreateService(
+        AppDbContext db,
+        Guid? tenantId,
+        Guid? actorCredentialId = null,
+        IAttendanceCredentialResolver? credentialResolver = null) =>
+        new(
+            db,
+            NullLogger<AttendanceService>.Instance,
+            new TestInvocationContextAccessor(tenantId, actorCredentialId ?? Guid.NewGuid()),
+            credentialResolver ?? new TestCredentialResolver(
+                Result<AttendanceCredentialSnapshot>.NotFound("Identity credential was not found")));
 
-    private sealed class TestInvocationContextAccessor(Guid? tenantId) : ITrustedInvocationContextAccessor
+    private sealed class TestInvocationContextAccessor(Guid? tenantId, Guid actorCredentialId)
+        : ITrustedInvocationContextAccessor
     {
         public TrustedInvocationContext? Current { get; } = tenantId is { } value
-            ? new TrustedInvocationContext(null, null, value, null, Guid.NewGuid())
+            ? new TrustedInvocationContext(
+                new TrustedActorIdentity(
+                    actorCredentialId,
+                    Guid.NewGuid(),
+                    value,
+                    Guid.NewGuid(),
+                    new HashSet<string>(),
+                    new HashSet<string>(),
+                    "test",
+                    DateTimeOffset.UtcNow.AddMinutes(5)),
+                null,
+                value,
+                null,
+                Guid.NewGuid())
             : null;
+    }
+
+    private sealed class TestCredentialResolver(Result<AttendanceCredentialSnapshot> result)
+        : IAttendanceCredentialResolver
+    {
+        public Task<Result<AttendanceCredentialSnapshot>> ResolveAsync(
+            Guid credentialId,
+            Guid tenantId,
+            CancellationToken ct) => Task.FromResult(result);
     }
 
     private static async Task<SeedData> SeedAttendanceAsync(TestDatabase database)
@@ -223,6 +741,7 @@ public sealed class AttendanceServiceTests
             IsEnabled = true
         };
 
+        var startsAt = DateTime.UtcNow.AddHours(-1);
         var participant = new AttendanceParticipant
         {
             Id = Guid.NewGuid(),
@@ -230,14 +749,13 @@ public sealed class AttendanceServiceTests
             ContextId = context.Id,
             CredentialId = Guid.NewGuid(),
             DisplayName = "Student One",
-            StartedAt = DateTime.UtcNow,
+            StartedAt = startsAt.AddHours(-1),
             IsActive = true,
             CreatedAt = DateTime.UtcNow,
             ConcurrencyStamp = Guid.NewGuid(),
             IsEnabled = true
         };
 
-        var startsAt = DateTime.UtcNow.AddMinutes(-5);
         var session = new AttendanceSession
         {
             Id = Guid.NewGuid(),
@@ -245,7 +763,7 @@ public sealed class AttendanceServiceTests
             ContextId = context.Id,
             Name = "Morning class",
             StartsAt = startsAt,
-            EndsAt = startsAt.AddHours(1),
+            EndsAt = DateTime.UtcNow,
             TimeZoneId = "UTC",
             Status = AttendanceSessionStatus.Open,
             CreatedAt = DateTime.UtcNow,
@@ -262,6 +780,20 @@ public sealed class AttendanceServiceTests
         return new SeedData(context, participant, session);
     }
 
+    private static AttendanceParticipant CreateParticipant(Guid tenantId, Guid contextId, DateTime startedAt) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = tenantId,
+        ContextId = contextId,
+        CredentialId = Guid.NewGuid(),
+        DisplayName = "Later participant",
+        StartedAt = startedAt,
+        IsActive = true,
+        CreatedAt = DateTime.UtcNow,
+        ConcurrencyStamp = Guid.NewGuid(),
+        IsEnabled = true
+    };
+
     private sealed record SeedData(
         AttendanceContext Context,
         AttendanceParticipant Participant,
@@ -271,25 +803,32 @@ public sealed class AttendanceServiceTests
     {
         private readonly SqliteConnection connection;
 
-        private TestDatabase(SqliteConnection connection, AppDbContext context, Guid tenantId)
+        private TestDatabase(
+            SqliteConnection connection,
+            AppDbContext context,
+            Guid tenantId,
+            Guid actorCredentialId)
         {
             this.connection = connection;
             Context = context;
             TenantId = tenantId;
+            ActorCredentialId = actorCredentialId;
         }
 
         public AppDbContext Context { get; }
         public Guid TenantId { get; }
+        public Guid ActorCredentialId { get; }
 
         public static async Task<TestDatabase> CreateAsync()
         {
             var tenantId = Guid.NewGuid();
+            var actorCredentialId = Guid.NewGuid();
             var connection = new SqliteConnection("Data Source=:memory:");
             await connection.OpenAsync();
             connection.CreateFunction("now", () => DateTime.UtcNow);
             connection.CreateFunction("uuid_generate_v4", () => Guid.NewGuid());
 
-            var options = new DbContextOptionsBuilder<AppDbContext>()
+            var options = new DbContextOptionsBuilder<AttendanceTestDbContext>()
                 .UseSqlite(connection)
                 .Options;
 
@@ -300,7 +839,7 @@ public sealed class AttendanceServiceTests
                 })
                 .Build();
 
-            var context = new AppDbContext(
+            var context = new AttendanceTestDbContext(
                 options,
                 new Microsoft.AspNetCore.Http.HttpContextAccessor(),
                 configuration,
@@ -309,7 +848,7 @@ public sealed class AttendanceServiceTests
             _ = typeof(AttendanceContext).Assembly;
             await context.Database.EnsureCreatedAsync();
 
-            return new TestDatabase(connection, context, tenantId);
+            return new TestDatabase(connection, context, tenantId, actorCredentialId);
         }
 
         public async ValueTask DisposeAsync()
@@ -323,6 +862,30 @@ public sealed class AttendanceServiceTests
         {
             public bool HasTrustedInvocation => true;
             public Guid? EffectiveTenantId => tenantId;
+        }
+
+        private sealed class AttendanceTestDbContext(
+            DbContextOptions<AttendanceTestDbContext> options,
+            Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor,
+            IConfiguration configuration,
+            XFramework.Domain.Shared.Security.IEffectiveTenantContextAccessor effectiveTenantContextAccessor)
+            : AppDbContext(options, httpContextAccessor, configuration, effectiveTenantContextAccessor)
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                var attendanceAssembly = typeof(AttendanceContext).Assembly;
+                var unrelatedEntityTypes = modelBuilder.Model.GetEntityTypes()
+                    .Where(entityType => entityType.ClrType.Assembly != attendanceAssembly)
+                    .Select(entityType => entityType.ClrType)
+                    .ToArray();
+
+                foreach (var entityType in unrelatedEntityTypes)
+                {
+                    modelBuilder.Ignore(entityType);
+                }
+            }
         }
     }
 }

--- a/src/Presentation/XFramework.Portal/Services/AttendancePortalReadService.cs
+++ b/src/Presentation/XFramework.Portal/Services/AttendancePortalReadService.cs
@@ -20,29 +20,19 @@ public sealed class AttendancePortalReadService(
         Guid tenantId,
         CancellationToken cancellationToken = default)
     {
-        var contexts = await dataContext.Query<AttendanceContext>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .OrderBy(x => x.Name)
-            .Take(500)
-            .ToListAsync(cancellationToken);
+        var response = await attendance.GetAttendanceContextOverview(new()
+        {
+            TenantId = tenantId,
+            Limit = 500,
+            Metadata = BuildMetadata(tenantId)
+        }, cancellationToken);
+        if (!response.IsSuccess || response.Response is null)
+        {
+            LogReadFailure("context overview", tenantId, response.HttpStatusCode, response.Message);
+            return [];
+        }
 
-        var participants = await dataContext.Query<AttendanceParticipant>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .Take(5000)
-            .ToListAsync(cancellationToken);
-
-        var sessions = await dataContext.Query<AttendanceSession>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .Take(5000)
-            .ToListAsync(cancellationToken);
-
-        return contexts.Select(context =>
+        return response.Response.Items.Select(context =>
             new AttendanceContextRow(
                 context.Id,
                 context.TenantId,
@@ -51,8 +41,8 @@ public sealed class AttendancePortalReadService(
                 context.ContextType,
                 context.Description,
                 context.IsActive,
-                participants.Count(x => x.ContextId == context.Id && x.IsActive),
-                sessions.Count(x => x.ContextId == context.Id),
+                context.ActiveParticipantCount,
+                context.SessionCount,
                 context.CreatedAt))
             .ToList();
     }
@@ -65,37 +55,26 @@ public sealed class AttendancePortalReadService(
         AttendanceSessionStatus? status,
         CancellationToken cancellationToken = default)
     {
-        var contexts = await LoadContextLabelsAsync(tenantId, cancellationToken);
-        var query = dataContext.Query<AttendanceSession>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted);
-
-        if (contextId is Guid selectedContextId)
-        {
-            query = query.Where(x => x.ContextId == selectedContextId);
-        }
-
-        if (status is AttendanceSessionStatus selectedStatus)
-        {
-            query = query.Where(x => x.Status == selectedStatus);
-        }
-
-        var sessions = await query
-            .OrderByDescending(x => x.StartsAt)
-            .Take(2000)
-            .ToListAsync(cancellationToken);
-
         var from = NormalizeUtc(fromUtc);
         var to = NormalizeUtc(toUtc);
+        var response = await attendance.GetAttendanceSessionReadList(new()
+        {
+            TenantId = tenantId,
+            ContextId = contextId,
+            FromUtc = from,
+            ToUtc = to,
+            Status = status,
+            Limit = 500,
+            Metadata = BuildMetadata(tenantId)
+        }, cancellationToken);
+        if (!response.IsSuccess || response.Response is null)
+        {
+            LogReadFailure("session list", tenantId, response.HttpStatusCode, response.Message);
+            return [];
+        }
 
-        return sessions
-            .Where(session =>
-            {
-                var startsAt = NormalizeUtc(session.StartsAt);
-                return startsAt >= from && startsAt <= to;
-            })
-            .Take(500)
+        var contexts = response.Response.Contexts.ToDictionary(context => context.Id, ContextLabel);
+        return response.Response.Items
             .Select(session =>
                 new AttendanceSessionRow(
                     session.Id,
@@ -116,55 +95,30 @@ public sealed class AttendancePortalReadService(
         Guid sessionId,
         CancellationToken cancellationToken = default)
     {
-        var session = await dataContext.Query<AttendanceSession>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.Id == sessionId)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (session is null)
+        var response = await attendance.GetAttendanceSessionDetailRead(new()
         {
+            TenantId = tenantId,
+            SessionId = sessionId,
+            Metadata = BuildMetadata(tenantId)
+        }, cancellationToken);
+        if (!response.IsSuccess || response.Response is null)
+        {
+            LogReadFailure("session detail", tenantId, response.HttpStatusCode, response.Message);
             return null;
         }
 
-        var context = await dataContext.Query<AttendanceContext>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.Id == session.ContextId)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        var participants = await dataContext.Query<AttendanceParticipant>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.ContextId == session.ContextId && x.IsActive)
-            .OrderBy(x => x.DisplayName)
-            .Take(1000)
-            .ToListAsync(cancellationToken);
-
-        var records = await dataContext.Query<AttendanceRecord>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.SessionId == sessionId)
-            .Take(1000)
-            .ToListAsync(cancellationToken);
-
-        var events = await dataContext.Query<AttendanceEvent>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.SessionId == sessionId)
-            .OrderByDescending(x => x.OccurredAt)
-            .Take(100)
-            .ToListAsync(cancellationToken);
+        var detail = response.Response;
 
         var credentialLabels = await LoadCredentialLabelsAsync(
             tenantId,
-            participants.Select(x => (Guid?)x.CredentialId).Concat(records.Select(x => (Guid?)x.CredentialId)),
+            detail.Participants.Select(x => (Guid?)x.CredentialId)
+                .Concat(detail.Records.Select(x => (Guid?)x.CredentialId)),
             cancellationToken);
-        var recordsByParticipant = records
+        var recordsByParticipant = detail.Records
             .GroupBy(x => x.ParticipantId)
-            .ToDictionary(x => x.Key, x => x.OrderByDescending(record => record.ModifiedAt ?? record.CreatedAt).First());
+            .ToDictionary(x => x.Key, x => x.First());
 
-        var roster = participants.Select(participant =>
+        var roster = detail.Participants.Select(participant =>
         {
             recordsByParticipant.TryGetValue(participant.Id, out var record);
             return new AttendanceSessionRosterRow(
@@ -181,7 +135,7 @@ public sealed class AttendancePortalReadService(
                 record?.Notes);
         }).ToList();
 
-        return new AttendanceSessionDetail(session, context, roster, events);
+        return new AttendanceSessionDetail(detail.Session, detail.Context, roster, detail.RecentEvents);
     }
 
     public async Task<IReadOnlyList<AttendanceParticipantRow>> LoadParticipantRowsAsync(
@@ -189,13 +143,20 @@ public sealed class AttendancePortalReadService(
         Guid contextId,
         CancellationToken cancellationToken = default)
     {
-        var participants = await dataContext.Query<AttendanceParticipant>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.ContextId == contextId)
-            .OrderBy(x => x.DisplayName)
-            .Take(1000)
-            .ToListAsync(cancellationToken);
+        var response = await attendance.GetAttendanceParticipantReadList(new()
+        {
+            TenantId = tenantId,
+            ContextId = contextId,
+            Limit = 1000,
+            Metadata = BuildMetadata(tenantId)
+        }, cancellationToken);
+        if (!response.IsSuccess || response.Response is null)
+        {
+            LogReadFailure("participant list", tenantId, response.HttpStatusCode, response.Message);
+            return [];
+        }
+
+        var participants = response.Response.Items;
 
         var labels = await LoadCredentialLabelsAsync(
             tenantId,
@@ -221,7 +182,6 @@ public sealed class AttendancePortalReadService(
         CancellationToken cancellationToken = default)
     {
         var credentials = await dataContext.Query<IdentityCredential>()
-            .IgnoreQueryFilters()
             .NoCache()
             .Include(x => x.IdentityInfo)
             .Where(x => x.TenantId == tenantId && !x.IsDeleted)
@@ -245,27 +205,22 @@ public sealed class AttendancePortalReadService(
             return [];
         }
 
-        var participants = await dataContext.Query<AttendanceParticipant>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && credentialIds.Contains(x.CredentialId))
-            .OrderByDescending(x => x.StartedAt)
-            .Take(500)
-            .ToListAsync(cancellationToken);
+        var response = await attendance.GetAttendanceCredentialHistory(new()
+        {
+            TenantId = tenantId,
+            CredentialIds = credentialIds.ToList(),
+            Metadata = BuildMetadata(tenantId)
+        }, cancellationToken);
+        if (!response.IsSuccess || response.Response is null)
+        {
+            LogReadFailure("credential participation", tenantId, response.HttpStatusCode, response.Message);
+            return [];
+        }
 
-        var contextIds = participants.Select(x => x.ContextId).Distinct().ToArray();
-        var contexts = contextIds.Length == 0
-            ? []
-            : await dataContext.Query<AttendanceContext>()
-                .IgnoreQueryFilters()
-                .NoCache()
-                .Where(x => x.TenantId == tenantId && !x.IsDeleted && contextIds.Contains(x.Id))
-                .Take(500)
-                .ToListAsync(cancellationToken);
-        var contextsById = contexts.ToDictionary(x => x.Id);
+        var contextsById = response.Response.Contexts.ToDictionary(x => x.Id);
         var credentialLabels = credentials.ToDictionary(x => x.Id, BuildCredentialLabel);
 
-        return participants.Select(participant =>
+        return response.Response.Participants.Select(participant =>
         {
             contextsById.TryGetValue(participant.ContextId, out var context);
             return
@@ -303,39 +258,23 @@ public sealed class AttendancePortalReadService(
             return [];
         }
 
-        var records = await dataContext.Query<AttendanceRecord>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted && credentialIds.Contains(x.CredentialId))
-            .OrderByDescending(x => x.CreatedAt)
-            .Take(500)
-            .ToListAsync(cancellationToken);
-
-        var sessionIds = records.Select(x => x.SessionId).Distinct().ToArray();
-        List<AttendanceSession> sessions = sessionIds.Length == 0
-            ? []
-            : await dataContext.Query<AttendanceSession>()
-                .IgnoreQueryFilters()
-                .NoCache()
-                .Where(x => x.TenantId == tenantId && !x.IsDeleted && sessionIds.Contains(x.Id))
-                .Take(500)
-                .ToListAsync(cancellationToken);
-
-        var contextIds = sessions.Select(x => x.ContextId).Distinct().ToArray();
-        List<AttendanceContext> contexts = contextIds.Length == 0
-            ? []
-            : await dataContext.Query<AttendanceContext>()
-                .IgnoreQueryFilters()
-                .NoCache()
-                .Where(x => x.TenantId == tenantId && !x.IsDeleted && contextIds.Contains(x.Id))
-                .Take(500)
-                .ToListAsync(cancellationToken);
+        var response = await attendance.GetAttendanceCredentialHistory(new()
+        {
+            TenantId = tenantId,
+            CredentialIds = credentialIds.ToList(),
+            Metadata = BuildMetadata(tenantId)
+        }, cancellationToken);
+        if (!response.IsSuccess || response.Response is null)
+        {
+            LogReadFailure("credential records", tenantId, response.HttpStatusCode, response.Message);
+            return [];
+        }
 
         var credentialLabels = credentials.ToDictionary(x => x.Id, BuildCredentialLabel);
-        var sessionsById = sessions.ToDictionary(x => x.Id);
-        var contextsById = contexts.ToDictionary(x => x.Id);
+        var sessionsById = response.Response.Sessions.ToDictionary(x => x.Id);
+        var contextsById = response.Response.Contexts.ToDictionary(x => x.Id);
 
-        return records.Select(record =>
+        return response.Response.Records.Select(record =>
         {
             sessionsById.TryGetValue(record.SessionId, out var session);
             var contextName = session is not null && contextsById.TryGetValue(session.ContextId, out var context)
@@ -363,14 +302,12 @@ public sealed class AttendancePortalReadService(
         Guid tenantId,
         CancellationToken cancellationToken = default)
     {
-        var response = await attendance.GetAttendanceContexts(new GetAttendanceContextsRequest
+        var response = await attendance.GetAttendanceContextOverview(new GetAttendanceContextOverviewRequest
         {
             TenantId = tenantId,
-            IsActive = true,
-            Page = 1,
-            PageSize = 500,
+            Limit = 500,
             Metadata = BuildMetadata(tenantId)
-        });
+        }, cancellationToken);
 
         if (!response.IsSuccess || response.Response is null)
         {
@@ -383,7 +320,7 @@ public sealed class AttendancePortalReadService(
         }
 
         var options = response.Response.Items
-            .Where(context => context.Id != Guid.Empty)
+            .Where(context => context.Id != Guid.Empty && context.IsActive)
             .OrderBy(context => context.Name)
             .Select(context => new AttendanceContextOption(context.Id, ContextLabel(context), context.ContextType, context.IsActive))
             .ToList();
@@ -412,7 +349,6 @@ public sealed class AttendancePortalReadService(
         }
 
         var credentials = await dataContext.Query<IdentityCredential>()
-            .IgnoreQueryFilters()
             .NoCache()
             .Include(x => x.IdentityInfo)
             .Where(x => x.TenantId == tenantId && !x.IsDeleted && ids.Contains(x.Id))
@@ -421,27 +357,12 @@ public sealed class AttendancePortalReadService(
         return credentials.ToDictionary(x => x.Id, BuildCredentialLabel);
     }
 
-    private async Task<IReadOnlyDictionary<Guid, string>> LoadContextLabelsAsync(
-        Guid tenantId,
-        CancellationToken cancellationToken)
-    {
-        var contexts = await dataContext.Query<AttendanceContext>()
-            .IgnoreQueryFilters()
-            .NoCache()
-            .Where(x => x.TenantId == tenantId && !x.IsDeleted)
-            .Take(500)
-            .ToListAsync(cancellationToken);
-
-        return contexts.ToDictionary(x => x.Id, ContextLabel);
-    }
-
     private async Task<List<IdentityCredential>> LoadUserCredentialsAsync(
         Guid tenantId,
         Guid identityInfoId,
         CancellationToken cancellationToken)
     {
         return await dataContext.Query<IdentityCredential>()
-            .IgnoreQueryFilters()
             .NoCache()
             .Include(x => x.IdentityInfo)
             .Where(x => x.TenantId == tenantId && !x.IsDeleted && x.IdentityInfoId == identityInfoId)
@@ -515,15 +436,23 @@ public sealed class AttendancePortalReadService(
         IpAddress = requestMetadata.IpAddress
     };
 
-    private static string ContextLabel(AttendanceContext context) => ContextLabel(context.Name, context.Code);
-
     private static string ContextLabel(AttendanceContextResponse context) => ContextLabel(context.Name, context.Code);
+
+    private static string ContextLabel(AttendanceContextOverviewResponse context) => ContextLabel(context.Name, context.Code);
 
     private static string ContextLabel(string name, string? code) =>
         string.IsNullOrWhiteSpace(code) ? name : $"{code} - {name}";
 
-    private static string DisplayNameForParticipant(AttendanceParticipant participant) =>
+    private static string DisplayNameForParticipant(AttendanceParticipantResponse participant) =>
         Normalize(participant.DisplayName) ?? $"Credential {ShortId(participant.CredentialId)}";
+
+    private void LogReadFailure(string operation, Guid tenantId, object statusCode, string? message) =>
+        logger.LogWarning(
+            "Attendance {Operation} could not be loaded for tenant {TenantId}. Status: {StatusCode}. Message: {Message}",
+            operation,
+            tenantId,
+            statusCode,
+            message);
 
     private static string LabelOrFallback(Guid? id, IReadOnlyDictionary<Guid, string> labels, string noun)
     {
@@ -604,10 +533,10 @@ public sealed record AttendanceParticipantRow(
     bool IsActive);
 
 public sealed record AttendanceSessionDetail(
-    AttendanceSession Session,
-    AttendanceContext? Context,
+    AttendanceSessionResponse Session,
+    AttendanceContextResponse? Context,
     IReadOnlyList<AttendanceSessionRosterRow> Roster,
-    IReadOnlyList<AttendanceEvent> RecentEvents);
+    IReadOnlyList<AttendanceEventResponse> RecentEvents);
 
 public sealed record AttendanceSessionRosterRow(
     Guid ParticipantId,

--- a/src/Shared/XFramework.Domain.Shared/ServiceIdentity/XFrameworkServiceScopes.cs
+++ b/src/Shared/XFramework.Domain.Shared/ServiceIdentity/XFrameworkServiceScopes.cs
@@ -9,6 +9,8 @@ public static class XFrameworkServiceScopes
     public const string TenantTarget = "tenant.target";
 
     public const string AttendanceAdmin = "attendance.admin";
+    public const string AttendanceRead = "attendance.read";
+    public const string AttendanceWrite = "attendance.write";
     public const string CommunicationsAdmin = "communications.admin";
     public const string CommunicationsChat = "communications.chat";
     public const string CommunityAdmin = "community.admin";
@@ -30,6 +32,8 @@ public static class XFrameworkServiceScopes
         DataContextMutate,
         TenantTarget,
         AttendanceAdmin,
+        AttendanceRead,
+        AttendanceWrite,
         CommunicationsAdmin,
         CommunicationsChat,
         CommunityAdmin,

--- a/src/Tests/Attendance.IntegrationTests/Infrastructure/AttendanceIntegrationTestBase.cs
+++ b/src/Tests/Attendance.IntegrationTests/Infrastructure/AttendanceIntegrationTestBase.cs
@@ -4,6 +4,7 @@ using Attendance.IntegrationTests.Infrastructure;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using XFramework.Domain.Contexts;
+using XFramework.Core.Patterns;
 using XFramework.Domain.Shared.BusinessObjects;
 using XFramework.Domain.Shared.DataContext;
 
@@ -35,7 +36,8 @@ public abstract class AttendanceIntegrationTestBase
         new(
             db,
             NullLogger<AttendanceService>.Instance,
-            new AttendanceTestInvocationContextAccessor(AttendanceIntegrationTestFixture.TestTenantId));
+            new AttendanceTestInvocationContextAccessor(AttendanceIntegrationTestFixture.TestTenantId),
+            new TestCredentialResolver());
 
     protected static RequestMetadata CreateMetadata(Guid? tenantId = null) => new()
     {
@@ -49,4 +51,19 @@ public abstract class AttendanceIntegrationTestBase
 
     protected static string UniqueCode(string prefix) =>
         $"{prefix}-{Guid.NewGuid():N}"[..Math.Min(32, prefix.Length + 33)];
+
+    private sealed class TestCredentialResolver : IAttendanceCredentialResolver
+    {
+        public Task<Result<AttendanceCredentialSnapshot>> ResolveAsync(
+            Guid credentialId,
+            Guid tenantId,
+            CancellationToken ct) =>
+            Task.FromResult(Result<AttendanceCredentialSnapshot>.Success(new(
+                credentialId,
+                tenantId,
+                true,
+                false,
+                $"Credential {credentialId:N}",
+                credentialId.ToString("N"))));
+    }
 }

--- a/src/Tests/Attendance.IntegrationTests/Infrastructure/AttendanceIntegrationTestFixture.cs
+++ b/src/Tests/Attendance.IntegrationTests/Infrastructure/AttendanceIntegrationTestFixture.cs
@@ -16,6 +16,8 @@ using Testcontainers.PostgreSql;
 using XFramework.Core.DataContext;
 using XFramework.Core.Extensions;
 using XFramework.Core.Middlewares;
+using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Contexts;
 using XFramework.Domain.Interceptors;
 using XFramework.Domain.Shared.BusinessObjects;
@@ -93,6 +95,14 @@ public sealed class AttendanceIntegrationTestFixture
                 ex is TypeInitializationException ||
                 ex.Message.Contains("Docker", StringComparison.OrdinalIgnoreCase))
             {
+                if (string.Equals(
+                        Environment.GetEnvironmentVariable("CI"),
+                        "true",
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    throw;
+                }
+
                 Assert.Ignore(
                     $"Attendance integration tests require a Testcontainers-compatible Docker endpoint or {ExternalConnectionStringEnvironmentVariable}.");
             }
@@ -158,6 +168,8 @@ public sealed class AttendanceIntegrationTestFixture
         var builder = XApplication.Configure<Bolt.Hub.Installers.BoltInstaller>();
         builder.WebHost.UseUrls(BoltUrl);
         OverrideConfig(builder, "Bolt.AttendanceTest", "00000000-0000-0000-0000-000000000030");
+        builder.Services.AddSingleton<IServiceTokenProvider, AttendanceTestServiceTokenProvider>();
+        builder.Services.AddSingleton<IServiceIdentityProvider, AttendanceBoltHubTestServiceIdentityProvider>();
 
         var app = (WebApplication)builder.Build();
         app.UseCorrelationId();
@@ -192,7 +204,10 @@ public sealed class AttendanceIntegrationTestFixture
         builder.Services.AddSingleton(CreateTestJwtOptions());
         builder.Services.AddTenantResolver();
         builder.Services.AddTenantModuleFeatures();
+        builder.Services.AddScoped<ITenantCredentialCapabilityService, AttendanceTestCapabilityService>();
+        builder.Services.AddScoped<IAttendanceCredentialResolver, AttendanceIntegrationCredentialResolver>();
         builder.Services.AddScoped<AttendanceService>();
+        builder.Services.AddScoped<IAttendanceReadService, AttendanceReadService>();
         builder.Services.AddValidatorsFromAssemblyContaining<AttendanceService>();
         builder.Services.AddAuthentication("AttendanceTest")
             .AddScheme<AuthenticationSchemeOptions, AttendanceTestAuthHandler>("AttendanceTest", _ => { });
@@ -323,6 +338,12 @@ public sealed class AttendanceIntegrationTestFixture
             ["BoltConfiguration:ClientGuid"] = clientGuid,
             ["BoltConfiguration:ClientName"] = clientName,
             ["BoltConfiguration:Anonymous"] = "true",
+            ["ServiceIdentity:ClientId"] = clientName,
+            ["ServiceIdentity:Authority"] = BoltUrl,
+            ["ServiceIdentity:AllowInsecureHttp"] = "true",
+            ["ServiceIdentity:GenerationId"] = "attendance-tests-g1",
+            ["ServiceIdentity:ClientSecret"] = "attendance-tests-client-secret-2026",
+            ["ServiceIdentity:DefaultScopes:0"] = XFrameworkServiceScopes.BoltService,
             ["Tenant:DefaultId"] = TestTenantId.ToString(),
             ["Logging:LogLevel:Default"] = "Warning"
         });
@@ -348,16 +369,24 @@ public sealed class AttendanceIntegrationTestFixture
                 Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning))
             .Options;
 
-        await using var db = new AppDbContext(
+        await using var primaryTenantDb = new AppDbContext(
             options,
             new Microsoft.AspNetCore.Http.HttpContextAccessor(),
             new ConfigurationBuilder().Build(),
             new XFramework.TestInfrastructure.TestEffectiveTenantContextAccessor(TestTenantId));
-        await db.Database.MigrateAsync();
-        await TestSeedData.SeedAll(db);
-        await SeedTenant(db, OtherTenantId, "Other Attendance Tenant");
-        await SeedAttendanceFeature(db, OtherTenantId);
-        await db.SaveChangesAsync();
+        await primaryTenantDb.Database.MigrateAsync();
+        await TestSeedData.SeedAll(primaryTenantDb);
+        await SeedAttendanceFeature(primaryTenantDb, TestTenantId);
+        await primaryTenantDb.SaveChangesAsync();
+
+        await using var otherTenantDb = new AppDbContext(
+            options,
+            new Microsoft.AspNetCore.Http.HttpContextAccessor(),
+            new ConfigurationBuilder().Build(),
+            new XFramework.TestInfrastructure.TestEffectiveTenantContextAccessor(OtherTenantId));
+        await SeedTenant(otherTenantDb, OtherTenantId, "Other Attendance Tenant");
+        await SeedAttendanceFeature(otherTenantDb, OtherTenantId);
+        await otherTenantDb.SaveChangesAsync();
     }
 
     private static async Task SeedTenant(AppDbContext db, Guid tenantId, string name)
@@ -413,5 +442,20 @@ public sealed class AttendanceIntegrationTestFixture
         RuntimeHelpers.RunClassConstructor(typeof(IdentityCredential).TypeHandle);
         RuntimeHelpers.RunClassConstructor(typeof(TenantModuleFeature).TypeHandle);
         RuntimeHelpers.RunClassConstructor(typeof(Wallets.Domain.Shared.Contracts.WalletType).TypeHandle);
+    }
+
+    private sealed class AttendanceIntegrationCredentialResolver : IAttendanceCredentialResolver
+    {
+        public Task<Result<AttendanceCredentialSnapshot>> ResolveAsync(
+            Guid credentialId,
+            Guid tenantId,
+            CancellationToken ct) =>
+            Task.FromResult(Result<AttendanceCredentialSnapshot>.Success(new(
+                credentialId,
+                tenantId,
+                true,
+                false,
+                $"Credential {credentialId:N}",
+                credentialId.ToString("N"))));
     }
 }

--- a/src/Tests/Attendance.IntegrationTests/Infrastructure/AttendanceTestIdentityProviders.cs
+++ b/src/Tests/Attendance.IntegrationTests/Infrastructure/AttendanceTestIdentityProviders.cs
@@ -1,3 +1,6 @@
+using Attendance.Domain.Shared.Contracts;
+using XFramework.Core.Patterns;
+using XFramework.Core.Services.FeatureGates;
 using XFramework.Domain.Shared.ServiceIdentity;
 using XFramework.Integration.Security;
 
@@ -15,7 +18,7 @@ internal static class AttendanceTestIdentity
         AttendanceIntegrationTestFixture.TestTenantId,
         Guid.Parse("00000000-0000-0000-0000-000000000187"),
         new HashSet<string>(StringComparer.Ordinal) { "attendance-test" },
-        new HashSet<string>(StringComparer.Ordinal),
+        new HashSet<string>(StringComparer.Ordinal) { AttendanceAuthorizationCapabilities.View },
         "attendance-tests-g1",
         DateTimeOffset.UtcNow.AddHours(1));
 
@@ -65,6 +68,49 @@ internal sealed class AttendanceTestServiceIdentityProvider : IServiceIdentityPr
                     AttendanceTestIdentity.Service.Scopes,
                     AttendanceTestIdentity.Service.GenerationId))
             : ServiceIdentityValidationResult.Failure("Invalid test service token."));
+}
+
+internal sealed class AttendanceBoltHubTestServiceIdentityProvider : IServiceIdentityProvider
+{
+    public Task<ServiceIdentityValidationResult> ValidateAsync(
+        string token,
+        string expectedAudience,
+        CancellationToken ct = default) =>
+        Task.FromResult(token == AttendanceTestIdentity.ServiceToken
+            ? ServiceIdentityValidationResult.Success(
+                new TrustedServiceIdentity(
+                    XFrameworkServiceNames.BoltHub,
+                    expectedAudience,
+                    new HashSet<string>(XFrameworkServiceScopes.AdminDefaults, StringComparer.Ordinal),
+                    "attendance-tests-g1"))
+            : ServiceIdentityValidationResult.Failure("Invalid test service token."));
+}
+
+internal sealed class AttendanceTestCapabilityService : ITenantCredentialCapabilityService
+{
+    public Task<Result<bool>> IsAllowedAsync(
+        Guid tenantId,
+        Guid credentialId,
+        string moduleKey,
+        string? subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct = default) =>
+        Task.FromResult(Result<bool>.Success(IsTestActor(tenantId, credentialId)));
+
+    public Task<Result> EnsureAllowedAsync(
+        Guid tenantId,
+        Guid credentialId,
+        string moduleKey,
+        string? subFeatureKey,
+        string capabilityKey,
+        CancellationToken ct = default) =>
+        Task.FromResult(IsTestActor(tenantId, credentialId)
+            ? Result.Success()
+            : Result.Forbidden("Attendance test actor capability denied."));
+
+    private static bool IsTestActor(Guid tenantId, Guid credentialId) =>
+        tenantId == AttendanceIntegrationTestFixture.TestTenantId &&
+        credentialId == AttendanceTestIdentity.Actor.CredentialId;
 }
 
 internal sealed class AttendanceTestInvocationContextAccessor(Guid tenantId)

--- a/src/Tests/Attendance.IntegrationTests/Tests/AttendanceGeneratedAuthorizationCompletenessTests.cs
+++ b/src/Tests/Attendance.IntegrationTests/Tests/AttendanceGeneratedAuthorizationCompletenessTests.cs
@@ -1,0 +1,60 @@
+using Attendance.Domain.Shared.Contracts;
+using FluentAssertions;
+using NUnit.Framework;
+using XFramework.Core.DataContext;
+using XFramework.Domain.Shared.Attributes;
+
+namespace GeneratedAuthorizationContractTests.Attendance;
+
+[TestFixture]
+[Category("Kind:Integration")]
+[Category("Module:Attendance")]
+[Category("Area:GeneratedAuthorization")]
+public sealed class AttendanceGeneratedAuthorizationCompletenessTests
+{
+    [Test]
+    public void GeneratedAttendanceEntities_KeepGenericDataContextAccessFailClosed()
+    {
+        var registryType = typeof(global::Attendance.Api.Services.IAttendanceReadService)
+            .Assembly
+            .GetType("XFramework.Core.DataContext.DataContextEntityRegistrations", throwOnError: true)!;
+        var entities = (Dictionary<string, Type>)registryType
+            .GetMethod("GetDataContextEntityTypes")!
+            .Invoke(null, null)!;
+        var policies = (IReadOnlyCollection<GeneratedEntityAuthorizationPolicy>)registryType
+            .GetMethod("GetDataContextAuthorizationPolicies")!
+            .Invoke(null, null)!;
+        var mutableEntities = (HashSet<string>)registryType
+            .GetMethod("GetDataContextMutableEntityTypes")!
+            .Invoke(null, null)!;
+        var expectedEntities = new[]
+        {
+            nameof(AttendanceAdjustment),
+            nameof(AttendanceContext),
+            nameof(AttendanceEvent),
+            nameof(AttendanceParticipant),
+            nameof(AttendancePolicy),
+            nameof(AttendanceRecord),
+            nameof(AttendanceSession)
+        };
+
+        entities.Keys.Should().BeEquivalentTo(expectedEntities);
+        policies.Should().BeEmpty("approved Attendance reads use explicit actor-authorized wrappers");
+        mutableEntities.Should().BeEmpty("Attendance business mutations must never use remote IDataContext");
+
+        foreach (var entityType in entities.Values)
+        {
+            var attribute = entityType.GetCustomAttributes(typeof(GenerateEndpointsAttribute), false)
+                .Cast<GenerateEndpointsAttribute>()
+                .Single();
+            attribute.Type.Should().Be(EndpointType.Rest);
+            attribute.Actions.Should().Be(EndpointActions.None);
+            attribute.AuthorizationFeature.Should().Be("attendance");
+            attribute.ActorRequirement.Should().Be(GeneratedActorRequirement.Required);
+            Attribute.IsDefined(entityType, typeof(AllowRemoteDataContextMutationAttribute))
+                .Should().BeFalse();
+            Attribute.IsDefined(entityType, typeof(AllowGeneratedServiceAccessAttribute))
+                .Should().BeFalse();
+        }
+    }
+}

--- a/src/Tests/Attendance.IntegrationTests/Tests/AttendanceMigrationOwnershipTests.cs
+++ b/src/Tests/Attendance.IntegrationTests/Tests/AttendanceMigrationOwnershipTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using NUnit.Framework;
+using XFramework.Domain.Migrations;
+
+namespace AttendanceMigrationTests;
+
+[TestFixture]
+[Category("Kind:Integration")]
+[Category("Module:Attendance")]
+public sealed class AttendanceMigrationOwnershipTests
+{
+    [Test]
+    public void AttendanceBaseline_UpAndDown_OnlyOperateOnAttendanceSchema()
+    {
+        var migration = new AddAttendanceBaseline();
+        var up = BuildOperations(migration, "Up");
+        var down = BuildOperations(migration, "Down");
+
+        up.Concat(down)
+            .OfType<SqlOperation>()
+            .Should()
+            .NotContain(operation =>
+                operation.Sql.Contains("\"Identity\".", StringComparison.Ordinal) ||
+                operation.Sql.Contains("\"Application\".", StringComparison.Ordinal));
+    }
+
+    private static IReadOnlyList<MigrationOperation> BuildOperations(Migration migration, string methodName)
+    {
+        var builder = new MigrationBuilder("Npgsql.EntityFrameworkCore.PostgreSQL");
+        var method = migration.GetType().GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Migration method {methodName} was not found.");
+
+        method.Invoke(migration, [builder]);
+        return builder.Operations;
+    }
+}

--- a/src/Tests/Attendance.IntegrationTests/Tests/AttendancePostgresTests.cs
+++ b/src/Tests/Attendance.IntegrationTests/Tests/AttendancePostgresTests.cs
@@ -79,17 +79,18 @@ public sealed class AttendancePostgresTests : AttendanceIntegrationTestBase
         });
         context.IsSuccess.Should().BeTrue(context.Message);
 
+        var startsAt = DateTime.UtcNow.AddMinutes(-30);
         var participant = await ServiceWrapper.AddAttendanceParticipant(new AddAttendanceParticipantRequest
         {
             Metadata = metadata,
             ContextId = context.Response!.Id,
             CredentialId = Guid.NewGuid(),
             DisplayName = "Wrapper Participant",
-            ReferenceCode = UniqueCode("P")
+            ReferenceCode = UniqueCode("P"),
+            StartedAt = startsAt.AddMinutes(-1)
         });
         participant.IsSuccess.Should().BeTrue(participant.Message);
 
-        var startsAt = DateTime.UtcNow.AddMinutes(-20);
         var session = await ServiceWrapper.CreateAttendanceSession(new CreateAttendanceSessionRequest
         {
             Metadata = metadata,
@@ -141,6 +142,15 @@ public sealed class AttendancePostgresTests : AttendanceIntegrationTestBase
             item.SessionId == session.Response.Id &&
             item.PresentCount == 1 &&
             item.AbsentCount == 0);
+
+        var closed = await ServiceWrapper.TransitionAttendanceSession(new TransitionAttendanceSessionRequest
+        {
+            Metadata = metadata,
+            SessionId = session.Response.Id,
+            Status = AttendanceSessionStatus.Closed
+        });
+        closed.IsSuccess.Should().BeTrue(closed.Message);
+        closed.Response!.Status.Should().Be(AttendanceSessionStatus.Closed);
 
         await using var db = CreateDbContext();
         var persistedRecord = await db.Set<AttendanceRecord>()
@@ -196,8 +206,42 @@ public sealed class AttendancePostgresTests : AttendanceIntegrationTestBase
     }
 
     [Test]
+    [Category(TestCategories.Wrappers)]
+    public async Task Wrapper_ConcurrentIdempotentEvents_ConvergeOnSingleEvent()
+    {
+        var seed = await SeedAttendanceAsync(CreateMetadata());
+        var idempotencyKey = UniqueCode("RACE");
+
+        RecordAttendanceEventRequest CreateRequest() => new()
+        {
+            Metadata = CreateMetadata(),
+            SessionId = seed.SessionId,
+            ParticipantId = seed.ParticipantId,
+            EventType = AttendanceEventType.CheckIn,
+            Source = AttendanceEventSource.Api,
+            OccurredAt = seed.StartsAt,
+            IdempotencyKey = idempotencyKey
+        };
+
+        var responses = await Task.WhenAll(
+            ServiceWrapper.RecordAttendanceEvent(CreateRequest()),
+            ServiceWrapper.RecordAttendanceEvent(CreateRequest()));
+
+        responses.Should().OnlyContain(response => response.IsSuccess);
+        responses.Select(response => response.Response!.Id).Distinct().Should().ContainSingle();
+
+        await using var db = CreateDbContext();
+        var persistedEventCount = await db.Set<AttendanceEvent>()
+            .IgnoreQueryFilters()
+            .CountAsync(item =>
+                item.TenantId == AttendanceIntegrationTestFixture.TestTenantId &&
+                item.IdempotencyKey == idempotencyKey);
+        persistedEventCount.Should().Be(1);
+    }
+
+    [Test]
     [Category(TestCategories.DataContext)]
-    public async Task RemoteDataContext_QueryAttendanceContext_ReturnsEntityFromAttendanceService()
+    public async Task RemoteDataContext_QueryAttendanceContext_IsDeniedBecauseReadsUseExplicitWrappers()
     {
         var metadata = CreateMetadata();
         var context = await ServiceWrapper.CreateAttendanceContext(new CreateAttendanceContextRequest
@@ -209,11 +253,129 @@ public sealed class AttendancePostgresTests : AttendanceIntegrationTestBase
         });
         context.IsSuccess.Should().BeTrue(context.Message);
 
-        var remoteContexts = await DataContext.Query<AttendanceContext>()
+        Func<Task> act = async () => await DataContext.Query<AttendanceContext>()
             .Where(item => item.Id == context.Response!.Id)
             .ToListAsync();
 
-        remoteContexts.Should().ContainSingle(item => item.Id == context.Response!.Id);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*403*");
+    }
+
+    [Test]
+    [Category(TestCategories.Wrappers)]
+    public async Task Wrapper_ApprovedReadOperations_ReturnTenantScopedAttendanceData()
+    {
+        var metadata = CreateMetadata();
+        var credentialId = Guid.NewGuid();
+        var context = await ServiceWrapper.CreateAttendanceContext(new CreateAttendanceContextRequest
+        {
+            Metadata = metadata,
+            Name = $"Read context {Guid.NewGuid():N}",
+            Code = UniqueCode("READ"),
+            ContextType = AttendanceContextType.Project
+        });
+        var startsAt = DateTime.UtcNow.AddMinutes(-5);
+        var participant = await ServiceWrapper.AddAttendanceParticipant(new AddAttendanceParticipantRequest
+        {
+            Metadata = metadata,
+            ContextId = context.Response!.Id,
+            CredentialId = credentialId,
+            DisplayName = "Read participant",
+            StartedAt = startsAt.AddMinutes(-1)
+        });
+        var session = await ServiceWrapper.CreateAttendanceSession(new CreateAttendanceSessionRequest
+        {
+            Metadata = metadata,
+            ContextId = context.Response.Id,
+            Name = "Read session",
+            StartsAt = startsAt,
+            EndsAt = startsAt.AddMinutes(30),
+            TimeZoneId = "UTC",
+            Status = AttendanceSessionStatus.Open
+        });
+        var attendanceEvent = await ServiceWrapper.RecordAttendanceEvent(new RecordAttendanceEventRequest
+        {
+            Metadata = metadata,
+            SessionId = session.Response!.Id,
+            ParticipantId = participant.Response!.Id,
+            EventType = AttendanceEventType.CheckIn,
+            Source = AttendanceEventSource.Api,
+            OccurredAt = startsAt,
+            IdempotencyKey = UniqueCode("READ-IN")
+        });
+        var removed = await ServiceWrapper.RemoveAttendanceParticipant(new RemoveAttendanceParticipantRequest
+        {
+            Metadata = metadata,
+            ParticipantId = participant.Response!.Id,
+            EndedAt = startsAt.AddMinutes(1)
+        });
+
+        context.IsSuccess.Should().BeTrue(context.Message);
+        participant.IsSuccess.Should().BeTrue(participant.Message);
+        session.IsSuccess.Should().BeTrue(session.Message);
+        attendanceEvent.IsSuccess.Should().BeTrue(attendanceEvent.Message);
+        removed.IsSuccess.Should().BeTrue(removed.Message);
+
+        var overview = await ServiceWrapper.GetAttendanceContextOverview(new()
+        {
+            Metadata = metadata,
+            TenantId = AttendanceIntegrationTestFixture.TestTenantId
+        });
+        var sessions = await ServiceWrapper.GetAttendanceSessionReadList(new()
+        {
+            Metadata = metadata,
+            TenantId = AttendanceIntegrationTestFixture.TestTenantId,
+            ContextId = context.Response.Id,
+            FromUtc = startsAt.AddMinutes(-1),
+            ToUtc = startsAt.AddMinutes(1)
+        });
+        var detail = await ServiceWrapper.GetAttendanceSessionDetailRead(new()
+        {
+            Metadata = metadata,
+            TenantId = AttendanceIntegrationTestFixture.TestTenantId,
+            SessionId = session.Response.Id
+        });
+        var participants = await ServiceWrapper.GetAttendanceParticipantReadList(new()
+        {
+            Metadata = metadata,
+            TenantId = AttendanceIntegrationTestFixture.TestTenantId,
+            ContextId = context.Response.Id
+        });
+        var history = await ServiceWrapper.GetAttendanceCredentialHistory(new()
+        {
+            Metadata = metadata,
+            TenantId = AttendanceIntegrationTestFixture.TestTenantId,
+            CredentialIds = [credentialId]
+        });
+
+        overview.IsSuccess.Should().BeTrue(overview.Message);
+        overview.Response!.Items.Should().ContainSingle(item =>
+            item.Id == context.Response.Id && item.ActiveParticipantCount == 0 && item.SessionCount == 1);
+        sessions.IsSuccess.Should().BeTrue(sessions.Message);
+        sessions.Response!.Items.Should().ContainSingle(item => item.Id == session.Response.Id);
+        detail.IsSuccess.Should().BeTrue(detail.Message);
+        // Historical session rosters are based on the participation interval, not current active state.
+        detail.Response!.Participants.Should().ContainSingle(item => item.Id == participant.Response.Id);
+        detail.Response.RecentEvents.Should().ContainSingle(item => item.Id == attendanceEvent.Response!.Id);
+        participants.IsSuccess.Should().BeTrue(participants.Message);
+        participants.Response!.Items.Should().ContainSingle(item => item.Id == participant.Response.Id);
+        history.IsSuccess.Should().BeTrue(history.Message);
+        history.Response!.Participants.Should().ContainSingle(item => item.CredentialId == credentialId);
+        history.Response.Records.Should().ContainSingle(item => item.CredentialId == credentialId);
+    }
+
+    [Test]
+    [Category(TestCategories.Auth)]
+    public async Task Wrapper_AttendanceReadForDifferentTenant_IsDenied()
+    {
+        var response = await ServiceWrapper.GetAttendanceContextOverview(new()
+        {
+            Metadata = CreateMetadata(),
+            TenantId = AttendanceIntegrationTestFixture.OtherTenantId
+        });
+
+        response.IsSuccess.Should().BeFalse();
+        response.HttpStatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.Forbidden);
     }
 
     private static async Task<SeedAttendance> SeedAttendanceAsync(XFramework.Domain.Shared.BusinessObjects.RequestMetadata metadata)
@@ -227,16 +389,17 @@ public sealed class AttendancePostgresTests : AttendanceIntegrationTestBase
         });
         context.IsSuccess.Should().BeTrue(context.Message);
 
+        var startsAt = DateTime.UtcNow.AddMinutes(-10);
         var participant = await ServiceWrapper.AddAttendanceParticipant(new AddAttendanceParticipantRequest
         {
             Metadata = metadata,
             ContextId = context.Response!.Id,
             CredentialId = Guid.NewGuid(),
-            DisplayName = "Project member"
+            DisplayName = "Project member",
+            StartedAt = startsAt.AddMinutes(-1)
         });
         participant.IsSuccess.Should().BeTrue(participant.Message);
 
-        var startsAt = DateTime.UtcNow.AddMinutes(-10);
         var session = await ServiceWrapper.CreateAttendanceSession(new CreateAttendanceSessionRequest
         {
             Metadata = metadata,

--- a/src/Tests/Portal.E2ETests/AttendancePortalContractTests.cs
+++ b/src/Tests/Portal.E2ETests/AttendancePortalContractTests.cs
@@ -99,17 +99,19 @@ public sealed class AttendancePortalContractTests
 
         service.Should().Contain("IDataContext dataContext");
         service.Should().Contain("IAttendanceServiceWrapper attendance");
-        service.Should().Contain("attendance.GetAttendanceContexts(new GetAttendanceContextsRequest");
-        service.Should().Contain("dataContext.Query<AttendanceContext>()");
-        service.Should().Contain("dataContext.Query<AttendanceSession>()");
-        service.Should().Contain("dataContext.Query<AttendanceParticipant>()");
-        service.Should().Contain("dataContext.Query<AttendanceRecord>()");
+        service.Should().Contain("attendance.GetAttendanceContextOverview(new");
+        service.Should().Contain("attendance.GetAttendanceSessionReadList(new");
+        service.Should().Contain("attendance.GetAttendanceSessionDetailRead(new");
+        service.Should().Contain("attendance.GetAttendanceParticipantReadList(new");
+        service.Should().Contain("attendance.GetAttendanceCredentialHistory(new");
         service.Should().Contain("dataContext.Query<IdentityCredential>()");
         service.Should().Contain("x.TenantId == tenantId");
         service.Should().Contain("BuildCredentialLabel");
         service.Should().Contain("AttendanceRecordStatus.Absent");
         service.Should().Contain("NormalizeUtc(fromUtc)");
         service.Should().Contain("context.Id != Guid.Empty");
+        service.Should().NotContain("dataContext.Query<Attendance");
+        service.Should().NotContain("IgnoreQueryFilters()");
         service.Should().NotContain("x.StartsAt >= fromUtc");
         service.Should().NotContain("SaveChangesAsync(");
     }

--- a/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
+++ b/src/Tests/Portal.E2ETests/ServiceIdentityComposeContractTests.cs
@@ -139,6 +139,8 @@ public sealed class ServiceIdentityComposeContractTests
             XFrameworkServiceScopes.DataContextQueryAllTenants,
             XFrameworkServiceScopes.DataContextMutate,
             XFrameworkServiceScopes.TenantTarget,
+            XFrameworkServiceScopes.AttendanceRead,
+            XFrameworkServiceScopes.AttendanceWrite,
             XFrameworkServiceScopes.CommunicationsAdmin,
             XFrameworkServiceScopes.CommunicationsChat,
             XFrameworkServiceScopes.IdentityAdmin,


### PR DESCRIPTION
## Summary
- enforce trusted actor and effective-tenant handling for Attendance events and adjustments
- replace generic remote Attendance `IDataContext` reads with explicit actor-authorized read wrappers
- validate participant credentials through IdentityServer and preserve date-effective membership history
- add payload-aware concurrent idempotency and explicit session lifecycle transitions
- apply least-privilege `attendance.read`/`attendance.write` Bolt scopes, Portal caller restrictions, and cancellation propagation
- remove cross-schema migration writes and add Attendance-focused CI, authorization, migration, wrapper, and PostgreSQL coverage
- update the Attendance agent guidance and backend audit with resolution evidence

## Root cause
The original Attendance implementation predated centralized trusted invocation and generated authorization parity. It accepted compatibility actor fields, depended on generic remote reads that now correctly fail closed, lacked destination-specific Bolt scopes/caller restrictions, and did not fully preserve historical participation or guard concurrent idempotent capture.

## Validation
- Attendance unit tests: 37 passed
- Attendance PostgreSQL/Bolt integration tests through xeon-dev loopback tunnel: 10 passed
- Portal Attendance contract tests: 6 passed
- Core generated authorization/data-context tests: 64 passed
- Source-generator authorization parity tests: 64 passed
- Bolt token-cache tests: 13 passed
- Attendance API build: succeeded with 0 warnings/errors
- Attendance package vulnerability scan: no vulnerable packages
- Docker Compose configuration: valid with protected values supplied as placeholders
- `git diff --check`: passed

## Residual risk
The Attendance integration fixture uses deterministic service/actor/identity providers instead of booting a second full IdentityServer process. Production IdentityServer wrapper failure mapping is directly tested, while issuance, validation, and independent service/Bolt token caches are covered by the shared security suites above.

No deployment or merge is included in this PR.